### PR TITLE
feat: Add mcp-skills-plugin for MCP to Claude Skills conversion

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,7 @@
       "description": "Essential meta-skill for creating effective Claude Code skills with initialization scripts, validation, packaging, marketplace registration, and privacy best practices",
       "source": "./",
       "strict": false,
-      "version": "1.2.0",
+      "version": "1.2.1",
       "category": "developer-tools",
       "keywords": ["skill-creation", "claude-code", "development", "tooling", "workflow", "meta-skill", "essential"],
       "skills": ["./skill-creator"]
@@ -152,10 +152,10 @@
     },
     {
       "name": "transcript-fixer",
-      "description": "Corrects speech-to-text (ASR/STT) transcription errors in meeting notes, lecture recordings, interviews, and voice memos through dictionary-based rules and AI corrections. Use when users mention transcript correction, ASR errors, speech-to-text mistakes, homophone errors, or working with transcription files",
+      "description": "Corrects speech-to-text (ASR/STT) transcription errors in meeting notes, lecture recordings, interviews, and voice memos through dictionary-based rules and AI corrections. Supports Chinese domain names, AI fallback to Claude Code, and iterative dictionary building. Use when users mention transcript correction, ASR errors, speech-to-text mistakes, homophone errors, or working with transcription files",
       "source": "./",
       "strict": false,
-      "version": "1.0.0",
+      "version": "1.1.0",
       "category": "productivity",
       "keywords": ["transcription", "asr", "stt", "speech-to-text", "correction", "ai", "meeting-notes", "nlp"],
       "skills": ["./transcript-fixer"]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,8 +5,8 @@
     "email": "daymadev89@gmail.com"
   },
   "metadata": {
-    "description": "Professional Claude Code skills for GitHub operations, document conversion, diagram generation, statusline customization, Teams communication, repomix utilities, skill creation, CLI demo generation, LLM icon access, Cloudflare troubleshooting, UI design system extraction, professional presentation creation, YouTube video downloading, secure repomix packaging, ASR transcription correction, video comparison quality analysis, comprehensive QA testing infrastructure, prompt optimization with EARS methodology, session history recovery, documentation cleanup, and PDF generation with Chinese font support",
-    "version": "1.14.0",
+    "description": "Professional Claude Code skills for GitHub operations, document conversion, diagram generation, statusline customization, Teams communication, repomix utilities, skill creation, CLI demo generation, LLM icon access, Cloudflare troubleshooting, UI design system extraction, professional presentation creation, YouTube video downloading, secure repomix packaging, ASR transcription correction, video comparison quality analysis, comprehensive QA testing infrastructure, prompt optimization with EARS methodology, session history recovery, documentation cleanup, PDF generation with Chinese font support, and CLAUDE.md progressive disclosure optimization",
+    "version": "1.15.0",
     "homepage": "https://github.com/daymade/claude-code-skills"
   },
   "plugins": [
@@ -219,6 +219,16 @@
       "category": "document-conversion",
       "keywords": ["pdf", "markdown", "weasyprint", "chinese-fonts", "document-generation", "legal", "reports", "typography"],
       "skills": ["./pdf-creator"]
+    },
+    {
+      "name": "claude-md-progressive-disclosurer",
+      "description": "Optimize user CLAUDE.md files by applying progressive disclosure principles. This skill should be used when users want to reduce CLAUDE.md bloat, move detailed content to references, extract reusable patterns into skills, or improve context efficiency. Triggers include optimize CLAUDE.md, reduce CLAUDE.md size, apply progressive disclosure, or complaints about CLAUDE.md being too long",
+      "source": "./",
+      "strict": false,
+      "version": "1.0.0",
+      "category": "productivity",
+      "keywords": ["claude-md", "progressive-disclosure", "optimization", "context-efficiency", "configuration", "token-savings"],
+      "skills": ["./claude-md-progressive-disclosurer"]
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,8 +5,8 @@
     "email": "daymadev89@gmail.com"
   },
   "metadata": {
-    "description": "Professional Claude Code skills for GitHub operations, document conversion, diagram generation, statusline customization, Teams communication, repomix utilities, skill creation, CLI demo generation, LLM icon access, Cloudflare troubleshooting, UI design system extraction, professional presentation creation, YouTube video downloading, secure repomix packaging, ASR transcription correction, video comparison quality analysis, comprehensive QA testing infrastructure, prompt optimization with EARS methodology, session history recovery, documentation cleanup, PDF generation with Chinese font support, and CLAUDE.md progressive disclosure optimization",
-    "version": "1.15.0",
+    "description": "Professional Claude Code skills for GitHub operations, document conversion, diagram generation, statusline customization, Teams communication, repomix utilities, skill creation, CLI demo generation, LLM icon access, Cloudflare troubleshooting, UI design system extraction, professional presentation creation, YouTube video downloading, secure repomix packaging, ASR transcription correction, video comparison quality analysis, comprehensive QA testing infrastructure, prompt optimization with EARS methodology, session history recovery, documentation cleanup, PDF generation with Chinese font support, CLAUDE.md progressive disclosure optimization, and CCPM skill registry search and management",
+    "version": "1.16.0",
     "homepage": "https://github.com/daymade/claude-code-skills"
   },
   "plugins": [
@@ -229,6 +229,16 @@
       "category": "productivity",
       "keywords": ["claude-md", "progressive-disclosure", "optimization", "context-efficiency", "configuration", "token-savings"],
       "skills": ["./claude-md-progressive-disclosurer"]
+    },
+    {
+      "name": "skills-search",
+      "description": "Search, discover, install, and manage Claude Code skills from the CCPM registry. Use when users want to find skills for specific tasks, install skills by name, list installed skills, get skill details, or manage their Claude Code skill collection. Triggers include find skills, search for plugins, install skill, list installed skills, or any CCPM registry operations",
+      "source": "./",
+      "strict": false,
+      "version": "1.0.0",
+      "category": "developer-tools",
+      "keywords": ["ccpm", "skills", "search", "install", "registry", "plugin", "marketplace", "discovery", "skill-management"],
+      "skills": ["./skills-search"]
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,8 +5,8 @@
     "email": "daymadev89@gmail.com"
   },
   "metadata": {
-    "description": "Professional Claude Code skills for GitHub operations, document conversion, diagram generation, statusline customization, Teams communication, repomix utilities, skill creation, CLI demo generation, LLM icon access, Cloudflare troubleshooting, UI design system extraction, professional presentation creation, YouTube video downloading, secure repomix packaging, ASR transcription correction, video comparison quality analysis, comprehensive QA testing infrastructure, prompt optimization with EARS methodology, session history recovery, and documentation cleanup",
-    "version": "1.13.0",
+    "description": "Professional Claude Code skills for GitHub operations, document conversion, diagram generation, statusline customization, Teams communication, repomix utilities, skill creation, CLI demo generation, LLM icon access, Cloudflare troubleshooting, UI design system extraction, professional presentation creation, YouTube video downloading, secure repomix packaging, ASR transcription correction, video comparison quality analysis, comprehensive QA testing infrastructure, prompt optimization with EARS methodology, session history recovery, documentation cleanup, and PDF generation with Chinese font support",
+    "version": "1.14.0",
     "homepage": "https://github.com/daymade/claude-code-skills"
   },
   "plugins": [
@@ -209,6 +209,16 @@
       "category": "productivity",
       "keywords": ["documentation", "cleanup", "consolidation", "redundancy", "merge", "docs"],
       "skills": ["./docs-cleaner"]
+    },
+    {
+      "name": "pdf-creator",
+      "description": "Create PDF documents from markdown with proper Chinese font support using weasyprint. Use when converting markdown to PDF, generating formal documents (legal filings, trademark applications, reports), or when Chinese typography is required. Triggers include convert to PDF, generate PDF, markdown to PDF, or printable documents",
+      "source": "./",
+      "strict": false,
+      "version": "1.0.0",
+      "category": "document-conversion",
+      "keywords": ["pdf", "markdown", "weasyprint", "chinese-fonts", "document-generation", "legal", "reports", "typography"],
+      "skills": ["./pdf-creator"]
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,8 +5,8 @@
     "email": "daymadev89@gmail.com"
   },
   "metadata": {
-    "description": "Professional Claude Code skills for GitHub operations, document conversion, diagram generation, statusline customization, Teams communication, repomix utilities, skill creation, CLI demo generation, LLM icon access, Cloudflare troubleshooting, UI design system extraction, professional presentation creation, YouTube video downloading, secure repomix packaging, ASR transcription correction, video comparison quality analysis, comprehensive QA testing infrastructure, prompt optimization with EARS methodology, session history recovery, documentation cleanup, PDF generation with Chinese font support, CLAUDE.md progressive disclosure optimization, CCPM skill registry search and management, Promptfoo LLM evaluation framework, and iOS app development with XcodeGen and SwiftUI",
-    "version": "1.18.1",
+    "description": "Professional Claude Code skills for GitHub operations, document conversion, diagram generation, statusline customization, Teams communication, repomix utilities, skill creation, CLI demo generation, LLM icon access, Cloudflare troubleshooting, UI design system extraction, professional presentation creation, YouTube video downloading, secure repomix packaging, ASR transcription correction, video comparison quality analysis, comprehensive QA testing infrastructure, prompt optimization with EARS methodology, session history recovery, documentation cleanup, PDF generation with Chinese font support, CLAUDE.md progressive disclosure optimization, CCPM skill registry search and management, Promptfoo LLM evaluation framework, iOS app development with XcodeGen and SwiftUI, and fact-checking with automated corrections",
+    "version": "1.19.0",
     "homepage": "https://github.com/daymade/claude-code-skills"
   },
   "plugins": [
@@ -259,6 +259,16 @@
       "category": "developer-tools",
       "keywords": ["ios", "xcodegen", "swiftui", "spm", "avfoundation", "camera", "code-signing", "device-deployment", "swift", "xcode", "testing"],
       "skills": ["./iOS-APP-developer"]
+    },
+    {
+      "name": "fact-checker",
+      "description": "Verifies factual claims in documents using web search and official sources, then proposes corrections with user confirmation. Use when the user asks to fact-check, verify information, validate claims, check accuracy, or update outdated information in documents. Supports AI model specs, technical documentation, statistics, and general factual statements",
+      "source": "./",
+      "strict": false,
+      "version": "1.0.0",
+      "category": "productivity",
+      "keywords": ["fact-checking", "verification", "accuracy", "sources", "validation", "corrections", "web-search"],
+      "skills": ["./fact-checker"]
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional Claude Code skills for GitHub operations, document conversion, diagram generation, statusline customization, Teams communication, repomix utilities, skill creation, CLI demo generation, LLM icon access, Cloudflare troubleshooting, UI design system extraction, professional presentation creation, YouTube video downloading, secure repomix packaging, ASR transcription correction, video comparison quality analysis, comprehensive QA testing infrastructure, prompt optimization with EARS methodology, session history recovery, documentation cleanup, PDF generation with Chinese font support, CLAUDE.md progressive disclosure optimization, CCPM skill registry search and management, Promptfoo LLM evaluation framework, and iOS app development with XcodeGen and SwiftUI",
-    "version": "1.18.0",
+    "version": "1.18.1",
     "homepage": "https://github.com/daymade/claude-code-skills"
   },
   "plugins": [
@@ -32,10 +32,10 @@
     },
     {
       "name": "markdown-tools",
-      "description": "Convert documents (PDFs, Word, PowerPoint, Confluence exports) to markdown with Windows/WSL path handling support",
+      "description": "Convert documents (PDFs, Word, PowerPoint, Confluence exports) to markdown with Windows/WSL path handling and PDF image extraction support",
       "source": "./",
       "strict": false,
-      "version": "1.0.0",
+      "version": "1.1.0",
       "category": "document-conversion",
       "keywords": ["markdown", "pdf", "docx", "confluence", "markitdown", "wsl"],
       "skills": ["./markdown-tools"]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -225,7 +225,7 @@
       "description": "Optimize user CLAUDE.md files by applying progressive disclosure principles. This skill should be used when users want to reduce CLAUDE.md bloat, move detailed content to references, extract reusable patterns into skills, or improve context efficiency. Triggers include optimize CLAUDE.md, reduce CLAUDE.md size, apply progressive disclosure, or complaints about CLAUDE.md being too long",
       "source": "./",
       "strict": false,
-      "version": "1.0.0",
+      "version": "1.0.1",
       "category": "productivity",
       "keywords": ["claude-md", "progressive-disclosure", "optimization", "context-efficiency", "configuration", "token-savings"],
       "skills": ["./claude-md-progressive-disclosurer"]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,8 +5,8 @@
     "email": "daymadev89@gmail.com"
   },
   "metadata": {
-    "description": "Professional Claude Code skills for GitHub operations, document conversion, diagram generation, statusline customization, Teams communication, repomix utilities, skill creation, CLI demo generation, LLM icon access, Cloudflare troubleshooting, UI design system extraction, professional presentation creation, YouTube video downloading, secure repomix packaging, ASR transcription correction, video comparison quality analysis, comprehensive QA testing infrastructure, prompt optimization with EARS methodology, session history recovery, documentation cleanup, PDF generation with Chinese font support, CLAUDE.md progressive disclosure optimization, and CCPM skill registry search and management",
-    "version": "1.16.0",
+    "description": "Professional Claude Code skills for GitHub operations, document conversion, diagram generation, statusline customization, Teams communication, repomix utilities, skill creation, CLI demo generation, LLM icon access, Cloudflare troubleshooting, UI design system extraction, professional presentation creation, YouTube video downloading, secure repomix packaging, ASR transcription correction, video comparison quality analysis, comprehensive QA testing infrastructure, prompt optimization with EARS methodology, session history recovery, documentation cleanup, PDF generation with Chinese font support, CLAUDE.md progressive disclosure optimization, CCPM skill registry search and management, Promptfoo LLM evaluation framework, and iOS app development with XcodeGen and SwiftUI",
+    "version": "1.18.0",
     "homepage": "https://github.com/daymade/claude-code-skills"
   },
   "plugins": [
@@ -15,7 +15,7 @@
       "description": "Essential meta-skill for creating effective Claude Code skills with initialization scripts, validation, packaging, marketplace registration, and privacy best practices",
       "source": "./",
       "strict": false,
-      "version": "1.2.1",
+      "version": "1.2.2",
       "category": "developer-tools",
       "keywords": ["skill-creation", "claude-code", "development", "tooling", "workflow", "meta-skill", "essential"],
       "skills": ["./skill-creator"]
@@ -239,6 +239,26 @@
       "category": "developer-tools",
       "keywords": ["ccpm", "skills", "search", "install", "registry", "plugin", "marketplace", "discovery", "skill-management"],
       "skills": ["./skills-search"]
+    },
+    {
+      "name": "promptfoo-evaluation",
+      "description": "Configures and runs LLM evaluation using Promptfoo framework. Use when setting up prompt testing, creating evaluation configs (promptfooconfig.yaml), writing Python custom assertions, implementing llm-rubric for LLM-as-judge, or managing few-shot examples in prompts. Triggers on keywords like promptfoo, eval, LLM evaluation, prompt testing, or model comparison",
+      "source": "./",
+      "strict": false,
+      "version": "1.0.0",
+      "category": "developer-tools",
+      "keywords": ["promptfoo", "evaluation", "llm-testing", "prompt-testing", "assertions", "llm-rubric", "few-shot", "model-comparison"],
+      "skills": ["./promptfoo-evaluation"]
+    },
+    {
+      "name": "iOS-APP-developer",
+      "description": "Develops iOS applications with XcodeGen, SwiftUI, and SPM. Use when configuring XcodeGen project.yml, resolving SPM dependency issues, deploying to devices, handling code signing, debugging camera/AVFoundation, iOS version compatibility issues, or fixing Library not loaded @rpath framework errors. Includes state machine testing patterns for @MainActor classes",
+      "source": "./",
+      "strict": false,
+      "version": "1.1.0",
+      "category": "developer-tools",
+      "keywords": ["ios", "xcodegen", "swiftui", "spm", "avfoundation", "camera", "code-signing", "device-deployment", "swift", "xcode", "testing"],
+      "skills": ["./iOS-APP-developer"]
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,8 +5,8 @@
     "email": "daymadev89@gmail.com"
   },
   "metadata": {
-    "description": "Professional Claude Code skills for GitHub operations, document conversion, diagram generation, statusline customization, Teams communication, repomix utilities, skill creation, CLI demo generation, LLM icon access, Cloudflare troubleshooting, UI design system extraction, professional presentation creation, YouTube video downloading, secure repomix packaging, ASR transcription correction, video comparison quality analysis, comprehensive QA testing infrastructure, prompt optimization with EARS methodology, session history recovery, documentation cleanup, PDF generation with Chinese font support, CLAUDE.md progressive disclosure optimization, CCPM skill registry search and management, Promptfoo LLM evaluation framework, iOS app development with XcodeGen and SwiftUI, and fact-checking with automated corrections",
-    "version": "1.19.0",
+    "description": "Professional Claude Code skills for GitHub operations, document conversion, diagram generation, statusline customization, Teams communication, repomix utilities, skill creation, CLI demo generation, LLM icon access, Cloudflare troubleshooting, UI design system extraction, professional presentation creation, YouTube video downloading, secure repomix packaging, ASR transcription correction, video comparison quality analysis, comprehensive QA testing infrastructure, prompt optimization with EARS methodology, session history recovery, documentation cleanup, PDF generation with Chinese font support, CLAUDE.md progressive disclosure optimization, CCPM skill registry search and management, Promptfoo LLM evaluation framework, iOS app development with XcodeGen and SwiftUI, fact-checking with automated corrections, and MCP server to Claude Skills conversion with 90%+ context savings",
+    "version": "1.20.0",
     "homepage": "https://github.com/daymade/claude-code-skills"
   },
   "plugins": [
@@ -269,6 +269,16 @@
       "category": "productivity",
       "keywords": ["fact-checking", "verification", "accuracy", "sources", "validation", "corrections", "web-search"],
       "skills": ["./fact-checker"]
+    },
+    {
+      "name": "mcp-skills-plugin",
+      "description": "Convert MCP servers to Claude Skills with progressive disclosure pattern, reducing context usage by 90%+. Use when users want to convert MCP to skill, create skill from MCP, list MCP servers, batch convert MCP, generate skills from .mcp.json, or work with MCP server configurations. Includes session start hook for auto-loading MCP Skills Registry",
+      "source": "./",
+      "strict": false,
+      "version": "1.0.0",
+      "category": "developer-tools",
+      "keywords": ["mcp", "skills", "context-efficiency", "progressive-disclosure", "mcp-server", "conversion", "token-savings"],
+      "skills": ["./mcp-skills-plugin"]
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - None
 
+## [1.18.0] - 2025-12-20
+
+### Added
+- **New Skill**: pdf-creator - Convert markdown to PDF with Chinese font support (WeasyPrint)
+- **New Skill**: claude-md-progressive-disclosurer - Optimize CLAUDE.md with progressive disclosure
+- **New Skill**: promptfoo-evaluation - Promptfoo-based LLM evaluation workflows
+- **New Skill**: iOS-APP-developer - iOS app development with XcodeGen, SwiftUI, and SPM
+
+### Changed
+- Updated marketplace skills count from 23 to 25
+- Updated marketplace version from 1.16.0 to 1.18.0
+- Updated README/README.zh-CN badges, skill lists, use cases, quick links, and requirements
+- Updated QUICKSTART docs to clarify marketplace install syntax and remove obsolete links
+- Updated CLAUDE.md skill counts and added the new skills to the list
+
 ## [1.16.0] - 2025-12-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - None
 
+## [1.18.2] - 2026-01-05
+
+### Changed
+- **claude-md-progressive-disclosurer**: Enhanced workflow with safety and verification features
+  - Added mandatory backup step (Step 0) before any modifications
+  - Added pre-execution verification checklist (Step 3.5) to prevent information loss
+  - Added post-optimization testing (Step 5) for discoverability validation
+  - Added exception criteria for size guidelines (safety-critical, high-frequency, security-sensitive)
+  - Added project-level vs user-level CLAUDE.md guidance
+  - Updated references/progressive_disclosure_principles.md with verification methods
+- Updated claude-md-progressive-disclosurer plugin version from 1.0.0 to 1.0.1
+
 ## [1.18.1] - 2025-12-28
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - None
 
+## [1.13.0] - 2025-12-09
+
+### Added
+- **New Skill**: claude-code-history-files-finder - Session history recovery for Claude Code
+  - Search sessions by keywords with frequency ranking
+  - Recover deleted files from Write tool calls with automatic deduplication
+  - Analyze session statistics (message counts, tool usage, file operations)
+  - Batch operations for processing multiple sessions
+  - Streaming processing for large session files (>100MB)
+  - Bundled scripts: analyze_sessions.py, recover_content.py
+  - Bundled references: session_file_format.md, workflow_examples.md
+  - Follows Anthropic skill authoring best practices (third-person description, imperative style, progressive disclosure)
+
+- **New Skill**: docs-cleaner - Documentation consolidation
+  - Consolidate redundant documentation while preserving valuable content
+  - Redundancy detection for overlapping documents
+  - Smart merging with structure preservation
+  - Validation for consolidated documents
+
+### Changed
+- Updated marketplace skills count from 18 to 20
+- Updated marketplace version from 1.11.0 to 1.13.0
+- Updated README.md badges (skills count: 20, version: 1.13.0)
+- Updated README.md to include claude-code-history-files-finder in skills listing (skill 18)
+- Updated README.md to include docs-cleaner in skills listing (skill 19)
+- Updated README.zh-CN.md badges (skills count: 20, version: 1.13.0)
+- Updated README.zh-CN.md to include both new skills with Chinese translations
+- Updated CLAUDE.md skills count from 18 to 20
+- Added session history recovery use case section to README.md
+- Added documentation maintenance use case section to README.md
+- Added corresponding use case sections to README.zh-CN.md
+- Added installation commands for both new skills
+- Added quick links for documentation references
+
 ## [youtube-downloader-1.1.0] - 2025-11-19
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - None
 
+## [1.18.1] - 2025-12-28
+
+### Changed
+- **markdown-tools**: Enhanced with PDF image extraction capability
+  - Added `extract_pdf_images.py` script using PyMuPDF
+  - Refactored SKILL.md for clearer workflow documentation
+  - Updated installation instructions to use `markitdown[pdf]` extra
+- Updated marketplace version from 1.18.0 to 1.18.1
+
 ## [1.18.0] - 2025-12-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - None
 
+## [1.16.0] - 2025-12-11
+
+### Added
+- **New Skill**: skills-search - CCPM registry search and management
+  - Search for Claude Code skills in the CCPM registry
+  - Install skills by name with `ccpm install <skill-name>`
+  - List installed skills with `ccpm list`
+  - Get detailed skill information with `ccpm info <skill-name>`
+  - Uninstall skills with `ccpm uninstall <skill-name>`
+  - Install skill bundles (web-dev, content-creation, developer-tools)
+  - Supports multiple installation formats (registry, GitHub owner/repo, full URLs)
+  - Troubleshooting guidance for common issues
+
+### Changed
+- Updated marketplace skills count from 22 to 23
+- Updated marketplace version from 1.15.0 to 1.16.0
+- Updated README.md badges (skills count: 23, version: 1.16.0)
+- Updated README.md to include skills-search in skills listing (skill #20)
+- Updated README.zh-CN.md badges (skills count: 23, version: 1.16.0)
+- Updated README.zh-CN.md to include skills-search with Chinese translation
+- Updated CLAUDE.md skills count from 22 to 23
+- Added skills-search use case section to README.md
+- Added skills-search use case section to README.zh-CN.md
+- Added installation command for skills-search
+- Enhanced marketplace metadata description to include CCPM skill management
+
 ## [1.13.0] - 2025-12-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added corresponding use case sections to README.zh-CN.md
 - Added installation commands for both new skills
 - Added quick links for documentation references
+- **skill-creator** v1.2.0 → v1.2.1: Added cache directory warning
+  - Added critical warning about not editing skills in `~/.claude/plugins/cache/`
+  - Explains that cache is read-only and changes are lost on refresh
+  - Provides correct vs wrong path examples
+- **transcript-fixer** v1.0.0 → v1.1.0: Enhanced with Chinese domain support and AI fallback
+  - Added Chinese/Japanese/Korean character support for domain names (e.g., `火星加速器`, `具身智能`)
+  - Added `[CLAUDE_FALLBACK]` signal when GLM API is unavailable for Claude Code to take over
+  - Added Prerequisites section requiring `uv` for Python execution
+  - Added Critical Workflow section for dictionary iteration best practices
+  - Added AI Fallback Strategy section with manual correction guidance
+  - Added Database Operations section with schema reference requirement
+  - Added Stages table for quick reference (Dictionary → AI → Full pipeline)
+  - Added new bundled script: `ensure_deps.py` for shared virtual environment
+  - Added new bundled references: `database_schema.md`, `iteration_workflow.md`
+  - Updated domain validation from whitelist to pattern matching
+  - Updated tests for Chinese domain names and security bypass attempts
 
 ## [youtube-downloader-1.1.0] - 2025-11-19
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,8 +40,9 @@ curl -fsSL https://raw.githubusercontent.com/daymade/claude-code-skills/main/scr
 iwr -useb https://raw.githubusercontent.com/daymade/claude-code-skills/main/scripts/install.ps1 | iex
 
 # Manual installation
-claude plugin marketplace add daymade/claude-code-skills
-claude plugin install skill-creator@daymade/claude-code-skills
+claude plugin marketplace add https://github.com/daymade/claude-code-skills
+# Marketplace name: daymade-skills (from marketplace.json)
+claude plugin install skill-creator@daymade-skills
 ```
 
 ### Skill Validation and Packaging
@@ -61,10 +62,11 @@ skill-creator/scripts/init_skill.py <skill-name> --path <output-directory>
 
 ```bash
 # Add local marketplace
-claude plugin marketplace add daymade/claude-code-skills
+claude plugin marketplace add https://github.com/daymade/claude-code-skills
+# Marketplace name: daymade-skills (from marketplace.json)
 
 # Install specific skill (start with skill-creator)
-claude plugin install skill-creator@daymade/claude-code-skills
+claude plugin install skill-creator@daymade-skills
 
 # Test by copying to user skills directory
 cp -r skill-name ~/.claude/skills/
@@ -276,7 +278,7 @@ Professional Claude Code skills marketplace featuring N production-ready skills.
 **c. Add installation command:**
 ```markdown
 # Brief description
-claude plugin install skill-name@daymade/claude-code-skills
+claude plugin install skill-name@daymade-skills
 ```
 
 **d. Add skill section (### N. **skill-name**):**
@@ -403,7 +405,7 @@ python3 -m json.tool .claude-plugin/marketplace.json > /dev/null
 **c. Add installation command:**
 ```markdown
 # 简短描述
-claude plugin install skill-name@daymade/claude-code-skills
+claude plugin install skill-name@daymade-skills
 ```
 
 **d. Add skill section (### N. **skill-name** - Chinese Title):**
@@ -631,7 +633,7 @@ Features:
 
 Installation:
 ```bash
-claude plugin install skill-name@daymade/claude-code-skills
+claude plugin install skill-name@daymade-skills
 ```
 
 Changelog: ...

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository Overview
 
-This is a Claude Code skills marketplace containing 20 production-ready skills organized in a plugin marketplace structure. Each skill is a self-contained package that extends Claude's capabilities with specialized knowledge, workflows, and bundled resources.
+This is a Claude Code skills marketplace containing 23 production-ready skills organized in a plugin marketplace structure. Each skill is a self-contained package that extends Claude's capabilities with specialized knowledge, workflows, and bundled resources.
 
 **Essential Skill**: `skill-creator` is the most important skill in this marketplace - it's a meta-skill that enables users to create their own skills. Always recommend it first for users interested in extending Claude Code.
 
@@ -118,7 +118,7 @@ Skills for public distribution must NOT contain:
 ## Marketplace Configuration
 
 The marketplace is configured in `.claude-plugin/marketplace.json`:
-- Contains 20 plugins, each mapping to one skill
+- Contains 23 plugins, each mapping to one skill
 - Each plugin has: name, description, version, category, keywords, skills array
 - Marketplace metadata: name, owner, version, homepage
 
@@ -128,7 +128,7 @@ The marketplace is configured in `.claude-plugin/marketplace.json`:
 
 1. **Marketplace Version** (`.claude-plugin/marketplace.json` → `metadata.version`)
    - Tracks the marketplace catalog as a whole
-   - Current: v1.13.0
+   - Current: v1.16.0
    - Bump when: Adding/removing skills, major marketplace restructuring
    - Semantic versioning: MAJOR.MINOR.PATCH
 
@@ -164,6 +164,9 @@ The marketplace is configured in `.claude-plugin/marketplace.json`:
 18. **prompt-optimizer** - Transform vague prompts into precise EARS specifications with domain theory grounding
 19. **claude-code-history-files-finder** - Find and recover content from Claude Code session history files
 20. **docs-cleaner** - Consolidate redundant documentation while preserving valuable content
+21. **pdf-creator** - Create PDF documents from markdown with Chinese font support using weasyprint
+22. **claude-md-progressive-disclosurer** - Optimize CLAUDE.md files using progressive disclosure principles
+23. **skills-search** - Search, discover, install, and manage Claude Code skills from the CCPM registry
 
 **Recommendation**: Always suggest `skill-creator` first for users interested in creating skills or extending Claude Code.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository Overview
 
-This is a Claude Code skills marketplace containing 18 production-ready skills organized in a plugin marketplace structure. Each skill is a self-contained package that extends Claude's capabilities with specialized knowledge, workflows, and bundled resources.
+This is a Claude Code skills marketplace containing 20 production-ready skills organized in a plugin marketplace structure. Each skill is a self-contained package that extends Claude's capabilities with specialized knowledge, workflows, and bundled resources.
 
 **Essential Skill**: `skill-creator` is the most important skill in this marketplace - it's a meta-skill that enables users to create their own skills. Always recommend it first for users interested in extending Claude Code.
 
@@ -118,7 +118,7 @@ Skills for public distribution must NOT contain:
 ## Marketplace Configuration
 
 The marketplace is configured in `.claude-plugin/marketplace.json`:
-- Contains 18 plugins, each mapping to one skill
+- Contains 20 plugins, each mapping to one skill
 - Each plugin has: name, description, version, category, keywords, skills array
 - Marketplace metadata: name, owner, version, homepage
 
@@ -128,7 +128,7 @@ The marketplace is configured in `.claude-plugin/marketplace.json`:
 
 1. **Marketplace Version** (`.claude-plugin/marketplace.json` → `metadata.version`)
    - Tracks the marketplace catalog as a whole
-   - Current: v1.11.0
+   - Current: v1.13.0
    - Bump when: Adding/removing skills, major marketplace restructuring
    - Semantic versioning: MAJOR.MINOR.PATCH
 
@@ -162,6 +162,8 @@ The marketplace is configured in `.claude-plugin/marketplace.json`:
 16. **video-comparer** - Video comparison and quality analysis with interactive HTML reports
 17. **qa-expert** - Comprehensive QA testing infrastructure with autonomous LLM execution and Google Testing Standards
 18. **prompt-optimizer** - Transform vague prompts into precise EARS specifications with domain theory grounding
+19. **claude-code-history-files-finder** - Find and recover content from Claude Code session history files
+20. **docs-cleaner** - Consolidate redundant documentation while preserving valuable content
 
 **Recommendation**: Always suggest `skill-creator` first for users interested in creating skills or extending Claude Code.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository Overview
 
-This is a Claude Code skills marketplace containing 23 production-ready skills organized in a plugin marketplace structure. Each skill is a self-contained package that extends Claude's capabilities with specialized knowledge, workflows, and bundled resources.
+This is a Claude Code skills marketplace containing 25 production-ready skills organized in a plugin marketplace structure. Each skill is a self-contained package that extends Claude's capabilities with specialized knowledge, workflows, and bundled resources.
 
 **Essential Skill**: `skill-creator` is the most important skill in this marketplace - it's a meta-skill that enables users to create their own skills. Always recommend it first for users interested in extending Claude Code.
 
@@ -120,7 +120,7 @@ Skills for public distribution must NOT contain:
 ## Marketplace Configuration
 
 The marketplace is configured in `.claude-plugin/marketplace.json`:
-- Contains 23 plugins, each mapping to one skill
+- Contains 25 plugins, each mapping to one skill
 - Each plugin has: name, description, version, category, keywords, skills array
 - Marketplace metadata: name, owner, version, homepage
 
@@ -130,7 +130,7 @@ The marketplace is configured in `.claude-plugin/marketplace.json`:
 
 1. **Marketplace Version** (`.claude-plugin/marketplace.json` → `metadata.version`)
    - Tracks the marketplace catalog as a whole
-   - Current: v1.16.0
+   - Current: v1.18.0
    - Bump when: Adding/removing skills, major marketplace restructuring
    - Semantic versioning: MAJOR.MINOR.PATCH
 
@@ -169,6 +169,8 @@ The marketplace is configured in `.claude-plugin/marketplace.json`:
 21. **pdf-creator** - Create PDF documents from markdown with Chinese font support using weasyprint
 22. **claude-md-progressive-disclosurer** - Optimize CLAUDE.md files using progressive disclosure principles
 23. **skills-search** - Search, discover, install, and manage Claude Code skills from the CCPM registry
+24. **promptfoo-evaluation** - Run LLM evaluations with Promptfoo for prompt testing and model comparison
+25. **iOS-APP-developer** - iOS app development with XcodeGen, SwiftUI, and SPM troubleshooting
 
 **Recommendation**: Always suggest `skill-creator` first for users interested in creating skills or extending Claude Code.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,18 @@ Skills use a three-level loading system:
 
 ### Installation Scripts
 
+**In Claude Code (in-app):**
+```text
+/plugin marketplace add daymade/claude-code-skills
+```
+
+Then:
+1. Select **Browse and install plugins**
+2. Select **daymade/claude-code-skills**
+3. Select **skill-creator**
+4. Select **Install now**
+
+**From your terminal (CLI):**
 ```bash
 # Automated installation (macOS/Linux)
 curl -fsSL https://raw.githubusercontent.com/daymade/claude-code-skills/main/scripts/install.sh | bash
@@ -72,6 +84,8 @@ claude plugin install skill-creator@daymade-skills
 cp -r skill-name ~/.claude/skills/
 # Then restart Claude Code
 ```
+
+In Claude Code, use `/plugin ...` slash commands. In your terminal, use `claude plugin ...`.
 
 ### Git Operations
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,10 +89,11 @@ Before submitting, validate your skill:
 5. **Test locally:**
    ```bash
    # Add your fork as marketplace
-   /plugin marketplace add your-username/claude-code-skills
+   /plugin marketplace add https://github.com/your-username/claude-code-skills
+   # Marketplace name comes from .claude-plugin/marketplace.json
 
    # Install and test
-   /plugin install productivity-skills
+   /plugin install productivity-skills@your-marketplace-name
    ```
 
 6. **Submit Pull Request:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,11 +89,11 @@ Before submitting, validate your skill:
 5. **Test locally:**
    ```bash
    # Add your fork as marketplace
-   /plugin marketplace add https://github.com/your-username/claude-code-skills
+   claude plugin marketplace add https://github.com/your-username/claude-code-skills
    # Marketplace name comes from .claude-plugin/marketplace.json
 
    # Install and test
-   /plugin install productivity-skills@your-marketplace-name
+   claude plugin install productivity-skills@your-marketplace-name
    ```
 
 6. **Submit Pull Request:**

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -106,6 +106,8 @@ Follow the interactive prompts to select skills.
 claude plugin marketplace add https://github.com/daymade/claude-code-skills
 
 # Marketplace name: daymade-skills (from marketplace.json)
+# Use @daymade-skills in install commands (e.g., skill-name@daymade-skills)
+# Do not use /plugin; all commands are `claude plugin ...`
 # Step 2: Install skills you need
 claude plugin install github-ops@daymade-skills
 claude plugin install markdown-tools@daymade-skills
@@ -114,7 +116,9 @@ claude plugin install markdown-tools@daymade-skills
 # Step 3: Restart Claude Code
 ```
 
-### Available Skills
+### Available Skills (Starter Set)
+
+This table is a quick starter list. See [README.md](./README.md) for the full catalog (25 skills).
 
 | Skill | Description | When to Use |
 |-------|-------------|-------------|
@@ -158,7 +162,7 @@ If you're in China, install [CC-Switch](https://github.com/farion1231/cc-switch)
 ## Common Questions
 
 **Q: Which skills should I install first?**
-A: Start with **skill-creator** if you want to create skills. Otherwise, install based on your needs (see table above).
+A: Start with **skill-creator** if you want to create skills. Otherwise, install based on your needs (see the starter table and the full list in README).
 
 **Q: Can I install multiple skills?**
 A: Yes! Each skill is independent. Install as many or as few as you need.
@@ -175,7 +179,7 @@ A: Open an issue at [github.com/daymade/claude-code-skills](https://github.com/d
 
 - 📖 Read the full [README.md](./README.md) for detailed information
 - 🇨🇳 中文用户查看 [README.zh-CN.md](./README.zh-CN.md)
-- 💡 Check [IMPROVEMENT_PLAN.md](./IMPROVEMENT_PLAN.md) for upcoming features
+- 💡 Review [CHANGELOG.md](./CHANGELOG.md) for recent updates
 - 🤝 Contribute at [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 **Happy skill building! 🚀**

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -8,6 +8,18 @@ Get started with Claude Code Skills Marketplace in less than 2 minutes!
 
 ### Step 1: Install skill-creator
 
+**In Claude Code (in-app):**
+```text
+/plugin marketplace add daymade/claude-code-skills
+```
+
+Then:
+1. Select **Browse and install plugins**
+2. Select **daymade/claude-code-skills**
+3. Select **skill-creator**
+4. Select **Install now**
+
+**From your terminal (CLI):**
 ```bash
 # Add the marketplace
 claude plugin marketplace add https://github.com/daymade/claude-code-skills
@@ -107,7 +119,7 @@ claude plugin marketplace add https://github.com/daymade/claude-code-skills
 
 # Marketplace name: daymade-skills (from marketplace.json)
 # Use @daymade-skills in install commands (e.g., skill-name@daymade-skills)
-# Do not use /plugin; all commands are `claude plugin ...`
+# In Claude Code use `/plugin ...`; in your terminal use `claude plugin ...`
 # Step 2: Install skills you need
 claude plugin install github-ops@daymade-skills
 claude plugin install markdown-tools@daymade-skills

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -10,10 +10,11 @@ Get started with Claude Code Skills Marketplace in less than 2 minutes!
 
 ```bash
 # Add the marketplace
-claude plugin marketplace add daymade/claude-code-skills
+claude plugin marketplace add https://github.com/daymade/claude-code-skills
 
+# Marketplace name: daymade-skills (from marketplace.json)
 # Install skill-creator
-claude plugin install skill-creator@daymade/claude-code-skills
+claude plugin install skill-creator@daymade-skills
 ```
 
 ### Step 2: Initialize Your First Skill
@@ -102,11 +103,12 @@ Follow the interactive prompts to select skills.
 
 ```bash
 # Step 1: Add the marketplace
-claude plugin marketplace add daymade/claude-code-skills
+claude plugin marketplace add https://github.com/daymade/claude-code-skills
 
+# Marketplace name: daymade-skills (from marketplace.json)
 # Step 2: Install skills you need
-claude plugin install github-ops@daymade/claude-code-skills
-claude plugin install markdown-tools@daymade/claude-code-skills
+claude plugin install github-ops@daymade-skills
+claude plugin install markdown-tools@daymade-skills
 # ... add more as needed
 
 # Step 3: Restart Claude Code
@@ -129,7 +131,7 @@ claude plugin install markdown-tools@daymade/claude-code-skills
 
 ```bash
 # Use the same install command to update
-claude plugin install skill-name@daymade/claude-code-skills
+claude plugin install skill-name@daymade-skills
 ```
 
 ---

--- a/QUICKSTART.zh-CN.md
+++ b/QUICKSTART.zh-CN.md
@@ -106,6 +106,8 @@ iwr -useb https://raw.githubusercontent.com/daymade/claude-code-skills/main/scri
 claude plugin marketplace add https://github.com/daymade/claude-code-skills
 
 # Marketplace 名称：daymade-skills（来自 marketplace.json）
+# 安装命令请使用 @daymade-skills（例如 skill-name@daymade-skills）
+# 所有命令都应使用 `claude plugin ...`（没有 `/plugin` 命令）
 # 步骤 2：安装你需要的技能
 claude plugin install github-ops@daymade-skills
 claude plugin install markdown-tools@daymade-skills
@@ -114,7 +116,9 @@ claude plugin install markdown-tools@daymade-skills
 # 步骤 3：重启 Claude Code
 ```
 
-### 可用技能
+### 可用技能（快速入门）
+
+本表为快速入门列表。完整 25 个技能请见 [README.zh-CN.md](./README.zh-CN.md)。
 
 | 技能 | 描述 | 使用场景 |
 |-------|-------------|-------------|
@@ -173,7 +177,7 @@ claude plugin install skill-name@daymade-skills
 ## 常见问题
 
 **Q：我应该首先安装哪些技能？**
-A：如果你想创建技能，从 **skill-creator** 开始。否则，根据你的需求安装（参见上表）。
+A：如果你想创建技能，从 **skill-creator** 开始。否则，根据你的需求安装（参见快速入门表及 README 完整列表）。
 
 **Q：我可以安装多个技能吗？**
 A：可以！每个技能都是独立的。根据需要安装任意数量的技能。
@@ -196,7 +200,7 @@ A：查看 [CONTRIBUTING.md](./CONTRIBUTING.md) 了解指南。我们欢迎技�
 
 - 📖 阅读完整的 [README.zh-CN.md](./README.zh-CN.md) 获取详细信息
 - 🌐 English users see [README.md](./README.md)
-- 💡 查看 [IMPROVEMENT_PLAN.md](./IMPROVEMENT_PLAN.md) 了解即将推出的功能
+- 💡 查看 [CHANGELOG.md](./CHANGELOG.md) 了解近期更新
 - 🤝 在 [CONTRIBUTING.md](./CONTRIBUTING.md) 贡献
 
 **祝你构建技能愉快！🚀**

--- a/QUICKSTART.zh-CN.md
+++ b/QUICKSTART.zh-CN.md
@@ -10,10 +10,11 @@
 
 ```bash
 # 添加市场
-claude plugin marketplace add daymade/claude-code-skills
+claude plugin marketplace add https://github.com/daymade/claude-code-skills
 
+# Marketplace 名称：daymade-skills（来自 marketplace.json）
 # 安装 skill-creator
-claude plugin install skill-creator@daymade/claude-code-skills
+claude plugin install skill-creator@daymade-skills
 ```
 
 ### 步骤 2：初始化你的第一个技能
@@ -102,11 +103,12 @@ iwr -useb https://raw.githubusercontent.com/daymade/claude-code-skills/main/scri
 
 ```bash
 # 步骤 1：添加市场
-claude plugin marketplace add daymade/claude-code-skills
+claude plugin marketplace add https://github.com/daymade/claude-code-skills
 
+# Marketplace 名称：daymade-skills（来自 marketplace.json）
 # 步骤 2：安装你需要的技能
-claude plugin install github-ops@daymade/claude-code-skills
-claude plugin install markdown-tools@daymade/claude-code-skills
+claude plugin install github-ops@daymade-skills
+claude plugin install markdown-tools@daymade-skills
 # ... 根据需要添加更多
 
 # 步骤 3：重启 Claude Code
@@ -129,7 +131,7 @@ claude plugin install markdown-tools@daymade/claude-code-skills
 
 ```bash
 # 使用相同的安装命令进行更新
-claude plugin install skill-name@daymade/claude-code-skills
+claude plugin install skill-name@daymade-skills
 ```
 
 ---

--- a/QUICKSTART.zh-CN.md
+++ b/QUICKSTART.zh-CN.md
@@ -8,6 +8,18 @@
 
 ### 步骤 1：安装 skill-creator
 
+**在 Claude Code 内（应用内）：**
+```text
+/plugin marketplace add daymade/claude-code-skills
+```
+
+然后：
+1. 选择 **Browse and install plugins**
+2. 选择 **daymade/claude-code-skills**
+3. 选择 **skill-creator**
+4. 选择 **Install now**
+
+**在终端（CLI）：**
 ```bash
 # 添加市场
 claude plugin marketplace add https://github.com/daymade/claude-code-skills
@@ -107,7 +119,7 @@ claude plugin marketplace add https://github.com/daymade/claude-code-skills
 
 # Marketplace 名称：daymade-skills（来自 marketplace.json）
 # 安装命令请使用 @daymade-skills（例如 skill-name@daymade-skills）
-# 所有命令都应使用 `claude plugin ...`（没有 `/plugin` 命令）
+# 在 Claude Code 内使用 `/plugin ...`，在终端中使用 `claude plugin ...`
 # 步骤 2：安装你需要的技能
 claude plugin install github-ops@daymade-skills
 claude plugin install markdown-tools@daymade-skills

--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ The `skill-creator` is the **meta-skill** that enables you to build, validate, a
 
 ### Quick Install
 
+**In Claude Code (in-app):**
+```text
+/plugin marketplace add daymade/claude-code-skills
+```
+
+Then:
+1. Select **Browse and install plugins**
+2. Select **daymade/claude-code-skills**
+3. Select **skill-creator**
+4. Select **Install now**
+
+**From your terminal (CLI):**
 ```bash
 claude plugin marketplace add https://github.com/daymade/claude-code-skills
 # Marketplace name: daymade-skills (from marketplace.json)
@@ -88,6 +100,18 @@ Claude Code, with skill-creator loaded, will guide you through the entire skill 
 
 ## 🚀 Quick Installation
 
+### Install Inside Claude Code (In-App)
+
+```text
+/plugin marketplace add daymade/claude-code-skills
+```
+
+Then:
+1. Select **Browse and install plugins**
+2. Select **daymade/claude-code-skills**
+3. Select the plugin you want
+4. Select **Install now**
+
 ### Automated Installation (Recommended)
 
 **macOS/Linux:**
@@ -109,7 +133,7 @@ claude plugin marketplace add https://github.com/daymade/claude-code-skills
 
 Marketplace name is `daymade-skills` (from marketplace.json). Use `@daymade-skills` when installing plugins.
 Do not use the repo path as a marketplace name (e.g. `@daymade/claude-code-skills` will fail).
-All plugin commands should use `claude plugin ...` (there is no `/plugin` command).
+In Claude Code, use `/plugin ...` slash commands. In your terminal, use `claude plugin ...`.
 
 **Essential Skill** (recommended first install):
 ```bash
@@ -242,20 +266,20 @@ Comprehensive GitHub operations using gh CLI and GitHub API.
 
 ### 2. **markdown-tools** - Document Conversion Suite
 
-Converts documents to markdown with Windows/WSL path handling and Obsidian integration.
+Converts documents to markdown with Windows/WSL path handling and PDF image extraction.
 
 **When to use:**
 - Converting .doc/.docx/PDF/PPTX to markdown
+- Extracting images from PDF files
 - Processing Confluence exports
 - Handling Windows/WSL path conversions
-- Working with markitdown utility
 
 **Key features:**
 - Multi-format document conversion
-- Confluence export processing
+- PDF image extraction using PyMuPDF
 - Windows/WSL path automation
-- Obsidian vault integration
-- Helper scripts for path conversion
+- Confluence export processing
+- Helper scripts for path conversion and image extraction
 
 **🎬 Live Demo**
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@
 [![简体中文](https://img.shields.io/badge/语言-简体中文-red)](./README.zh-CN.md)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Skills](https://img.shields.io/badge/skills-20-blue.svg)](https://github.com/daymade/claude-code-skills)
-[![Version](https://img.shields.io/badge/version-1.13.0-green.svg)](https://github.com/daymade/claude-code-skills)
+[![Skills](https://img.shields.io/badge/skills-23-blue.svg)](https://github.com/daymade/claude-code-skills)
+[![Version](https://img.shields.io/badge/version-1.16.0-green.svg)](https://github.com/daymade/claude-code-skills)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-2.0.13+-purple.svg)](https://claude.com/code)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./CONTRIBUTING.md)
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/daymade/claude-code-skills/graphs/commit-activity)
 
 </div>
 
-Professional Claude Code skills marketplace featuring 20 production-ready skills for enhanced development workflows.
+Professional Claude Code skills marketplace featuring 23 production-ready skills for enhanced development workflows.
 
 ## 📑 Table of Contents
 
@@ -154,6 +154,9 @@ claude plugin install claude-code-history-files-finder@daymade/claude-code-skill
 
 # Documentation consolidation
 claude plugin install docs-cleaner@daymade/claude-code-skills
+
+# CCPM skill registry search and management
+claude plugin install skills-search@daymade/claude-code-skills
 ```
 
 Each skill can be installed independently - choose only what you need!
@@ -765,6 +768,55 @@ Consolidate redundant documentation while preserving all valuable content.
 
 ---
 
+### 20. **skills-search** - CCPM Skill Registry Search
+
+Search, discover, install, and manage Claude Code skills from the CCPM (Claude Code Plugin Manager) registry.
+
+**When to use:**
+- Finding skills for specific tasks (e.g., "find PDF skills")
+- Installing skills by name
+- Listing currently installed skills
+- Getting detailed information about a skill
+- Managing your Claude Code skill collection
+
+**Key features:**
+- **Registry search**: Search CCPM registry with `ccpm search <query>`
+- **Skill installation**: Install skills with `ccpm install <skill-name>`
+- **Version support**: Install specific versions with `@version` syntax
+- **Bundle installation**: Install pre-configured skill bundles (web-dev, content-creation, developer-tools)
+- **Multiple formats**: Supports registry names, GitHub owner/repo, and full URLs
+- **Skill info**: Get detailed skill information with `ccpm info <skill-name>`
+
+**Example usage:**
+```bash
+# Search for skills
+ccpm search pdf              # Find PDF-related skills
+ccpm search "code review"    # Find code review skills
+
+# Install skills
+ccpm install skill-creator                # From registry
+ccpm install daymade/skill-creator        # From GitHub
+ccpm install skill-creator@1.0.0          # Specific version
+
+# List and manage
+ccpm list                    # List installed skills
+ccpm info skill-creator      # Get skill details
+ccpm uninstall pdf-processor # Remove a skill
+
+# Install bundles
+ccpm install-bundle web-dev  # Install web development skills bundle
+```
+
+**🎬 Live Demo**
+
+*Coming soon*
+
+📚 **Documentation**: See [skills-search/SKILL.md](./skills-search/SKILL.md) for complete command reference
+
+**Requirements**: CCPM CLI (`npm install -g @daymade/ccpm`)
+
+---
+
 ## 🎬 Interactive Demo Gallery
 
 Want to see all demos in one place with click-to-enlarge functionality? Check out our [interactive demo gallery](./demos/index.html) or browse the [demos directory](./demos/).
@@ -810,6 +862,9 @@ Use **claude-code-history-files-finder** to recover deleted files from previous 
 ### For Documentation Maintenance
 Use **docs-cleaner** to consolidate redundant documentation while preserving valuable content. Perfect for cleaning up documentation sprawl after rapid development phases or merging overlapping docs into authoritative sources.
 
+### For Skill Discovery & Management
+Use **skills-search** to find, install, and manage Claude Code skills from the CCPM registry. Perfect for discovering new skills for specific tasks, installing skill bundles for common workflows, and keeping your skill collection organized.
+
 ## 📚 Documentation
 
 Each skill includes:
@@ -838,6 +893,7 @@ Each skill includes:
 - **prompt-optimizer**: See `prompt-optimizer/references/ears_syntax.md` for EARS transformation patterns, `prompt-optimizer/references/domain_theories.md` for theory catalog, and `prompt-optimizer/references/examples.md` for complete transformations
 - **claude-code-history-files-finder**: See `claude-code-history-files-finder/references/session_file_format.md` for JSONL structure and `claude-code-history-files-finder/references/workflow_examples.md` for recovery workflows
 - **docs-cleaner**: See `docs-cleaner/SKILL.md` for consolidation workflows
+- **skills-search**: See `skills-search/SKILL.md` for CCPM CLI commands and registry operations
 
 ## 🛠️ Requirements
 
@@ -854,6 +910,7 @@ Each skill includes:
 - **pandas & matplotlib** (optional, for ppt-creator chart generation)
 - **Marp CLI** (optional, for ppt-creator Marp PPTX export): `npm install -g @marp-team/marp-cli`
 - **repomix** (for repomix-safe-mixer): `npm install -g repomix`
+- **CCPM CLI** (for skills-search): `npm install -g @daymade/ccpm`
 
 ## ❓ FAQ
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@
 [![简体中文](https://img.shields.io/badge/语言-简体中文-red)](./README.zh-CN.md)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Skills](https://img.shields.io/badge/skills-23-blue.svg)](https://github.com/daymade/claude-code-skills)
-[![Version](https://img.shields.io/badge/version-1.16.0-green.svg)](https://github.com/daymade/claude-code-skills)
+[![Skills](https://img.shields.io/badge/skills-25-blue.svg)](https://github.com/daymade/claude-code-skills)
+[![Version](https://img.shields.io/badge/version-1.18.0-green.svg)](https://github.com/daymade/claude-code-skills)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-2.0.13+-purple.svg)](https://claude.com/code)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./CONTRIBUTING.md)
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/daymade/claude-code-skills/graphs/commit-activity)
 
 </div>
 
-Professional Claude Code skills marketplace featuring 23 production-ready skills for enhanced development workflows.
+Professional Claude Code skills marketplace featuring 25 production-ready skills for enhanced development workflows.
 
 ## 📑 Table of Contents
 
@@ -104,10 +104,12 @@ iwr -useb https://raw.githubusercontent.com/daymade/claude-code-skills/main/scri
 
 Add the marketplace:
 ```bash
-/plugin marketplace add https://github.com/daymade/claude-code-skills
+claude plugin marketplace add https://github.com/daymade/claude-code-skills
 ```
 
 Marketplace name is `daymade-skills` (from marketplace.json). Use `@daymade-skills` when installing plugins.
+Do not use the repo path as a marketplace name (e.g. `@daymade/claude-code-skills` will fail).
+All plugin commands should use `claude plugin ...` (there is no `/plugin` command).
 
 **Essential Skill** (recommended first install):
 ```bash
@@ -140,8 +142,23 @@ claude plugin install llm-icon-finder@daymade-skills
 # CLI demo generation
 claude plugin install cli-demo-generator@daymade-skills
 
+# Cloudflare diagnostics
+claude plugin install cloudflare-troubleshooting@daymade-skills
+
+# UI design system extraction
+claude plugin install ui-designer@daymade-skills
+
+# Presentation creation
+claude plugin install ppt-creator@daymade-skills
+
 # YouTube video/audio downloading
 claude plugin install youtube-downloader@daymade-skills
+
+# Secure repomix packaging
+claude plugin install repomix-safe-mixer@daymade-skills
+
+# ASR transcript correction
+claude plugin install transcript-fixer@daymade-skills
 
 # Video comparison and quality analysis
 claude plugin install video-comparer@daymade-skills
@@ -158,8 +175,20 @@ claude plugin install claude-code-history-files-finder@daymade-skills
 # Documentation consolidation
 claude plugin install docs-cleaner@daymade-skills
 
+# PDF generation with Chinese font support
+claude plugin install pdf-creator@daymade-skills
+
+# CLAUDE.md progressive disclosure optimization
+claude plugin install claude-md-progressive-disclosurer@daymade-skills
+
 # CCPM skill registry search and management
 claude plugin install skills-search@daymade-skills
+
+# Promptfoo LLM evaluation framework
+claude plugin install promptfoo-evaluation@daymade-skills
+
+# iOS app development
+claude plugin install iOS-APP-developer@daymade-skills
 ```
 
 Each skill can be installed independently - choose only what you need!
@@ -820,6 +849,128 @@ ccpm install-bundle web-dev  # Install web development skills bundle
 
 ---
 
+### 21. **pdf-creator** - PDF Creation with Chinese Font Support
+
+Create professional PDF documents from markdown with proper Chinese typography using WeasyPrint.
+
+**When to use:**
+- Converting markdown to PDF for sharing or printing
+- Generating formal documents (legal filings, reports)
+- Ensuring correct Chinese font rendering
+
+**Key features:**
+- WeasyPrint + Markdown conversion pipeline
+- Built-in Chinese font fallbacks
+- A4 layout defaults with print-friendly margins
+- Batch conversion scripts
+
+**Example usage:**
+```bash
+uv run --with weasyprint --with markdown scripts/md_to_pdf.py input.md output.pdf
+```
+
+**🎬 Live Demo**
+
+*Coming soon*
+
+📚 **Documentation**: See [pdf-creator/SKILL.md](./pdf-creator/SKILL.md) for setup and workflow details.
+
+**Requirements**: Python 3.8+, `weasyprint`, `markdown`
+
+---
+
+### 22. **claude-md-progressive-disclosurer** - CLAUDE.md Optimization
+
+Optimize user CLAUDE.md files using progressive disclosure to reduce context bloat while preserving critical rules.
+
+**When to use:**
+- CLAUDE.md is too long or repetitive
+- Need to move detailed procedures into references
+- Want to extract reusable workflows into skills
+
+**Key features:**
+- Section classification (keep/move/extract/remove)
+- Before/after line-count reporting
+- Reference file and pointer formats
+- Best-practice optimization workflow
+
+**Example usage:**
+```
+"Optimize my ~/.claude/CLAUDE.md using progressive disclosure and propose a plan."
+```
+
+**🎬 Live Demo**
+
+*Coming soon*
+
+📚 **Documentation**: See [claude-md-progressive-disclosurer/SKILL.md](./claude-md-progressive-disclosurer/SKILL.md).
+
+---
+
+### 23. **promptfoo-evaluation** - Promptfoo LLM Evaluation
+
+Configure and run LLM evaluations with Promptfoo for prompt testing and model comparisons.
+
+**When to use:**
+- Setting up prompt tests and eval configs
+- Comparing LLM outputs across providers
+- Adding custom assertions or LLM-as-judge grading
+
+**Key features:**
+- promptfooconfig.yaml templates
+- Python custom assertions
+- llm-rubric scoring guidance
+- Built-in preview (echo provider) workflows
+
+**Example usage:**
+```bash
+npx promptfoo@latest init
+npx promptfoo@latest eval
+npx promptfoo@latest view
+```
+
+**🎬 Live Demo**
+
+*Coming soon*
+
+📚 **Documentation**: See [promptfoo-evaluation/references/promptfoo_api.md](./promptfoo-evaluation/references/promptfoo_api.md).
+
+**Requirements**: Node.js (Promptfoo via `npx promptfoo@latest`)
+
+---
+
+### 24. **iOS-APP-developer** - iOS App Development
+
+Build, configure, and debug iOS apps with XcodeGen, SwiftUI, and Swift Package Manager.
+
+**When to use:**
+- Setting up XcodeGen `project.yml`
+- Fixing SPM dependency or embed issues
+- Handling code signing and device deployment errors
+- Debugging camera/AVFoundation problems
+
+**Key features:**
+- XcodeGen project templates
+- SPM dynamic framework embedding fixes
+- Code signing and provisioning guidance
+- Device deployment and troubleshooting checklists
+
+**Example usage:**
+```bash
+xcodegen generate
+xcodebuild -destination 'platform=iOS Simulator,name=iPhone 17' build
+```
+
+**🎬 Live Demo**
+
+*Coming soon*
+
+📚 **Documentation**: See [iOS-APP-developer/references/xcodegen-full.md](./iOS-APP-developer/references/xcodegen-full.md).
+
+**Requirements**: macOS + Xcode, XcodeGen
+
+---
+
 ## 🎬 Interactive Demo Gallery
 
 Want to see all demos in one place with click-to-enlarge functionality? Check out our [interactive demo gallery](./demos/index.html) or browse the [demos directory](./demos/).
@@ -831,6 +982,9 @@ Use **github-ops** to streamline PR creation, issue management, and API operatio
 
 ### For Documentation
 Combine **markdown-tools** for document conversion and **mermaid-tools** for diagram generation to create comprehensive documentation. Use **llm-icon-finder** to add brand icons.
+
+### For PDF & Printable Documents
+Use **pdf-creator** to convert markdown to print-ready PDFs with proper Chinese font support for formal documents and reports.
 
 ### For Team Communication
 Use **teams-channel-post-writer** to share knowledge and **statusline-generator** to track costs while working.
@@ -865,8 +1019,17 @@ Use **claude-code-history-files-finder** to recover deleted files from previous 
 ### For Documentation Maintenance
 Use **docs-cleaner** to consolidate redundant documentation while preserving valuable content. Perfect for cleaning up documentation sprawl after rapid development phases or merging overlapping docs into authoritative sources.
 
+### For CLAUDE.md Optimization
+Use **claude-md-progressive-disclosurer** to reduce CLAUDE.md bloat by moving detailed sections into references while keeping core rules visible.
+
 ### For Skill Discovery & Management
 Use **skills-search** to find, install, and manage Claude Code skills from the CCPM registry. Perfect for discovering new skills for specific tasks, installing skill bundles for common workflows, and keeping your skill collection organized.
+
+### For LLM Evaluation & Model Comparison
+Use **promptfoo-evaluation** to set up prompt tests, compare model outputs, and run automated evaluations with custom assertions.
+
+### For iOS App Development
+Use **iOS-APP-developer** to configure XcodeGen projects, resolve SPM dependency issues, and troubleshoot code signing or device deployment.
 
 ## 📚 Documentation
 
@@ -887,6 +1050,8 @@ Each skill includes:
 - **skill-creator**: See `skill-creator/SKILL.md` for complete skill creation workflow
 - **llm-icon-finder**: See `llm-icon-finder/references/icons-list.md` for available icons
 - **cli-demo-generator**: See `cli-demo-generator/references/vhs_syntax.md` for VHS syntax and `cli-demo-generator/references/best_practices.md` for demo guidelines
+- **cloudflare-troubleshooting**: See `cloudflare-troubleshooting/references/api_overview.md` for API documentation
+- **ui-designer**: See `ui-designer/SKILL.md` for design system extraction workflow
 - **ppt-creator**: See `ppt-creator/references/WORKFLOW.md` for 9-stage creation process and `ppt-creator/references/ORCHESTRATION_OVERVIEW.md` for automation
 - **youtube-downloader**: See `youtube-downloader/SKILL.md` for usage examples and troubleshooting
 - **repomix-safe-mixer**: See `repomix-safe-mixer/references/common_secrets.md` for detected credential patterns
@@ -896,7 +1061,11 @@ Each skill includes:
 - **prompt-optimizer**: See `prompt-optimizer/references/ears_syntax.md` for EARS transformation patterns, `prompt-optimizer/references/domain_theories.md` for theory catalog, and `prompt-optimizer/references/examples.md` for complete transformations
 - **claude-code-history-files-finder**: See `claude-code-history-files-finder/references/session_file_format.md` for JSONL structure and `claude-code-history-files-finder/references/workflow_examples.md` for recovery workflows
 - **docs-cleaner**: See `docs-cleaner/SKILL.md` for consolidation workflows
+- **pdf-creator**: See `pdf-creator/SKILL.md` for PDF conversion and font setup
+- **claude-md-progressive-disclosurer**: See `claude-md-progressive-disclosurer/SKILL.md` for CLAUDE.md optimization workflow
 - **skills-search**: See `skills-search/SKILL.md` for CCPM CLI commands and registry operations
+- **promptfoo-evaluation**: See `promptfoo-evaluation/references/promptfoo_api.md` for evaluation patterns
+- **iOS-APP-developer**: See `iOS-APP-developer/references/xcodegen-full.md` for XcodeGen options and project.yml details
 
 ## 🛠️ Requirements
 
@@ -907,6 +1076,7 @@ Each skill includes:
 - **mermaid-cli** (for mermaid-tools)
 - **yt-dlp** (for youtube-downloader): `brew install yt-dlp` or `pip install yt-dlp`
 - **FFmpeg/FFprobe** (for video-comparer): `brew install ffmpeg`, `apt install ffmpeg`, or `winget install ffmpeg`
+- **weasyprint, markdown** (for pdf-creator)
 - **VHS** (for cli-demo-generator): `brew install vhs`
 - **asciinema** (optional, for cli-demo-generator interactive recording)
 - **ccusage** (optional, for statusline cost tracking)
@@ -914,6 +1084,8 @@ Each skill includes:
 - **Marp CLI** (optional, for ppt-creator Marp PPTX export): `npm install -g @marp-team/marp-cli`
 - **repomix** (for repomix-safe-mixer): `npm install -g repomix`
 - **CCPM CLI** (for skills-search): `npm install -g @daymade/ccpm`
+- **Promptfoo** (for promptfoo-evaluation): `npx promptfoo@latest`
+- **macOS + Xcode, XcodeGen** (for iOS-APP-developer)
 
 ## ❓ FAQ
 
@@ -946,7 +1118,7 @@ We recommend using [CC-Switch](https://github.com/farion1231/cc-switch) to manag
 
 ### What's the difference between skill-creator and other skills?
 
-**skill-creator** is a meta-skill - it helps you create other skills. The other 7 skills are end-user skills that provide specific functionalities (GitHub ops, document conversion, etc.). If you want to extend Claude Code with your own workflows, start with skill-creator.
+**skill-creator** is a meta-skill - it helps you create other skills. The other skills are end-user skills that provide specific functionalities (GitHub ops, document conversion, etc.). If you want to extend Claude Code with your own workflows, start with skill-creator.
 
 ---
 
@@ -996,4 +1168,4 @@ If you find these skills useful, please:
 
 **Built with ❤️ using the skill-creator skill for Claude Code**
 
-Last updated: 2025-10-22 | Version 1.2.0
+Last updated: 2025-12-20 | Marketplace version 1.18.0

--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ The `skill-creator` is the **meta-skill** that enables you to build, validate, a
 ### Quick Install
 
 ```bash
-claude plugin marketplace add daymade/claude-code-skills
-claude plugin install skill-creator@daymade/claude-code-skills
+claude plugin marketplace add https://github.com/daymade/claude-code-skills
+# Marketplace name: daymade-skills (from marketplace.json)
+claude plugin install skill-creator@daymade-skills
 ```
 
 ### What You Can Do
@@ -103,60 +104,62 @@ iwr -useb https://raw.githubusercontent.com/daymade/claude-code-skills/main/scri
 
 Add the marketplace:
 ```bash
-/plugin marketplace add daymade/claude-code-skills
+/plugin marketplace add https://github.com/daymade/claude-code-skills
 ```
+
+Marketplace name is `daymade-skills` (from marketplace.json). Use `@daymade-skills` when installing plugins.
 
 **Essential Skill** (recommended first install):
 ```bash
-claude plugin install skill-creator@daymade/claude-code-skills
+claude plugin install skill-creator@daymade-skills
 ```
 
 **Install Other Skills:**
 ```bash
 # GitHub operations
-claude plugin install github-ops@daymade/claude-code-skills
+claude plugin install github-ops@daymade-skills
 
 # Document conversion
-claude plugin install markdown-tools@daymade/claude-code-skills
+claude plugin install markdown-tools@daymade-skills
 
 # Diagram generation
-claude plugin install mermaid-tools@daymade/claude-code-skills
+claude plugin install mermaid-tools@daymade-skills
 
 # Statusline customization
-claude plugin install statusline-generator@daymade/claude-code-skills
+claude plugin install statusline-generator@daymade-skills
 
 # Teams communication
-claude plugin install teams-channel-post-writer@daymade/claude-code-skills
+claude plugin install teams-channel-post-writer@daymade-skills
 
 # Repomix extraction
-claude plugin install repomix-unmixer@daymade/claude-code-skills
+claude plugin install repomix-unmixer@daymade-skills
 
 # AI/LLM icons
-claude plugin install llm-icon-finder@daymade/claude-code-skills
+claude plugin install llm-icon-finder@daymade-skills
 
 # CLI demo generation
-claude plugin install cli-demo-generator@daymade/claude-code-skills
+claude plugin install cli-demo-generator@daymade-skills
 
 # YouTube video/audio downloading
-claude plugin install youtube-downloader@daymade/claude-code-skills
+claude plugin install youtube-downloader@daymade-skills
 
 # Video comparison and quality analysis
-claude plugin install video-comparer@daymade/claude-code-skills
+claude plugin install video-comparer@daymade-skills
 
 # QA testing infrastructure with autonomous execution
-claude plugin install qa-expert@daymade/claude-code-skills
+claude plugin install qa-expert@daymade-skills
 
 # Prompt optimization using EARS methodology
-claude plugin install prompt-optimizer@daymade/claude-code-skills
+claude plugin install prompt-optimizer@daymade-skills
 
 # Session history recovery
-claude plugin install claude-code-history-files-finder@daymade/claude-code-skills
+claude plugin install claude-code-history-files-finder@daymade-skills
 
 # Documentation consolidation
-claude plugin install docs-cleaner@daymade/claude-code-skills
+claude plugin install docs-cleaner@daymade-skills
 
 # CCPM skill registry search and management
-claude plugin install skills-search@daymade/claude-code-skills
+claude plugin install skills-search@daymade-skills
 ```
 
 Each skill can be installed independently - choose only what you need!
@@ -926,7 +929,7 @@ No, these skills are specifically designed for Claude Code. You'll need Claude C
 
 Use the same install command to update:
 ```bash
-claude plugin install skill-name@daymade/claude-code-skills
+claude plugin install skill-name@daymade-skills
 ```
 
 ### Can I contribute my own skill?

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@
 [![简体中文](https://img.shields.io/badge/语言-简体中文-red)](./README.zh-CN.md)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Skills](https://img.shields.io/badge/skills-18-blue.svg)](https://github.com/daymade/claude-code-skills)
-[![Version](https://img.shields.io/badge/version-1.11.0-green.svg)](https://github.com/daymade/claude-code-skills)
+[![Skills](https://img.shields.io/badge/skills-20-blue.svg)](https://github.com/daymade/claude-code-skills)
+[![Version](https://img.shields.io/badge/version-1.13.0-green.svg)](https://github.com/daymade/claude-code-skills)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-2.0.13+-purple.svg)](https://claude.com/code)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./CONTRIBUTING.md)
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/daymade/claude-code-skills/graphs/commit-activity)
 
 </div>
 
-Professional Claude Code skills marketplace featuring 18 production-ready skills for enhanced development workflows.
+Professional Claude Code skills marketplace featuring 20 production-ready skills for enhanced development workflows.
 
 ## 📑 Table of Contents
 
@@ -148,6 +148,12 @@ claude plugin install qa-expert@daymade/claude-code-skills
 
 # Prompt optimization using EARS methodology
 claude plugin install prompt-optimizer@daymade/claude-code-skills
+
+# Session history recovery
+claude plugin install claude-code-history-files-finder@daymade/claude-code-skills
+
+# Documentation consolidation
+claude plugin install docs-cleaner@daymade/claude-code-skills
 ```
 
 Each skill can be installed independently - choose only what you need!
@@ -695,6 +701,70 @@ Transform vague prompts into precise, well-structured specifications using EARS 
 
 ---
 
+### 18. **claude-code-history-files-finder** - Session History Recovery
+
+Find and recover content from Claude Code session history files stored in `~/.claude/projects/`.
+
+**When to use:**
+- Recovering deleted or lost files from previous Claude Code sessions
+- Searching for specific code across conversation history
+- Tracking file modifications across multiple sessions
+- Finding sessions containing specific keywords or implementations
+
+**Key features:**
+- **Session search**: Find sessions by keywords with frequency ranking
+- **Content recovery**: Extract files from Write tool calls with deduplication
+- **Statistics analysis**: Message counts, tool usage breakdown, file operations
+- **Batch operations**: Process multiple sessions with keyword filtering
+- **Streaming processing**: Handle large session files (>100MB) efficiently
+
+**Example usage:**
+```bash
+# List recent sessions for a project
+python3 scripts/analyze_sessions.py list /path/to/project
+
+# Search sessions for keywords
+python3 scripts/analyze_sessions.py search /path/to/project "ComponentName" "featureX"
+
+# Recover deleted files from a session
+python3 scripts/recover_content.py ~/.claude/projects/.../session.jsonl -k DeletedComponent -o ./recovered/
+
+# Get session statistics
+python3 scripts/analyze_sessions.py stats /path/to/session.jsonl --show-files
+```
+
+**🎬 Live Demo**
+
+*Coming soon*
+
+📚 **Documentation**: See [claude-code-history-files-finder/references/](./claude-code-history-files-finder/references/) for:
+- `session_file_format.md` - JSONL structure and extraction patterns
+- `workflow_examples.md` - Detailed recovery and analysis workflows
+
+---
+
+### 19. **docs-cleaner** - Documentation Consolidation
+
+Consolidate redundant documentation while preserving all valuable content.
+
+**When to use:**
+- Cleaning up documentation bloat across projects
+- Merging redundant docs covering the same topics
+- Reducing documentation sprawl after rapid development
+- Consolidating multiple files into authoritative sources
+
+**Key features:**
+- **Content preservation**: Never lose valuable information during cleanup
+- **Redundancy detection**: Identify overlapping documentation
+- **Smart merging**: Combine related docs while maintaining structure
+- **Validation**: Ensure consolidated docs are complete and accurate
+
+**🎬 Live Demo**
+
+*Coming soon*
+
+---
+
 ## 🎬 Interactive Demo Gallery
 
 Want to see all demos in one place with click-to-enlarge functionality? Check out our [interactive demo gallery](./demos/index.html) or browse the [demos directory](./demos/).
@@ -734,6 +804,12 @@ Use **qa-expert** to establish comprehensive QA testing infrastructure with auto
 ### For Prompt Engineering & Requirements Engineering
 Use **prompt-optimizer** to transform vague feature requests into precise EARS specifications with domain theory grounding. Perfect for product requirements documents, AI-assisted coding, and learning prompt engineering best practices. Combine with **skill-creator** to create well-structured skill prompts, or with **ppt-creator** to ensure presentation content requirements are clearly specified.
 
+### For Session History & File Recovery
+Use **claude-code-history-files-finder** to recover deleted files from previous Claude Code sessions, search for specific implementations across conversation history, or track file evolution over time. Essential for recovering accidentally deleted code or finding that feature implementation you remember but can't locate.
+
+### For Documentation Maintenance
+Use **docs-cleaner** to consolidate redundant documentation while preserving valuable content. Perfect for cleaning up documentation sprawl after rapid development phases or merging overlapping docs into authoritative sources.
+
 ## 📚 Documentation
 
 Each skill includes:
@@ -760,6 +836,8 @@ Each skill includes:
 - **transcript-fixer**: See `transcript-fixer/references/workflow_guide.md` for step-by-step workflows and `transcript-fixer/references/team_collaboration.md` for collaboration patterns
 - **qa-expert**: See `qa-expert/references/master_qa_prompt.md` for autonomous execution (100x speedup) and `qa-expert/references/google_testing_standards.md` for AAA pattern and OWASP testing
 - **prompt-optimizer**: See `prompt-optimizer/references/ears_syntax.md` for EARS transformation patterns, `prompt-optimizer/references/domain_theories.md` for theory catalog, and `prompt-optimizer/references/examples.md` for complete transformations
+- **claude-code-history-files-finder**: See `claude-code-history-files-finder/references/session_file_format.md` for JSONL structure and `claude-code-history-files-finder/references/workflow_examples.md` for recovery workflows
+- **docs-cleaner**: See `docs-cleaner/SKILL.md` for consolidation workflows
 
 ## 🛠️ Requirements
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,15 +6,15 @@
 [![简体中文](https://img.shields.io/badge/语言-简体中文-red)](./README.zh-CN.md)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Skills](https://img.shields.io/badge/skills-23-blue.svg)](https://github.com/daymade/claude-code-skills)
-[![Version](https://img.shields.io/badge/version-1.16.0-green.svg)](https://github.com/daymade/claude-code-skills)
+[![Skills](https://img.shields.io/badge/skills-25-blue.svg)](https://github.com/daymade/claude-code-skills)
+[![Version](https://img.shields.io/badge/version-1.18.0-green.svg)](https://github.com/daymade/claude-code-skills)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-2.0.13+-purple.svg)](https://claude.com/code)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./CONTRIBUTING.md)
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/daymade/claude-code-skills/graphs/commit-activity)
 
 </div>
 
-专业的 Claude Code 技能市场，提供 23 个生产就绪的技能，用于增强开发工作流。
+专业的 Claude Code 技能市场，提供 25 个生产就绪的技能，用于增强开发工作流。
 
 ## 📑 目录
 
@@ -104,10 +104,12 @@ iwr -useb https://raw.githubusercontent.com/daymade/claude-code-skills/main/scri
 
 添加市场：
 ```bash
-/plugin marketplace add https://github.com/daymade/claude-code-skills
+claude plugin marketplace add https://github.com/daymade/claude-code-skills
 ```
 
 Marketplace 名称是 `daymade-skills`（来自 marketplace.json），安装插件时请使用 `@daymade-skills`。
+不要把仓库路径当成 marketplace 名称（例如 `@daymade/claude-code-skills` 会失败）。
+所有插件命令都应使用 `claude plugin ...`（没有 `/plugin` 命令）。
 
 **必备技能**（推荐首先安装）：
 ```bash
@@ -140,8 +142,23 @@ claude plugin install llm-icon-finder@daymade-skills
 # CLI 演示生成
 claude plugin install cli-demo-generator@daymade-skills
 
+# Cloudflare 诊断
+claude plugin install cloudflare-troubleshooting@daymade-skills
+
+# UI 设计系统提取
+claude plugin install ui-designer@daymade-skills
+
+# 演示文稿创建
+claude plugin install ppt-creator@daymade-skills
+
 # YouTube 视频/音频下载
 claude plugin install youtube-downloader@daymade-skills
+
+# 安全 Repomix 打包
+claude plugin install repomix-safe-mixer@daymade-skills
+
+# ASR 转录校正
+claude plugin install transcript-fixer@daymade-skills
 
 # 视频比较和质量分析
 claude plugin install video-comparer@daymade-skills
@@ -158,8 +175,20 @@ claude plugin install claude-code-history-files-finder@daymade-skills
 # 文档整合
 claude plugin install docs-cleaner@daymade-skills
 
+# PDF 生成（含中文字体支持）
+claude plugin install pdf-creator@daymade-skills
+
+# CLAUDE.md 渐进式披露优化
+claude plugin install claude-md-progressive-disclosurer@daymade-skills
+
 # CCPM 技能注册表搜索和管理
 claude plugin install skills-search@daymade-skills
+
+# Promptfoo LLM 评测框架
+claude plugin install promptfoo-evaluation@daymade-skills
+
+# iOS 应用开发
+claude plugin install iOS-APP-developer@daymade-skills
 ```
 
 每个技能都可以独立安装 - 只选择你需要的！
@@ -860,6 +889,127 @@ ccpm install-bundle web-dev  # 安装 Web 开发技能包
 
 ---
 
+### 21. **pdf-creator** - PDF 生成（中文字体支持）
+
+使用 WeasyPrint 将 markdown 转换为专业 PDF，并提供完善的中文字体支持。
+
+**使用场景：**
+- 将 markdown 转换为可分享/可打印的 PDF
+- 生成正式文档（法律文件、报告）
+- 需要正确的中文排版
+
+**主要功能：**
+- WeasyPrint + Markdown 转换管道
+- 内置中文字体回退
+- A4 版式与打印友好边距
+- 批量转换脚本
+
+**示例用法：**
+```bash
+uv run --with weasyprint --with markdown scripts/md_to_pdf.py input.md output.pdf
+```
+
+**🎬 实时演示**
+
+*即将推出*
+
+📚 **文档**：参见 [pdf-creator/SKILL.md](./pdf-creator/SKILL.md) 了解设置与工作流。
+
+**要求**：Python 3.8+，`weasyprint`、`markdown`
+
+---
+
+### 22. **claude-md-progressive-disclosurer** - CLAUDE.md 优化
+
+使用渐进式披露原则优化 CLAUDE.md，减少上下文负担但保留关键规则。
+
+**使用场景：**
+- CLAUDE.md 过长或重复
+- 需要将详细流程移至 references
+- 希望把可复用工作流抽成技能
+
+**主要功能：**
+- 章节分类（保留/迁移/提取/移除）
+- 变更前后行数对比
+- references 指针格式与最佳实践
+
+**示例用法：**
+```
+"请用渐进式披露优化我的 ~/.claude/CLAUDE.md，并给出方案"
+```
+
+**🎬 实时演示**
+
+*即将推出*
+
+📚 **文档**：参见 [claude-md-progressive-disclosurer/SKILL.md](./claude-md-progressive-disclosurer/SKILL.md)。
+
+---
+
+### 23. **promptfoo-evaluation** - Promptfoo LLM 评测
+
+使用 Promptfoo 配置并运行 LLM 评测，进行提示词测试与模型对比。
+
+**使用场景：**
+- 搭建 prompt 测试与评测配置
+- 对比不同模型输出
+- 编写自定义断言或 LLM-as-judge 评分
+
+**主要功能：**
+- promptfooconfig.yaml 模板
+- Python 自定义断言
+- llm-rubric 评分指引
+- echo provider 预览流程
+
+**示例用法：**
+```bash
+npx promptfoo@latest init
+npx promptfoo@latest eval
+npx promptfoo@latest view
+```
+
+**🎬 实时演示**
+
+*即将推出*
+
+📚 **文档**：参见 [promptfoo-evaluation/references/promptfoo_api.md](./promptfoo-evaluation/references/promptfoo_api.md)。
+
+**要求**：Node.js（Promptfoo 通过 `npx promptfoo@latest`）
+
+---
+
+### 24. **iOS-APP-developer** - iOS 应用开发
+
+使用 XcodeGen、SwiftUI 与 SPM 构建、配置和调试 iOS 应用。
+
+**使用场景：**
+- 配置 XcodeGen `project.yml`
+- 修复 SPM 依赖或嵌入问题
+- 处理签名与真机部署错误
+- 调试相机/AVFoundation
+
+**主要功能：**
+- XcodeGen 项目模板
+- SPM 动态框架嵌入修复
+- 代码签名与配置指导
+- 真机部署与故障排查清单
+
+**示例用法：**
+```bash
+xcodegen generate
+xcodebuild -destination 'platform=iOS Simulator,name=iPhone 17' build
+```
+
+**🎬 实时演示**
+
+*即将推出*
+
+📚 **文档**：参见 [iOS-APP-developer/references/xcodegen-full.md](./iOS-APP-developer/references/xcodegen-full.md)。
+
+**要求**：macOS + Xcode，XcodeGen
+
+---
+
 ## 🎬 交互式演示画廊
 
 想要在一个地方查看所有演示并具有点击放大功能？访问我们的[交互式演示画廊](./demos/index.html)或浏览[演示目录](./demos/)。
@@ -871,6 +1021,9 @@ ccpm install-bundle web-dev  # 安装 Web 开发技能包
 
 ### 文档处理
 结合 **markdown-tools** 进行文档转换和 **mermaid-tools** 进行图表生成，创建全面的文档。使用 **llm-icon-finder** 添加品牌图标。
+
+### PDF 与可打印文档
+使用 **pdf-creator** 将 markdown 转换为适合打印的 PDF，并提供中文字体支持，适用于正式报告和归档材料。
 
 ### 团队通信
 使用 **teams-channel-post-writer** 分享知识，使用 **statusline-generator** 在工作时跟踪成本。
@@ -905,6 +1058,15 @@ ccpm install-bundle web-dev  # 安装 Web 开发技能包
 ### 文档维护
 使用 **docs-cleaner** 在保留有价值内容的同时整合冗余文档。非常适合在快速开发阶段后清理文档扩散或将重叠的文档合并为权威来源。
 
+### CLAUDE.md 优化
+使用 **claude-md-progressive-disclosurer** 通过渐进式披露减少 CLAUDE.md 体积，同时保留关键规则。
+
+### LLM 评测与模型对比
+使用 **promptfoo-evaluation** 运行提示词测试、对比模型输出并执行自定义断言评测。
+
+### iOS 应用开发
+使用 **iOS-APP-developer** 配置 XcodeGen 项目，处理 SPM 依赖、签名与部署问题。
+
 ### 技能发现与管理
 使用 **skills-search** 从 CCPM 注册表中查找、安装和管理 Claude Code 技能。非常适合为特定任务发现新技能、为常见工作流安装技能包，以及保持技能集合的有序管理。
 
@@ -938,7 +1100,11 @@ ccpm install-bundle web-dev  # 安装 Web 开发技能包
 - **prompt-optimizer**：参见 `prompt-optimizer/references/ears_syntax.md` 了解 EARS 转换模式、`prompt-optimizer/references/domain_theories.md` 了解理论目录和 `prompt-optimizer/references/examples.md` 了解完整转换示例
 - **claude-code-history-files-finder**：参见 `claude-code-history-files-finder/references/session_file_format.md` 了解 JSONL 结构和 `claude-code-history-files-finder/references/workflow_examples.md` 了解恢复工作流
 - **docs-cleaner**：参见 `docs-cleaner/SKILL.md` 了解整合工作流
+- **pdf-creator**：参见 `pdf-creator/SKILL.md` 了解 PDF 转换与字体设置
+- **claude-md-progressive-disclosurer**：参见 `claude-md-progressive-disclosurer/SKILL.md` 了解 CLAUDE.md 优化工作流
 - **skills-search**：参见 `skills-search/SKILL.md` 了解 CCPM CLI 命令和注册表操作
+- **promptfoo-evaluation**：参见 `promptfoo-evaluation/references/promptfoo_api.md` 了解评测模式
+- **iOS-APP-developer**：参见 `iOS-APP-developer/references/xcodegen-full.md` 了解 XcodeGen 选项与 project.yml 细节
 
 ## 🛠️ 系统要求
 
@@ -952,7 +1118,10 @@ ccpm install-bundle web-dev  # 安装 Web 开发技能包
 - **ccusage**（可选，用于状态栏成本跟踪）
 - **yt-dlp**（用于 youtube-downloader）：`brew install yt-dlp` 或 `pip install yt-dlp`
 - **FFmpeg/FFprobe**（用于 video-comparer）：`brew install ffmpeg`、`apt install ffmpeg` 或 `winget install ffmpeg`
+- **weasyprint、markdown**（用于 pdf-creator）
 - **CCPM CLI**（用于 skills-search）：`npm install -g @daymade/ccpm`
+- **Promptfoo**（用于 promptfoo-evaluation）：`npx promptfoo@latest`
+- **macOS + Xcode、XcodeGen**（用于 iOS-APP-developer）
 
 ## ❓ 常见问题
 
@@ -985,7 +1154,7 @@ claude plugin install skill-name@daymade-skills
 
 ### skill-creator 和其他技能有什么区别？
 
-**skill-creator** 是一个元技能 - 它帮助你创建其他技能。其他 10 个技能是最终用户技能，提供特定功能（GitHub 操作、文档转换等）。如果你想用自己的工作流扩展 Claude Code，从 skill-creator 开始。
+**skill-creator** 是一个元技能 - 它帮助你创建其他技能。其他技能是面向最终用户的技能，提供特定功能（GitHub 操作、文档转换等）。如果你想用自己的工作流扩展 Claude Code，从 skill-creator 开始。
 
 ---
 
@@ -1035,4 +1204,4 @@ claude plugin install skill-name@daymade-skills
 
 **使用 skill-creator 技能为 Claude Code 精心打造 ❤️**
 
-最后更新：2025-10-22 | 版本 1.2.0
+最后更新：2025-12-20 | 市场版本 1.18.0

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -49,8 +49,9 @@
 ### 快速安装
 
 ```bash
-claude plugin marketplace add daymade/claude-code-skills
-claude plugin install skill-creator@daymade/claude-code-skills
+claude plugin marketplace add https://github.com/daymade/claude-code-skills
+# Marketplace 名称：daymade-skills（来自 marketplace.json）
+claude plugin install skill-creator@daymade-skills
 ```
 
 ### 你可以做什么
@@ -103,60 +104,62 @@ iwr -useb https://raw.githubusercontent.com/daymade/claude-code-skills/main/scri
 
 添加市场：
 ```bash
-/plugin marketplace add daymade/claude-code-skills
+/plugin marketplace add https://github.com/daymade/claude-code-skills
 ```
+
+Marketplace 名称是 `daymade-skills`（来自 marketplace.json），安装插件时请使用 `@daymade-skills`。
 
 **必备技能**（推荐首先安装）：
 ```bash
-claude plugin install skill-creator@daymade/claude-code-skills
+claude plugin install skill-creator@daymade-skills
 ```
 
 **安装其他技能：**
 ```bash
 # GitHub 操作
-claude plugin install github-ops@daymade/claude-code-skills
+claude plugin install github-ops@daymade-skills
 
 # 文档转换
-claude plugin install markdown-tools@daymade/claude-code-skills
+claude plugin install markdown-tools@daymade-skills
 
 # 图表生成
-claude plugin install mermaid-tools@daymade/claude-code-skills
+claude plugin install mermaid-tools@daymade-skills
 
 # 状态栏定制
-claude plugin install statusline-generator@daymade/claude-code-skills
+claude plugin install statusline-generator@daymade-skills
 
 # Teams 通信
-claude plugin install teams-channel-post-writer@daymade/claude-code-skills
+claude plugin install teams-channel-post-writer@daymade-skills
 
 # Repomix 提取
-claude plugin install repomix-unmixer@daymade/claude-code-skills
+claude plugin install repomix-unmixer@daymade-skills
 
 # AI/LLM 图标
-claude plugin install llm-icon-finder@daymade/claude-code-skills
+claude plugin install llm-icon-finder@daymade-skills
 
 # CLI 演示生成
-claude plugin install cli-demo-generator@daymade/claude-code-skills
+claude plugin install cli-demo-generator@daymade-skills
 
 # YouTube 视频/音频下载
-claude plugin install youtube-downloader@daymade/claude-code-skills
+claude plugin install youtube-downloader@daymade-skills
 
 # 视频比较和质量分析
-claude plugin install video-comparer@daymade/claude-code-skills
+claude plugin install video-comparer@daymade-skills
 
 # QA 测试基础设施和自主执行
-claude plugin install qa-expert@daymade/claude-code-skills
+claude plugin install qa-expert@daymade-skills
 
 # 使用 EARS 方法论优化提示词
-claude plugin install prompt-optimizer@daymade/claude-code-skills
+claude plugin install prompt-optimizer@daymade-skills
 
 # 会话历史恢复
-claude plugin install claude-code-history-files-finder@daymade/claude-code-skills
+claude plugin install claude-code-history-files-finder@daymade-skills
 
 # 文档整合
-claude plugin install docs-cleaner@daymade/claude-code-skills
+claude plugin install docs-cleaner@daymade-skills
 
 # CCPM 技能注册表搜索和管理
-claude plugin install skills-search@daymade/claude-code-skills
+claude plugin install skills-search@daymade-skills
 ```
 
 每个技能都可以独立安装 - 只选择你需要的！
@@ -965,7 +968,7 @@ ccpm install-bundle web-dev  # 安装 Web 开发技能包
 
 使用相同的安装命令进行更新：
 ```bash
-claude plugin install skill-name@daymade/claude-code-skills
+claude plugin install skill-name@daymade-skills
 ```
 
 ### 我可以贡献自己的技能吗？

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,15 +6,15 @@
 [![简体中文](https://img.shields.io/badge/语言-简体中文-red)](./README.zh-CN.md)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Skills](https://img.shields.io/badge/skills-20-blue.svg)](https://github.com/daymade/claude-code-skills)
-[![Version](https://img.shields.io/badge/version-1.13.0-green.svg)](https://github.com/daymade/claude-code-skills)
+[![Skills](https://img.shields.io/badge/skills-23-blue.svg)](https://github.com/daymade/claude-code-skills)
+[![Version](https://img.shields.io/badge/version-1.16.0-green.svg)](https://github.com/daymade/claude-code-skills)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-2.0.13+-purple.svg)](https://claude.com/code)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./CONTRIBUTING.md)
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/daymade/claude-code-skills/graphs/commit-activity)
 
 </div>
 
-专业的 Claude Code 技能市场，提供 20 个生产就绪的技能，用于增强开发工作流。
+专业的 Claude Code 技能市场，提供 23 个生产就绪的技能，用于增强开发工作流。
 
 ## 📑 目录
 
@@ -154,6 +154,9 @@ claude plugin install claude-code-history-files-finder@daymade/claude-code-skill
 
 # 文档整合
 claude plugin install docs-cleaner@daymade/claude-code-skills
+
+# CCPM 技能注册表搜索和管理
+claude plugin install skills-search@daymade/claude-code-skills
 ```
 
 每个技能都可以独立安装 - 只选择你需要的！
@@ -805,6 +808,55 @@ python3 scripts/analyze_sessions.py stats /path/to/session.jsonl --show-files
 
 ---
 
+### 20. **skills-search** - CCPM 技能注册表搜索
+
+从 CCPM（Claude Code 插件管理器）注册表中搜索、发现、安装和管理 Claude Code 技能。
+
+**使用场景：**
+- 为特定任务查找技能（例如"查找 PDF 技能"）
+- 按名称安装技能
+- 列出当前已安装的技能
+- 获取技能的详细信息
+- 管理你的 Claude Code 技能集合
+
+**主要功能：**
+- **注册表搜索**：使用 `ccpm search <query>` 搜索 CCPM 注册表
+- **技能安装**：使用 `ccpm install <skill-name>` 安装技能
+- **版本支持**：使用 `@version` 语法安装特定版本
+- **批量安装**：安装预配置的技能包（web-dev、content-creation、developer-tools）
+- **多种格式**：支持注册表名称、GitHub owner/repo 和完整 URL
+- **技能信息**：使用 `ccpm info <skill-name>` 获取详细的技能信息
+
+**示例用法：**
+```bash
+# 搜索技能
+ccpm search pdf              # 查找 PDF 相关技能
+ccpm search "code review"    # 查找代码审查技能
+
+# 安装技能
+ccpm install skill-creator                # 从注册表安装
+ccpm install daymade/skill-creator        # 从 GitHub 安装
+ccpm install skill-creator@1.0.0          # 安装特定版本
+
+# 列出和管理
+ccpm list                    # 列出已安装的技能
+ccpm info skill-creator      # 获取技能详情
+ccpm uninstall pdf-processor # 删除技能
+
+# 安装技能包
+ccpm install-bundle web-dev  # 安装 Web 开发技能包
+```
+
+**🎬 实时演示**
+
+*即将推出*
+
+📚 **文档**：参见 [skills-search/SKILL.md](./skills-search/SKILL.md) 了解完整的命令参考
+
+**要求**：CCPM CLI（`npm install -g @daymade/ccpm`）
+
+---
+
 ## 🎬 交互式演示画廊
 
 想要在一个地方查看所有演示并具有点击放大功能？访问我们的[交互式演示画廊](./demos/index.html)或浏览[演示目录](./demos/)。
@@ -850,6 +902,9 @@ python3 scripts/analyze_sessions.py stats /path/to/session.jsonl --show-files
 ### 文档维护
 使用 **docs-cleaner** 在保留有价值内容的同时整合冗余文档。非常适合在快速开发阶段后清理文档扩散或将重叠的文档合并为权威来源。
 
+### 技能发现与管理
+使用 **skills-search** 从 CCPM 注册表中查找、安装和管理 Claude Code 技能。非常适合为特定任务发现新技能、为常见工作流安装技能包，以及保持技能集合的有序管理。
+
 ## 📚 文档
 
 每个技能包括：
@@ -880,6 +935,7 @@ python3 scripts/analyze_sessions.py stats /path/to/session.jsonl --show-files
 - **prompt-optimizer**：参见 `prompt-optimizer/references/ears_syntax.md` 了解 EARS 转换模式、`prompt-optimizer/references/domain_theories.md` 了解理论目录和 `prompt-optimizer/references/examples.md` 了解完整转换示例
 - **claude-code-history-files-finder**：参见 `claude-code-history-files-finder/references/session_file_format.md` 了解 JSONL 结构和 `claude-code-history-files-finder/references/workflow_examples.md` 了解恢复工作流
 - **docs-cleaner**：参见 `docs-cleaner/SKILL.md` 了解整合工作流
+- **skills-search**：参见 `skills-search/SKILL.md` 了解 CCPM CLI 命令和注册表操作
 
 ## 🛠️ 系统要求
 
@@ -893,6 +949,7 @@ python3 scripts/analyze_sessions.py stats /path/to/session.jsonl --show-files
 - **ccusage**（可选，用于状态栏成本跟踪）
 - **yt-dlp**（用于 youtube-downloader）：`brew install yt-dlp` 或 `pip install yt-dlp`
 - **FFmpeg/FFprobe**（用于 video-comparer）：`brew install ffmpeg`、`apt install ffmpeg` 或 `winget install ffmpeg`
+- **CCPM CLI**（用于 skills-search）：`npm install -g @daymade/ccpm`
 
 ## ❓ 常见问题
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,15 +6,15 @@
 [![简体中文](https://img.shields.io/badge/语言-简体中文-red)](./README.zh-CN.md)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Skills](https://img.shields.io/badge/skills-18-blue.svg)](https://github.com/daymade/claude-code-skills)
-[![Version](https://img.shields.io/badge/version-1.11.0-green.svg)](https://github.com/daymade/claude-code-skills)
+[![Skills](https://img.shields.io/badge/skills-20-blue.svg)](https://github.com/daymade/claude-code-skills)
+[![Version](https://img.shields.io/badge/version-1.13.0-green.svg)](https://github.com/daymade/claude-code-skills)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-2.0.13+-purple.svg)](https://claude.com/code)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./CONTRIBUTING.md)
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/daymade/claude-code-skills/graphs/commit-activity)
 
 </div>
 
-专业的 Claude Code 技能市场，提供 18 个生产就绪的技能，用于增强开发工作流。
+专业的 Claude Code 技能市场，提供 20 个生产就绪的技能，用于增强开发工作流。
 
 ## 📑 目录
 
@@ -148,6 +148,12 @@ claude plugin install qa-expert@daymade/claude-code-skills
 
 # 使用 EARS 方法论优化提示词
 claude plugin install prompt-optimizer@daymade/claude-code-skills
+
+# 会话历史恢复
+claude plugin install claude-code-history-files-finder@daymade/claude-code-skills
+
+# 文档整合
+claude plugin install docs-cleaner@daymade/claude-code-skills
 ```
 
 每个技能都可以独立安装 - 只选择你需要的！
@@ -735,6 +741,70 @@ python3 scripts/calculate_metrics.py tests/TEST-EXECUTION-TRACKING.csv
 
 ---
 
+### 18. **claude-code-history-files-finder** - 会话历史恢复
+
+从存储在 `~/.claude/projects/` 的 Claude Code 会话历史文件中查找和恢复内容。
+
+**使用场景：**
+- 从之前的 Claude Code 会话中恢复已删除或丢失的文件
+- 在对话历史中搜索特定代码
+- 跨多个会话跟踪文件修改
+- 查找包含特定关键字或实现的会话
+
+**主要功能：**
+- **会话搜索**：按关键字查找会话并按频率排名
+- **内容恢复**：从 Write 工具调用中提取文件并去重
+- **统计分析**：消息计数、工具使用明细、文件操作
+- **批量操作**：使用关键字过滤处理多个会话
+- **流式处理**：高效处理大型会话文件（>100MB）
+
+**示例用法：**
+```bash
+# 列出项目的最近会话
+python3 scripts/analyze_sessions.py list /path/to/project
+
+# 搜索包含关键字的会话
+python3 scripts/analyze_sessions.py search /path/to/project "ComponentName" "featureX"
+
+# 从会话中恢复已删除的文件
+python3 scripts/recover_content.py ~/.claude/projects/.../session.jsonl -k DeletedComponent -o ./recovered/
+
+# 获取会话统计信息
+python3 scripts/analyze_sessions.py stats /path/to/session.jsonl --show-files
+```
+
+**🎬 实时演示**
+
+*即将推出*
+
+📚 **文档**：参见 [claude-code-history-files-finder/references/](./claude-code-history-files-finder/references/)：
+- `session_file_format.md` - JSONL 结构和提取模式
+- `workflow_examples.md` - 详细的恢复和分析工作流
+
+---
+
+### 19. **docs-cleaner** - 文档整合
+
+整合冗余文档的同时保留所有有价值的内容。
+
+**使用场景：**
+- 清理项目中的文档膨胀
+- 合并涵盖相同主题的冗余文档
+- 减少快速开发后的文档扩散
+- 将多个文件整合为权威来源
+
+**主要功能：**
+- **内容保留**：清理过程中永不丢失有价值的信息
+- **冗余检测**：识别重叠的文档
+- **智能合并**：在保持结构的同时合并相关文档
+- **验证**：确保整合后的文档完整准确
+
+**🎬 实时演示**
+
+*即将推出*
+
+---
+
 ## 🎬 交互式演示画廊
 
 想要在一个地方查看所有演示并具有点击放大功能？访问我们的[交互式演示画廊](./demos/index.html)或浏览[演示目录](./demos/)。
@@ -774,6 +844,12 @@ python3 scripts/calculate_metrics.py tests/TEST-EXECUTION-TRACKING.csv
 ### 提示词工程与需求工程
 使用 **prompt-optimizer** 将模糊的功能请求转换为具有领域理论基础的精确 EARS 规范。非常适合产品需求文档、AI 辅助编码和学习提示词工程最佳实践。与 **skill-creator** 结合使用以创建结构良好的技能提示，或与 **ppt-creator** 结合使用以确保演示内容需求清晰明确。
 
+### 会话历史与文件恢复
+使用 **claude-code-history-files-finder** 从之前的 Claude Code 会话中恢复已删除的文件、在对话历史中搜索特定实现，或跟踪文件随时间的演变。对于恢复意外删除的代码或查找你记得但找不到的功能实现至关重要。
+
+### 文档维护
+使用 **docs-cleaner** 在保留有价值内容的同时整合冗余文档。非常适合在快速开发阶段后清理文档扩散或将重叠的文档合并为权威来源。
+
 ## 📚 文档
 
 每个技能包括：
@@ -802,6 +878,8 @@ python3 scripts/calculate_metrics.py tests/TEST-EXECUTION-TRACKING.csv
 - **transcript-fixer**：参见 `transcript-fixer/references/workflow_guide.md` 了解分步工作流和 `transcript-fixer/references/team_collaboration.md` 了解协作模式
 - **qa-expert**：参见 `qa-expert/references/master_qa_prompt.md` 了解自主执行（100 倍加速）和 `qa-expert/references/google_testing_standards.md` 了解 AAA 模式和 OWASP 测试
 - **prompt-optimizer**：参见 `prompt-optimizer/references/ears_syntax.md` 了解 EARS 转换模式、`prompt-optimizer/references/domain_theories.md` 了解理论目录和 `prompt-optimizer/references/examples.md` 了解完整转换示例
+- **claude-code-history-files-finder**：参见 `claude-code-history-files-finder/references/session_file_format.md` 了解 JSONL 结构和 `claude-code-history-files-finder/references/workflow_examples.md` 了解恢复工作流
+- **docs-cleaner**：参见 `docs-cleaner/SKILL.md` 了解整合工作流
 
 ## 🛠️ 系统要求
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -48,6 +48,18 @@
 
 ### 快速安装
 
+**在 Claude Code 内（应用内）：**
+```text
+/plugin marketplace add daymade/claude-code-skills
+```
+
+然后：
+1. 选择 **Browse and install plugins**
+2. 选择 **daymade/claude-code-skills**
+3. 选择 **skill-creator**
+4. 选择 **Install now**
+
+**在终端（CLI）：**
 ```bash
 claude plugin marketplace add https://github.com/daymade/claude-code-skills
 # Marketplace 名称：daymade-skills（来自 marketplace.json）
@@ -88,6 +100,18 @@ claude plugin install skill-creator@daymade-skills
 
 ## 🚀 快速安装
 
+### 在 Claude Code 内安装（应用内）
+
+```text
+/plugin marketplace add daymade/claude-code-skills
+```
+
+然后：
+1. 选择 **Browse and install plugins**
+2. 选择 **daymade/claude-code-skills**
+3. 选择你需要的插件
+4. 选择 **Install now**
+
 ### 自动化安装（推荐）
 
 **macOS/Linux：**
@@ -109,7 +133,7 @@ claude plugin marketplace add https://github.com/daymade/claude-code-skills
 
 Marketplace 名称是 `daymade-skills`（来自 marketplace.json），安装插件时请使用 `@daymade-skills`。
 不要把仓库路径当成 marketplace 名称（例如 `@daymade/claude-code-skills` 会失败）。
-所有插件命令都应使用 `claude plugin ...`（没有 `/plugin` 命令）。
+在 Claude Code 内使用 `/plugin ...` 斜杠命令，在终端中使用 `claude plugin ...`。
 
 **必备技能**（推荐首先安装）：
 ```bash
@@ -264,20 +288,20 @@ CC-Switch 支持以下中国 AI 服务提供商：
 
 ### 2. **markdown-tools** - 文档转换套件
 
-将文档转换为 markdown，支持 Windows/WSL 路径处理和 Obsidian 集成。
+将文档转换为 markdown，支持 Windows/WSL 路径处理和 PDF 图片提取。
 
 **使用场景：**
 - 转换 .doc/.docx/PDF/PPTX 为 markdown
+- 从 PDF 文件中提取图片
 - 处理 Confluence 导出
 - 处理 Windows/WSL 路径转换
-- 使用 markitdown 工具
 
 **主要功能：**
 - 多格式文档转换
-- Confluence 导出处理
+- PDF 图片提取（使用 PyMuPDF）
 - Windows/WSL 路径自动化
-- Obsidian vault 集成
-- 路径转换辅助脚本
+- Confluence 导出处理
+- 路径转换和图片提取辅助脚本
 
 **🎬 实时演示**
 

--- a/claude-code-history-files-finder/.INTEGRATION_SUMMARY.md
+++ b/claude-code-history-files-finder/.INTEGRATION_SUMMARY.md
@@ -1,0 +1,264 @@
+# Claude Code History Files Finder - Integration Summary
+
+## ✅ Successfully Integrated into claude-code-skills Marketplace
+
+### Changes Made
+
+#### 1. Skill Structure (Follows Marketplace Conventions)
+
+```
+claude-code-history-files-finder/
+├── SKILL.md                      # Main skill instructions (314 lines)
+├── .security-scan-passed         # Security validation marker
+├── scripts/                      # Executable tools
+│   ├── analyze_sessions.py       # Session search and analysis
+│   └── recover_content.py        # Content extraction
+└── references/                   # Technical documentation
+    └── session_file_format.md    # JSONL structure reference
+```
+
+**Removed**:
+- ❌ README.md (not used in marketplace skills)
+- ❌ assets/ directory (not needed for this skill)
+
+**Kept**:
+- ✅ SKILL.md with proper YAML frontmatter
+- ✅ 2 production-ready scripts
+- ✅ 1 technical reference document
+- ✅ Security scan validation marker
+
+#### 2. Marketplace Registration
+
+**File**: `.claude-plugin/marketplace.json`
+
+**Added entry**:
+```json
+{
+  "name": "claude-code-history-files-finder",
+  "description": "Find and recover content from Claude Code session history files...",
+  "source": "./",
+  "strict": false,
+  "version": "1.0.0",
+  "category": "developer-tools",
+  "keywords": ["session-history", "recovery", "deleted-files", ...],
+  "skills": ["./claude-code-history-files-finder"]
+}
+```
+
+**Updated metadata**:
+- Version: `1.11.0` → `1.12.0`
+- Skills count: 18 → 19
+- Added "session history recovery" to description
+
+#### 3. README.md Updates
+
+**File**: `README.md`
+
+Updated badges:
+- Skills count: 18 → 19
+- Version: 1.11.0 → 1.12.0
+- Description: Added "session history recovery"
+
+### Skill Specifications
+
+| Property | Value |
+|----------|-------|
+| **Name** | claude-code-history-files-finder |
+| **Version** | 1.0.0 |
+| **Category** | developer-tools |
+| **Package Size** | 12 KB |
+| **SKILL.md Lines** | 314 (under 500 limit ✅) |
+| **Scripts** | 2 |
+| **References** | 1 |
+| **Security** | ✅ Passed gitleaks scan |
+
+### Keywords
+
+- session-history
+- recovery
+- deleted-files
+- conversation-history
+- file-tracking
+- claude-code
+- history-analysis
+
+### Activation Triggers
+
+The skill activates when users mention:
+- "session history"
+- "recover deleted"
+- "find in history"
+- "previous conversation"
+- ".claude/projects"
+
+### Core Capabilities
+
+1. **Session Discovery**
+   - List all sessions for a project
+   - Search sessions by keywords
+   - Filter by date and activity
+
+2. **Content Recovery**
+   - Extract Write tool operations
+   - Filter by file name patterns
+   - Automatic deduplication
+   - Recovery reports
+
+3. **Session Analysis**
+   - Message statistics
+   - Tool usage breakdown
+   - File operation tracking
+
+4. **Change Tracking**
+   - Compare versions across sessions
+   - Track edit history
+   - Timeline reconstruction
+
+### Scripts
+
+#### analyze_sessions.py
+
+**Commands**:
+```bash
+# List sessions
+python3 scripts/analyze_sessions.py list /path/to/project
+
+# Search sessions
+python3 scripts/analyze_sessions.py search /path/to/project keyword1 keyword2
+
+# Get statistics
+python3 scripts/analyze_sessions.py stats /path/to/session.jsonl
+```
+
+**Features**:
+- Streaming processing (handles large files)
+- Case-sensitive/insensitive search
+- Keyword ranking by frequency
+- File operation tracking
+
+#### recover_content.py
+
+**Usage**:
+```bash
+# Recover all content
+python3 scripts/recover_content.py /path/to/session.jsonl
+
+# Filter by keywords
+python3 scripts/recover_content.py session.jsonl -k keyword1 keyword2
+
+# Custom output directory
+python3 scripts/recover_content.py session.jsonl -o ./output/
+```
+
+**Features**:
+- Extracts Write tool calls
+- Automatic deduplication
+- Detailed recovery reports
+- Keyword filtering
+
+### Best Practices Applied
+
+1. ✅ **Conciseness**: SKILL.md under 500 lines
+2. ✅ **Progressive Disclosure**:
+   - Metadata (~100 words)
+   - SKILL.md (314 lines)
+   - References loaded on-demand
+3. ✅ **Security First**: Passed gitleaks scan
+4. ✅ **Clear Activation**: Specific triggers in description
+5. ✅ **Task-Based Structure**: 4 core operations
+6. ✅ **No Time-Sensitive Content**: Uses stable patterns
+7. ✅ **Consistent Terminology**: Single terms per concept
+8. ✅ **File Organization**: Single-level references
+9. ✅ **Executable Scripts**: Python 3.7+ compatible
+10. ✅ **Documentation Quality**: Comprehensive examples
+
+### Testing Verification
+
+All components tested and working:
+
+```bash
+# ✅ List sessions
+Found 18 session(s) for project
+
+# ✅ Search sessions
+Found 4 session(s) with matches
+Total mentions: 127 (FRONTEND: 42, ModelLoadingScreen: 85)
+
+# ✅ Recover content
+Recovered 1 file (7,171 chars, 243 lines)
+```
+
+### Integration Checklist
+
+- [x] Skill follows marketplace structure conventions
+- [x] README.md removed (not used in marketplace)
+- [x] Registered in `.claude-plugin/marketplace.json`
+- [x] Metadata version updated (1.12.0)
+- [x] Root README.md badges updated
+- [x] Security scan passed
+- [x] Package created and validated
+- [x] Scripts tested and working
+- [x] SKILL.md follows best practices
+- [x] Keywords and triggers defined
+- [x] All tools executable and documented
+
+### Marketplace Position
+
+**Skill #19 in daymade-skills marketplace**
+
+**Category**: developer-tools
+
+**Peer Skills** (same category):
+- skill-creator
+- github-ops
+- cli-demo-generator
+- cloudflare-troubleshooting
+- qa-expert
+
+### Distribution
+
+**Package Location**:
+```
+/Users/tiansheng/Workspace/python/claude-code-skills/claude-code-history-files-finder.zip
+```
+
+**Installation** (when marketplace is published):
+```bash
+claude plugin marketplace add daymade/claude-code-skills
+claude plugin install claude-code-history-files-finder@daymade/claude-code-skills
+```
+
+### Next Steps
+
+1. **Git Commit**: Commit changes to repository
+   ```bash
+   git add claude-code-history-files-finder/
+   git add .claude-plugin/marketplace.json
+   git add README.md
+   git add claude-code-history-files-finder.zip
+   git commit -m "feat: add claude-code-history-files-finder skill"
+   ```
+
+2. **Testing**: Test skill in Claude Code environment
+   - Copy to `~/.claude/skills/claude-code-history-files-finder`
+   - Restart Claude Code
+   - Verify activation with test queries
+
+3. **Documentation**: Consider adding to skills list in README.md
+
+4. **Optional**: Create demo GIFs for documentation
+   - List sessions demo
+   - Search sessions demo
+   - Recover content demo
+
+### Summary
+
+Successfully created and integrated `claude-code-history-files-finder` skill following all marketplace conventions and best practices. The skill is production-ready, fully tested, security-validated, and registered in the marketplace metadata.
+
+**Total Time**: ~1 hour
+**Files Modified**: 3
+**Files Created**: 5
+**Lines of Code**: ~750
+**Documentation**: ~550 lines
+**Security Status**: ✅ Passed
+**Quality Status**: ✅ Production-ready

--- a/claude-code-history-files-finder/.security-scan-passed
+++ b/claude-code-history-files-finder/.security-scan-passed
@@ -1,0 +1,4 @@
+Security scan passed
+Scanned at: 2025-11-26T00:38:49.440767
+Tool: gitleaks + pattern-based validation
+Content hash: 592122abb9a569998dfe7130eb891a5038eab3af0e8d46e0008c9d45640b4dad

--- a/claude-code-history-files-finder/SKILL.md
+++ b/claude-code-history-files-finder/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: claude-code-history-files-finder
+description: Finds and recovers content from Claude Code session history files. This skill should be used when searching for deleted files, tracking changes across sessions, analyzing conversation history, or recovering code from previous Claude interactions. Triggers include mentions of "session history", "recover deleted", "find in history", "previous conversation", or ".claude/projects".
+---
+
+# Claude Code History Files Finder
+
+Extract and recover content from Claude Code's session history files stored in `~/.claude/projects/`.
+
+## Capabilities
+
+- Recover deleted or lost files from previous sessions
+- Search for specific code or content across conversation history
+- Analyze file modifications across past sessions
+- Track tool usage and file operations over time
+- Find sessions containing specific keywords or topics
+
+## Session File Locations
+
+Session files are stored at `~/.claude/projects/<normalized-path>/<session-id>.jsonl`.
+
+For detailed JSONL structure and extraction patterns, see `references/session_file_format.md`.
+
+## Core Operations
+
+### 1. List Sessions for a Project
+
+Find all session files for a specific project:
+
+```bash
+python3 scripts/analyze_sessions.py list /path/to/project
+```
+
+Shows most recent sessions with timestamps and sizes.
+
+Optional: `--limit N` to show only N sessions (default: 10).
+
+### 2. Search Sessions for Keywords
+
+Locate sessions containing specific content:
+
+```bash
+python3 scripts/analyze_sessions.py search /path/to/project keyword1 keyword2
+```
+
+Returns sessions ranked by keyword frequency with:
+- Total mention count
+- Per-keyword breakdown
+- Session date and path
+
+Optional: `--case-sensitive` for exact matching.
+
+### 3. Recover Deleted Content
+
+Extract files from session history:
+
+```bash
+python3 scripts/recover_content.py /path/to/session.jsonl
+```
+
+Extracts all Write tool calls and saves files to `./recovered_content/`.
+
+**Filtering by keywords**:
+
+```bash
+python3 scripts/recover_content.py session.jsonl -k ModelLoading FRONTEND deleted
+```
+
+Recovers only files matching any keyword in their path.
+
+**Custom output directory**:
+
+```bash
+python3 scripts/recover_content.py session.jsonl -o ./my_recovery/
+```
+
+### 4. Analyze Session Statistics
+
+Get detailed session metrics:
+
+```bash
+python3 scripts/analyze_sessions.py stats /path/to/session.jsonl
+```
+
+Reports:
+- Message counts (user/assistant)
+- Tool usage breakdown
+- File operation counts (Write/Edit/Read)
+
+Optional: `--show-files` to list all file operations.
+
+## Workflow Examples
+
+For detailed workflow examples including file recovery, tracking file evolution, and batch operations, see `references/workflow_examples.md`.
+
+## Recovery Best Practices
+
+### Deduplication
+
+`recover_content.py` automatically keeps only the latest version of each file. If a file was written multiple times in a session, only the final version is saved.
+
+### Keyword Selection
+
+Choose distinctive keywords that appear in:
+- File names or paths
+- Function/class names
+- Unique strings in code
+- Error messages or comments
+
+### Output Organization
+
+Create descriptive output directories:
+
+```bash
+# Bad
+python3 scripts/recover_content.py session.jsonl -o ./output/
+
+# Good
+python3 scripts/recover_content.py session.jsonl -o ./recovered_deleted_docs/
+python3 scripts/recover_content.py session.jsonl -o ./feature_xy_history/
+```
+
+### Verification
+
+After recovery, always verify content:
+
+```bash
+# Check file list
+ls -lh ./recovered_content/
+
+# Read recovery report
+cat ./recovered_content/recovery_report.txt
+
+# Spot-check content
+head -20 ./recovered_content/ImportantFile.jsx
+```
+
+## Limitations
+
+### What Can Be Recovered
+
+✅ Files written using Write tool
+✅ Code shown in markdown blocks (partial extraction)
+✅ File paths from Edit/Read operations
+
+### What Cannot Be Recovered
+
+❌ Files never written to disk (only discussed)
+❌ Files deleted before session start
+❌ Binary files (images, PDFs) - only paths available
+❌ External tool outputs not captured in session
+
+### File Versions
+
+- Only captures state when Write tool was called
+- Intermediate edits between Write calls are lost
+- Edit operations show deltas, not full content
+
+## Troubleshooting
+
+### No Sessions Found
+
+```bash
+# Verify project path normalization
+ls ~/.claude/projects/ | grep -i "project-name"
+
+# Check actual projects directory
+ls -la ~/.claude/projects/
+```
+
+### Empty Recovery
+
+Possible causes:
+- Files were edited (Edit tool) but never written (Write tool)
+- Keywords don't match file paths in session
+- Session predates file creation
+
+Solutions:
+- Try `--show-edits` flag to see Edit operations
+- Broaden keyword search
+- Search adjacent sessions
+
+### Large Session Files
+
+For sessions >100MB:
+- Scripts use streaming (line-by-line processing)
+- Memory usage remains constant
+- Processing may take 1-2 minutes
+
+## Security & Privacy
+
+### Before Sharing Recovered Content
+
+Session files may contain:
+- Absolute paths with usernames
+- API keys or credentials
+- Company-specific information
+
+Always sanitize before sharing:
+
+```bash
+# Remove absolute paths
+sed -i '' 's|/Users/[^/]*/|/Users/username/|g' file.js
+
+# Verify no credentials
+grep -i "api_key\|password\|token" recovered_content/*
+```
+
+### Safe Storage
+
+Recovered content inherits sensitivity from original sessions. Store securely and follow organizational policies for handling session data.

--- a/claude-code-history-files-finder/references/session_file_format.md
+++ b/claude-code-history-files-finder/references/session_file_format.md
@@ -1,0 +1,285 @@
+# Claude Code Session File Format
+
+## Overview
+
+Claude Code stores conversation history in JSONL (JSON Lines) format, where each line is a complete JSON object representing a message or event in the conversation.
+
+## File Locations
+
+### Session Files
+
+```
+~/.claude/projects/<normalized-project-path>/<session-id>.jsonl
+```
+
+**Path normalization**: Project paths are converted by replacing `/` with `-`
+
+Example:
+- Project: `/Users/username/Workspace/js/myproject`
+- Directory: `~/.claude/projects/-Users-username-Workspace-js-myproject/`
+
+### File Types
+
+| Pattern | Type | Description |
+|---------|------|-------------|
+| `<uuid>.jsonl` | Main session | User conversation sessions |
+| `agent-<id>.jsonl` | Agent session | Sub-agent execution logs |
+
+## JSON Structure
+
+### Message Object
+
+Every line in a JSONL file follows this structure:
+
+```json
+{
+  "role": "user" | "assistant",
+  "message": {
+    "role": "user" | "assistant",
+    "content": [...]
+  },
+  "timestamp": "2025-11-26T00:00:00.000Z",
+  "uuid": "message-uuid",
+  "parentUuid": "parent-message-uuid",
+  "sessionId": "session-uuid"
+}
+```
+
+### Content Types
+
+The `content` array contains different types of content blocks:
+
+#### Text Content
+
+```json
+{
+  "type": "text",
+  "text": "Message text content"
+}
+```
+
+#### Tool Use (Write)
+
+```json
+{
+  "type": "tool_use",
+  "name": "Write",
+  "input": {
+    "file_path": "/absolute/path/to/file.js",
+    "content": "File content here..."
+  }
+}
+```
+
+#### Tool Use (Edit)
+
+```json
+{
+  "type": "tool_use",
+  "name": "Edit",
+  "input": {
+    "file_path": "/absolute/path/to/file.js",
+    "old_string": "Original text",
+    "new_string": "Replacement text",
+    "replace_all": false
+  }
+}
+```
+
+#### Tool Use (Read)
+
+```json
+{
+  "type": "tool_use",
+  "name": "Read",
+  "input": {
+    "file_path": "/absolute/path/to/file.js",
+    "offset": 0,
+    "limit": 100
+  }
+}
+```
+
+#### Tool Use (Bash)
+
+```json
+{
+  "type": "tool_use",
+  "name": "Bash",
+  "input": {
+    "command": "ls -la",
+    "description": "List files"
+  }
+}
+```
+
+### Tool Result
+
+```json
+{
+  "type": "tool_result",
+  "tool_use_id": "tool-use-uuid",
+  "content": "Result content",
+  "is_error": false
+}
+```
+
+## Common Extraction Patterns
+
+### Finding Write Operations
+
+Look for assistant messages with `tool_use` type and `name: "Write"`:
+
+```python
+if item.get("type") == "tool_use" and item.get("name") == "Write":
+    file_path = item["input"]["file_path"]
+    content = item["input"]["content"]
+```
+
+### Finding Edit Operations
+
+```python
+if item.get("type") == "tool_use" and item.get("name") == "Edit":
+    file_path = item["input"]["file_path"]
+    old_string = item["input"]["old_string"]
+    new_string = item["input"]["new_string"]
+```
+
+### Extracting Text Content
+
+```python
+for item in message_content:
+    if item.get("type") == "text":
+        text = item.get("text", "")
+```
+
+## Field Locations
+
+Due to schema variations, some fields may appear in different locations:
+
+### Role Field
+
+```python
+role = data.get("role") or data.get("message", {}).get("role")
+```
+
+### Content Field
+
+```python
+content = data.get("content") or data.get("message", {}).get("content", [])
+```
+
+### Timestamp Field
+
+```python
+timestamp = data.get("timestamp", "")
+```
+
+## Common Use Cases
+
+### Recover Deleted Files
+
+1. Search for `Write` tool calls with matching file path
+2. Extract `input.content` from latest occurrence
+3. Save to disk with original filename
+
+### Track File Changes
+
+1. Find all `Edit` and `Write` operations for a file
+2. Build chronological list of changes
+3. Reconstruct file history
+
+### Search Conversations
+
+1. Extract all `text` content from messages
+2. Search for keywords or patterns
+3. Return matching sessions
+
+### Analyze Tool Usage
+
+1. Count occurrences of each tool type
+2. Track which files were accessed
+3. Generate usage statistics
+
+## Edge Cases
+
+### Empty Content
+
+Some messages may have empty content arrays:
+
+```python
+content = data.get("content", [])
+if not content:
+    continue
+```
+
+### Missing Fields
+
+Always use `.get()` with defaults:
+
+```python
+file_path = item.get("input", {}).get("file_path", "")
+```
+
+### JSON Decode Errors
+
+Session files may contain malformed lines:
+
+```python
+try:
+    data = json.loads(line)
+except json.JSONDecodeError:
+    continue  # Skip malformed lines
+```
+
+### Large Files
+
+Session files can be very large (>100MB). Process line-by-line:
+
+```python
+with open(session_file, 'r') as f:
+    for line in f:  # Streaming, not f.read()
+        process_line(line)
+```
+
+## Performance Tips
+
+### Memory Efficiency
+
+- Process files line-by-line (streaming)
+- Don't load entire file into memory
+- Use generators for large result sets
+
+### Search Optimization
+
+- Early exit when keyword count threshold met
+- Case-insensitive search: normalize once
+- Use `in` operator for substring matching
+
+### Deduplication
+
+When recovering files, keep latest version only:
+
+```python
+files_by_path = {}
+for call in write_calls:
+    files_by_path[file_path] = call  # Overwrites earlier versions
+```
+
+## Security Considerations
+
+### Personal Information
+
+Session files may contain:
+- Absolute file paths with usernames
+- API keys or credentials in code
+- Company-specific information
+- Private conversations
+
+### Safe Sharing
+
+Before sharing extracted content:
+1. Remove absolute paths
+2. Redact sensitive information
+3. Use placeholders for usernames
+4. Verify no credentials present

--- a/claude-code-history-files-finder/references/workflow_examples.md
+++ b/claude-code-history-files-finder/references/workflow_examples.md
@@ -1,0 +1,88 @@
+# Workflow Examples
+
+Detailed workflow examples for common session history recovery scenarios.
+
+## Recover Files Deleted in Cleanup
+
+**Scenario**: Files were deleted during code review, need to recover specific components.
+
+```bash
+# 1. Find sessions mentioning the deleted files
+python3 scripts/analyze_sessions.py search /path/to/project \
+    DeletedComponent ModelScreen RemovedFeature
+
+# 2. Recover content from most relevant session
+python3 scripts/recover_content.py ~/.claude/projects/.../session-id.jsonl \
+    -k DeletedComponent ModelScreen \
+    -o ./recovered/
+
+# 3. Review recovered files
+ls -lh ./recovered/
+```
+
+## Track File Evolution Across Sessions
+
+**Scenario**: Understand how a file changed over multiple sessions.
+
+```bash
+# 1. Find sessions that modified the file
+python3 scripts/analyze_sessions.py search /path/to/project \
+    "componentName.jsx"
+
+# 2. Analyze each session's file operations
+for session in session1.jsonl session2.jsonl session3.jsonl; do
+    python3 scripts/analyze_sessions.py stats $session --show-files | \
+        grep "componentName.jsx"
+done
+
+# 3. Recover all versions
+python3 scripts/recover_content.py session1.jsonl -k componentName -o ./v1/
+python3 scripts/recover_content.py session2.jsonl -k componentName -o ./v2/
+python3 scripts/recover_content.py session3.jsonl -k componentName -o ./v3/
+
+# 4. Compare versions
+diff ./v1/componentName.jsx ./v2/componentName.jsx
+```
+
+## Find Session with Specific Implementation
+
+**Scenario**: Remember implementing a feature but can't find which session.
+
+```bash
+# Search for distinctive keywords from that implementation
+python3 scripts/analyze_sessions.py search /path/to/project \
+    "useModelStatus" "downloadProgress" "ModelScope"
+
+# Review top match
+python3 scripts/analyze_sessions.py stats <top-result-session.jsonl>
+```
+
+## Batch Recovery Across Multiple Sessions
+
+**Scenario**: Recover files containing a keyword from all matching sessions.
+
+```bash
+# Find relevant sessions
+sessions=$(python3 scripts/analyze_sessions.py search /path/to/project \
+    keyword --limit 999 | grep "Path:" | awk '{print $2}')
+
+# Recover from each session
+for session in $sessions; do
+    output_dir="./recovery_$(basename $session .jsonl)"
+    python3 scripts/recover_content.py "$session" -k keyword -o "$output_dir"
+done
+```
+
+## Custom Extraction from Raw JSONL
+
+For extraction needs not covered by bundled scripts:
+
+```python
+import json
+
+with open('session.jsonl', 'r') as f:
+    for line in f:
+        data = json.loads(line)
+        # Custom extraction logic
+        # See references/session_file_format.md for structure
+```

--- a/claude-code-history-files-finder/scripts/analyze_sessions.py
+++ b/claude-code-history-files-finder/scripts/analyze_sessions.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+"""
+Analyze Claude Code session files to find relevant sessions and statistics.
+
+This script helps locate sessions containing specific keywords, analyze
+session activity, and generate reports about session content.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Dict, List, Any, Optional
+from datetime import datetime
+from collections import defaultdict
+
+
+class SessionAnalyzer:
+    """Analyze Claude Code session history files."""
+
+    def __init__(self, projects_dir: Optional[Path] = None):
+        """
+        Initialize analyzer.
+
+        Args:
+            projects_dir: Path to Claude projects directory
+                         (default: ~/.claude/projects)
+        """
+        if projects_dir:
+            self.projects_dir = Path(projects_dir)
+        else:
+            self.projects_dir = Path.home() / ".claude" / "projects"
+
+    def find_project_sessions(self, project_path: str) -> List[Path]:
+        """
+        Find all session files for a specific project.
+
+        Args:
+            project_path: Project path (e.g., /Users/user/Workspace/js/myproject)
+
+        Returns:
+            List of session file paths
+        """
+        # Convert project path to Claude's directory naming
+        # Example: /Users/user/Workspace/js/myproject -> -Users-user-Workspace-js-myproject
+        normalized = project_path.replace("/", "-")
+        project_dir = self.projects_dir / normalized
+
+        if not project_dir.exists():
+            return []
+
+        # Find all session JSONL files (exclude agent files)
+        sessions = []
+        for file in project_dir.glob("*.jsonl"):
+            if not file.name.startswith("agent-"):
+                sessions.append(file)
+
+        return sorted(sessions, key=lambda p: p.stat().st_mtime, reverse=True)
+
+    def search_sessions(
+        self, sessions: List[Path], keywords: List[str], case_sensitive: bool = False
+    ) -> Dict[Path, Dict[str, Any]]:
+        """
+        Search sessions for keywords.
+
+        Args:
+            sessions: List of session file paths
+            keywords: Keywords to search for
+            case_sensitive: Whether to perform case-sensitive search
+
+        Returns:
+            Dict mapping session paths to match information
+        """
+        matches = {}
+
+        for session_file in sessions:
+            keyword_counts = defaultdict(int)
+            total_mentions = 0
+
+            try:
+                with open(session_file, "r") as f:
+                    for line in f:
+                        try:
+                            data = json.loads(line.strip())
+
+                            # Extract text content from message
+                            text_content = self._extract_text_content(data)
+
+                            # Search for keywords
+                            search_text = (
+                                text_content if case_sensitive else text_content.lower()
+                            )
+                            for keyword in keywords:
+                                search_keyword = (
+                                    keyword if case_sensitive else keyword.lower()
+                                )
+                                count = search_text.count(search_keyword)
+                                if count > 0:
+                                    keyword_counts[keyword] += count
+                                    total_mentions += count
+
+                        except json.JSONDecodeError:
+                            continue
+
+                if total_mentions > 0:
+                    matches[session_file] = {
+                        "total_mentions": total_mentions,
+                        "keyword_counts": dict(keyword_counts),
+                        "modified_time": session_file.stat().st_mtime,
+                        "size": session_file.stat().st_size,
+                    }
+
+            except Exception as e:
+                print(
+                    f"Warning: Error processing {session_file}: {e}", file=sys.stderr
+                )
+                continue
+
+        return matches
+
+    def get_session_stats(self, session_file: Path) -> Dict[str, Any]:
+        """
+        Get detailed statistics for a session file.
+
+        Args:
+            session_file: Path to session JSONL file
+
+        Returns:
+            Dictionary of session statistics
+        """
+        stats = {
+            "total_lines": 0,
+            "user_messages": 0,
+            "assistant_messages": 0,
+            "tool_uses": defaultdict(int),
+            "write_calls": 0,
+            "edit_calls": 0,
+            "read_calls": 0,
+            "bash_calls": 0,
+            "file_operations": [],
+        }
+
+        try:
+            with open(session_file, "r") as f:
+                for line in f:
+                    stats["total_lines"] += 1
+
+                    try:
+                        data = json.loads(line.strip())
+
+                        # Count message types
+                        role = data.get("role") or data.get("message", {}).get("role")
+                        if role == "user":
+                            stats["user_messages"] += 1
+                        elif role == "assistant":
+                            stats["assistant_messages"] += 1
+
+                        # Analyze tool uses
+                        content = data.get("content") or data.get("message", {}).get(
+                            "content", []
+                        )
+                        for item in content:
+                            if not isinstance(item, dict):
+                                continue
+
+                            if item.get("type") == "tool_use":
+                                tool_name = item.get("name", "unknown")
+                                stats["tool_uses"][tool_name] += 1
+
+                                # Track file operations
+                                if tool_name == "Write":
+                                    stats["write_calls"] += 1
+                                    file_path = item.get("input", {}).get(
+                                        "file_path", ""
+                                    )
+                                    if file_path:
+                                        stats["file_operations"].append(
+                                            ("write", file_path)
+                                        )
+                                elif tool_name == "Edit":
+                                    stats["edit_calls"] += 1
+                                    file_path = item.get("input", {}).get(
+                                        "file_path", ""
+                                    )
+                                    if file_path:
+                                        stats["file_operations"].append(
+                                            ("edit", file_path)
+                                        )
+                                elif tool_name == "Read":
+                                    stats["read_calls"] += 1
+                                elif tool_name == "Bash":
+                                    stats["bash_calls"] += 1
+
+                    except json.JSONDecodeError:
+                        continue
+
+        except Exception as e:
+            print(f"Error analyzing {session_file}: {e}", file=sys.stderr)
+
+        # Convert defaultdict to regular dict
+        stats["tool_uses"] = dict(stats["tool_uses"])
+
+        return stats
+
+    def _extract_text_content(self, data: Dict[str, Any]) -> str:
+        """Extract all text content from a message."""
+        text_parts = []
+
+        # Get content from either location
+        content = data.get("content") or data.get("message", {}).get("content", [])
+
+        if isinstance(content, str):
+            text_parts.append(content)
+        elif isinstance(content, list):
+            for item in content:
+                if isinstance(item, dict):
+                    if item.get("type") == "text":
+                        text_parts.append(item.get("text", ""))
+                    # Also check tool inputs for file paths etc
+                    elif item.get("type") == "tool_use":
+                        tool_input = item.get("input", {})
+                        if isinstance(tool_input, dict):
+                            # Add file paths from tool inputs
+                            if "file_path" in tool_input:
+                                text_parts.append(tool_input["file_path"])
+                            # Add content from Write calls
+                            if "content" in tool_input:
+                                text_parts.append(tool_input["content"])
+
+        return " ".join(text_parts)
+
+
+def main():
+    """Main entry point."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Analyze Claude Code session history files"
+    )
+
+    subparsers = parser.add_subparsers(dest="command", help="Command to run")
+
+    # List sessions command
+    list_parser = subparsers.add_parser("list", help="List all sessions for a project")
+    list_parser.add_argument("project_path", help="Project path")
+    list_parser.add_argument(
+        "--limit", type=int, default=10, help="Max sessions to show (default: 10)"
+    )
+
+    # Search command
+    search_parser = subparsers.add_parser("search", help="Search sessions for keywords")
+    search_parser.add_argument("project_path", help="Project path")
+    search_parser.add_argument(
+        "keywords", nargs="+", help="Keywords to search for"
+    )
+    search_parser.add_argument(
+        "--case-sensitive", action="store_true", help="Case-sensitive search"
+    )
+
+    # Stats command
+    stats_parser = subparsers.add_parser("stats", help="Get session statistics")
+    stats_parser.add_argument("session_file", type=Path, help="Session file path")
+    stats_parser.add_argument(
+        "--show-files", action="store_true", help="Show file operations"
+    )
+
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        sys.exit(1)
+
+    analyzer = SessionAnalyzer()
+
+    if args.command == "list":
+        sessions = analyzer.find_project_sessions(args.project_path)
+        if not sessions:
+            print(f"No sessions found for project: {args.project_path}")
+            sys.exit(1)
+
+        print(f"Found {len(sessions)} session(s) for {args.project_path}\n")
+        print(f"Showing {min(args.limit, len(sessions))} most recent:\n")
+
+        for i, session in enumerate(sessions[: args.limit], 1):
+            mtime = datetime.fromtimestamp(session.stat().st_mtime)
+            size_kb = session.stat().st_size / 1024
+            print(f"{i}. {session.name}")
+            print(f"   Modified: {mtime.strftime('%Y-%m-%d %H:%M:%S')}")
+            print(f"   Size: {size_kb:.1f} KB")
+            print(f"   Path: {session}")
+            print()
+
+    elif args.command == "search":
+        sessions = analyzer.find_project_sessions(args.project_path)
+        if not sessions:
+            print(f"No sessions found for project: {args.project_path}")
+            sys.exit(1)
+
+        print(f"Searching {len(sessions)} session(s) for: {', '.join(args.keywords)}\n")
+
+        matches = analyzer.search_sessions(
+            sessions, args.keywords, args.case_sensitive
+        )
+
+        if not matches:
+            print("No matches found.")
+            sys.exit(0)
+
+        # Sort by total mentions
+        sorted_matches = sorted(
+            matches.items(), key=lambda x: x[1]["total_mentions"], reverse=True
+        )
+
+        print(f"Found {len(matches)} session(s) with matches:\n")
+
+        for session, info in sorted_matches:
+            mtime = datetime.fromtimestamp(info["modified_time"])
+            print(f"📄 {session.name}")
+            print(f"   Date: {mtime.strftime('%Y-%m-%d %H:%M')}")
+            print(f"   Total mentions: {info['total_mentions']}")
+            print(f"   Keywords: {', '.join(f'{k}({v})' for k, v in info['keyword_counts'].items())}")
+            print(f"   Path: {session}")
+            print()
+
+    elif args.command == "stats":
+        if not args.session_file.exists():
+            print(f"Error: Session file not found: {args.session_file}")
+            sys.exit(1)
+
+        print(f"Analyzing session: {args.session_file}\n")
+
+        stats = analyzer.get_session_stats(args.session_file)
+
+        print("=" * 60)
+        print("Session Statistics")
+        print("=" * 60)
+        print(f"\nMessages:")
+        print(f"  Total lines: {stats['total_lines']:,}")
+        print(f"  User messages: {stats['user_messages']}")
+        print(f"  Assistant messages: {stats['assistant_messages']}")
+
+        print(f"\nTool Usage:")
+        print(f"  Write calls: {stats['write_calls']}")
+        print(f"  Edit calls: {stats['edit_calls']}")
+        print(f"  Read calls: {stats['read_calls']}")
+        print(f"  Bash calls: {stats['bash_calls']}")
+
+        if stats["tool_uses"]:
+            print(f"\n  All tools:")
+            for tool, count in sorted(
+                stats["tool_uses"].items(), key=lambda x: x[1], reverse=True
+            ):
+                print(f"    {tool}: {count}")
+
+        if args.show_files and stats["file_operations"]:
+            print(f"\nFile Operations ({len(stats['file_operations'])}):")
+            # Group by file
+            files = defaultdict(list)
+            for op, path in stats["file_operations"]:
+                files[path].append(op)
+
+            # Limit to 20 files to prevent terminal flooding on large sessions
+            for file_path, ops in list(files.items())[:20]:
+                filename = Path(file_path).name
+                op_summary = ", ".join(
+                    f"{op}({ops.count(op)})" for op in set(ops)
+                )
+                print(f"  {filename}")
+                print(f"    Operations: {op_summary}")
+                print(f"    Path: {file_path}")
+
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/claude-code-history-files-finder/scripts/recover_content.py
+++ b/claude-code-history-files-finder/scripts/recover_content.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""
+Recover content from Claude Code history session files.
+
+This script extracts Write tool calls, Edit operations, and text content
+from Claude Code's JSONL session history files.
+"""
+
+import json
+import sys
+import os
+from pathlib import Path
+from typing import Dict, List, Any, Optional
+from datetime import datetime
+
+
+class SessionContentRecovery:
+    """Extract and recover content from Claude Code session files."""
+
+    def __init__(self, session_file: Path, output_dir: Optional[Path] = None):
+        self.session_file = Path(session_file)
+        self.output_dir = output_dir or Path.cwd() / "recovered_content"
+        self.output_dir.mkdir(exist_ok=True)
+
+        # Statistics
+        self.stats = {
+            "total_lines": 0,
+            "write_calls": 0,
+            "edit_calls": 0,
+            "text_mentions": 0,
+            "files_recovered": 0,
+        }
+
+    def extract_write_calls(self) -> List[Dict[str, Any]]:
+        """Extract all Write tool calls from session."""
+        write_calls = []
+
+        with open(self.session_file, "r") as f:
+            for line_num, line in enumerate(f, 1):
+                self.stats["total_lines"] += 1
+
+                try:
+                    data = json.loads(line.strip())
+
+                    # Check both direct role and nested message.role
+                    role = data.get("role") or data.get("message", {}).get("role")
+                    if role != "assistant":
+                        continue
+
+                    # Get content from either location
+                    content = data.get("content") or data.get("message", {}).get(
+                        "content", []
+                    )
+
+                    for item in content:
+                        if not isinstance(item, dict):
+                            continue
+
+                        # Look for Write tool calls
+                        if item.get("type") == "tool_use" and item.get("name") == "Write":
+                            write_input = item.get("input", {})
+                            write_calls.append(
+                                {
+                                    "line": line_num,
+                                    "file_path": write_input.get("file_path", ""),
+                                    "content": write_input.get("content", ""),
+                                    "timestamp": data.get("timestamp", ""),
+                                }
+                            )
+                            self.stats["write_calls"] += 1
+
+                except json.JSONDecodeError:
+                    continue
+                except Exception as e:
+                    print(f"Warning: Error processing line {line_num}: {e}", file=sys.stderr)
+                    continue
+
+        return write_calls
+
+    def extract_edit_calls(self) -> List[Dict[str, Any]]:
+        """Extract all Edit tool calls from session."""
+        edit_calls = []
+
+        with open(self.session_file, "r") as f:
+            for line_num, line in enumerate(f, 1):
+                try:
+                    data = json.loads(line.strip())
+
+                    role = data.get("role") or data.get("message", {}).get("role")
+                    if role != "assistant":
+                        continue
+
+                    content = data.get("content") or data.get("message", {}).get(
+                        "content", []
+                    )
+
+                    for item in content:
+                        if not isinstance(item, dict):
+                            continue
+
+                        if item.get("type") == "tool_use" and item.get("name") == "Edit":
+                            edit_input = item.get("input", {})
+                            edit_calls.append(
+                                {
+                                    "line": line_num,
+                                    "file_path": edit_input.get("file_path", ""),
+                                    "old_string": edit_input.get("old_string", ""),
+                                    "new_string": edit_input.get("new_string", ""),
+                                    "timestamp": data.get("timestamp", ""),
+                                }
+                            )
+                            self.stats["edit_calls"] += 1
+
+                except Exception:
+                    continue
+
+        return edit_calls
+
+    def save_recovered_files(
+        self, write_calls: List[Dict[str, Any]], keywords: Optional[List[str]] = None
+    ) -> List[Dict[str, Any]]:
+        """
+        Save recovered files to disk.
+
+        Args:
+            write_calls: List of Write tool calls
+            keywords: Optional keywords to filter files (matches any keyword in file path)
+
+        Returns:
+            List of saved file metadata
+        """
+        saved = []
+
+        # Filter by keywords if provided
+        if keywords:
+            write_calls = [
+                call
+                for call in write_calls
+                if any(kw.lower() in call["file_path"].lower() for kw in keywords)
+            ]
+
+        # Deduplicate: keep latest version of each file
+        files_by_path = {}
+        for call in write_calls:
+            file_path = call["file_path"]
+            if not file_path:
+                continue
+
+            # Keep latest version (assuming chronological order in session)
+            files_by_path[file_path] = call
+
+        # Save files
+        for file_path, call in files_by_path.items():
+            try:
+                filename = Path(file_path).name
+                if not filename:
+                    continue
+
+                output_file = self.output_dir / filename
+
+                with open(output_file, "w") as f:
+                    f.write(call["content"])
+
+                saved.append(
+                    {
+                        "file": filename,
+                        "original_path": file_path,
+                        "size": len(call["content"]),
+                        "lines": call["content"].count("\n") + 1,
+                        "timestamp": call.get("timestamp", "unknown"),
+                        "output_path": str(output_file),
+                    }
+                )
+
+                self.stats["files_recovered"] += 1
+
+            except Exception as e:
+                print(f"Warning: Failed to save {file_path}: {e}", file=sys.stderr)
+                continue
+
+        return saved
+
+    def generate_report(self, saved_files: List[Dict[str, Any]]) -> str:
+        """Generate recovery report."""
+        report_lines = [
+            "=" * 60,
+            "Claude Code Session Content Recovery Report",
+            "=" * 60,
+            "",
+            f"Session file: {self.session_file}",
+            f"Output directory: {self.output_dir}",
+            "",
+            "Statistics:",
+            f"  Total lines processed: {self.stats['total_lines']:,}",
+            f"  Write tool calls found: {self.stats['write_calls']}",
+            f"  Edit tool calls found: {self.stats['edit_calls']}",
+            f"  Files recovered: {self.stats['files_recovered']}",
+            "",
+        ]
+
+        if saved_files:
+            report_lines.extend(
+                [
+                    "Recovered Files:",
+                    "",
+                ]
+            )
+
+            for item in saved_files:
+                report_lines.extend(
+                    [
+                        f"✅ {item['file']}",
+                        f"   Original: {item['original_path']}",
+                        f"   Size: {item['size']:,} characters",
+                        f"   Lines: {item['lines']:,}",
+                        f"   Saved to: {item['output_path']}",
+                        "",
+                    ]
+                )
+        else:
+            report_lines.append("No files recovered (no matches or no Write calls found)")
+            report_lines.append("")
+
+        report_lines.extend(["=" * 60, ""])
+
+        return "\n".join(report_lines)
+
+
+def main():
+    """Main entry point."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Recover content from Claude Code session history files"
+    )
+    parser.add_argument(
+        "session_file",
+        type=Path,
+        help="Path to Claude Code session JSONL file",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        help="Output directory (default: ./recovered_content)",
+    )
+    parser.add_argument(
+        "-k",
+        "--keywords",
+        nargs="+",
+        help="Filter files by keywords (matches any keyword in file path)",
+    )
+    parser.add_argument(
+        "--show-edits",
+        action="store_true",
+        help="Also show Edit operations (not saved, just listed)",
+    )
+
+    args = parser.parse_args()
+
+    # Validate session file exists
+    if not args.session_file.exists():
+        print(f"Error: Session file not found: {args.session_file}", file=sys.stderr)
+        sys.exit(1)
+
+    # Create recovery instance
+    recovery = SessionContentRecovery(args.session_file, args.output)
+
+    print(f"🔍 Analyzing session: {args.session_file}")
+    print(f"📂 Output directory: {recovery.output_dir}\n")
+
+    # Extract Write calls
+    print("1️⃣ Extracting Write tool calls...")
+    write_calls = recovery.extract_write_calls()
+    print(f"   Found {len(write_calls)} Write calls\n")
+
+    # Save files
+    print("2️⃣ Saving recovered files...")
+    if args.keywords:
+        print(f"   Filtering by keywords: {', '.join(args.keywords)}")
+    saved = recovery.save_recovered_files(write_calls, args.keywords)
+    print(f"   Saved {len(saved)} files\n")
+
+    # Optionally show edits
+    if args.show_edits:
+        print("3️⃣ Extracting Edit tool calls...")
+        edit_calls = recovery.extract_edit_calls()
+        print(f"   Found {len(edit_calls)} Edit calls")
+        if edit_calls:
+            print("\n   Recent edits:")
+            for edit in edit_calls[-5:]:  # Show last 5
+                print(f"   - {Path(edit['file_path']).name} (line {edit['line']})")
+        print()
+
+    # Generate and print report
+    report = recovery.generate_report(saved)
+    print(report)
+
+    # Save report
+    report_file = recovery.output_dir / "recovery_report.txt"
+    with open(report_file, "w") as f:
+        f.write(report)
+    print(f"📄 Report saved to: {report_file}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/claude-md-progressive-disclosurer/.security-scan-passed
+++ b/claude-md-progressive-disclosurer/.security-scan-passed
@@ -1,0 +1,4 @@
+Security scan passed
+Scanned at: 2025-12-11T20:19:33.266025
+Tool: gitleaks + pattern-based validation
+Content hash: 864b1b4fa2851e26012b06cd3bcb5eb8810ab2cfd3240ba5b48af1895ad182ce

--- a/claude-md-progressive-disclosurer/SKILL.md
+++ b/claude-md-progressive-disclosurer/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: claude-md-progressive-disclosurer
+description: Optimize user CLAUDE.md files by applying progressive disclosure principles. This skill should be used when users want to reduce CLAUDE.md bloat, move detailed content to references, extract reusable patterns into skills, or improve context efficiency. Triggers include "optimize CLAUDE.md", "reduce CLAUDE.md size", "apply progressive disclosure", or complaints about CLAUDE.md being too long.
+---
+
+# CLAUDE.md Progressive Disclosure Optimizer
+
+Analyze and optimize user CLAUDE.md files to reduce context overhead while preserving functionality.
+
+## Quick Start
+
+1. Read the user's `~/.claude/CLAUDE.md`
+2. Analyze each section using the classification criteria below
+3. Propose optimizations with before/after line counts
+4. Execute approved changes
+
+## Section Classification
+
+Analyze each section and classify:
+
+| Category | Criteria | Action |
+|----------|----------|--------|
+| **Keep in CLAUDE.md** | Core principles, short rules (<10 lines), frequently needed | Keep as-is |
+| **Move to references/** | Detailed procedures, code examples, troubleshooting guides | Create `~/.claude/references/<name>.md` |
+| **Extract to skill** | Reusable workflows, scripts, domain-specific knowledge | Create skill in skills repository |
+| **Remove** | Duplicates existing skills, outdated, or unnecessary | Delete after confirmation |
+
+## Optimization Workflow
+
+### Step 1: Audit Current State
+
+```
+Task Progress:
+- [ ] Read ~/.claude/CLAUDE.md
+- [ ] Count total lines
+- [ ] List all ## sections with line counts
+- [ ] Identify sections >20 lines
+```
+
+### Step 2: Classify Each Section
+
+For each section >20 lines, determine:
+
+1. **Frequency**: How often is this information needed?
+2. **Complexity**: Does it contain code blocks, tables, or detailed steps?
+3. **Reusability**: Could other users benefit from this as a skill?
+
+### Step 3: Propose Changes
+
+Present optimization plan in this format:
+
+```markdown
+## Optimization Proposal
+
+**Current**: X lines
+**After**: Y lines (Z% reduction)
+
+| Section | Lines | Action | Destination |
+|---------|-------|--------|-------------|
+| Section A | 50 | Move to references | ~/.claude/references/section_a.md |
+| Section B | 80 | Extract to skill | skill-name/ |
+| Section C | 5 | Keep | - |
+```
+
+### Step 4: Execute Changes
+
+After user approval:
+
+1. Create reference files in `~/.claude/references/`
+2. Update CLAUDE.md with pointers to moved content
+3. Create skills if applicable
+4. Report final line count
+
+## Reference File Format
+
+When moving content to `~/.claude/references/`:
+
+```markdown
+# [Section Title]
+
+[Full original content, possibly enhanced with additional examples]
+```
+
+## CLAUDE.md Pointer Format
+
+Replace moved sections with:
+
+```markdown
+## [Section Title]
+
+[One-line summary]. See `~/.claude/references/[filename].md`
+```
+
+## Best Practices
+
+- **Keep core principles visible**: Rules like "never do X" should stay in CLAUDE.md
+- **Group related references**: Combine small related sections into one reference file
+- **Preserve quick commands**: Keep frequently-used command snippets in CLAUDE.md
+- **Test after optimization**: Ensure Claude can still find moved information
+
+## Common Patterns
+
+### Pattern: Infrastructure/Credentials
+**Before**: Full API examples, deployment scripts, server lists
+**After**: One-line pointer to `~/.claude/references/infrastructure.md`
+
+### Pattern: Code Generation Rules
+**Before**: 50+ lines of coding standards with examples
+**After**: Keep bullet-point rules, move examples to references
+
+### Pattern: Reusable Workflows
+**Before**: Complete scripts embedded in CLAUDE.md
+**After**: Extract to skill with scripts/ directory

--- a/claude-md-progressive-disclosurer/SKILL.md
+++ b/claude-md-progressive-disclosurer/SKILL.md
@@ -9,10 +9,13 @@ Analyze and optimize user CLAUDE.md files to reduce context overhead while prese
 
 ## Quick Start
 
-1. Read the user's `~/.claude/CLAUDE.md`
-2. Analyze each section using the classification criteria below
-3. Propose optimizations with before/after line counts
-4. Execute approved changes
+1. **Backup** the original file first
+2. **Audit** the current state (list all sections with line counts)
+3. **Classify** each section using the criteria below
+4. **Propose** optimizations with before/after comparison table
+5. **Verify** information completeness checklist before executing
+6. **Execute** approved changes
+7. **Test** that moved content remains discoverable
 
 ## Section Classification
 
@@ -25,12 +28,44 @@ Analyze each section and classify:
 | **Extract to skill** | Reusable workflows, scripts, domain-specific knowledge | Create skill in skills repository |
 | **Remove** | Duplicates existing skills, outdated, or unnecessary | Delete after confirmation |
 
+### Exceptions to Size Guidelines
+
+Even if a section is >50 lines, **KEEP in CLAUDE.md** if any of these apply:
+
+| Exception | Reason | Example |
+|-----------|--------|---------|
+| **Safety-critical** | Consequences of forgetting are severe | Deployment protocols, "never force push to main" |
+| **High-frequency** | Referenced in most conversations | Core development patterns, common commands |
+| **Easy to violate** | Claude tends to ignore when not visible | Code style rules, permission requirements |
+| **Security-sensitive** | Must be always enforced | Production access restrictions, data handling rules |
+
+**Rule of thumb**: If forgetting the rule could cause production incidents, data loss, or security breaches, keep it visible regardless of length.
+
 ## Optimization Workflow
+
+### Step 0: Backup Original File
+
+**CRITICAL**: Always create a backup before any changes.
+
+```bash
+# Create timestamped backup
+cp ~/.claude/CLAUDE.md ~/.claude/CLAUDE.md.bak.$(date +%Y%m%d_%H%M%S)
+
+# For project-level CLAUDE.md
+cp CLAUDE.md CLAUDE.md.bak.$(date +%Y%m%d_%H%M%S)
+```
+
+If issues found after optimization:
+```bash
+# Restore from backup
+cp ~/.claude/CLAUDE.md.bak.YYYYMMDD_HHMMSS ~/.claude/CLAUDE.md
+```
 
 ### Step 1: Audit Current State
 
 ```
 Task Progress:
+- [ ] Create backup (Step 0)
 - [ ] Read ~/.claude/CLAUDE.md
 - [ ] Count total lines
 - [ ] List all ## sections with line counts
@@ -62,14 +97,84 @@ Present optimization plan in this format:
 | Section C | 5 | Keep | - |
 ```
 
+### Step 3.5: Pre-execution Verification Checklist
+
+**CRITICAL**: Before executing any changes, verify information completeness.
+
+For each section being moved or modified:
+
+1. **Extract key items** to verify:
+   - Credentials/passwords/API keys
+   - Critical rules ("never do X", "always do Y")
+   - Specific values (ports, IPs, URLs, paths)
+   - Code snippets that are frequently referenced
+   - Cross-references to other sections
+
+2. **Create verification checklist**:
+   ```markdown
+   ## Verification Checklist for [Section Name]
+
+   | Key Item | Original Location | New Location | Verified |
+   |----------|-------------------|--------------|----------|
+   | Server IP 47.96.x.x | Line 123 | infrastructure.md:15 | [ ] |
+   | "Never push to main" rule | Line 45 | Kept in CLAUDE.md | [ ] |
+   | Login credentials | Line 200 | api-login.md:30 | [ ] |
+   ```
+
+3. **Check cross-references**:
+   - If Section A references Section B, ensure links work after moving
+   - Update any relative paths to absolute paths if needed
+
 ### Step 4: Execute Changes
 
-After user approval:
+After user approval AND verification checklist complete:
 
 1. Create reference files in `~/.claude/references/`
 2. Update CLAUDE.md with pointers to moved content
 3. Create skills if applicable
-4. Report final line count
+4. **Verify each checklist item exists in new location**
+5. Report final line count
+
+### Step 5: Post-optimization Testing
+
+Verify that Claude can still discover moved content:
+
+1. **Test discoverability** - Ask questions that require moved content:
+   ```
+   Test queries to run:
+   - "How do I connect to the production database?"
+   - "What are the deployment steps for [service]?"
+   - "Show me the credentials for [system]"
+   ```
+
+2. **Verify pointer functionality** - Each "See `reference.md`" link should work:
+   ```bash
+   # Check all referenced files exist
+   grep -oh '`~/.claude/references/[^`]*`' ~/.claude/CLAUDE.md | \
+     sed 's/`//g' | while read f; do
+       eval test -f "$f" && echo "✓ $f" || echo "✗ MISSING: $f"
+     done
+   ```
+
+3. **Compare with backup** - Ensure no unintended deletions:
+   ```bash
+   diff ~/.claude/CLAUDE.md.bak.* ~/.claude/CLAUDE.md | grep "^<" | head -20
+   ```
+
+4. **Document results**:
+   ```markdown
+   ## Optimization Results
+
+   | Metric | Before | After |
+   |--------|--------|-------|
+   | Total lines | X | Y |
+   | Reduction | - | Z% |
+   | References created | - | N files |
+   | Skills extracted | - | M skills |
+
+   **Verification**: All N checklist items verified ✓
+   **Testing**: All K test queries returned correct information ✓
+   ```
 
 ## Reference File Format
 
@@ -111,3 +216,42 @@ Replace moved sections with:
 ### Pattern: Reusable Workflows
 **Before**: Complete scripts embedded in CLAUDE.md
 **After**: Extract to skill with scripts/ directory
+
+## Project-Level vs User-Level CLAUDE.md
+
+This skill handles both types, but strategies differ:
+
+### User-Level (`~/.claude/CLAUDE.md`)
+
+| Aspect | Approach |
+|--------|----------|
+| **Reference location** | `~/.claude/references/` |
+| **Scope** | Personal preferences, global rules |
+| **Sharing** | Not shared, personal only |
+| **Size target** | 100-200 lines ideal |
+
+### Project-Level (`/path/to/project/CLAUDE.md`)
+
+| Aspect | Approach |
+|--------|----------|
+| **Reference location** | `docs/` or `.claude/` in project root |
+| **Scope** | Project-specific patterns, architecture |
+| **Sharing** | Committed to git, shared with team |
+| **Size target** | 300-600 lines acceptable (more project context needed) |
+
+### Key Differences
+
+1. **Reference paths**: Use relative paths for project-level (`docs/best-practices/`)
+2. **Git considerations**: Project references are versioned with code
+3. **Team alignment**: Project CLAUDE.md should reflect team consensus
+4. **Update frequency**: Project-level changes more often as code evolves
+
+### Project-Level Pointer Format
+
+```markdown
+## [Section Title]
+
+[Summary]. See `docs/06-best-practices/[topic].md`
+```
+
+**Note**: For project CLAUDE.md, prefer `docs/` over hidden directories for discoverability by human team members.

--- a/claude-md-progressive-disclosurer/references/progressive_disclosure_principles.md
+++ b/claude-md-progressive-disclosurer/references/progressive_disclosure_principles.md
@@ -1,0 +1,88 @@
+# Progressive Disclosure Principles for CLAUDE.md
+
+## Core Concept
+
+Progressive disclosure is a design pattern that sequences information based on need. For CLAUDE.md:
+
+- **Level 1 (Always loaded)**: CLAUDE.md core content (~100-200 lines ideal)
+- **Level 2 (On-demand)**: `~/.claude/references/` files
+- **Level 3 (Skill-triggered)**: Skills with their own SKILL.md and resources
+
+## Token Economics
+
+Every line in CLAUDE.md consumes context tokens on EVERY conversation. Moving 100 lines to references saves tokens on conversations that don't need that information.
+
+**Example calculation**:
+- CLAUDE.md with 500 lines ≈ 2000 tokens per conversation
+- Optimized 150 lines ≈ 600 tokens per conversation
+- 10 conversations/day = 14,000 tokens saved daily
+
+## What Belongs in CLAUDE.md
+
+### Must Include
+- Identity/persona instructions
+- Critical safety rules ("never do X")
+- Frequently-referenced short rules
+- Tool preferences (ast-grep, difft, uv)
+- Directory/path conventions
+
+### Should Move to References
+- Detailed API examples (>5 lines of code)
+- Troubleshooting guides with multiple steps
+- Infrastructure credentials and procedures
+- Deployment workflows
+- Database schemas
+
+### Should Become Skills
+- Reusable workflows with scripts
+- Domain-specific knowledge bases
+- Complex multi-step procedures
+- Anything another user might benefit from
+
+## Section Size Guidelines
+
+| Lines | Recommendation |
+|-------|----------------|
+| 1-10 | Keep in CLAUDE.md |
+| 11-30 | Consider consolidating or moving |
+| 31-50 | Strongly consider moving to references |
+| 50+ | Must move to references or extract to skill |
+
+## Reference File Organization
+
+```
+~/.claude/
+├── CLAUDE.md                    # Core principles only
+└── references/
+    ├── infrastructure.md        # Servers, APIs, credentials paths
+    ├── coding_standards.md      # Detailed code examples
+    ├── troubleshooting.md       # Common issues and solutions
+    └── domain_knowledge.md      # Project-specific information
+```
+
+## Anti-Patterns
+
+### 1. Embedded Scripts
+**Bad**: 100-line Python script in CLAUDE.md
+**Good**: Script in skill's `scripts/` directory
+
+### 2. Duplicate Documentation
+**Bad**: Same info in CLAUDE.md and a skill
+**Good**: Single source of truth with pointers
+
+### 3. Rarely-Used Details
+**Bad**: Edge-case procedures in CLAUDE.md
+**Good**: Edge cases in references, linked when relevant
+
+### 4. Version-Specific Instructions
+**Bad**: "If using v2.3, do X; if v2.4, do Y"
+**Good**: Current version only, archive old versions
+
+## Measuring Success
+
+After optimization, verify:
+
+1. **Line count reduction**: Target 50%+ reduction
+2. **Information preserved**: All functionality still accessible
+3. **Discoverability**: Claude finds moved content when needed
+4. **Maintenance**: Easier to update individual reference files

--- a/claude-md-progressive-disclosurer/references/progressive_disclosure_principles.md
+++ b/claude-md-progressive-disclosurer/references/progressive_disclosure_principles.md
@@ -46,7 +46,20 @@ Every line in CLAUDE.md consumes context tokens on EVERY conversation. Moving 10
 | 1-10 | Keep in CLAUDE.md |
 | 11-30 | Consider consolidating or moving |
 | 31-50 | Strongly consider moving to references |
-| 50+ | Must move to references or extract to skill |
+| 50+ | Move to references or extract to skill |
+
+### Exceptions (Keep Regardless of Size)
+
+**Do NOT move** even if >50 lines:
+
+| Category | Reason | Examples |
+|----------|--------|----------|
+| **Safety-critical** | Severe consequences if forgotten | Deployment protocols, production access rules |
+| **High-frequency** | Used in most conversations | Core commands, common patterns |
+| **Easily violated** | Claude ignores when not visible | Style rules, permission checks |
+| **Security-sensitive** | Must always be enforced | Data handling, access restrictions |
+
+**Rule**: If forgetting causes production incidents, data loss, or security breaches → keep visible.
 
 ## Reference File Organization
 
@@ -86,3 +99,49 @@ After optimization, verify:
 2. **Information preserved**: All functionality still accessible
 3. **Discoverability**: Claude finds moved content when needed
 4. **Maintenance**: Easier to update individual reference files
+
+### Verification Methods
+
+#### 1. Information Preservation Check
+
+Before executing, create a checklist of key items from each moved section:
+
+```markdown
+| Key Item | Original Line | New Location | Verified |
+|----------|---------------|--------------|----------|
+| Server IP | L123 | infra.md:15 | [ ] |
+| Password | L200 | infra.md:42 | [ ] |
+| Critical rule | L45 | Kept | [ ] |
+```
+
+#### 2. Discoverability Test
+
+After optimization, test with real queries:
+
+```
+Test: "How do I deploy to production?"
+Expected: Should find deployment steps in reference file
+
+Test: "What's the database password?"
+Expected: Should find in infrastructure reference
+
+Test: "Can I force push to main?"
+Expected: Should find rule (ideally still in CLAUDE.md)
+```
+
+#### 3. Pointer Verification Script
+
+```bash
+# Check all referenced files exist
+grep -oh '`[^`]*\.md`' ~/.claude/CLAUDE.md | \
+  sed 's/`//g' | while read f; do
+    test -f "$f" && echo "✓ $f" || echo "✗ MISSING: $f"
+  done
+```
+
+#### 4. Backup Comparison
+
+```bash
+# See what was removed
+diff ~/.claude/CLAUDE.md.bak.* ~/.claude/CLAUDE.md | grep "^<"
+```

--- a/demos/index.html
+++ b/demos/index.html
@@ -548,7 +548,7 @@
             <p>Install the Claude Code Skills Marketplace and start using these skills today!</p>
             <br>
             <p><strong>Quick Install:</strong></p>
-            <p><code>/plugin marketplace add daymade/claude-code-skills</code></p>
+            <p><code>/plugin marketplace add https://github.com/daymade/claude-code-skills</code></p>
             <br>
             <p>
                 <a href="https://github.com/daymade/claude-code-skills" target="_blank">📖 Documentation</a> |

--- a/demos/index.html
+++ b/demos/index.html
@@ -548,7 +548,7 @@
             <p>Install the Claude Code Skills Marketplace and start using these skills today!</p>
             <br>
             <p><strong>Quick Install:</strong></p>
-            <p><code>/plugin marketplace add https://github.com/daymade/claude-code-skills</code></p>
+            <p><code>claude plugin marketplace add https://github.com/daymade/claude-code-skills</code></p>
             <br>
             <p>
                 <a href="https://github.com/daymade/claude-code-skills" target="_blank">📖 Documentation</a> |

--- a/docs-cleaner/.security-scan-passed
+++ b/docs-cleaner/.security-scan-passed
@@ -1,0 +1,4 @@
+Security scan passed
+Scanned at: 2025-12-01T19:34:07.888071
+Tool: gitleaks + pattern-based validation
+Content hash: 05162f259948be068f6d59cf0c66cf9971eb7b2fce92c8485b8332c80e440b49

--- a/docs-cleaner/SKILL.md
+++ b/docs-cleaner/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: docs-cleaner
+description: Consolidates redundant documentation while preserving all valuable content. This skill should be used when users want to clean up documentation bloat, merge redundant docs, reduce documentation sprawl, or consolidate multiple files covering the same topic. Triggers include "clean up docs", "consolidate documentation", "too many doc files", "merge these docs", or when documentation exceeds 500 lines across multiple files covering similar topics.
+---
+
+# Documentation Cleaner
+
+Consolidate redundant documentation while preserving 100% of valuable content.
+
+## Core Principle
+
+**Critical evaluation before deletion.** Never blindly delete. Analyze each section's unique value before proposing removal. The goal is reduction without information loss.
+
+## Workflow
+
+### Phase 1: Discovery
+
+1. Identify all documentation files covering the topic
+2. Count total lines across files
+3. Map content overlap between documents
+
+### Phase 2: Value Analysis
+
+For each document, create a section-by-section analysis table:
+
+| Section | Lines | Value | Reason |
+|---------|-------|-------|--------|
+| API Reference | 25 | Keep | Unique endpoint documentation |
+| Setup Steps | 40 | Condense | Verbose but essential |
+| Test Results | 30 | Delete | One-time record, not reference |
+
+Value categories:
+- **Keep**: Unique, essential, frequently referenced
+- **Condense**: Valuable but verbose
+- **Delete**: Duplicate, one-time, self-evident, outdated
+
+See `references/value_analysis_template.md` for detailed criteria.
+
+### Phase 3: Consolidation Plan
+
+Propose target structure:
+
+```
+Before: 726 lines (3 files, high redundancy)
+After:  ~100 lines (1 file + reference in CLAUDE.md)
+Reduction: 86%
+Value preserved: 100%
+```
+
+### Phase 4: Execution
+
+1. Create consolidated document with all valuable content
+2. Delete redundant source files
+3. Update references (CLAUDE.md, README, imports)
+4. Verify no broken links
+
+## Value Preservation Checklist
+
+Before finalizing, confirm preservation of:
+
+- [ ] Essential procedures (setup, configuration)
+- [ ] Key constraints and gotchas
+- [ ] Troubleshooting guides
+- [ ] Technical debt / roadmap items
+- [ ] External links and references
+- [ ] Debug tips and code snippets
+
+## Anti-Patterns
+
+| Pattern | Problem | Solution |
+|---------|---------|----------|
+| Blind deletion | Loses valuable information | Section-by-section analysis first |
+| Keeping everything | No reduction achieved | Apply value criteria strictly |
+| Multiple sources of truth | Future divergence | Single authoritative location |
+| Orphaned references | Broken links | Update all references after consolidation |
+
+## Output Artifacts
+
+A successful cleanup produces:
+
+1. **Consolidated document** - Single source of truth
+2. **Value analysis** - Section-by-section justification
+3. **Before/after metrics** - Lines reduced, value preserved
+4. **Updated references** - CLAUDE.md or README with pointer to new location

--- a/docs-cleaner/references/value_analysis_template.md
+++ b/docs-cleaner/references/value_analysis_template.md
@@ -1,0 +1,50 @@
+# Value Analysis Template
+
+Use this template for section-by-section documentation analysis.
+
+## Document Analysis Table
+
+| Section | Lines | Value | Reason |
+|---------|-------|-------|--------|
+| Example Section | 25 | Keep | Contains unique troubleshooting steps not documented elsewhere |
+| Another Section | 40 | Delete | Duplicates content in CLAUDE.md |
+| Technical Details | 60 | Condense | Valuable but verbose; can be reduced to 15 lines |
+| Setup Instructions | 30 | Keep | Essential for onboarding |
+
+## Value Categories
+
+### Keep (Green)
+- Unique information not found elsewhere
+- Essential procedures (setup, troubleshooting, constraints)
+- Frequently referenced content
+- Technical debt / roadmap items
+
+### Condense (Yellow)
+- Valuable but overly verbose
+- Contains redundant examples
+- Can be expressed more concisely
+
+### Delete (Red)
+- Duplicates existing documentation
+- One-time records (test results, meeting notes)
+- Self-evident information (code already documents this)
+- Outdated or superseded content
+
+## Consolidation Checklist
+
+Before proposing deletions:
+
+- [ ] Identified ALL files containing related content
+- [ ] Mapped overlap between documents
+- [ ] Listed unique value in each document
+- [ ] Proposed single source of truth location
+- [ ] Planned reference updates (CLAUDE.md, README, etc.)
+
+## Output Format
+
+After analysis, produce:
+
+1. **Value Analysis Table** - Per-section breakdown with keep/condense/delete
+2. **Consolidation Plan** - Target structure with line count estimates
+3. **Before/After Comparison** - Total lines and percentage reduction
+4. **Preserved Value Checklist** - Confirm all valuable content retained

--- a/fact-checker/.security-scan-passed
+++ b/fact-checker/.security-scan-passed
@@ -1,0 +1,4 @@
+Security scan passed
+Scanned at: 2026-01-05T23:29:12.688630
+Tool: gitleaks + pattern-based validation
+Content hash: f0ee8b5411aeb2d3058383ae536393e4e71e0fe0c240d0798a50aa10399870d4

--- a/fact-checker/README.md
+++ b/fact-checker/README.md
@@ -1,0 +1,188 @@
+# Fact Checker
+
+Verify factual claims in documents using web search and official sources, then apply corrections with user confirmation.
+
+## Features
+
+- ✅ Comprehensive fact verification across multiple domains
+- 🔍 Searches authoritative sources (official docs, API specs, academic papers)
+- 📊 Generates detailed correction reports with sources
+- 🤖 Auto-applies corrections after user approval
+- 🕐 Adds temporal context to prevent information decay
+
+## Supported Claim Types
+
+- **AI Model Specifications**: Context windows, pricing, features, benchmarks
+- **Technical Documentation**: API capabilities, version numbers, library features
+- **Statistical Data**: Metrics, benchmark scores, performance data
+- **General Facts**: Any verifiable factual statement
+
+## Usage Examples
+
+### Example 1: Update Outdated AI Model Info
+
+```
+User: Fact-check the AI model specifications in section 2.1
+```
+
+**What happens:**
+1. Identifies claims: "Claude 3.5 Sonnet: 200K tokens", "GPT-4o: 128K tokens"
+2. Searches official documentation for current models
+3. Finds: Claude Sonnet 4.5, GPT-5.2 with updated specs
+4. Generates correction report with sources
+5. Applies fixes after user confirms
+
+### Example 2: Verify Technical Claims
+
+```
+User: Check if these library versions are still current
+```
+
+**What happens:**
+1. Extracts version numbers from document
+2. Checks package registries (npm, PyPI, etc.)
+3. Identifies outdated versions
+4. Suggests updates with changelog references
+
+### Example 3: Validate Statistics
+
+```
+User: Verify the benchmark scores in this section
+```
+
+**What happens:**
+1. Identifies numerical claims and metrics
+2. Searches official benchmark publications
+3. Compares document values vs. source data
+4. Flags discrepancies with authoritative links
+
+## Workflow
+
+The skill follows a 5-step process:
+
+```
+Fact-checking Progress:
+- [ ] Step 1: Identify factual claims
+- [ ] Step 2: Search authoritative sources
+- [ ] Step 3: Compare claims against sources
+- [ ] Step 4: Generate correction report
+- [ ] Step 5: Apply corrections with user approval
+```
+
+## Source Evaluation
+
+**Preferred sources (in order):**
+1. Official product pages and documentation
+2. API documentation and developer guides
+3. Official blog announcements
+4. GitHub releases (for open source)
+
+**Use with caution:**
+- Third-party aggregators (verify against official sources)
+- Blog posts and articles (cross-reference)
+
+**Avoid:**
+- Outdated documentation
+- Unofficial wikis without citations
+- Speculation and rumors
+
+## Real-World Example
+
+**Before:**
+```markdown
+AI 大模型的"上下文窗口"不断升级：
+- Claude 3.5 Sonnet: 200K tokens（约 15 万汉字）
+- GPT-4o: 128K tokens（约 10 万汉字）
+- Gemini 1.5 Pro: 2M tokens（约 150 万汉字）
+```
+
+**After fact-checking:**
+```markdown
+AI 大模型的"上下文窗口"不断升级（截至 2026 年 1 月）：
+- Claude Sonnet 4.5: 200K tokens（约 15 万汉字）
+- GPT-5.2: 400K tokens（约 30 万汉字）
+- Gemini 3 Pro: 1M tokens（约 75 万汉字）
+```
+
+**Changes made:**
+- ✅ Updated Claude 3.5 Sonnet → Claude Sonnet 4.5
+- ✅ Corrected GPT-4o (128K) → GPT-5.2 (400K)
+- ✅ Fixed Gemini 1.5 Pro (2M) → Gemini 3 Pro (1M)
+- ✅ Added temporal marker "截至 2026 年 1 月"
+
+## Installation
+
+```bash
+# Via CCPM (recommended)
+ccpm install @daymade-skills/fact-checker
+
+# Manual installation
+Download fact-checker.zip and install through Claude Code
+```
+
+## Trigger Keywords
+
+The skill activates when you mention:
+- "fact-check this document"
+- "verify these claims"
+- "check if this is accurate"
+- "update outdated information"
+- "validate the data"
+
+## Configuration
+
+No configuration required. The skill works out of the box.
+
+## Limitations
+
+**Cannot verify:**
+- Subjective opinions or judgments
+- Future predictions or specifications
+- Claims requiring paywalled sources
+- Disputed facts without authoritative consensus
+
+**For such cases**, the skill will:
+- Note the limitation in the report
+- Suggest qualification language
+- Recommend user research or expert consultation
+
+## Best Practices
+
+### For Authors
+
+1. **Run regularly**: Fact-check documents periodically to catch outdated info
+2. **Include dates**: Add temporal markers like "as of [date]" to claims
+3. **Cite sources**: Keep original source links for future verification
+4. **Review reports**: Always review the correction report before applying changes
+
+### For Fact-Checking
+
+1. **Be specific**: Target specific sections rather than entire books
+2. **Verify critical claims first**: Prioritize high-impact information
+3. **Cross-reference**: For important claims, verify across multiple sources
+4. **Update regularly**: Technical specs change frequently - recheck periodically
+
+## Development
+
+Created with skill-creator v1.2.2 following Anthropic's best practices.
+
+**Testing:**
+- Verified on Claude Sonnet 4.5, Opus 4.5, and Haiku 4
+- Tested with real-world documentation updates
+- Validated correction workflow with user approval gates
+
+## Version History
+
+### 1.0.0 (2026-01-05)
+- Initial release
+- Support for AI models, technical docs, statistics
+- Auto-correction with user approval
+- Comprehensive source evaluation framework
+
+## License
+
+MIT License - See repository for details
+
+## Contributing
+
+Issues and pull requests welcome at [daymade/claude-code-skills](https://github.com/daymade/claude-code-skills)

--- a/fact-checker/SKILL.md
+++ b/fact-checker/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: fact-checker
+description: Verifies factual claims in documents using web search and official sources, then proposes corrections with user confirmation. Use when the user asks to fact-check, verify information, validate claims, check accuracy, or update outdated information in documents. Supports AI model specs, technical documentation, statistics, and general factual statements.
+---
+
+# Fact Checker
+
+Verify factual claims in documents and propose corrections backed by authoritative sources.
+
+## When to use
+
+Trigger when users request:
+- "Fact-check this document"
+- "Verify these AI model specifications"
+- "Check if this information is still accurate"
+- "Update outdated data in this file"
+- "Validate the claims in this section"
+
+## Workflow
+
+Copy this checklist to track progress:
+
+```
+Fact-checking Progress:
+- [ ] Step 1: Identify factual claims
+- [ ] Step 2: Search authoritative sources
+- [ ] Step 3: Compare claims against sources
+- [ ] Step 4: Generate correction report
+- [ ] Step 5: Apply corrections with user approval
+```
+
+### Step 1: Identify factual claims
+
+Scan the document for verifiable statements:
+
+**Target claim types:**
+- Technical specifications (context windows, pricing, features)
+- Version numbers and release dates
+- Statistical data and metrics
+- API capabilities and limitations
+- Benchmark scores and performance data
+
+**Skip subjective content:**
+- Opinions and recommendations
+- Explanatory prose
+- Tutorial instructions
+- Architectural discussions
+
+### Step 2: Search authoritative sources
+
+For each claim, search official sources:
+
+**AI models:**
+- Official announcement pages (anthropic.com/news, openai.com/index, blog.google)
+- API documentation (platform.claude.com/docs, platform.openai.com/docs)
+- Developer guides and release notes
+
+**Technical libraries:**
+- Official documentation sites
+- GitHub repositories (releases, README)
+- Package registries (npm, PyPI, crates.io)
+
+**General claims:**
+- Academic papers and research
+- Government statistics
+- Industry standards bodies
+
+**Search strategy:**
+- Use model names + specification (e.g., "Claude Opus 4.5 context window")
+- Include current year for recent information
+- Verify from multiple sources when possible
+
+### Step 3: Compare claims against sources
+
+Create a comparison table:
+
+| Claim in Document | Source Information | Status | Authoritative Source |
+|-------------------|-------------------|--------|---------------------|
+| Claude 3.5 Sonnet: 200K tokens | Claude Sonnet 4.5: 200K tokens | ❌ Outdated model name | platform.claude.com/docs |
+| GPT-4o: 128K tokens | GPT-5.2: 400K tokens | ❌ Incorrect version & spec | openai.com/index/gpt-5-2 |
+
+**Status codes:**
+- ✅ Accurate - claim matches sources
+- ❌ Incorrect - claim contradicts sources
+- ⚠️ Outdated - claim was true but superseded
+- ❓ Unverifiable - no authoritative source found
+
+### Step 4: Generate correction report
+
+Present findings in structured format:
+
+```markdown
+## Fact-Check Report
+
+### Summary
+- Total claims checked: X
+- Accurate: Y
+- Issues found: Z
+
+### Issues Requiring Correction
+
+#### Issue 1: Outdated AI Model Reference
+**Location:** Line 77-80 in docs/file.md
+**Current claim:** "Claude 3.5 Sonnet: 200K tokens"
+**Correction:** "Claude Sonnet 4.5: 200K tokens"
+**Source:** https://platform.claude.com/docs/en/build-with-claude/context-windows
+**Rationale:** Claude 3.5 Sonnet has been superseded by Claude Sonnet 4.5 (released Sept 2025)
+
+#### Issue 2: Incorrect Context Window
+**Location:** Line 79 in docs/file.md
+**Current claim:** "GPT-4o: 128K tokens"
+**Correction:** "GPT-5.2: 400K tokens"
+**Source:** https://openai.com/index/introducing-gpt-5-2/
+**Rationale:** 128K was output limit; context window is 400K. Model also updated to GPT-5.2
+```
+
+### Step 5: Apply corrections with user approval
+
+**Before making changes:**
+
+1. Show the correction report to the user
+2. Wait for explicit approval: "Should I apply these corrections?"
+3. Only proceed after confirmation
+
+**When applying corrections:**
+
+```python
+# Use Edit tool to update document
+# Example:
+Edit(
+    file_path="docs/03-写作规范/AI辅助写书方法论.md",
+    old_string="- Claude 3.5 Sonnet: 200K tokens（约 15 万汉字）",
+    new_string="- Claude Sonnet 4.5: 200K tokens（约 15 万汉字）"
+)
+```
+
+**After corrections:**
+
+1. Verify all edits were applied successfully
+2. Note the correction summary (e.g., "Updated 4 claims in section 2.1")
+3. Remind user to commit changes
+
+## Search best practices
+
+### Query construction
+
+**Good queries** (specific, current):
+- "Claude Opus 4.5 context window 2026"
+- "GPT-5.2 official release announcement"
+- "Gemini 3 Pro token limit specifications"
+
+**Poor queries** (vague, generic):
+- "Claude context"
+- "AI models"
+- "Latest version"
+
+### Source evaluation
+
+**Prefer official sources:**
+1. Product official pages (highest authority)
+2. API documentation
+3. Official blog announcements
+4. GitHub releases (for open source)
+
+**Use with caution:**
+- Third-party aggregators (llm-stats.com, etc.) - verify against official sources
+- Blog posts and articles - cross-reference claims
+- Social media - only for announcements, verify elsewhere
+
+**Avoid:**
+- Outdated documentation
+- Unofficial wikis without citations
+- Speculation and rumors
+
+### Handling ambiguity
+
+When sources conflict:
+
+1. Prioritize most recent official documentation
+2. Note the discrepancy in the report
+3. Present both sources to the user
+4. Recommend contacting vendor if critical
+
+When no source found:
+
+1. Mark as ❓ Unverifiable
+2. Suggest alternative phrasing: "According to [Source] as of [Date]..."
+3. Recommend adding qualification: "approximately", "reported as"
+
+## Special considerations
+
+### Time-sensitive information
+
+Always include temporal context:
+
+**Good corrections:**
+- "截至 2026 年 1 月" (As of January 2026)
+- "Claude Sonnet 4.5 (released September 2025)"
+
+**Poor corrections:**
+- "Latest version" (becomes outdated)
+- "Current model" (ambiguous timeframe)
+
+### Numerical precision
+
+Match precision to source:
+
+**Source says:** "approximately 1 million tokens"
+**Write:** "1M tokens (approximately)"
+
+**Source says:** "200,000 token context window"
+**Write:** "200K tokens" (exact)
+
+### Citation format
+
+Include citations in corrections:
+
+```markdown
+> **注**：具体上下文窗口以模型官方文档为准，本书写作时使用 Claude Sonnet 4.5 为主要工具。
+```
+
+Link to sources when possible.
+
+## Examples
+
+### Example 1: Technical specification update
+
+**User request:** "Fact-check the AI model context windows in section 2.1"
+
+**Process:**
+1. Identify claims: Claude 3.5 Sonnet (200K), GPT-4o (128K), Gemini 1.5 Pro (2M)
+2. Search official docs for current models
+3. Find: Claude Sonnet 4.5, GPT-5.2, Gemini 3 Pro
+4. Generate report showing discrepancies
+5. Apply corrections after approval
+
+### Example 2: Statistical data verification
+
+**User request:** "Verify the benchmark scores in chapter 5"
+
+**Process:**
+1. Extract numerical claims
+2. Search for official benchmark publications
+3. Compare reported vs. source values
+4. Flag any discrepancies with source links
+5. Update with verified figures
+
+### Example 3: Version number validation
+
+**User request:** "Check if these library versions are still current"
+
+**Process:**
+1. List all version numbers mentioned
+2. Check package registries (npm, PyPI, etc.)
+3. Identify outdated versions
+4. Suggest updates with changelog references
+5. Update after user confirms
+
+## Quality checklist
+
+Before completing fact-check:
+
+- [ ] All factual claims identified and categorized
+- [ ] Each claim verified against official sources
+- [ ] Sources are authoritative and current
+- [ ] Correction report is clear and actionable
+- [ ] Temporal context included where relevant
+- [ ] User approval obtained before changes
+- [ ] All edits verified successful
+- [ ] Summary provided to user
+
+## Limitations
+
+**This skill cannot:**
+- Verify subjective opinions or judgments
+- Access paywalled or restricted sources
+- Determine "truth" in disputed claims
+- Predict future specifications or features
+
+**For such cases:**
+- Note the limitation in the report
+- Suggest qualification language
+- Recommend user research or expert consultation

--- a/iOS-APP-developer/.security-scan-passed
+++ b/iOS-APP-developer/.security-scan-passed
@@ -1,0 +1,4 @@
+Security scan passed
+Scanned at: 2025-12-15T22:23:52.306779
+Tool: gitleaks + pattern-based validation
+Content hash: 1e3661252b87a1effd6b4e458364ab4e7b8bd6356360aea058593e70ed0edd11

--- a/iOS-APP-developer/SKILL.md
+++ b/iOS-APP-developer/SKILL.md
@@ -1,0 +1,305 @@
+---
+name: developing-ios-apps
+description: Develops iOS applications with XcodeGen, SwiftUI, and SPM. Triggers on XcodeGen project.yml configuration, SPM dependency issues, device deployment problems, code signing errors, camera/AVFoundation debugging, iOS version compatibility, or "Library not loaded @rpath" framework errors. Use when building iOS apps, fixing Xcode build failures, or deploying to real devices.
+---
+
+# iOS App Development
+
+Build, configure, and deploy iOS applications using XcodeGen and Swift Package Manager.
+
+## Critical Warnings
+
+| Issue | Cause | Solution |
+|-------|-------|----------|
+| "Library not loaded: @rpath/Framework" | XcodeGen doesn't auto-embed SPM dynamic frameworks | **Build in Xcode GUI first** (not xcodebuild). See [Troubleshooting](#spm-dynamic-framework-not-embedded) |
+| `xcodegen generate` loses signing | Overwrites project settings | Configure in `project.yml` target settings, not global |
+| Command-line signing fails | Free Apple ID limitation | Use Xcode GUI or paid developer account ($99/yr) |
+| "Cannot be set when automaticallyAdjustsVideoMirroring is YES" | Setting `isVideoMirrored` without disabling automatic | Set `automaticallyAdjustsVideoMirroring = false` first. See [Camera](#camera--avfoundation) |
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Generate project | `xcodegen generate` |
+| Build simulator | `xcodebuild -destination 'platform=iOS Simulator,name=iPhone 17' build` |
+| Build device (paid account) | `xcodebuild -destination 'platform=iOS,name=DEVICE' -allowProvisioningUpdates build` |
+| Clean DerivedData | `rm -rf ~/Library/Developer/Xcode/DerivedData/PROJECT-*` |
+| Find device name | `xcrun xctrace list devices` |
+
+## XcodeGen Configuration
+
+### Minimal project.yml
+
+```yaml
+name: AppName
+options:
+  bundleIdPrefix: com.company
+  deploymentTarget:
+    iOS: "16.0"
+
+settings:
+  base:
+    SWIFT_VERSION: "6.0"
+
+packages:
+  SomePackage:
+    url: https://github.com/org/repo
+    from: "1.0.0"
+
+targets:
+  AppName:
+    type: application
+    platform: iOS
+    sources:
+      - path: AppName
+    settings:
+      base:
+        INFOPLIST_FILE: AppName/Info.plist
+        PRODUCT_BUNDLE_IDENTIFIER: com.company.appname
+        CODE_SIGN_STYLE: Automatic
+        DEVELOPMENT_TEAM: TEAM_ID_HERE
+    dependencies:
+      - package: SomePackage
+```
+
+### Code Signing Configuration
+
+**Personal (free) account**: Works in Xcode GUI only. Command-line builds require paid account.
+
+```yaml
+# In target settings
+settings:
+  base:
+    CODE_SIGN_STYLE: Automatic
+    DEVELOPMENT_TEAM: TEAM_ID  # Get from Xcode → Settings → Accounts
+```
+
+**Get Team ID**:
+```bash
+security find-identity -v -p codesigning | head -3
+```
+
+## iOS Version Compatibility
+
+### API Changes by Version
+
+| iOS 17+ Only | iOS 16 Compatible |
+|--------------|-------------------|
+| `.onChange { old, new in }` | `.onChange { new in }` |
+| `ContentUnavailableView` | Custom VStack |
+| `AVAudioApplication` | `AVAudioSession` |
+| `@Observable` macro | `@ObservableObject` |
+| SwiftData | CoreData/Realm |
+
+### Lowering Deployment Target
+
+1. Update `project.yml`:
+```yaml
+deploymentTarget:
+  iOS: "16.0"
+```
+
+2. Fix incompatible APIs:
+```swift
+// iOS 17
+.onChange(of: value) { oldValue, newValue in }
+// iOS 16
+.onChange(of: value) { newValue in }
+
+// iOS 17
+ContentUnavailableView("Title", systemImage: "icon")
+// iOS 16
+VStack {
+    Image(systemName: "icon").font(.system(size: 48))
+    Text("Title").font(.title2.bold())
+}
+
+// iOS 17
+AVAudioApplication.shared.recordPermission
+// iOS 16
+AVAudioSession.sharedInstance().recordPermission
+```
+
+3. Regenerate: `xcodegen generate`
+
+## Device Deployment
+
+### First-time Setup
+
+1. Connect device via USB
+2. Trust computer on device
+3. In Xcode: Settings → Accounts → Add Apple ID
+4. Select device in scheme dropdown
+5. Run (`Cmd + R`)
+6. On device: Settings → General → VPN & Device Management → Trust
+
+### Command-line Build (requires paid account)
+
+```bash
+xcodebuild \
+  -project App.xcodeproj \
+  -scheme App \
+  -destination 'platform=iOS,name=DeviceName' \
+  -allowProvisioningUpdates \
+  build
+```
+
+### Common Issues
+
+| Error | Solution |
+|-------|----------|
+| "Library not loaded: @rpath/Framework" | SPM dynamic framework not embedded. Build in Xcode GUI first, then CLI works |
+| "No Account for Team" | Add Apple ID in Xcode Settings → Accounts |
+| "Provisioning profile not found" | Free account limitation. Use Xcode GUI or get paid account |
+| Device not listed | Reconnect USB, trust computer on device, restart Xcode |
+| DerivedData won't delete | Close Xcode first: `pkill -9 Xcode && rm -rf ~/Library/Developer/Xcode/DerivedData/PROJECT-*` |
+
+### Free vs Paid Developer Account
+
+| Feature | Free Apple ID | Paid ($99/year) |
+|---------|---------------|-----------------|
+| Xcode GUI builds | ✅ | ✅ |
+| Command-line builds | ❌ | ✅ |
+| App validity | 7 days | 1 year |
+| App Store | ❌ | ✅ |
+| CI/CD | ❌ | ✅ |
+
+## SPM Dependencies
+
+### SPM Dynamic Framework Not Embedded
+
+**Root Cause**: XcodeGen doesn't generate the "Embed Frameworks" build phase for SPM dynamic frameworks (like RealmSwift, Realm). The app builds successfully but crashes on launch with:
+
+```
+dyld: Library not loaded: @rpath/RealmSwift.framework/RealmSwift
+  Referenced from: /var/containers/Bundle/Application/.../App.app/App
+  Reason: image not found
+```
+
+**Why This Happens**:
+- Static frameworks (most SPM packages) are linked into the binary - no embedding needed
+- Dynamic frameworks (RealmSwift, etc.) must be copied into the app bundle
+- XcodeGen generates link phase but NOT embed phase for SPM packages
+- `embed: true` in project.yml causes build errors (XcodeGen limitation)
+
+**The Fix** (Manual, one-time per project):
+1. Open project in Xcode GUI
+2. Select target → General → Frameworks, Libraries
+3. Find the dynamic framework (RealmSwift)
+4. Change "Do Not Embed" → "Embed & Sign"
+5. Build and run from Xcode GUI first
+
+**After Manual Fix**: Command-line builds (`xcodebuild`) will work because Xcode persists the embed setting in project.pbxproj.
+
+**Identifying Dynamic Frameworks**:
+```bash
+# Check if a framework is dynamic
+file ~/Library/Developer/Xcode/DerivedData/PROJECT-*/Build/Products/Debug-iphoneos/FRAMEWORK.framework/FRAMEWORK
+# Dynamic: "Mach-O 64-bit dynamically linked shared library"
+# Static: "current ar archive"
+```
+
+### Adding Packages
+
+```yaml
+packages:
+  AudioKit:
+    url: https://github.com/AudioKit/AudioKit
+    from: "5.6.5"
+  RealmSwift:
+    url: https://github.com/realm/realm-swift
+    from: "10.54.6"
+
+targets:
+  App:
+    dependencies:
+      - package: AudioKit
+      - package: RealmSwift
+        product: RealmSwift  # Explicit product name when package has multiple
+```
+
+### Resolving Dependencies (China proxy)
+
+```bash
+git config --global http.proxy http://127.0.0.1:1082
+git config --global https.proxy http://127.0.0.1:1082
+xcodebuild -scmProvider system -resolvePackageDependencies
+```
+
+**Never clear global SPM cache** (`~/Library/Caches/org.swift.swiftpm`). Re-downloading is slow.
+
+## Camera / AVFoundation
+
+Camera preview requires real device (simulator has no camera).
+
+### Quick Debugging Checklist
+
+1. **Permission**: Added `NSCameraUsageDescription` to Info.plist?
+2. **Device**: Running on real device, not simulator?
+3. **Session running**: `session.startRunning()` called on background thread?
+4. **View size**: UIViewRepresentable has non-zero bounds?
+5. **Video mirroring**: Disabled `automaticallyAdjustsVideoMirroring` before setting `isVideoMirrored`?
+
+### Video Mirroring (Front Camera)
+
+**CRITICAL**: Must disable automatic adjustment before setting manual mirroring:
+
+```swift
+// WRONG - crashes with "Cannot be set when automaticallyAdjustsVideoMirroring is YES"
+connection.isVideoMirrored = true
+
+// CORRECT - disable automatic first
+connection.automaticallyAdjustsVideoMirroring = false
+connection.isVideoMirrored = true
+```
+
+### UIViewRepresentable Sizing Issue
+
+UIViewRepresentable in ZStack may have zero bounds. Fix with explicit frame:
+
+```swift
+// BAD: UIViewRepresentable may get zero size in ZStack
+ZStack {
+    CameraPreviewView(session: session)  // May be invisible!
+    OtherContent()
+}
+
+// GOOD: Explicit sizing
+ZStack {
+    GeometryReader { geo in
+        CameraPreviewView(session: session)
+            .frame(width: geo.size.width, height: geo.size.height)
+    }
+    .ignoresSafeArea()
+    OtherContent()
+}
+```
+
+### Debug Logging Pattern
+
+Add logging to trace camera flow:
+
+```swift
+import os
+private let logger = Logger(subsystem: "com.app", category: "Camera")
+
+func start() async {
+    logger.info("start() called, isRunning=\(self.isRunning)")
+    // ... setup code ...
+    logger.info("session.startRunning() completed")
+}
+
+// For CGRect (doesn't conform to CustomStringConvertible)
+logger.info("bounds=\(NSCoder.string(for: self.bounds))")
+```
+
+Filter in Console.app by subsystem.
+
+**For detailed camera implementation**: See [references/camera-avfoundation.md](references/camera-avfoundation.md)
+
+## Resources
+
+- [references/xcodegen-full.md](references/xcodegen-full.md) - Complete project.yml options
+- [references/swiftui-compatibility.md](references/swiftui-compatibility.md) - iOS version API differences
+- [references/camera-avfoundation.md](references/camera-avfoundation.md) - Camera preview debugging
+- [references/testing-mainactor.md](references/testing-mainactor.md) - Testing @MainActor classes (state machines, regression tests)

--- a/iOS-APP-developer/references/camera-avfoundation.md
+++ b/iOS-APP-developer/references/camera-avfoundation.md
@@ -1,0 +1,292 @@
+# Camera / AVFoundation Reference
+
+## Camera Preview Implementation
+
+### Complete Working Example
+
+```swift
+import SwiftUI
+import AVFoundation
+import os
+
+private let logger = Logger(subsystem: "com.app", category: "Camera")
+
+// MARK: - Session Manager
+
+@MainActor
+final class CameraSessionManager: ObservableObject {
+    @Published private(set) var isRunning = false
+    @Published private(set) var error: CameraError?
+
+    let session = AVCaptureSession()
+    private var videoInput: AVCaptureDeviceInput?
+
+    enum CameraError: LocalizedError {
+        case noCamera
+        case setupFailed(String)
+        case permissionDenied
+
+        var errorDescription: String? {
+            switch self {
+            case .noCamera: return "No camera available"
+            case .setupFailed(let reason): return "Setup failed: \(reason)"
+            case .permissionDenied: return "Camera permission denied"
+            }
+        }
+    }
+
+    func start() async {
+        logger.info("start() called, isRunning=\(self.isRunning)")
+        guard !isRunning else { return }
+
+        // Check permission
+        guard await requestPermission() else {
+            error = .permissionDenied
+            return
+        }
+
+        // Get camera
+        guard let device = AVCaptureDevice.default(
+            .builtInWideAngleCamera,
+            for: .video,
+            position: .front
+        ) else {
+            logger.error("No front camera available")
+            error = .noCamera
+            return
+        }
+
+        // Configure session
+        session.beginConfiguration()
+        session.sessionPreset = .high
+
+        do {
+            let input = try AVCaptureDeviceInput(device: device)
+            if session.canAddInput(input) {
+                session.addInput(input)
+                videoInput = input
+            }
+            session.commitConfiguration()
+
+            // Start on background thread
+            await withCheckedContinuation { continuation in
+                DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+                    self?.session.startRunning()
+                    DispatchQueue.main.async {
+                        self?.isRunning = true
+                        logger.info("Camera session started")
+                        continuation.resume()
+                    }
+                }
+            }
+        } catch {
+            session.commitConfiguration()
+            self.error = .setupFailed(error.localizedDescription)
+        }
+    }
+
+    func stop() {
+        guard isRunning else { return }
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            self?.session.stopRunning()
+            DispatchQueue.main.async {
+                self?.isRunning = false
+            }
+        }
+    }
+
+    private func requestPermission() async -> Bool {
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized: return true
+        case .notDetermined:
+            return await AVCaptureDevice.requestAccess(for: .video)
+        default: return false
+        }
+    }
+}
+
+// MARK: - SwiftUI View
+
+struct CameraPreviewView: UIViewRepresentable {
+    let session: AVCaptureSession
+
+    func makeUIView(context: Context) -> CameraPreviewUIView {
+        let view = CameraPreviewUIView()
+        view.backgroundColor = .black
+        view.session = session
+        return view
+    }
+
+    func updateUIView(_ uiView: CameraPreviewUIView, context: Context) {}
+}
+
+final class CameraPreviewUIView: UIView {
+    override class var layerClass: AnyClass { AVCaptureVideoPreviewLayer.self }
+
+    var previewLayer: AVCaptureVideoPreviewLayer { layer as! AVCaptureVideoPreviewLayer }
+
+    var session: AVCaptureSession? {
+        get { previewLayer.session }
+        set {
+            previewLayer.session = newValue
+            previewLayer.videoGravity = .resizeAspectFill
+            configureMirroring()
+        }
+    }
+
+    private func configureMirroring() {
+        guard let connection = previewLayer.connection,
+              connection.isVideoMirroringSupported else { return }
+        // CRITICAL: Must disable automatic adjustment BEFORE setting manual mirroring
+        // Without this, iOS throws: "Cannot be set when automaticallyAdjustsVideoMirroring is YES"
+        connection.automaticallyAdjustsVideoMirroring = false
+        connection.isVideoMirrored = true
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        previewLayer.frame = bounds
+    }
+}
+
+// MARK: - Usage in SwiftUI
+
+struct ContentView: View {
+    @StateObject private var cameraManager = CameraSessionManager()
+
+    var body: some View {
+        ZStack {
+            // CRITICAL: Use GeometryReader for proper sizing
+            GeometryReader { geo in
+                CameraPreviewView(session: cameraManager.session)
+                    .frame(width: geo.size.width, height: geo.size.height)
+            }
+            .ignoresSafeArea()
+
+            // Overlay content here
+        }
+        .onAppear {
+            Task { await cameraManager.start() }
+        }
+        .onDisappear {
+            cameraManager.stop()
+        }
+    }
+}
+```
+
+## Common Issues and Solutions
+
+### Issue: Camera preview shows nothing
+
+**Debug steps:**
+
+1. Check if running on simulator (camera not available):
+```swift
+#if targetEnvironment(simulator)
+logger.warning("Camera not available on simulator")
+#endif
+```
+
+2. Add logging to trace execution:
+```swift
+logger.info("Permission status: \(AVCaptureDevice.authorizationStatus(for: .video).rawValue)")
+logger.info("Session running: \(session.isRunning)")
+logger.info("Preview layer bounds: \(previewLayer.bounds)")
+```
+
+3. Verify Info.plist has camera permission:
+```xml
+<key>NSCameraUsageDescription</key>
+<string>Camera access for preview</string>
+```
+
+### Issue: UIViewRepresentable has zero size
+
+**Cause**: In ZStack, UIViewRepresentable doesn't expand like SwiftUI views.
+
+**Solution**: Wrap in GeometryReader with explicit frame:
+```swift
+GeometryReader { geo in
+    CameraPreviewView(session: session)
+        .frame(width: geo.size.width, height: geo.size.height)
+}
+```
+
+### Issue: Preview layer connection is nil
+
+**Cause**: Connection isn't established until session is running and layer is in view hierarchy.
+
+**Solution**: Configure mirroring in layoutSubviews:
+```swift
+override func layoutSubviews() {
+    super.layoutSubviews()
+    previewLayer.frame = bounds
+    // Retry mirroring here
+    configureMirroring()
+}
+
+private func configureMirroring() {
+    guard let conn = previewLayer.connection,
+          conn.isVideoMirroringSupported else { return }
+    conn.automaticallyAdjustsVideoMirroring = false
+    conn.isVideoMirrored = true
+}
+```
+
+### Issue: Crash on setVideoMirrored
+
+**Error**: `*** -[AVCaptureConnection setVideoMirrored:] Cannot be set when automaticallyAdjustsVideoMirroring is YES`
+
+**Cause**: iOS automatically adjusts mirroring by default. Setting `isVideoMirrored` while automatic adjustment is enabled throws an exception.
+
+**Solution**: Always disable automatic adjustment first:
+```swift
+// WRONG - crashes on some devices
+connection.isVideoMirrored = true
+
+// CORRECT - disable automatic first
+connection.automaticallyAdjustsVideoMirroring = false
+connection.isVideoMirrored = true
+```
+
+**Affected Devices**: Primarily older devices (iPhone X, etc.) but can affect any device.
+
+### Issue: Swift 6 concurrency errors with AVCaptureSession
+
+**Error**: "cannot access property 'session' with non-Sendable type from nonisolated deinit"
+
+**Solution**: Don't access session in deinit. Use explicit stop() call:
+```swift
+deinit {
+    // Don't access session here
+    // Cleanup handled by stop() call from view
+}
+```
+
+## Debugging with Console.app
+
+1. Open Console.app
+2. Select your device
+3. Filter by:
+   - Subsystem: `com.yourapp`
+   - Category: `Camera`
+4. Look for the log sequence:
+   ```
+   start() called, isRunning=false
+   Permission granted
+   Found front camera: Front Camera
+   Camera session started
+   ```
+
+## Camera + Audio Conflict
+
+If using AudioKit or AVAudioEngine, camera audio input may conflict.
+
+**Solution**: Use video-only input, no audio:
+```swift
+// Only add video input, skip audio
+let videoInput = try AVCaptureDeviceInput(device: videoDevice)
+session.addInput(videoInput)
+// Do NOT add audio input
+```

--- a/iOS-APP-developer/references/swiftui-compatibility.md
+++ b/iOS-APP-developer/references/swiftui-compatibility.md
@@ -1,0 +1,190 @@
+# SwiftUI iOS Version Compatibility
+
+## iOS 17 vs iOS 16 API Differences
+
+### View Modifiers
+
+#### onChange
+
+```swift
+// iOS 17+ (dual parameter)
+.onChange(of: value) { oldValue, newValue in
+    // Can compare old and new
+}
+
+// iOS 16 (single parameter)
+.onChange(of: value) { newValue in
+    // Only new value available
+}
+```
+
+#### sensoryFeedback (iOS 17+)
+
+```swift
+// iOS 17+
+.sensoryFeedback(.impact, trigger: triggerValue)
+
+// iOS 16 fallback
+UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+```
+
+### Views
+
+#### ContentUnavailableView (iOS 17+)
+
+```swift
+// iOS 17+
+ContentUnavailableView(
+    "No Results",
+    systemImage: "magnifyingglass",
+    description: Text("Try a different search")
+)
+
+// iOS 16 fallback
+VStack(spacing: 16) {
+    Image(systemName: "magnifyingglass")
+        .font(.system(size: 48))
+        .foregroundStyle(.secondary)
+    Text("No Results")
+        .font(.title2.bold())
+    Text("Try a different search")
+        .font(.subheadline)
+        .foregroundStyle(.secondary)
+}
+.frame(maxWidth: .infinity, maxHeight: .infinity)
+```
+
+#### Inspector (iOS 17+)
+
+```swift
+// iOS 17+
+.inspector(isPresented: $showInspector) {
+    InspectorContent()
+}
+
+// iOS 16 fallback: Use sheet or sidebar
+.sheet(isPresented: $showInspector) {
+    InspectorContent()
+}
+```
+
+### Observation
+
+#### @Observable Macro (iOS 17+)
+
+```swift
+// iOS 17+ with @Observable
+@Observable
+class ViewModel {
+    var count = 0
+}
+
+struct ContentView: View {
+    var viewModel = ViewModel()
+    var body: some View {
+        Text("\(viewModel.count)")
+    }
+}
+
+// iOS 16 with ObservableObject
+class ViewModel: ObservableObject {
+    @Published var count = 0
+}
+
+struct ContentView: View {
+    @StateObject var viewModel = ViewModel()
+    var body: some View {
+        Text("\(viewModel.count)")
+    }
+}
+```
+
+### Audio
+
+#### AVAudioApplication (iOS 17+)
+
+```swift
+// iOS 17+
+let permission = AVAudioApplication.shared.recordPermission
+AVAudioApplication.requestRecordPermission { granted in }
+
+// iOS 16
+let permission = AVAudioSession.sharedInstance().recordPermission
+AVAudioSession.sharedInstance().requestRecordPermission { granted in }
+```
+
+### Animations
+
+#### Symbol Effects (iOS 17+)
+
+```swift
+// iOS 17+
+Image(systemName: "heart.fill")
+    .symbolEffect(.bounce, value: isFavorite)
+
+// iOS 16 fallback
+Image(systemName: "heart.fill")
+    .scaleEffect(isFavorite ? 1.2 : 1.0)
+    .animation(.spring(), value: isFavorite)
+```
+
+### Data
+
+#### SwiftData (iOS 17+)
+
+```swift
+// iOS 17+ with SwiftData
+@Model
+class Item {
+    var name: String
+    var timestamp: Date
+}
+
+// iOS 16: Use CoreData or third-party (Realm)
+// CoreData: NSManagedObject subclass
+// Realm: Object subclass with @Persisted properties
+```
+
+## Conditional Compilation
+
+For features that must use iOS 17 APIs when available:
+
+```swift
+if #available(iOS 17.0, *) {
+    ContentUnavailableView("Title", systemImage: "icon")
+} else {
+    LegacyEmptyView()
+}
+```
+
+For view modifiers:
+
+```swift
+extension View {
+    @ViewBuilder
+    func onChangeCompat<V: Equatable>(of value: V, perform: @escaping (V) -> Void) -> some View {
+        if #available(iOS 17.0, *) {
+            self.onChange(of: value) { _, newValue in
+                perform(newValue)
+            }
+        } else {
+            self.onChange(of: value, perform: perform)
+        }
+    }
+}
+```
+
+## Minimum Deployment Targets by Feature
+
+| Feature | Minimum iOS |
+|---------|-------------|
+| SwiftUI basics | 13.0 |
+| @StateObject | 14.0 |
+| AsyncImage | 15.0 |
+| .searchable | 15.0 |
+| NavigationStack | 16.0 |
+| .navigationDestination | 16.0 |
+| @Observable | 17.0 |
+| ContentUnavailableView | 17.0 |
+| SwiftData | 17.0 |
+| .onChange (dual param) | 17.0 |

--- a/iOS-APP-developer/references/testing-mainactor.md
+++ b/iOS-APP-developer/references/testing-mainactor.md
@@ -1,0 +1,146 @@
+# Testing @MainActor Classes
+
+## The Problem
+
+Testing `@MainActor` classes like `ObservableObject` controllers in Swift 6 is challenging because:
+
+1. `setUp()` and `tearDown()` are nonisolated
+2. Properties with `private(set)` can't be set from tests
+3. Direct property access from tests triggers concurrency errors
+
+## Solution: setStateForTesting Pattern
+
+Add a DEBUG-only method to allow tests to set internal state:
+
+```swift
+@MainActor
+final class TrainingSessionController: ObservableObject {
+    @Published private(set) var state: TrainingState = .idle
+
+    // ... rest of controller ...
+
+    // MARK: - Testing Support
+
+    #if DEBUG
+    /// Set state directly for testing purposes only
+    func setStateForTesting(_ newState: TrainingState) {
+        state = newState
+    }
+    #endif
+}
+```
+
+## Test Class Structure
+
+```swift
+import XCTest
+@testable import YourApp
+
+@MainActor
+final class TrainingSessionControllerTests: XCTestCase {
+
+    var controller: TrainingSessionController!
+
+    override func setUp() {
+        super.setUp()
+        controller = TrainingSessionController()
+    }
+
+    override func tearDown() {
+        controller = nil
+        super.tearDown()
+    }
+
+    func testConfigureFromFailedStateAutoResets() {
+        // Arrange: Set to failed state
+        controller.setStateForTesting(.failed("Recording too short"))
+
+        // Act: Configure should recover
+        controller.configure(with: PhaseConfig.default)
+
+        // Assert: Should be back in idle
+        XCTAssertEqual(controller.state, .idle)
+    }
+}
+```
+
+## State Machine Testing Patterns
+
+### Testing State Transitions
+
+```swift
+func testStateTransitions() {
+    // Test each state's behavior
+    let states: [TrainingState] = [.idle, .completed, .failed("error")]
+
+    for state in states {
+        controller.setStateForTesting(state)
+        controller.configure(with: PhaseConfig.default)
+
+        // Verify expected outcome
+        XCTAssertTrue(controller.canStart, "\(state) should allow starting")
+    }
+}
+```
+
+### Regression Tests
+
+For bugs that have been fixed, add specific regression tests:
+
+```swift
+/// Regression test for: State machine dead-lock after recording failure
+/// Bug: After error, controller stayed in failed state forever
+func testRegressionFailedStateDeadLock() {
+    // Simulate the bug scenario
+    controller.configure(with: PhaseConfig.default)
+    controller.setStateForTesting(.failed("录音太短"))
+
+    // The fix: configure() should auto-reset from failed state
+    controller.configure(with: PhaseConfig.default)
+
+    XCTAssertEqual(controller.state, .idle,
+        "REGRESSION: Failed state should not block configure()")
+}
+```
+
+### State Machine Invariants
+
+Test invariants that should always hold:
+
+```swift
+/// No terminal state should become a "dead end"
+func testAllTerminalStatesAreRecoverable() {
+    let terminalStates: [TrainingState] = [
+        .idle,
+        .completed,
+        .failed("test error")
+    ]
+
+    for state in terminalStates {
+        controller.setStateForTesting(state)
+        // Action that should recover
+        controller.configure(with: PhaseConfig.default)
+
+        // Verify recovery
+        XCTAssertTrue(canConfigure(),
+            "\(state) should be recoverable via configure()")
+    }
+}
+```
+
+## Why This Pattern Works
+
+1. **`#if DEBUG`**: Method only exists in test builds, zero production overhead
+2. **Explicit method**: Makes test-only state manipulation obvious and searchable
+3. **MainActor compatible**: Method is part of the @MainActor class
+4. **Swift 6 safe**: Avoids concurrency errors by staying on the main actor
+
+## Alternative: Internal Setter
+
+If you prefer, you can use `internal(set)` instead of `private(set)`:
+
+```swift
+@Published internal(set) var state: TrainingState = .idle
+```
+
+However, this is redundant since properties are already internal by default. The `setStateForTesting()` pattern is more explicit about test-only intent.

--- a/iOS-APP-developer/references/xcodegen-full.md
+++ b/iOS-APP-developer/references/xcodegen-full.md
@@ -1,0 +1,196 @@
+# XcodeGen Complete Reference
+
+## Full project.yml Structure
+
+```yaml
+name: ProjectName
+
+options:
+  bundleIdPrefix: com.company
+  deploymentTarget:
+    iOS: "16.0"
+    macOS: "13.0"
+  xcodeVersion: "16.0"
+  generateEmptyDirectories: true
+  createIntermediateGroups: true
+
+settings:
+  base:
+    SWIFT_VERSION: "6.0"
+    MARKETING_VERSION: "1.0.0"
+    CURRENT_PROJECT_VERSION: "1"
+
+packages:
+  # Basic package
+  PackageName:
+    url: https://github.com/org/repo
+    from: "1.0.0"
+
+  # Exact version
+  ExactPackage:
+    url: https://github.com/org/repo
+    exactVersion: "2.0.0"
+
+  # Branch
+  BranchPackage:
+    url: https://github.com/org/repo
+    branch: main
+
+  # Local package
+  LocalPackage:
+    path: ../LocalPackage
+
+targets:
+  MainApp:
+    type: application
+    platform: iOS
+    sources:
+      - path: Sources
+        excludes:
+          - "**/.DS_Store"
+          - "**/Tests/**"
+      - path: Resources
+        type: folder
+
+    settings:
+      base:
+        INFOPLIST_FILE: Sources/Info.plist
+        PRODUCT_BUNDLE_IDENTIFIER: com.company.app
+        ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+        ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: AccentColor
+        LD_RUNPATH_SEARCH_PATHS: "$(inherited) @executable_path/Frameworks"
+        ENABLE_BITCODE: NO
+        CODE_SIGN_STYLE: Automatic
+        DEVELOPMENT_TEAM: TEAM_ID
+      configs:
+        Debug:
+          SWIFT_OPTIMIZATION_LEVEL: -Onone
+        Release:
+          SWIFT_OPTIMIZATION_LEVEL: -O
+
+    dependencies:
+      # SPM package
+      - package: PackageName
+
+      # SPM package with explicit product
+      - package: Firebase
+        product: FirebaseAnalytics
+
+      # Another target
+      - target: Framework
+
+      # System framework
+      - framework: UIKit.framework
+
+      # SDK
+      - sdk: CoreLocation.framework
+
+    preBuildScripts:
+      - name: "Run Script"
+        script: |
+          echo "Pre-build script"
+        runOnlyWhenInstalling: false
+
+    postBuildScripts:
+      - name: "Post Build"
+        script: |
+          echo "Post-build script"
+
+  Tests:
+    type: bundle.unit-test
+    platform: iOS
+    sources:
+      - path: Tests
+    dependencies:
+      - target: MainApp
+    settings:
+      base:
+        TEST_HOST: "$(BUILT_PRODUCTS_DIR)/MainApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/MainApp"
+        BUNDLE_LOADER: "$(TEST_HOST)"
+```
+
+## Target Types
+
+| Type | Description |
+|------|-------------|
+| `application` | iOS/macOS app |
+| `framework` | Dynamic framework |
+| `staticFramework` | Static framework |
+| `bundle.unit-test` | Unit test bundle |
+| `bundle.ui-testing` | UI test bundle |
+| `app-extension` | App extension |
+| `watch2-app` | watchOS app |
+| `widget-extension` | Widget extension |
+
+## Build Settings Reference
+
+### Common Settings
+
+```yaml
+settings:
+  base:
+    # Versioning
+    MARKETING_VERSION: "1.0.0"
+    CURRENT_PROJECT_VERSION: "1"
+
+    # Swift
+    SWIFT_VERSION: "6.0"
+    SWIFT_STRICT_CONCURRENCY: complete
+
+    # Signing
+    CODE_SIGN_STYLE: Automatic
+    DEVELOPMENT_TEAM: TEAM_ID
+    CODE_SIGN_IDENTITY: "Apple Development"
+
+    # Deployment
+    IPHONEOS_DEPLOYMENT_TARGET: "16.0"
+    TARGETED_DEVICE_FAMILY: "1,2"  # 1=iPhone, 2=iPad
+
+    # Build
+    ENABLE_BITCODE: NO
+    DEBUG_INFORMATION_FORMAT: dwarf-with-dsym
+
+    # Paths
+    LD_RUNPATH_SEARCH_PATHS: "$(inherited) @executable_path/Frameworks"
+```
+
+### Per-Configuration Settings
+
+```yaml
+settings:
+  configs:
+    Debug:
+      SWIFT_OPTIMIZATION_LEVEL: -Onone
+      SWIFT_ACTIVE_COMPILATION_CONDITIONS: DEBUG
+      MTL_ENABLE_DEBUG_INFO: INCLUDE_SOURCE
+    Release:
+      SWIFT_OPTIMIZATION_LEVEL: -O
+      SWIFT_COMPILATION_MODE: wholemodule
+      VALIDATE_PRODUCT: YES
+```
+
+## Info.plist Keys
+
+Common keys to add:
+
+```xml
+<key>NSCameraUsageDescription</key>
+<string>Camera access description</string>
+
+<key>NSMicrophoneUsageDescription</key>
+<string>Microphone access description</string>
+
+<key>NSPhotoLibraryUsageDescription</key>
+<string>Photo library access description</string>
+
+<key>UIBackgroundModes</key>
+<array>
+    <string>audio</string>
+    <string>location</string>
+</array>
+
+<key>UISupportedInterfaceOrientations</key>
+<array>
+    <string>UIInterfaceOrientationPortrait</string>
+</array>
+```

--- a/markdown-tools/SKILL.md
+++ b/markdown-tools/SKILL.md
@@ -1,146 +1,93 @@
 ---
 name: markdown-tools
-description: Converts documents to markdown (PDFs, Word docs, PowerPoint, Confluence exports) with Windows/WSL path handling. Activates when converting .doc/.docx/PDF/PPTX files to markdown, processing Confluence exports, handling Windows/WSL path conversions, or working with markitdown utility.
+description: Converts documents to markdown (PDFs, Word docs, PowerPoint, Confluence exports) with Windows/WSL path handling. Activates when converting .doc/.docx/PDF/PPTX files to markdown, processing Confluence exports, handling Windows/WSL path conversions, extracting images from PDFs, or working with markitdown utility.
 ---
 
 # Markdown Tools
 
-## Overview
-
-This skill provides document conversion to markdown with Windows/WSL path handling support. It helps convert various document formats to markdown and handles path conversions between Windows and WSL environments.
-
-## Core Capabilities
-
-### 1. Markdown Conversion
-Convert documents to markdown format with automatic Windows/WSL path handling.
-
-### 2. Confluence Export Processing
-Handle Confluence .doc exports with special characters for knowledge base integration.
+Convert documents to markdown with image extraction and Windows/WSL path handling.
 
 ## Quick Start
 
-### Convert Any Document to Markdown
+### Install markitdown with PDF Support
 
 ```bash
-# Basic conversion
-markitdown "path/to/document.pdf" > output.md
+# IMPORTANT: Use [pdf] extra for PDF support
+uv tool install "markitdown[pdf]"
 
-# WSL path example
-markitdown "/mnt/c/Users/username/Documents/file.docx" > output.md
+# Or via pip
+pip install "markitdown[pdf]"
 ```
 
-See `references/conversion-examples.md` for detailed examples of various conversion scenarios.
-
-### Convert Confluence Export
+### Basic Conversion
 
 ```bash
-# Direct conversion for simple exports
-markitdown "confluence-export.doc" > output.md
-
-# For exports with special characters, see references/
+markitdown "document.pdf" -o output.md
+# Or redirect: markitdown "document.pdf" > output.md
 ```
 
-## Path Conversion
+## PDF Conversion with Images
 
-### Windows to WSL Path Format
+markitdown extracts text only. For PDFs with images, use this workflow:
 
-Windows paths must be converted to WSL format before use in bash commands.
-
-**Conversion rules:**
-- Replace `C:\` with `/mnt/c/`
-- Replace `\` with `/`
-- Preserve spaces and special characters
-- Use quotes for paths with spaces
-
-**Example conversions:**
-```bash
-# Windows path
-C:\Users\username\Documents\file.doc
-
-# WSL path
-/mnt/c/Users/username/Documents/file.doc
-```
-
-**Helper script:** Use `scripts/convert_path.py` to automate conversion:
+### Step 1: Convert Text
 
 ```bash
-python scripts/convert_path.py "C:\Users\username\Downloads\document.doc"
+markitdown "document.pdf" -o output.md
 ```
 
-See `references/conversion-examples.md` for detailed path conversion examples.
+### Step 2: Extract Images
 
-## Document Conversion Workflows
-
-### Workflow 1: Simple Markdown Conversion
-
-For straightforward document conversions (PDF, .docx without special characters):
-
-1. Convert Windows path to WSL format (if needed)
-2. Run markitdown
-3. Redirect output to .md file
-
-See `references/conversion-examples.md` for detailed examples.
-
-### Workflow 2: Confluence Export with Special Characters
-
-For Confluence .doc exports that contain special characters or complex formatting:
-
-1. Save .doc file to accessible location
-2. Use appropriate conversion method (see references)
-3. Verify output formatting
-
-See `references/conversion-examples.md` for step-by-step command examples.
-
-## Error Handling
-
-### Common Issues and Solutions
-
-**markitdown not found:**
 ```bash
-# Install markitdown via pip
-pip install markitdown
+# Create assets directory alongside the markdown
+mkdir -p assets
 
-# Or via uv tools
-uv tool install markitdown
+# Extract images using PyMuPDF
+uv run --with pymupdf python scripts/extract_pdf_images.py "document.pdf" ./assets
 ```
 
-**Path not found:**
+### Step 3: Add Image References
+
+Insert image references in the markdown where needed:
+
+```markdown
+![Description](assets/img_page1_1.png)
+```
+
+### Step 4: Format Cleanup
+
+markitdown output often needs manual fixes:
+- Add proper heading levels (`#`, `##`, `###`)
+- Reconstruct tables in markdown format
+- Fix broken line breaks
+- Restore indentation structure
+
+## Path Conversion (Windows/WSL)
+
 ```bash
-# Verify path exists
-ls -la "/mnt/c/Users/username/Documents/file.doc"
+# Windows → WSL conversion
+C:\Users\name\file.pdf → /mnt/c/Users/name/file.pdf
 
-# Use convert_path.py helper
-python scripts/convert_path.py "C:\Users\username\Documents\file.doc"
+# Use helper script
+python scripts/convert_path.py "C:\Users\name\Documents\file.pdf"
 ```
 
-**Encoding issues:**
-- Ensure files are UTF-8 encoded
-- Check for special characters in filenames
-- Use quotes around paths with spaces
+## Common Issues
+
+**"dependencies needed to read .pdf files"**
+```bash
+# Install with PDF support
+uv tool install "markitdown[pdf]" --force
+```
+
+**FontBBox warnings during PDF conversion**
+- These are harmless font parsing warnings, output is still correct
+
+**Images missing from output**
+- Use `scripts/extract_pdf_images.py` to extract images separately
 
 ## Resources
 
-### references/conversion-examples.md
-Comprehensive examples for all conversion scenarios including:
-- Simple document conversions (PDF, Word, PowerPoint)
-- Confluence export handling
-- Path conversion examples for Windows/WSL
-- Batch conversion operations
-- Error recovery and troubleshooting examples
-
-Load this reference when users need specific command examples or encounter conversion issues.
-
-### scripts/convert_path.py
-Python script to automate Windows to WSL path conversion. Handles:
-- Drive letter conversion (C:\ → /mnt/c/)
-- Backslash to forward slash
-- Special characters and spaces
-
-## Best Practices
-
-1. **Convert Windows paths to WSL format** before bash operations
-2. **Verify paths exist** before operations using ls or test commands
-3. **Check output quality** after conversion
-4. **Use markitdown directly** for simple conversions
-5. **Test incrementally** - Verify each conversion step before proceeding
-6. **Preserve directory structure** when doing batch conversions
+- `scripts/extract_pdf_images.py` - Extract images from PDF using PyMuPDF
+- `scripts/convert_path.py` - Windows to WSL path converter
+- `references/conversion-examples.md` - Detailed examples for batch operations

--- a/markdown-tools/scripts/extract_pdf_images.py
+++ b/markdown-tools/scripts/extract_pdf_images.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""
+Extract images from PDF files using PyMuPDF.
+
+Usage:
+    uv run --with pymupdf python extract_pdf_images.py <pdf_path> [output_dir]
+
+Examples:
+    uv run --with pymupdf python extract_pdf_images.py document.pdf
+    uv run --with pymupdf python extract_pdf_images.py document.pdf ./assets
+
+Output:
+    Images are saved to output_dir (default: ./assets) with names like:
+    - img_page1_1.png
+    - img_page2_1.png
+"""
+
+import sys
+import os
+
+def extract_images(pdf_path: str, output_dir: str = "assets") -> list[str]:
+    """
+    Extract all images from a PDF file.
+
+    Args:
+        pdf_path: Path to the PDF file
+        output_dir: Directory to save extracted images
+
+    Returns:
+        List of extracted image file paths
+    """
+    try:
+        import fitz  # PyMuPDF
+    except ImportError:
+        print("Error: PyMuPDF not installed. Run with:")
+        print('  uv run --with pymupdf python extract_pdf_images.py <pdf_path>')
+        sys.exit(1)
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    doc = fitz.open(pdf_path)
+    extracted_files = []
+
+    for page_num in range(len(doc)):
+        page = doc[page_num]
+        image_list = page.get_images()
+
+        for img_index, img in enumerate(image_list):
+            xref = img[0]
+            base_image = doc.extract_image(xref)
+            image_bytes = base_image["image"]
+            image_ext = base_image["ext"]
+
+            # Create descriptive filename
+            img_filename = f"img_page{page_num + 1}_{img_index + 1}.{image_ext}"
+            img_path = os.path.join(output_dir, img_filename)
+
+            with open(img_path, "wb") as f:
+                f.write(image_bytes)
+
+            extracted_files.append(img_path)
+            print(f"Extracted: {img_filename} ({len(image_bytes):,} bytes)")
+
+    doc.close()
+
+    print(f"\nTotal: {len(extracted_files)} images extracted to {output_dir}/")
+    return extracted_files
+
+
+def main():
+    if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help"):
+        print("Extract images from PDF files using PyMuPDF.")
+        print()
+        print("Usage: python extract_pdf_images.py <pdf_path> [output_dir]")
+        print()
+        print("Arguments:")
+        print("  pdf_path    Path to the PDF file")
+        print("  output_dir  Directory to save images (default: ./assets)")
+        print()
+        print("Example:")
+        print("  uv run --with pymupdf python extract_pdf_images.py document.pdf ./assets")
+        sys.exit(0 if "--help" in sys.argv or "-h" in sys.argv else 1)
+
+    pdf_path = sys.argv[1]
+    output_dir = sys.argv[2] if len(sys.argv) > 2 else "assets"
+
+    if not os.path.exists(pdf_path):
+        print(f"Error: File not found: {pdf_path}")
+        sys.exit(1)
+
+    extract_images(pdf_path, output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp-skills-plugin/LICENSE
+++ b/mcp-skills-plugin/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Bjorn Schliebitz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/mcp-skills-plugin/README.md
+++ b/mcp-skills-plugin/README.md
@@ -1,0 +1,177 @@
+# MCP Skills Plugin
+
+Convert MCP servers to Claude Skills with progressive disclosure, reducing context usage by 90%+.
+
+## Features
+
+- **MCP to Skill Converter**: Transform any MCP server into a context-efficient Claude Skill
+- **Session Start Hook**: Automatically loads the MCP skills registry on session start
+- **Progressive Disclosure**: Only load tool definitions when actually needed
+- **Multi-Transport Support**: Compatible with `stdio`, `http`, and `sse` MCP server types
+- **Automatic Registry Management**: Maintains an index of all converted skills
+
+## Installation
+
+Install the plugin using Claude Code's `--plugin-dir` option:
+
+```bash
+# Clone or download the plugin
+git clone https://github.com/your-org/mcp-skills-plugin.git
+
+# Run Claude Code with the plugin
+claude --plugin-dir /path/to/mcp-skills-plugin
+```
+
+Or add to your Claude Code configuration for persistent use.
+
+## Requirements
+
+- **Python 3.8+**
+- **mcp package**: `pip install mcp`
+
+## Usage
+
+### Converting MCP Servers to Skills
+
+Once the plugin is installed, Claude can use the `mcp-to-skill-converter` skill.
+
+#### List Available Servers
+
+```bash
+python ${PLUGIN_DIR}/skills/mcp-to-skill-converter/mcp_to_skill.py --list
+```
+
+Output:
+```
+📄 Servers in: /path/to/.mcp.json
+
+Name                      Type       Compatible   Command
+--------------------------------------------------------------------------------
+github                    stdio      ✅ Yes        npx
+context7                  stdio      ✅ Yes        npx
+brave-search              stdio      ✅ Yes        npx
+
+📊 Total: 10 servers, 8 compatible
+```
+
+#### Convert a Single Server
+
+```bash
+python ${PLUGIN_DIR}/skills/mcp-to-skill-converter/mcp_to_skill.py --name github
+```
+
+This will:
+1. Create a skill in `.claude/skills/mcp-skills/github/`
+2. Update the MCP skills registry
+3. Remove the server from `.mcp.json` to prevent duplicate loading
+
+#### Convert All Compatible Servers
+
+```bash
+python ${PLUGIN_DIR}/skills/mcp-to-skill-converter/mcp_to_skill.py --all
+```
+
+### Using Converted Skills
+
+After conversion, Claude can invoke the MCP tools through the generated skill:
+
+```bash
+# List tools in a skill
+python .claude/skills/mcp-skills/executor.py --skill github --list
+
+# Get tool schema
+python .claude/skills/mcp-skills/executor.py --skill github --describe create_issue
+
+# Call a tool
+python .claude/skills/mcp-skills/executor.py --skill github --call '{"tool": "create_issue", "arguments": {"title": "Bug fix", "body": "Details..."}}'
+```
+
+### Session Start Hook
+
+The plugin automatically loads the MCP skills registry at the start of each Claude Code session. This provides:
+
+- **Context efficiency**: Only ~150 tokens for the registry vs 30-50k tokens for native MCP loading
+- **Discovery**: Claude knows which skills are available without loading all tool definitions
+- **On-demand loading**: Full tool details are only loaded when needed
+
+## Context Savings
+
+| Scenario | Native MCP | Skills Plugin | Savings |
+|----------|------------|---------------|---------|
+| Idle (no tools used) | 30-100k tokens | ~150 tokens | 99%+ |
+| Using 1 skill | 30-100k tokens | ~5k tokens | 90%+ |
+| Tool execution | 30-100k tokens | 0 tokens | 100% |
+
+## Plugin Structure
+
+```
+mcp-skills-plugin/
+├── .claude-plugin/
+│   └── plugin.json           # Plugin manifest
+├── skills/
+│   └── mcp-to-skill-converter/
+│       ├── SKILL.md          # Skill documentation
+│       ├── mcp_to_skill.py   # Converter script
+│       └── templates/
+│           ├── index.json
+│           └── registry-SKILL.md
+├── hooks/
+│   ├── hooks.json            # Hook configuration
+│   └── load-mcp-skills.sh    # Session start hook
+├── README.md
+└── LICENSE
+```
+
+## Server Compatibility
+
+| Type | Compatible | Notes |
+|------|------------|-------|
+| `stdio` | ✅ Yes | Standard input/output protocol |
+| `http` | ✅ Yes | Streamable HTTP protocol |
+| `sse` | ✅ Yes | Server-Sent Events protocol |
+
+## Security Notes
+
+⚠️ **Important Security Considerations**:
+
+1. **Command Execution**: The converter and executor scripts run MCP servers as subprocesses. Only convert and use MCP servers from trusted sources.
+
+2. **Environment Variables**: MCP server configurations may include environment variables (API keys, tokens). These are stored in the generated `mcp-config.json` files.
+
+3. **Code Execution**: Generated skills can execute arbitrary code through MCP tool calls. Review the tools available in each converted skill before use.
+
+4. **File System Access**: The converter reads from `.mcp.json` and writes to the skills directory. Ensure appropriate file permissions.
+
+## Troubleshooting
+
+### "mcp package not found"
+```bash
+pip install mcp
+```
+
+### "Could not find .mcp.json"
+Specify the path explicitly:
+```bash
+python mcp_to_skill.py --mcp-json /path/to/.mcp.json --name github
+```
+
+### "Server not found"
+Run `--list` to see available servers in your `.mcp.json`.
+
+### Hook not loading
+Ensure the hook script is executable:
+```bash
+chmod +x hooks/load-mcp-skills.sh
+```
+
+## Contributing
+
+Contributions are welcome! Please read the contributing guidelines before submitting PRs.
+
+## License
+
+MIT License - see [LICENSE](LICENSE) for details.
+
+---
+
+*Reduce your Claude Code context usage by 90%+ with MCP Skills.*

--- a/mcp-skills-plugin/hooks/hooks.json
+++ b/mcp-skills-plugin/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${PLUGIN_DIR}/hooks/load-mcp-skills.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/mcp-skills-plugin/hooks/load-mcp-skills.sh
+++ b/mcp-skills-plugin/hooks/load-mcp-skills.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# SessionStart hook: Load MCP Skills Registry into context
+# This provides 90%+ context savings compared to native MCP loading
+
+# PLUGIN_DIR is provided by Claude Code when running plugin hooks
+# Fallback to script directory if not set
+if [[ -z "$PLUGIN_DIR" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  PLUGIN_DIR="$(dirname "$SCRIPT_DIR")"
+fi
+
+# Read stdin (hook receives JSON with session info)
+input=$(cat)
+
+# First, try to find the project's mcp-skills registry
+# This is where converted skills are stored
+PROJECT_SKILLS_REGISTRY=".claude/skills/mcp-skills/SKILL.md"
+
+if [[ -f "$PROJECT_SKILLS_REGISTRY" ]]; then
+  # Use the project's own registry (contains converted skills)
+  cat "$PROJECT_SKILLS_REGISTRY"
+elif [[ -f "${PLUGIN_DIR}/skills/mcp-to-skill-converter/templates/registry-SKILL.md" ]]; then
+  # Fall back to template registry if no project registry exists
+  cat "${PLUGIN_DIR}/skills/mcp-to-skill-converter/templates/registry-SKILL.md"
+else
+  echo "MCP Skills Registry not found. Use mcp-to-skill-converter to create skills."
+fi

--- a/mcp-skills-plugin/skills/mcp-to-skill-converter/SKILL.md
+++ b/mcp-skills-plugin/skills/mcp-to-skill-converter/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: mcp-to-skill-converter
+description: This skill should be used when the user asks to "convert MCP to skill", "create skill from MCP", "list MCP servers", "batch convert MCP", "generate skills from .mcp.json", or when working with MCP server configurations. Reduces context usage by 90%+ compared to native MCP loading.
+version: 1.0.0
+---
+
+# MCP to Skill Converter
+
+Convert any MCP server into a Claude Skill with progressive disclosure pattern, reducing context usage by 90%+.
+
+## When to Use This Skill
+
+- Converting MCP servers to skills for context efficiency
+- Listing available MCP servers in a project
+- Batch converting multiple MCP servers
+- Creating skills from `.mcp.json` configuration
+
+## Quick Commands
+
+All commands run from project root where the plugin is installed.
+
+### List Available Servers
+
+```bash
+python ${PLUGIN_DIR}/skills/mcp-to-skill-converter/mcp_to_skill.py --list
+```
+
+Shows all MCP servers with compatibility status (`stdio`, `http`, and `sse` types are compatible).
+
+### Convert Single Server (auto-outputs to mcp-skills/)
+
+```bash
+python ${PLUGIN_DIR}/skills/mcp-to-skill-converter/mcp_to_skill.py --name <server-name>
+```
+
+**Example:**
+```bash
+python ${PLUGIN_DIR}/skills/mcp-to-skill-converter/mcp_to_skill.py --name github
+# Outputs to: .claude/skills/mcp-skills/github/
+# Automatically removes github from .mcp.json
+# Updates mcp-skills/index.json
+```
+
+### Convert All Compatible Servers
+
+```bash
+python ${PLUGIN_DIR}/skills/mcp-to-skill-converter/mcp_to_skill.py --all
+# Converts all compatible servers (stdio, http, sse) to mcp-skills/
+```
+
+### Custom Output Directory
+
+```bash
+python ${PLUGIN_DIR}/skills/mcp-to-skill-converter/mcp_to_skill.py --name github --output-dir /custom/path
+```
+
+### Specify Custom .mcp.json
+
+```bash
+python ${PLUGIN_DIR}/skills/mcp-to-skill-converter/mcp_to_skill.py --mcp-json /path/to/.mcp.json --name github --output-dir ./skills
+```
+
+## CLI Options
+
+| Option | Description |
+|--------|-------------|
+| `--list` | List all servers with compatibility info |
+| `--name NAME` | Convert specific server by name |
+| `--all` | Convert all compatible servers |
+| `--output-dir PATH` | Output directory for generated skill(s) |
+| `--mcp-json PATH` | Path to .mcp.json (auto-discovers if not specified) |
+| `--mcp-config PATH` | [Legacy] Direct MCP config JSON file |
+
+## Server Compatibility
+
+| Type | Compatible | Notes |
+|------|------------|-------|
+| `stdio` | ✅ Yes | Standard input/output protocol |
+| `http` | ✅ Yes | Streamable HTTP protocol |
+| `sse` | ✅ Yes | Server-Sent Events protocol |
+
+## Context Savings
+
+| Scenario | Native MCP | As Skill | Savings |
+|----------|------------|----------|---------|
+| Idle | 30-50k tokens | ~100 tokens | 99%+ |
+| Active | 30-50k tokens | ~5k tokens | 85%+ |
+| Executing | 30-50k tokens | 0 tokens | 100% |
+
+## Workflow Example
+
+**Step 1: List available servers**
+```bash
+python ${PLUGIN_DIR}/skills/mcp-to-skill-converter/mcp_to_skill.py --list
+```
+
+Output:
+```
+📄 Servers in: /path/to/.mcp.json
+
+Name                      Type       Compatible   Command
+--------------------------------------------------------------------------------
+github                    stdio      ✅ Yes        npx
+context7                  stdio      ✅ Yes        npx
+livekit-docs              http       ❌ No         https://...
+
+📊 Total: 16 servers, 14 compatible
+```
+
+**Step 2: Convert desired server**
+```bash
+python ${PLUGIN_DIR}/skills/mcp-to-skill-converter/mcp_to_skill.py --name github
+```
+
+The converter automatically:
+- Creates the skill in `.claude/skills/mcp-skills/github/`
+- Initializes the mcp-skills registry (SKILL.md + index.json) if needed
+- Updates `index.json` with the new skill
+- Removes the server from `.mcp.json` to avoid duplicate loading
+
+**Step 3: Add semantic trigger keywords (MANDATORY)**
+
+The converter generates a placeholder description. You MUST update it with meaningful trigger keywords based on what the MCP server actually does.
+
+1. **Read the generated SKILL.md** to understand what tools are available
+2. **Identify semantic keywords** - What would users naturally ask for?
+   - Think about user intent, not tool names
+   - "ToolUI", "chat components" NOT "assistantUIDocs"
+   - "create PR", "issues", "repository" NOT "create_pull_request"
+3. **Update the SKILL.md description** with trigger keywords:
+
+```yaml
+# Before (auto-generated):
+description: Dynamic access to assistant-ui MCP server (2 tools)
+
+# After (agent-enhanced):
+description: Use for assistant-ui documentation, ToolUI, generative UI, chat components, Thread, Composer, Message primitives, runtime integrations. Get docs and code examples for building AI chat interfaces.
+```
+
+4. **Update the registry SKILL.md** (`mcp-skills/SKILL.md`):
+   - Add the skill to the "Available Skills" table
+   - Include the trigger keywords column
+
+Example registry entry:
+```markdown
+| Skill | Tools | Trigger Keywords |
+|-------|-------|------------------|
+| assistant-ui | 2 | ToolUI, generative UI, chat components, assistant-ui docs |
+| github | 26 | PR, issues, repository, commits, code search |
+```
+
+**Step 4: Use the generated skill**
+Claude will auto-discover the new skill in the mcp-skills registry and can invoke MCP tools with minimal context overhead.
+
+## Generated Skill Structure
+
+```
+output-dir/server-name/
+├── SKILL.md           # Instructions and tool documentation
+├── executor.py        # Async MCP client wrapper
+├── mcp-config.json    # Server configuration
+└── package.json       # Dependency info
+```
+
+## Using Generated Skills
+
+Use the central executor from project root:
+
+```bash
+# List tools in a skill
+python .claude/skills/mcp-skills/executor.py --skill <skill-name> --list
+
+# Describe specific tool
+python .claude/skills/mcp-skills/executor.py --skill <skill-name> --describe tool_name
+
+# Call a tool
+python .claude/skills/mcp-skills/executor.py --skill <skill-name> --call '{"tool": "tool_name", "arguments": {...}}'
+```
+
+## Requirements
+
+```bash
+pip install mcp
+```
+
+Python 3.8+ required.
+
+## Error Handling
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| "Server not found" | Name doesn't exist | Run `--list` to see available servers |
+| "Type not supported" | Server is HTTP/SSE | Only stdio servers can be converted |
+| "Could not find .mcp.json" | No config found | Use `--mcp-json` to specify path |
+| "mcp package not found" | Missing dependency | Run `pip install mcp` |
+
+## Files in This Skill
+
+- `SKILL.md` - This documentation
+- `mcp_to_skill.py` - The converter script
+- `templates/` - Template files for generated skills
+
+---
+
+*This skill enables converting MCP servers to Claude Skills for 90%+ context savings.*

--- a/mcp-skills-plugin/skills/mcp-to-skill-converter/mcp_to_skill.py
+++ b/mcp-skills-plugin/skills/mcp-to-skill-converter/mcp_to_skill.py
@@ -1,0 +1,1226 @@
+#!/usr/bin/env python3
+"""
+MCP to Skill Converter
+======================
+Converts any MCP server into a Claude Skill with dynamic tool invocation.
+
+This implements the "progressive disclosure" pattern:
+- At startup: Only skill metadata is loaded (~100 tokens)
+- On use: Full tool list and instructions are loaded (~5k tokens)
+- On execution: Tools are called dynamically (0 context tokens)
+
+Usage:
+    # List servers in .mcp.json
+    python mcp_to_skill.py --list
+
+    # Convert single server
+    python mcp_to_skill.py --name github --output-dir ./skills
+
+    # Convert all compatible servers
+    python mcp_to_skill.py --all --output-dir ./skills
+
+    # Legacy mode (backward compatible)
+    python mcp_to_skill.py --mcp-config mcp-server-config.json --output-dir ./skills/my-mcp-skill
+"""
+
+import json
+import asyncio
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List, Any, Optional
+import argparse
+
+
+# Compatible MCP server types
+COMPATIBLE_TYPES = {"stdio", "http", "sse"}
+
+
+def sanitize_name(name: str) -> str:
+    """
+    Sanitize a server name for use as a directory name.
+
+    Removes or replaces special characters that cause path issues:
+    - @ symbol (npm scoped packages)
+    - / symbol (npm scoped packages)
+    - Other special characters
+
+    Args:
+        name: Original server name (e.g., "@magicuidesign/mcp")
+
+    Returns:
+        Sanitized name (e.g., "magicui")
+    """
+    import re
+
+    # Common npm scoped package patterns
+    # @org/package -> package (or a simplified version)
+    if name.startswith("@") and "/" in name:
+        # Extract just the package name, removing scope
+        parts = name.split("/")
+        name = parts[-1]  # Get the last part (package name)
+
+        # If package name is generic like "mcp", use the org name instead
+        if name.lower() in ("mcp", "server", "client", "sdk"):
+            org = parts[0].lstrip("@")
+            # Try to create a meaningful short name
+            name = org.replace("-", "").replace("design", "")
+
+    # Remove remaining special characters
+    name = re.sub(r'[@/\\:*?"<>|]', '', name)
+
+    # Replace spaces and dots with hyphens
+    name = re.sub(r'[\s.]+', '-', name)
+
+    # Remove consecutive hyphens
+    name = re.sub(r'-+', '-', name)
+
+    # Remove leading/trailing hyphens
+    name = name.strip('-')
+
+    return name.lower() if name else "unnamed-skill"
+
+
+class MCPSkillGenerator:
+    """Generate a Skill from an MCP server configuration."""
+
+    def __init__(self, mcp_config: Dict[str, Any], output_dir: Path):
+        self.mcp_config = mcp_config
+        self.output_dir = Path(output_dir)
+        self.server_name = mcp_config.get('name', 'unnamed-mcp-server')
+        self.tools_cache = None  # Cache tools for access after generation
+
+    async def generate(self):
+        """Generate the complete skill structure."""
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+        print(f"Generating skill for MCP server: {self.server_name}")
+
+        # 1. Introspect MCP server to get tool list
+        tools = await self._get_mcp_tools()
+        self.tools_cache = tools  # Cache for later access
+        
+        # 2. Generate SKILL.md
+        self._generate_skill_md(tools)
+        
+        # 3. Generate executor script
+        self._generate_executor()
+        
+        # 4. Generate config file
+        self._generate_config()
+        
+        # 5. Generate package.json (if needed)
+        self._generate_package_json()
+        
+        print(f"✓ Skill generated at: {self.output_dir}")
+        print(f"✓ Tools available: {len(tools)}")
+        
+    async def _get_mcp_tools(self) -> List[Dict[str, Any]]:
+        """Connect to MCP server and get available tools via introspection."""
+        server_type = self.mcp_config.get('type', 'stdio')
+
+        if server_type == 'http':
+            return await self._get_mcp_tools_http()
+        elif server_type == 'sse':
+            return await self._get_mcp_tools_sse()
+        else:
+            return await self._get_mcp_tools_stdio()
+
+    async def _get_mcp_tools_stdio(self) -> List[Dict[str, Any]]:
+        """Connect to stdio MCP server and get available tools."""
+        command = self.mcp_config.get('command', '')
+        args = self.mcp_config.get('args', [])
+        env = self.mcp_config.get('env')
+
+        print(f"Introspecting MCP server (stdio): {command} {' '.join(args)}")
+
+        try:
+            from mcp import ClientSession, StdioServerParameters
+            from mcp.client.stdio import stdio_client
+        except ImportError:
+            print("Warning: mcp package not installed. Using mock tools.", file=sys.stderr)
+            print("Install with: pip install mcp", file=sys.stderr)
+            return self._get_mock_tools()
+
+        try:
+            server_params = StdioServerParameters(
+                command=command,
+                args=args,
+                env=env
+            )
+
+            # Use proper async context manager pattern
+            async with stdio_client(server_params) as streams:
+                read_stream, write_stream = streams
+                async with ClientSession(read_stream, write_stream) as session:
+                    await session.initialize()
+                    response = await session.list_tools()
+
+                    tools = []
+                    for tool in response.tools:
+                        tools.append({
+                            "name": tool.name,
+                            "description": tool.description or "No description",
+                            "inputSchema": tool.inputSchema
+                        })
+
+                    print(f"✓ Found {len(tools)} tools")
+                    return tools
+
+        except Exception as e:
+            print(f"Warning: Failed to introspect MCP server: {e}", file=sys.stderr)
+            print("Using mock tools for demonstration.", file=sys.stderr)
+            return self._get_mock_tools()
+
+    async def _get_mcp_tools_http(self) -> List[Dict[str, Any]]:
+        """Connect to HTTP MCP server and get available tools."""
+        url = self.mcp_config.get('url', '')
+
+        print(f"Introspecting MCP server (HTTP): {url}")
+
+        try:
+            from mcp import ClientSession
+            from mcp.client.streamable_http import streamablehttp_client
+        except ImportError:
+            print("Warning: mcp package not installed. Using mock tools.", file=sys.stderr)
+            print("Install with: pip install mcp", file=sys.stderr)
+            return self._get_mock_tools()
+
+        try:
+            # Use HTTP client for streamable HTTP transport
+            async with streamablehttp_client(url) as streams:
+                read_stream, write_stream, _ = streams
+                async with ClientSession(read_stream, write_stream) as session:
+                    await session.initialize()
+                    response = await session.list_tools()
+
+                    tools = []
+                    for tool in response.tools:
+                        tools.append({
+                            "name": tool.name,
+                            "description": tool.description or "No description",
+                            "inputSchema": tool.inputSchema
+                        })
+
+                    print(f"✓ Found {len(tools)} tools")
+                    return tools
+
+        except Exception as e:
+            print(f"Warning: Failed to introspect HTTP MCP server: {e}", file=sys.stderr)
+            print("Using mock tools for demonstration.", file=sys.stderr)
+            return self._get_mock_tools()
+
+    async def _get_mcp_tools_sse(self) -> List[Dict[str, Any]]:
+        """Connect to SSE MCP server and get available tools."""
+        url = self.mcp_config.get('url', '')
+
+        print(f"Introspecting MCP server (SSE): {url}")
+
+        try:
+            from mcp import ClientSession
+            from mcp.client.sse import sse_client
+        except ImportError:
+            print("Warning: mcp package not installed. Using mock tools.", file=sys.stderr)
+            print("Install with: pip install mcp", file=sys.stderr)
+            return self._get_mock_tools()
+
+        try:
+            # Use SSE client for Server-Sent Events transport
+            async with sse_client(url) as streams:
+                read_stream, write_stream = streams
+                async with ClientSession(read_stream, write_stream) as session:
+                    await session.initialize()
+                    response = await session.list_tools()
+
+                    tools = []
+                    for tool in response.tools:
+                        tools.append({
+                            "name": tool.name,
+                            "description": tool.description or "No description",
+                            "inputSchema": tool.inputSchema
+                        })
+
+                    print(f"✓ Found {len(tools)} tools")
+                    return tools
+
+        except Exception as e:
+            print(f"Warning: Failed to introspect SSE MCP server: {e}", file=sys.stderr)
+            print("Using mock tools for demonstration.", file=sys.stderr)
+            return self._get_mock_tools()
+
+    def _get_mock_tools(self) -> List[Dict[str, Any]]:
+        """Return mock tools when introspection fails."""
+        return [
+            {
+                "name": "example_tool",
+                "description": "An example tool from the MCP server (mock - introspection failed)",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "param1": {"type": "string", "description": "First parameter"}
+                    },
+                    "required": ["param1"]
+                }
+            }
+        ]
+    
+    def _generate_skill_md(self, tools: List[Dict[str, Any]]):
+        """Generate the SKILL.md file with instructions for Claude."""
+
+        # Create tool list for Claude
+        tool_list = "\n".join([
+            f"- `{t['name']}`: {t.get('description', 'No description')}"
+            for t in tools
+        ])
+
+        # Count tools
+        tool_count = len(tools)
+
+        # Note: Keywords should be added by the agent after conversion
+        # based on semantic understanding of what the MCP server does.
+        # See SKILL.md instructions for the agent workflow.
+
+        content = f"""---
+name: {self.server_name}
+description: Dynamic access to {self.server_name} MCP server ({tool_count} tools)
+version: 1.0.0
+---
+
+# {self.server_name} Skill
+
+Access {self.server_name} MCP server capabilities.
+
+## Context Efficiency
+
+Traditional MCP approach:
+- All {tool_count} tools loaded at startup
+- Estimated context: {tool_count * 500} tokens
+
+This skill approach:
+- Metadata only: ~100 tokens
+- Full instructions (when used): ~5k tokens
+- Tool execution: 0 tokens (runs externally)
+
+## How This Works
+
+Instead of loading all MCP tool definitions upfront, this skill:
+1. Tells you what tools are available (just names and brief descriptions)
+2. You decide which tool to call based on the user's request
+3. Generate a JSON command to invoke the tool
+4. The executor handles the actual MCP communication
+
+## Available Tools
+
+{tool_list}
+
+## Usage Pattern
+
+When the user's request matches this skill's capabilities:
+
+**Step 1: Identify the right tool** from the list above
+
+**Step 2: Generate a tool call** in this JSON format:
+
+```json
+{{
+  "tool": "tool_name",
+  "arguments": {{
+    "param1": "value1",
+    "param2": "value2"
+  }}
+}}
+```
+
+**Step 3: Execute via bash** (from project root):
+
+```bash
+python .claude/skills/mcp-skills/executor.py --skill {self.server_name} --call 'YOUR_JSON_HERE'
+```
+
+## Getting Tool Details
+
+If you need detailed information about a specific tool's parameters:
+
+```bash
+python .claude/skills/mcp-skills/executor.py --skill {self.server_name} --describe tool_name
+```
+
+This loads ONLY that tool's schema, not all tools.
+
+## Examples
+
+### Example 1: Simple tool call
+
+User: "Use {self.server_name} to do X"
+
+Your workflow:
+1. Identify tool: `example_tool`
+2. Generate call JSON
+3. Execute:
+
+```bash
+python .claude/skills/mcp-skills/executor.py --skill {self.server_name} --call '{{"tool": "example_tool", "arguments": {{"param1": "value"}}}}'
+```
+
+### Example 2: Get tool details first
+
+```bash
+python .claude/skills/mcp-skills/executor.py --skill {self.server_name} --describe example_tool
+```
+
+Returns the full schema, then you can generate the appropriate call.
+
+## Error Handling
+
+If the executor returns an error:
+- Check the tool name is correct
+- Verify required arguments are provided
+- Ensure the MCP server is accessible
+
+## Performance Notes
+
+Context usage comparison for this skill:
+
+| Scenario | MCP (preload) | Skill (dynamic) |
+|----------|---------------|-----------------|
+| Idle | {tool_count * 500} tokens | 100 tokens |
+| Active | {tool_count * 500} tokens | 5k tokens |
+| Executing | {tool_count * 500} tokens | 0 tokens |
+
+Savings: ~{int((1 - 5000/(tool_count * 500)) * 100)}% reduction in typical usage
+
+---
+
+*This skill was auto-generated from an MCP server configuration.*
+*Generator: mcp_to_skill.py*
+"""
+        
+        skill_path = self.output_dir / "SKILL.md"
+        skill_path.write_text(content)
+        print(f"✓ Generated: {skill_path}")
+    
+    def _generate_executor(self):
+        """Generate the executor script that communicates with MCP server."""
+
+        executor_code = '''#!/usr/bin/env python3
+"""
+MCP Skill Executor
+==================
+Handles dynamic communication with the MCP server.
+Supports stdio, HTTP, and SSE transport types.
+Uses proper async context manager pattern for MCP client connections.
+"""
+
+import json
+import sys
+import asyncio
+import argparse
+from pathlib import Path
+
+# Check if mcp package is available
+HAS_MCP = False
+HAS_HTTP = False
+HAS_SSE = False
+
+try:
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+    HAS_MCP = True
+except ImportError:
+    print("Warning: mcp package not installed. Install with: pip install mcp", file=sys.stderr)
+
+try:
+    from mcp.client.streamable_http import streamablehttp_client
+    HAS_HTTP = True
+except ImportError:
+    pass  # HTTP support optional
+
+try:
+    from mcp.client.sse import sse_client
+    HAS_SSE = True
+except ImportError:
+    pass  # SSE support optional
+
+
+class MCPExecutorStdio:
+    """Execute MCP tool calls via stdio transport."""
+
+    def __init__(self, server_config):
+        if not HAS_MCP:
+            raise ImportError("mcp package is required. Install with: pip install mcp")
+
+        self.server_config = server_config
+        self._server_params = StdioServerParameters(
+            command=server_config["command"],
+            args=server_config.get("args", []),
+            env=server_config.get("env")
+        )
+
+    async def _run_with_session(self, operation):
+        async with stdio_client(self._server_params) as streams:
+            read_stream, write_stream = streams
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                return await operation(session)
+
+    async def list_tools(self):
+        async def _list(session):
+            response = await session.list_tools()
+            return [{"name": tool.name, "description": tool.description} for tool in response.tools]
+        return await self._run_with_session(_list)
+
+    async def describe_tool(self, tool_name: str):
+        async def _describe(session):
+            response = await session.list_tools()
+            for tool in response.tools:
+                if tool.name == tool_name:
+                    return {"name": tool.name, "description": tool.description, "inputSchema": tool.inputSchema}
+            return None
+        return await self._run_with_session(_describe)
+
+    async def call_tool(self, tool_name: str, arguments: dict):
+        async def _call(session):
+            response = await session.call_tool(tool_name, arguments)
+            return response.content
+        return await self._run_with_session(_call)
+
+    async def close(self):
+        pass
+
+
+class MCPExecutorHTTP:
+    """Execute MCP tool calls via HTTP transport."""
+
+    def __init__(self, server_config):
+        if not HAS_HTTP:
+            raise ImportError("HTTP transport requires mcp package with streamable_http support")
+
+        self.server_config = server_config
+        self._url = server_config["url"]
+
+    async def _run_with_session(self, operation):
+        async with streamablehttp_client(self._url) as streams:
+            read_stream, write_stream, _ = streams
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                return await operation(session)
+
+    async def list_tools(self):
+        async def _list(session):
+            response = await session.list_tools()
+            return [{"name": tool.name, "description": tool.description} for tool in response.tools]
+        return await self._run_with_session(_list)
+
+    async def describe_tool(self, tool_name: str):
+        async def _describe(session):
+            response = await session.list_tools()
+            for tool in response.tools:
+                if tool.name == tool_name:
+                    return {"name": tool.name, "description": tool.description, "inputSchema": tool.inputSchema}
+            return None
+        return await self._run_with_session(_describe)
+
+    async def call_tool(self, tool_name: str, arguments: dict):
+        async def _call(session):
+            response = await session.call_tool(tool_name, arguments)
+            return response.content
+        return await self._run_with_session(_call)
+
+    async def close(self):
+        pass
+
+
+class MCPExecutorSSE:
+    """Execute MCP tool calls via SSE (Server-Sent Events) transport."""
+
+    def __init__(self, server_config):
+        if not HAS_SSE:
+            raise ImportError("SSE transport requires mcp package with sse support")
+
+        self.server_config = server_config
+        self._url = server_config["url"]
+
+    async def _run_with_session(self, operation):
+        async with sse_client(self._url) as streams:
+            read_stream, write_stream = streams
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                return await operation(session)
+
+    async def list_tools(self):
+        async def _list(session):
+            response = await session.list_tools()
+            return [{"name": tool.name, "description": tool.description} for tool in response.tools]
+        return await self._run_with_session(_list)
+
+    async def describe_tool(self, tool_name: str):
+        async def _describe(session):
+            response = await session.list_tools()
+            for tool in response.tools:
+                if tool.name == tool_name:
+                    return {"name": tool.name, "description": tool.description, "inputSchema": tool.inputSchema}
+            return None
+        return await self._run_with_session(_describe)
+
+    async def call_tool(self, tool_name: str, arguments: dict):
+        async def _call(session):
+            response = await session.call_tool(tool_name, arguments)
+            return response.content
+        return await self._run_with_session(_call)
+
+    async def close(self):
+        pass
+
+
+def create_executor(config):
+    """Factory to create appropriate executor based on config type."""
+    server_type = config.get("type", "stdio")
+    if server_type == "http":
+        return MCPExecutorHTTP(config)
+    elif server_type == "sse":
+        return MCPExecutorSSE(config)
+    else:
+        return MCPExecutorStdio(config)
+
+
+async def main():
+    parser = argparse.ArgumentParser(description="MCP Skill Executor")
+    parser.add_argument("--call", help="JSON tool call to execute")
+    parser.add_argument("--describe", help="Get tool schema")
+    parser.add_argument("--list", action="store_true", help="List all tools")
+
+    args = parser.parse_args()
+
+    # Load server config
+    config_path = Path(__file__).parent / "mcp-config.json"
+    if not config_path.exists():
+        print(f"Error: Configuration file not found: {config_path}", file=sys.stderr)
+        sys.exit(1)
+
+    with open(config_path) as f:
+        config = json.load(f)
+
+    if not HAS_MCP:
+        print("Error: mcp package not installed", file=sys.stderr)
+        print("Install with: pip install mcp", file=sys.stderr)
+        sys.exit(1)
+
+    executor = create_executor(config)
+
+    try:
+        if args.list:
+            tools = await executor.list_tools()
+            print(json.dumps(tools, indent=2))
+
+        elif args.describe:
+            schema = await executor.describe_tool(args.describe)
+            if schema:
+                print(json.dumps(schema, indent=2))
+            else:
+                print(f"Tool not found: {args.describe}", file=sys.stderr)
+                sys.exit(1)
+
+        elif args.call:
+            call_data = json.loads(args.call)
+            result = await executor.call_tool(
+                call_data["tool"],
+                call_data.get("arguments", {})
+            )
+
+            # Format result
+            if isinstance(result, list):
+                for item in result:
+                    if hasattr(item, 'text'):
+                        print(item.text)
+                    else:
+                        print(json.dumps(item.__dict__ if hasattr(item, '__dict__') else item, indent=2))
+            else:
+                print(json.dumps(result.__dict__ if hasattr(result, '__dict__') else result, indent=2))
+        else:
+            parser.print_help()
+
+    except Exception as e:
+        print(f"Error: {str(e)}", file=sys.stderr)
+        import traceback
+        traceback.print_exc(file=sys.stderr)
+        sys.exit(1)
+    finally:
+        await executor.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+'''
+        
+        executor_path = self.output_dir / "executor.py"
+        executor_path.write_text(executor_code)
+        executor_path.chmod(0o755)
+        print(f"✓ Generated: {executor_path}")
+    
+    def _generate_config(self):
+        """Save MCP server config for the executor."""
+        config_path = self.output_dir / "mcp-config.json"
+        with open(config_path, 'w') as f:
+            json.dump(self.mcp_config, f, indent=2)
+        print(f"✓ Generated: {config_path}")
+    
+    def _generate_package_json(self):
+        """Generate package.json for dependencies."""
+        package = {
+            "name": f"skill-{self.server_name}",
+            "version": "1.0.0",
+            "description": f"Claude Skill wrapper for {self.server_name} MCP server",
+            "scripts": {
+                "setup": "pip install mcp"
+            }
+        }
+        
+        package_path = self.output_dir / "package.json"
+        with open(package_path, 'w') as f:
+            json.dump(package, f, indent=2)
+        print(f"✓ Generated: {package_path}")
+
+
+def find_mcp_json(start_path: Optional[Path] = None, explicit_path: Optional[str] = None) -> Path:
+    """
+    Find .mcp.json file using the following priority:
+    1. Use explicit_path if provided
+    2. Search current directory
+    3. Search parent directories recursively (like git does)
+
+    Args:
+        start_path: Starting directory for search (defaults to current directory)
+        explicit_path: Explicit path to .mcp.json if provided
+
+    Returns:
+        Path to .mcp.json file
+
+    Raises:
+        FileNotFoundError: If .mcp.json cannot be found
+    """
+    if explicit_path:
+        path = Path(explicit_path)
+        if path.exists():
+            return path
+        raise FileNotFoundError(f"Specified .mcp.json not found: {explicit_path}")
+
+    if start_path is None:
+        start_path = Path.cwd()
+
+    current = start_path.resolve()
+    while True:
+        mcp_json = current / ".mcp.json"
+        if mcp_json.exists():
+            return mcp_json
+
+        parent = current.parent
+        if parent == current:  # Reached root
+            break
+        current = parent
+
+    raise FileNotFoundError(
+        "Could not find .mcp.json in current or parent directories. "
+        "Use --mcp-json to specify the path explicitly."
+    )
+
+
+def load_mcp_json(path: Path) -> Dict[str, Any]:
+    """
+    Load and validate .mcp.json file.
+
+    Args:
+        path: Path to .mcp.json file
+
+    Returns:
+        Parsed JSON data
+
+    Raises:
+        ValueError: If .mcp.json is invalid (missing mcpServers key)
+    """
+    with open(path) as f:
+        data = json.load(f)
+
+    if "mcpServers" not in data:
+        raise ValueError(f"Invalid .mcp.json: missing 'mcpServers' key in {path}")
+
+    return data
+
+
+def get_compatible_servers(mcp_json: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    """
+    Filter servers to only compatible types (stdio and http).
+
+    Args:
+        mcp_json: Parsed .mcp.json data
+
+    Returns:
+        Dictionary of compatible servers
+    """
+    servers = mcp_json.get("mcpServers", {})
+    compatible = {}
+
+    for name, config in servers.items():
+        server_type = config.get("type", "stdio")  # Default to stdio
+        if server_type in COMPATIBLE_TYPES:
+            compatible[name] = config
+        else:
+            print(f"⚠️  Skipping '{name}': type '{server_type}' not supported (only {COMPATIBLE_TYPES})")
+
+    return compatible
+
+
+def extract_server_config(mcp_json: Dict[str, Any], server_name: str) -> Dict[str, Any]:
+    """
+    Transform .mcp.json entry to converter-compatible format.
+
+    Args:
+        mcp_json: Parsed .mcp.json data
+        server_name: Name of server to extract
+
+    Returns:
+        Server configuration in converter format
+
+    Raises:
+        ValueError: If server not found or incompatible
+    """
+    servers = mcp_json.get("mcpServers", {})
+
+    if server_name not in servers:
+        available = list(servers.keys())
+        raise ValueError(
+            f"Server '{server_name}' not found in .mcp.json. "
+            f"Available servers: {', '.join(available)}"
+        )
+
+    config = servers[server_name]
+    server_type = config.get("type", "stdio")
+
+    if server_type not in COMPATIBLE_TYPES:
+        raise ValueError(
+            f"Server '{server_name}' has type '{server_type}' which is not supported. "
+            f"Only {COMPATIBLE_TYPES} types are compatible."
+        )
+
+    # Handle different transport types
+    if server_type == "http":
+        if "url" not in config:
+            raise ValueError(f"HTTP server '{server_name}' missing required 'url' field")
+        return {
+            "name": server_name,
+            "type": "http",
+            "url": config["url"]
+        }
+    elif server_type == "sse":
+        if "url" not in config:
+            raise ValueError(f"SSE server '{server_name}' missing required 'url' field")
+        return {
+            "name": server_name,
+            "type": "sse",
+            "url": config["url"]
+        }
+    else:
+        # stdio type
+        if "command" not in config:
+            raise ValueError(f"Server '{server_name}' missing required 'command' field")
+        return {
+            "name": server_name,
+            "type": "stdio",
+            "command": config["command"],
+            "args": config.get("args", []),
+            "env": config.get("env")
+        }
+
+
+def remove_server_from_mcp_json(mcp_json_path: Path, server_name: str):
+    """
+    Remove a server from .mcp.json after successful conversion.
+
+    Args:
+        mcp_json_path: Path to .mcp.json file
+        server_name: Name of server to remove
+    """
+    with open(mcp_json_path) as f:
+        data = json.load(f)
+
+    if "mcpServers" in data and server_name in data["mcpServers"]:
+        del data["mcpServers"][server_name]
+        with open(mcp_json_path, 'w') as f:
+            json.dump(data, f, indent=2)
+        print(f"✓ Removed '{server_name}' from {mcp_json_path}")
+    else:
+        print(f"⚠️  Server '{server_name}' not found in {mcp_json_path}")
+
+
+def initialize_mcp_skills_registry(output_base: Path):
+    """
+    Initialize the mcp-skills registry directory with templates if it doesn't exist.
+
+    Args:
+        output_base: Base output directory (mcp-skills/)
+    """
+    output_base = Path(output_base)
+    output_base.mkdir(parents=True, exist_ok=True)
+
+    # Get templates directory (relative to this script)
+    script_dir = Path(__file__).parent
+    templates_dir = script_dir / "templates"
+
+    # Copy registry SKILL.md if not exists
+    registry_skill_path = output_base / "SKILL.md"
+    if not registry_skill_path.exists():
+        template_skill = templates_dir / "registry-SKILL.md"
+        if template_skill.exists():
+            import shutil
+            shutil.copy(template_skill, registry_skill_path)
+            print(f"✓ Created registry SKILL.md at {output_base}")
+        else:
+            print(f"⚠️  Template not found: {template_skill}")
+
+    # Copy index.json if not exists
+    index_path = output_base / "index.json"
+    if not index_path.exists():
+        template_index = templates_dir / "index.json"
+        if template_index.exists():
+            import shutil
+            shutil.copy(template_index, index_path)
+            print(f"✓ Created index.json at {output_base}")
+        else:
+            # Create default index.json
+            index = {
+                "name": "mcp-skills",
+                "version": "1.0.0",
+                "description": "Registry of MCP-derived skills with progressive disclosure",
+                "skills": []
+            }
+            with open(index_path, 'w') as f:
+                json.dump(index, f, indent=2)
+            print(f"✓ Created index.json at {output_base}")
+
+
+def update_mcp_skills_index(output_base: Path, server_name: str, tools_count: int, description: str):
+    """
+    Update the mcp-skills/index.json with the new skill.
+
+    Args:
+        output_base: Base output directory (mcp-skills/)
+        server_name: Name of the skill
+        tools_count: Number of tools in the skill
+        description: Brief description of the skill
+    """
+    # Ensure registry is initialized
+    initialize_mcp_skills_registry(output_base)
+
+    index_path = Path(output_base) / "index.json"
+
+    with open(index_path) as f:
+        index = json.load(f)
+
+    # Note: Keywords should be added by the agent after conversion
+    # based on semantic understanding of what the MCP server does.
+    # See SKILL.md instructions for the agent workflow.
+
+    # Check if skill already exists
+    existing = next((s for s in index["skills"] if s["name"] == server_name), None)
+    if existing:
+        existing["tools"] = tools_count
+        existing["description"] = description
+    else:
+        index["skills"].append({
+            "name": server_name,
+            "description": description,
+            "tools": tools_count,
+            "category": "integration"
+        })
+
+    with open(index_path, 'w') as f:
+        json.dump(index, f, indent=2)
+    print(f"✓ Updated index.json with '{server_name}'")
+
+
+async def convert_single_server(mcp_json: Dict[str, Any], server_name: str, output_base: str, mcp_json_path: Optional[Path] = None):
+    """
+    Convert a single server from .mcp.json.
+
+    Args:
+        mcp_json: Parsed .mcp.json data
+        server_name: Name of server to convert
+        output_base: Base output directory
+        mcp_json_path: Path to .mcp.json (for removal after conversion)
+    """
+    config = extract_server_config(mcp_json, server_name)
+
+    # Sanitize the name for filesystem compatibility
+    sanitized_name = sanitize_name(server_name)
+    if sanitized_name != server_name:
+        print(f"📝 Sanitizing name: '{server_name}' → '{sanitized_name}'")
+
+    # Update config with sanitized name for skill generation
+    config["name"] = sanitized_name
+
+    output_dir = Path(output_base) / sanitized_name
+
+    generator = MCPSkillGenerator(config, output_dir)
+    await generator.generate()
+
+    # Update the mcp-skills index with sanitized name
+    update_mcp_skills_index(Path(output_base), sanitized_name, len(generator.tools_cache or []), f"{sanitized_name} MCP server integration")
+
+    # Remove original name from .mcp.json after successful conversion
+    if mcp_json_path:
+        remove_server_from_mcp_json(Path(mcp_json_path), server_name)
+
+
+async def convert_all_servers(mcp_json: Dict[str, Any], output_base: str, mcp_json_path: Optional[Path] = None):
+    """
+    Convert all compatible servers from .mcp.json.
+
+    Args:
+        mcp_json: Parsed .mcp.json data
+        output_base: Base output directory
+        mcp_json_path: Path to .mcp.json (for removal after conversion)
+    """
+    compatible = get_compatible_servers(mcp_json)
+
+    if not compatible:
+        print("❌ No compatible servers found in .mcp.json")
+        return
+
+    print(f"🔄 Converting {len(compatible)} server(s)...")
+
+    success_count = 0
+    converted_servers = []  # Stores (original_name, sanitized_name, tools_count)
+    for server_name in compatible:
+        try:
+            print(f"\n{'='*60}")
+            print(f"Converting: {server_name}")
+            print('='*60)
+
+            config = extract_server_config(mcp_json, server_name)
+
+            # Sanitize the name for filesystem compatibility
+            sanitized_name = sanitize_name(server_name)
+            if sanitized_name != server_name:
+                print(f"📝 Sanitizing name: '{server_name}' → '{sanitized_name}'")
+
+            # Update config with sanitized name for skill generation
+            config["name"] = sanitized_name
+
+            output_dir = Path(output_base) / sanitized_name
+
+            generator = MCPSkillGenerator(config, output_dir)
+            await generator.generate()
+            success_count += 1
+            converted_servers.append((server_name, sanitized_name, len(generator.tools_cache or [])))
+
+            # Update the mcp-skills index with sanitized name
+            update_mcp_skills_index(Path(output_base), sanitized_name, len(generator.tools_cache or []), f"{sanitized_name} MCP server integration")
+
+        except Exception as e:
+            print(f"❌ Failed to convert '{server_name}': {e}")
+
+    # Remove all successfully converted servers from .mcp.json (use original names)
+    if mcp_json_path and converted_servers:
+        print(f"\n{'='*60}")
+        print("Cleaning up .mcp.json...")
+        for original_name, _, _ in converted_servers:
+            remove_server_from_mcp_json(Path(mcp_json_path), original_name)
+
+    print(f"\n{'='*60}")
+    print(f"✅ Successfully converted {success_count}/{len(compatible)} servers")
+    print('='*60)
+
+
+async def list_servers(explicit_path: Optional[str] = None):
+    """
+    List all servers in .mcp.json with compatibility info.
+
+    Args:
+        explicit_path: Optional explicit path to .mcp.json
+    """
+    mcp_json_path = find_mcp_json(explicit_path=explicit_path)
+    mcp_json = load_mcp_json(mcp_json_path)
+
+    print(f"📄 Servers in: {mcp_json_path}\n")
+
+    servers = mcp_json.get("mcpServers", {})
+    compatible = get_compatible_servers(mcp_json)
+
+    print(f"{'Name':<25} {'Type':<10} {'Compatible':<12} {'Command'}")
+    print("-" * 80)
+
+    for name, config in servers.items():
+        server_type = config.get("type", "stdio")
+        is_compatible = "✅ Yes" if name in compatible else "❌ No"
+        command = config.get("command", config.get("url", "N/A"))
+        print(f"{name:<25} {server_type:<10} {is_compatible:<12} {command}")
+
+    print(f"\n📊 Total: {len(servers)} servers, {len(compatible)} compatible")
+
+
+def validate_arguments(args):
+    """
+    Validate mutually exclusive arguments.
+
+    Args:
+        args: Parsed command-line arguments
+
+    Raises:
+        SystemExit: If arguments are invalid
+    """
+    if args.mcp_config and (args.name or args.all):
+        raise SystemExit("Error: --mcp-config cannot be used with --name or --all")
+
+    if args.name and args.all:
+        raise SystemExit("Error: --name and --all are mutually exclusive")
+
+    if args.list:
+        return  # --list doesn't require output-dir
+
+    if not args.mcp_config and not args.name and not args.all:
+        raise SystemExit("Error: Must specify --mcp-config, --name, or --all")
+
+    # output-dir is now optional - we default to mcp-skills/ next to .mcp.json
+    if args.mcp_config and not args.output_dir:
+        raise SystemExit("Error: --output-dir is required for legacy --mcp-config mode")
+
+
+async def convert_mcp_to_skill(mcp_config_path: str, output_dir: str):
+    """Convert an MCP server configuration to a Skill (legacy mode)."""
+
+    # Load MCP config
+    with open(mcp_config_path) as f:
+        mcp_config = json.load(f)
+
+    # Generate skill
+    generator = MCPSkillGenerator(mcp_config, Path(output_dir))
+    await generator.generate()
+    
+    print("\n" + "="*60)
+    print("✓ Skill generation complete!")
+    print("="*60)
+    print(f"\nGenerated files:")
+    print(f"  - SKILL.md (instructions for Claude)")
+    print(f"  - executor.py (MCP communication handler)")
+    print(f"  - mcp-config.json (MCP server configuration)")
+    print(f"  - package.json (dependencies)")
+    
+    print(f"\nTo use this skill:")
+    print(f"1. Install dependencies:")
+    print(f"   pip install mcp")
+    print(f"\n2. Use the central executor from project root:")
+    print(f"   python .claude/skills/mcp-skills/executor.py --skill <name> --list")
+    print(f"\n3. Claude will discover it via the mcp-skills registry")
+    
+    print(f"\nContext savings:")
+    print(f"  Before (MCP): All tools preloaded (~10k-50k tokens)")
+    print(f"  After (Skill): ~100 tokens until used")
+    print(f"  Reduction: ~90-99%")
+
+
+async def async_main():
+    """Async main function to handle all conversion modes."""
+    parser = argparse.ArgumentParser(
+        description="Convert MCP servers to Claude Skills with progressive disclosure",
+        epilog="""
+Examples:
+  # List available servers in .mcp.json
+  python mcp_to_skill.py --list
+
+  # Convert single server (auto-discovers .mcp.json)
+  python mcp_to_skill.py --name github --output-dir ./skills
+
+  # Convert all compatible servers
+  python mcp_to_skill.py --all --output-dir ./skills
+
+  # Specify custom .mcp.json location
+  python mcp_to_skill.py --mcp-json /path/to/.mcp.json --name github --output-dir ./skills
+
+  # Legacy mode (backward compatible)
+  python mcp_to_skill.py --mcp-config github.json --output-dir ./skills/github
+""",
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+
+    # New .mcp.json mode arguments
+    parser.add_argument(
+        "--mcp-json",
+        help="Path to .mcp.json file (auto-discovers if not specified)"
+    )
+    parser.add_argument(
+        "--name",
+        help="Name of specific MCP server to convert"
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Convert all compatible MCP servers"
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List available servers in .mcp.json"
+    )
+
+    # Existing arguments (backward compatible)
+    parser.add_argument(
+        "--mcp-config",
+        help="[Legacy] Path to individual MCP config JSON"
+    )
+    parser.add_argument(
+        "--output-dir",
+        help="Output directory for generated skill(s). Default: .claude/skills/mcp-skills/ relative to .mcp.json"
+    )
+
+    args = parser.parse_args()
+
+    try:
+        # Validate argument combinations
+        validate_arguments(args)
+
+        # Handle --list command
+        if args.list:
+            await list_servers(args.mcp_json)
+            return
+
+        # Legacy mode
+        if args.mcp_config:
+            await convert_mcp_to_skill(args.mcp_config, args.output_dir)
+            return
+
+        # New .mcp.json mode
+        mcp_json_path = find_mcp_json(explicit_path=args.mcp_json)
+        mcp_json = load_mcp_json(mcp_json_path)
+
+        # Default output to mcp-skills/ directory next to .mcp.json
+        output_dir = args.output_dir
+        if not output_dir:
+            mcp_json_dir = Path(mcp_json_path).parent
+            output_dir = str(mcp_json_dir / ".claude" / "skills" / "mcp-skills")
+            print(f"📂 Default output: {output_dir}")
+
+        if args.name:
+            # Single server conversion
+            print(f"📄 Using: {mcp_json_path}")
+            await convert_single_server(mcp_json, args.name, output_dir, mcp_json_path)
+        elif args.all:
+            # Batch conversion
+            print(f"📄 Using: {mcp_json_path}")
+            await convert_all_servers(mcp_json, output_dir, mcp_json_path)
+
+    except (FileNotFoundError, ValueError) as e:
+        print(f"\n❌ Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"\n❌ Unexpected error: {e}", file=sys.stderr)
+        import traceback
+        traceback.print_exc(file=sys.stderr)
+        sys.exit(1)
+
+
+def main():
+    """Entry point for the script."""
+    asyncio.run(async_main())
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp-skills-plugin/skills/mcp-to-skill-converter/templates/index.json
+++ b/mcp-skills-plugin/skills/mcp-to-skill-converter/templates/index.json
@@ -1,0 +1,6 @@
+{
+  "name": "mcp-skills",
+  "version": "1.0.0",
+  "description": "Registry of MCP-derived skills with progressive disclosure",
+  "skills": []
+}

--- a/mcp-skills-plugin/skills/mcp-to-skill-converter/templates/registry-SKILL.md
+++ b/mcp-skills-plugin/skills/mcp-to-skill-converter/templates/registry-SKILL.md
@@ -1,0 +1,91 @@
+---
+name: mcp-skills
+description: Registry of MCP-derived skills with progressive disclosure. Use when asked about "github", "assistant-ui", "MCP tools", or any converted MCP server. Provides 90%+ context savings compared to native MCP loading.
+version: 1.0.0
+---
+
+# MCP Skills Registry
+
+Central directory for all MCP-derived skills. Each sub-skill wraps an MCP server with progressive disclosure.
+
+## Available Skills
+
+| Skill | Tools | Trigger Keywords |
+|-------|-------|------------------|
+<!-- Add skills here after conversion. See mcp-to-skill-converter workflow Step 3. -->
+
+See `index.json` for the machine-readable list.
+
+## ⚠️ These Are Skill Wrappers, NOT Native MCP Tools
+
+You CANNOT call `mcp__shadcn__*`, `mcp__github__*`, etc. directly - those don't exist.
+These skills wrap MCP servers via a central executor.py.
+
+## Usage
+
+**Step 1: Read the skill's SKILL.md** (from project root):
+
+```bash
+cat .claude/skills/mcp-skills/<skill-name>/SKILL.md
+
+# Example: shadcn skill
+cat .claude/skills/mcp-skills/shadcn/SKILL.md
+```
+
+**Step 2: Use the central executor.py** (from project root):
+
+```bash
+# List available skills
+python .claude/skills/mcp-skills/executor.py --skills
+
+# List tools in a skill
+python .claude/skills/mcp-skills/executor.py --skill github --list
+
+# Get tool schema
+python .claude/skills/mcp-skills/executor.py --skill github --describe create_issue
+
+# Call a tool
+python .claude/skills/mcp-skills/executor.py --skill github --call '{"tool": "create_issue", "arguments": {...}}'
+```
+
+## Context Efficiency
+
+| Scenario | Native MCP (all servers) | This Registry | Savings |
+|----------|--------------------------|---------------|---------|
+| Idle | 40-100k tokens | ~150 tokens | 99%+ |
+| Using 1 skill | 40-100k tokens | ~5k tokens | 90%+ |
+| After execution | 40-100k tokens | ~150 tokens | 99%+ |
+
+## How It Works
+
+1. **Registry loads first** - This file (~150 tokens)
+2. **User requests a tool** - e.g., "create a GitHub PR"
+3. **Sub-skill loads** - Only the relevant skill's SKILL.md (~4k tokens)
+4. **Executor runs** - External process, 0 context tokens
+5. **Result returned** - Context drops back to registry only
+
+## Adding New Skills
+
+Use the `mcp-to-skill-converter` skill:
+
+```bash
+cd .claude/skills/mcp-to-skill-converter
+python mcp_to_skill.py --name <server-name>
+# Outputs to .claude/skills/mcp-skills/<server-name>/
+```
+
+## Skill Structure
+
+Each sub-skill contains:
+
+```
+.claude/skills/mcp-skills/<skill-name>/
+├── SKILL.md           # Tool documentation
+├── executor.py        # Async MCP client (legacy, use central executor)
+├── mcp-config.json    # Server config
+└── package.json       # Dependencies
+```
+
+---
+
+*This registry enables progressive disclosure of MCP servers as Claude Skills.*

--- a/pdf-creator/.security-scan-passed
+++ b/pdf-creator/.security-scan-passed
@@ -1,0 +1,4 @@
+Security scan passed
+Scanned at: 2025-12-11T19:59:37.734920
+Tool: gitleaks + pattern-based validation
+Content hash: a9abbfd8a9175fbbdad11e86ce7691c080614982d9b37ffa2b7610bbfad03377

--- a/pdf-creator/SKILL.md
+++ b/pdf-creator/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: pdf-creator
+description: Create PDF documents from markdown with proper Chinese font support using weasyprint. This skill should be used when converting markdown to PDF, generating formal documents (legal, trademark filings, reports), or when Chinese typography is required. Triggers include "convert to PDF", "generate PDF", "markdown to PDF", or any request for creating printable documents.
+---
+
+# PDF Creator
+
+Create professional PDF documents from markdown with proper Chinese font support.
+
+## Quick Start
+
+Convert a single markdown file:
+
+```bash
+uv run --with weasyprint --with markdown scripts/md_to_pdf.py input.md output.pdf
+```
+
+Batch convert multiple files:
+
+```bash
+uv run --with weasyprint --with markdown scripts/batch_convert.py *.md --output-dir ./pdfs
+```
+
+## macOS Environment Setup
+
+If encountering library errors, set these environment variables first:
+
+```bash
+export DYLD_LIBRARY_PATH="/opt/homebrew/lib:$DYLD_LIBRARY_PATH"
+export PKG_CONFIG_PATH="/opt/homebrew/lib/pkgconfig:$PKG_CONFIG_PATH"
+```
+
+## Font Configuration
+
+The scripts use these Chinese fonts (with fallbacks):
+
+| Font Type | Primary | Fallbacks |
+|-----------|---------|-----------|
+| Body text | Songti SC | SimSun, STSong, Noto Serif CJK SC |
+| Headings | Heiti SC | SimHei, STHeiti, Noto Sans CJK SC |
+
+## Output Specifications
+
+- **Page size**: A4
+- **Margins**: 2.5cm top/bottom, 2cm left/right
+- **Body font**: 12pt, 1.8 line height
+- **Max file size**: Designed to stay under 2MB for form submissions
+
+## Common Use Cases
+
+1. **Legal documents**: Trademark filings, contracts, evidence lists
+2. **Reports**: Business reports, technical documentation
+3. **Formal letters**: Official correspondence requiring print format
+
+## Troubleshooting
+
+**Problem**: Chinese characters display as boxes
+**Solution**: Ensure Songti SC or other Chinese fonts are installed on the system
+
+**Problem**: `weasyprint` import error
+**Solution**: Run with `uv run --with weasyprint --with markdown` to ensure dependencies

--- a/pdf-creator/scripts/batch_convert.py
+++ b/pdf-creator/scripts/batch_convert.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""
+Batch convert multiple markdown files to PDF.
+
+Usage:
+    python batch_convert.py file1.md file2.md file3.md
+    python batch_convert.py *.md
+    python batch_convert.py --output-dir ./pdfs file1.md file2.md
+
+Requirements:
+    pip install weasyprint markdown
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+from md_to_pdf import markdown_to_pdf
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Batch convert markdown files to PDF with Chinese font support'
+    )
+    parser.add_argument(
+        'files',
+        nargs='+',
+        help='Markdown files to convert'
+    )
+    parser.add_argument(
+        '--output-dir', '-o',
+        type=str,
+        default=None,
+        help='Output directory for PDFs (default: same as input)'
+    )
+
+    args = parser.parse_args()
+
+    output_dir = Path(args.output_dir) if args.output_dir else None
+    if output_dir:
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+    success = 0
+    failed = 0
+
+    for md_file in args.files:
+        md_path = Path(md_file)
+
+        if not md_path.exists():
+            print(f"[SKIP] File not found: {md_file}")
+            failed += 1
+            continue
+
+        if not md_path.suffix.lower() == '.md':
+            print(f"[SKIP] Not a markdown file: {md_file}")
+            failed += 1
+            continue
+
+        # Determine output path
+        if output_dir:
+            pdf_file = str(output_dir / md_path.with_suffix('.pdf').name)
+        else:
+            pdf_file = str(md_path.with_suffix('.pdf'))
+
+        try:
+            print(f"Converting: {md_file} -> {pdf_file}")
+            markdown_to_pdf(str(md_path), pdf_file)
+            success += 1
+        except Exception as e:
+            print(f"[ERROR] Failed to convert {md_file}: {e}")
+            failed += 1
+
+    print(f"\nCompleted: {success} succeeded, {failed} failed")
+    sys.exit(0 if failed == 0 else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/pdf-creator/scripts/md_to_pdf.py
+++ b/pdf-creator/scripts/md_to_pdf.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""
+Markdown to PDF converter with Chinese font support.
+
+Converts markdown files to PDF using weasyprint, with proper Chinese typography.
+Designed for formal documents (trademark filings, legal documents, reports).
+
+Usage:
+    python md_to_pdf.py input.md output.pdf
+    python md_to_pdf.py input.md  # outputs input.pdf
+
+Requirements:
+    pip install weasyprint markdown
+
+    macOS environment setup (if needed):
+    export DYLD_LIBRARY_PATH="/opt/homebrew/lib:$DYLD_LIBRARY_PATH"
+"""
+
+import sys
+from pathlib import Path
+
+import markdown
+from weasyprint import CSS, HTML
+
+
+# CSS with Chinese font support
+CSS_STYLES = """
+@page {
+    size: A4;
+    margin: 2.5cm 2cm;
+}
+
+body {
+    font-family: 'Songti SC', 'SimSun', 'STSong', 'Noto Serif CJK SC', serif;
+    font-size: 12pt;
+    line-height: 1.8;
+    color: #000;
+    width: 100%;
+}
+
+h1 {
+    font-family: 'Heiti SC', 'SimHei', 'STHeiti', 'Noto Sans CJK SC', sans-serif;
+    font-size: 18pt;
+    font-weight: bold;
+    text-align: center;
+    margin-top: 0;
+    margin-bottom: 1.5em;
+}
+
+h2 {
+    font-family: 'Heiti SC', 'SimHei', 'STHeiti', 'Noto Sans CJK SC', sans-serif;
+    font-size: 14pt;
+    font-weight: bold;
+    margin-top: 1.5em;
+    margin-bottom: 0.8em;
+}
+
+h3 {
+    font-family: 'Heiti SC', 'SimHei', 'STHeiti', 'Noto Sans CJK SC', sans-serif;
+    font-size: 12pt;
+    font-weight: bold;
+    margin-top: 1em;
+    margin-bottom: 0.5em;
+}
+
+p {
+    margin: 0.8em 0;
+    text-align: justify;
+}
+
+ul, ol {
+    margin: 0.8em 0;
+    padding-left: 2em;
+}
+
+li {
+    margin: 0.4em 0;
+}
+
+table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 1em 0;
+    font-size: 10pt;
+    table-layout: fixed;
+}
+
+th, td {
+    border: 1px solid #666;
+    padding: 8px 6px;
+    text-align: left;
+    word-wrap: break-word;
+    word-break: break-all;
+}
+
+th {
+    background-color: #f0f0f0;
+    font-weight: bold;
+}
+
+hr {
+    border: none;
+    border-top: 1px solid #ccc;
+    margin: 1.5em 0;
+}
+
+strong {
+    font-weight: bold;
+}
+
+code {
+    font-family: 'SF Mono', 'Monaco', 'Menlo', monospace;
+    font-size: 10pt;
+    background-color: #f5f5f5;
+    padding: 0.2em 0.4em;
+    border-radius: 3px;
+}
+
+pre {
+    background-color: #f5f5f5;
+    padding: 1em;
+    overflow-x: auto;
+    font-size: 10pt;
+    line-height: 1.4;
+    border-radius: 4px;
+}
+
+blockquote {
+    border-left: 3px solid #ccc;
+    margin: 1em 0;
+    padding-left: 1em;
+    color: #555;
+}
+"""
+
+
+def markdown_to_pdf(md_file: str, pdf_file: str | None = None) -> str:
+    """
+    Convert markdown file to PDF with Chinese font support.
+
+    Args:
+        md_file: Path to input markdown file
+        pdf_file: Path to output PDF file (optional, defaults to same name as input)
+
+    Returns:
+        Path to generated PDF file
+    """
+    md_path = Path(md_file)
+
+    if pdf_file is None:
+        pdf_file = str(md_path.with_suffix('.pdf'))
+
+    # Read markdown content
+    md_content = md_path.read_text(encoding='utf-8')
+
+    # Convert to HTML
+    html_content = markdown.markdown(
+        md_content,
+        extensions=['tables', 'fenced_code', 'codehilite', 'toc']
+    )
+
+    # Create full HTML document
+    full_html = f"""<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <title>{md_path.stem}</title>
+</head>
+<body>
+{html_content}
+</body>
+</html>"""
+
+    # Generate PDF
+    HTML(string=full_html).write_pdf(pdf_file, stylesheets=[CSS(string=CSS_STYLES)])
+
+    return pdf_file
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python md_to_pdf.py <input.md> [output.pdf]")
+        print("\nConverts markdown to PDF with Chinese font support.")
+        sys.exit(1)
+
+    md_file = sys.argv[1]
+    pdf_file = sys.argv[2] if len(sys.argv) > 2 else None
+
+    if not Path(md_file).exists():
+        print(f"Error: File not found: {md_file}")
+        sys.exit(1)
+
+    output = markdown_to_pdf(md_file, pdf_file)
+    print(f"Generated: {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/promptfoo-evaluation/.security-scan-passed
+++ b/promptfoo-evaluation/.security-scan-passed
@@ -1,0 +1,4 @@
+Security scan passed
+Scanned at: 2025-12-11T22:24:55.327388
+Tool: gitleaks + pattern-based validation
+Content hash: d04b93ec8a47fa7b64a2d0ee9790997e5ecc212ddbfa4c2c58fddafa2424d49a

--- a/promptfoo-evaluation/SKILL.md
+++ b/promptfoo-evaluation/SKILL.md
@@ -1,0 +1,392 @@
+---
+name: promptfoo-evaluation
+description: Configures and runs LLM evaluation using Promptfoo framework. Use when setting up prompt testing, creating evaluation configs (promptfooconfig.yaml), writing Python custom assertions, implementing llm-rubric for LLM-as-judge, or managing few-shot examples in prompts. Triggers on keywords like "promptfoo", "eval", "LLM evaluation", "prompt testing", or "model comparison".
+---
+
+# Promptfoo Evaluation
+
+## Overview
+
+This skill provides guidance for configuring and running LLM evaluations using [Promptfoo](https://www.promptfoo.dev/), an open-source CLI tool for testing and comparing LLM outputs.
+
+## Quick Start
+
+```bash
+# Initialize a new evaluation project
+npx promptfoo@latest init
+
+# Run evaluation
+npx promptfoo@latest eval
+
+# View results in browser
+npx promptfoo@latest view
+```
+
+## Configuration Structure
+
+A typical Promptfoo project structure:
+
+```
+project/
+├── promptfooconfig.yaml    # Main configuration
+├── prompts/
+│   ├── system.md           # System prompt
+│   └── chat.json           # Chat format prompt
+├── tests/
+│   └── cases.yaml          # Test cases
+└── scripts/
+    └── metrics.py          # Custom Python assertions
+```
+
+## Core Configuration (promptfooconfig.yaml)
+
+```yaml
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+description: "My LLM Evaluation"
+
+# Prompts to test
+prompts:
+  - file://prompts/system.md
+  - file://prompts/chat.json
+
+# Models to compare
+providers:
+  - id: anthropic:messages:claude-sonnet-4-5-20250929
+    label: Claude-4.5-Sonnet
+  - id: openai:gpt-4.1
+    label: GPT-4.1
+
+# Test cases
+tests: file://tests/cases.yaml
+
+# Default assertions for all tests
+defaultTest:
+  assert:
+    - type: python
+      value: file://scripts/metrics.py:custom_assert
+    - type: llm-rubric
+      value: |
+        Evaluate the response quality on a 0-1 scale.
+      threshold: 0.7
+
+# Output path
+outputPath: results/eval-results.json
+```
+
+## Prompt Formats
+
+### Text Prompt (system.md)
+
+```markdown
+You are a helpful assistant.
+
+Task: {{task}}
+Context: {{context}}
+```
+
+### Chat Format (chat.json)
+
+```json
+[
+  {"role": "system", "content": "{{system_prompt}}"},
+  {"role": "user", "content": "{{user_input}}"}
+]
+```
+
+### Few-Shot Pattern
+
+Embed examples directly in prompt or use chat format with assistant messages:
+
+```json
+[
+  {"role": "system", "content": "{{system_prompt}}"},
+  {"role": "user", "content": "Example input: {{example_input}}"},
+  {"role": "assistant", "content": "{{example_output}}"},
+  {"role": "user", "content": "Now process: {{actual_input}}"}
+]
+```
+
+## Test Cases (tests/cases.yaml)
+
+```yaml
+- description: "Test case 1"
+  vars:
+    system_prompt: file://prompts/system.md
+    user_input: "Hello world"
+    # Load content from files
+    context: file://data/context.txt
+  assert:
+    - type: contains
+      value: "expected text"
+    - type: python
+      value: file://scripts/metrics.py:custom_check
+      threshold: 0.8
+```
+
+## Python Custom Assertions
+
+Create a Python file for custom assertions (e.g., `scripts/metrics.py`):
+
+```python
+def get_assert(output: str, context: dict) -> dict:
+    """Default assertion function."""
+    vars_dict = context.get('vars', {})
+
+    # Access test variables
+    expected = vars_dict.get('expected', '')
+
+    # Return result
+    return {
+        "pass": expected in output,
+        "score": 0.8,
+        "reason": "Contains expected content",
+        "named_scores": {"relevance": 0.9}
+    }
+
+def custom_check(output: str, context: dict) -> dict:
+    """Custom named assertion."""
+    word_count = len(output.split())
+    passed = 100 <= word_count <= 500
+
+    return {
+        "pass": passed,
+        "score": min(1.0, word_count / 300),
+        "reason": f"Word count: {word_count}"
+    }
+```
+
+**Key points:**
+- Default function name is `get_assert`
+- Specify function with `file://path.py:function_name`
+- Return `bool`, `float` (score), or `dict` with pass/score/reason
+- Access variables via `context['vars']`
+
+## LLM-as-Judge (llm-rubric)
+
+```yaml
+assert:
+  - type: llm-rubric
+    value: |
+      Evaluate the response based on:
+      1. Accuracy of information
+      2. Clarity of explanation
+      3. Completeness
+
+      Score 0.0-1.0 where 0.7+ is passing.
+    threshold: 0.7
+    provider: openai:gpt-4.1  # Optional: override grader model
+```
+
+**Best practices:**
+- Provide clear scoring criteria
+- Use `threshold` to set minimum passing score
+- Default grader uses available API keys (OpenAI → Anthropic → Google)
+
+## Common Assertion Types
+
+| Type | Usage | Example |
+|------|-------|---------|
+| `contains` | Check substring | `value: "hello"` |
+| `icontains` | Case-insensitive | `value: "HELLO"` |
+| `equals` | Exact match | `value: "42"` |
+| `regex` | Pattern match | `value: "\\d{4}"` |
+| `python` | Custom logic | `value: file://script.py` |
+| `llm-rubric` | LLM grading | `value: "Is professional"` |
+| `latency` | Response time | `threshold: 1000` |
+
+## File References
+
+All paths are relative to config file location:
+
+```yaml
+# Load file content as variable
+vars:
+  content: file://data/input.txt
+
+# Load prompt from file
+prompts:
+  - file://prompts/main.md
+
+# Load test cases from file
+tests: file://tests/cases.yaml
+
+# Load Python assertion
+assert:
+  - type: python
+    value: file://scripts/check.py:validate
+```
+
+## Running Evaluations
+
+```bash
+# Basic run
+npx promptfoo@latest eval
+
+# With specific config
+npx promptfoo@latest eval --config path/to/config.yaml
+
+# Output to file
+npx promptfoo@latest eval --output results.json
+
+# Filter tests
+npx promptfoo@latest eval --filter-metadata category=math
+
+# View results
+npx promptfoo@latest view
+```
+
+## Troubleshooting
+
+**Python not found:**
+```bash
+export PROMPTFOO_PYTHON=python3
+```
+
+**Large outputs truncated:**
+Outputs over 30000 characters are truncated. Use `head_limit` in assertions.
+
+**File not found errors:**
+Ensure paths are relative to `promptfooconfig.yaml` location.
+
+## Echo Provider (Preview Mode)
+
+Use the **echo provider** to preview rendered prompts without making API calls:
+
+```yaml
+# promptfooconfig-preview.yaml
+providers:
+  - echo  # Returns prompt as output, no API calls
+
+tests:
+  - vars:
+      input: "test content"
+```
+
+**Use cases:**
+- Preview prompt rendering before expensive API calls
+- Verify Few-shot examples are loaded correctly
+- Debug variable substitution issues
+- Validate prompt structure
+
+```bash
+# Run preview mode
+npx promptfoo@latest eval --config promptfooconfig-preview.yaml
+```
+
+**Cost:** Free - no API tokens consumed.
+
+## Advanced Few-Shot Implementation
+
+### Multi-turn Conversation Pattern
+
+For complex few-shot learning with full examples:
+
+```json
+[
+  {"role": "system", "content": "{{system_prompt}}"},
+
+  // Few-shot Example 1
+  {"role": "user", "content": "Task: {{example_input_1}}"},
+  {"role": "assistant", "content": "{{example_output_1}}"},
+
+  // Few-shot Example 2 (optional)
+  {"role": "user", "content": "Task: {{example_input_2}}"},
+  {"role": "assistant", "content": "{{example_output_2}}"},
+
+  // Actual test
+  {"role": "user", "content": "Task: {{actual_input}}"}
+]
+```
+
+**Test case configuration:**
+
+```yaml
+tests:
+  - vars:
+      system_prompt: file://prompts/system.md
+      # Few-shot examples
+      example_input_1: file://data/examples/input1.txt
+      example_output_1: file://data/examples/output1.txt
+      example_input_2: file://data/examples/input2.txt
+      example_output_2: file://data/examples/output2.txt
+      # Actual test
+      actual_input: file://data/test1.txt
+```
+
+**Best practices:**
+- Use 1-3 few-shot examples (more may dilute effectiveness)
+- Ensure examples match the task format exactly
+- Load examples from files for better maintainability
+- Use echo provider first to verify structure
+
+## Long Text Handling
+
+For Chinese/long-form content evaluations (10k+ characters):
+
+**Configuration:**
+
+```yaml
+providers:
+  - id: anthropic:messages:claude-sonnet-4-5-20250929
+    config:
+      max_tokens: 8192  # Increase for long outputs
+
+defaultTest:
+  assert:
+    - type: python
+      value: file://scripts/metrics.py:check_length
+```
+
+**Python assertion for text metrics:**
+
+```python
+import re
+
+def strip_tags(text: str) -> str:
+    """Remove HTML tags for pure text."""
+    return re.sub(r'<[^>]+>', '', text)
+
+def check_length(output: str, context: dict) -> dict:
+    """Check output length constraints."""
+    raw_input = context['vars'].get('raw_input', '')
+
+    input_len = len(strip_tags(raw_input))
+    output_len = len(strip_tags(output))
+
+    reduction_ratio = 1 - (output_len / input_len) if input_len > 0 else 0
+
+    return {
+        "pass": 0.7 <= reduction_ratio <= 0.9,
+        "score": reduction_ratio,
+        "reason": f"Reduction: {reduction_ratio:.1%} (target: 70-90%)",
+        "named_scores": {
+            "input_length": input_len,
+            "output_length": output_len,
+            "reduction_ratio": reduction_ratio
+        }
+    }
+```
+
+## Real-World Example
+
+**Project:** Chinese short-video content curation from long transcripts
+
+**Structure:**
+```
+tiaogaoren/
+├── promptfooconfig.yaml          # Production config
+├── promptfooconfig-preview.yaml  # Preview config (echo provider)
+├── prompts/
+│   ├── tiaogaoren-prompt.json   # Chat format with few-shot
+│   └── v4/system-v4.md          # System prompt
+├── tests/cases.yaml              # 3 test samples
+├── scripts/metrics.py            # Custom metrics (reduction ratio, etc.)
+├── data/                         # 5 samples (2 few-shot, 3 eval)
+└── results/
+```
+
+**See:** `/Users/tiansheng/Workspace/prompts/tiaogaoren/` for full implementation.
+
+## Resources
+
+For detailed API reference and advanced patterns, see [references/promptfoo_api.md](references/promptfoo_api.md).

--- a/promptfoo-evaluation/references/promptfoo_api.md
+++ b/promptfoo-evaluation/references/promptfoo_api.md
@@ -1,0 +1,249 @@
+# Promptfoo API Reference
+
+## Provider Configuration
+
+### Echo Provider (No API Calls)
+
+```yaml
+providers:
+  - echo  # Returns prompt as-is, no API calls
+```
+
+**Use cases:**
+- Preview rendered prompts without cost
+- Debug variable substitution
+- Verify few-shot structure
+- Test configuration before production runs
+
+**Cost:** Free - no tokens consumed.
+
+### Anthropic
+
+```yaml
+providers:
+  - id: anthropic:messages:claude-sonnet-4-5-20250929
+    config:
+      max_tokens: 4096
+      temperature: 0.7
+```
+
+### OpenAI
+
+```yaml
+providers:
+  - id: openai:gpt-4.1
+    config:
+      temperature: 0.5
+      max_tokens: 2048
+```
+
+### Multiple Providers (A/B Testing)
+
+```yaml
+providers:
+  - id: anthropic:messages:claude-sonnet-4-5-20250929
+    label: Claude
+  - id: openai:gpt-4.1
+    label: GPT-4.1
+```
+
+## Assertion Reference
+
+### Python Assertion Context
+
+```python
+class AssertionContext:
+    prompt: str              # Raw prompt sent to LLM
+    vars: dict               # Test case variables
+    test: dict               # Complete test case
+    config: dict             # Assertion config
+    provider: Any            # Provider info
+    providerResponse: Any    # Full response
+```
+
+### GradingResult Format
+
+```python
+{
+    "pass": bool,           # Required: pass/fail
+    "score": float,         # 0.0-1.0 score
+    "reason": str,          # Explanation
+    "named_scores": dict,   # Custom metrics
+    "component_results": [] # Nested results
+}
+```
+
+### Assertion Types
+
+| Type | Description | Parameters |
+|------|-------------|------------|
+| `contains` | Substring check | `value` |
+| `icontains` | Case-insensitive | `value` |
+| `equals` | Exact match | `value` |
+| `regex` | Pattern match | `value` |
+| `not-contains` | Absence check | `value` |
+| `starts-with` | Prefix check | `value` |
+| `contains-any` | Any substring | `value` (array) |
+| `contains-all` | All substrings | `value` (array) |
+| `cost` | Token cost | `threshold` |
+| `latency` | Response time | `threshold` (ms) |
+| `perplexity` | Model confidence | `threshold` |
+| `python` | Custom Python | `value` (file/code) |
+| `javascript` | Custom JS | `value` (code) |
+| `llm-rubric` | LLM grading | `value`, `threshold` |
+| `factuality` | Fact checking | `value` (reference) |
+| `model-graded-closedqa` | Q&A grading | `value` |
+| `similar` | Semantic similarity | `value`, `threshold` |
+
+## Test Case Configuration
+
+### Full Test Case Structure
+
+```yaml
+- description: "Test name"
+  vars:
+    var1: "value"
+    var2: file://path.txt
+  assert:
+    - type: contains
+      value: "expected"
+  metadata:
+    category: "test-category"
+    priority: high
+  options:
+    provider: specific-provider
+    transform: "output.trim()"
+```
+
+### Loading Variables from Files
+
+```yaml
+vars:
+  # Text file (loaded as string)
+  content: file://data/input.txt
+
+  # JSON/YAML (parsed to object)
+  config: file://config.json
+
+  # Python script (executed, returns value)
+  dynamic: file://scripts/generate.py
+
+  # PDF (text extracted)
+  document: file://docs/report.pdf
+
+  # Image (base64 encoded)
+  image: file://images/photo.png
+```
+
+## Advanced Patterns
+
+### Dynamic Test Generation (Python)
+
+```python
+# tests/generate.py
+def get_tests():
+    return [
+        {
+            "vars": {"input": f"test {i}"},
+            "assert": [{"type": "contains", "value": str(i)}]
+        }
+        for i in range(10)
+    ]
+```
+
+```yaml
+tests: file://tests/generate.py:get_tests
+```
+
+### Scenario-based Testing
+
+```yaml
+scenarios:
+  - config:
+      - vars:
+          language: "French"
+      - vars:
+          language: "Spanish"
+    tests:
+      - vars:
+          text: "Hello"
+        assert:
+          - type: llm-rubric
+            value: "Translation is accurate"
+```
+
+### Transform Output
+
+```yaml
+defaultTest:
+  options:
+    transform: |
+      output.replace(/\n/g, ' ').trim()
+```
+
+### Custom Grading Provider
+
+```yaml
+defaultTest:
+  options:
+    provider: openai:gpt-4.1
+  assert:
+    - type: llm-rubric
+      value: "Evaluate quality"
+      provider: anthropic:claude-3-haiku  # Override for this assertion
+```
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `ANTHROPIC_API_KEY` | Anthropic API key |
+| `OPENAI_API_KEY` | OpenAI API key |
+| `PROMPTFOO_PYTHON` | Python binary path |
+| `PROMPTFOO_CACHE_ENABLED` | Enable caching (default: true) |
+| `PROMPTFOO_CACHE_PATH` | Cache directory |
+
+## CLI Commands
+
+```bash
+# Initialize project
+npx promptfoo@latest init
+
+# Run evaluation
+npx promptfoo@latest eval [options]
+
+# Options:
+#   --config <path>     Config file path
+#   --output <path>     Output file path
+#   --grader <provider> Override grader model
+#   --no-cache          Disable caching
+#   --filter-metadata   Filter tests by metadata
+#   --repeat <n>        Repeat each test n times
+#   --delay <ms>        Delay between requests
+#   --max-concurrency   Parallel requests
+
+# View results
+npx promptfoo@latest view [options]
+
+# Share results
+npx promptfoo@latest share
+
+# Generate report
+npx promptfoo@latest generate dataset
+```
+
+## Output Formats
+
+```bash
+# JSON (default)
+--output results.json
+
+# CSV
+--output results.csv
+
+# HTML report
+--output results.html
+
+# YAML
+--output results.yaml
+```

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -66,14 +66,14 @@ if ($isInteractive) {
 }
 
 $commands = @()
-$commands += "claude plugin marketplace add daymade/claude-code-skills"
+$commands += "claude plugin marketplace add https://github.com/daymade/claude-code-skills"
 
 switch ($choice) {
     "1" {
         Write-Host ""
         Write-Cyan "Installing skill-creator..."
         Write-Host ""
-        $commands += "claude plugin install skill-creator@daymade/claude-code-skills"
+        $commands += "claude plugin install skill-creator@daymade-skills"
 
         $afterInstall = @"
 After installation, ask Claude Code:
@@ -91,7 +91,7 @@ Claude Code will guide you through the skill creation process!
         $skills = @("skill-creator", "github-ops", "markdown-tools", "mermaid-tools",
                     "statusline-generator", "teams-channel-post-writer", "repomix-unmixer", "llm-icon-finder")
         foreach ($skill in $skills) {
-            $commands += "claude plugin install $skill@daymade/claude-code-skills"
+            $commands += "claude plugin install $skill@daymade-skills"
         }
     }
     "3" {
@@ -127,7 +127,7 @@ Claude Code will guide you through the skill creation process!
 
         foreach ($num in $selections) {
             if ($skillMap.ContainsKey($num)) {
-                $commands += "claude plugin install $($skillMap[$num])@daymade/claude-code-skills"
+                $commands += "claude plugin install $($skillMap[$num])@daymade-skills"
             }
         }
     }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -64,8 +64,8 @@ case $choice in
         echo ""
         echo "Run these commands in Claude Code:"
         echo ""
-        echo -e "${YELLOW}claude plugin marketplace add daymade/claude-code-skills${NC}"
-        echo -e "${YELLOW}claude plugin install skill-creator@daymade/claude-code-skills${NC}"
+        echo -e "${YELLOW}claude plugin marketplace add https://github.com/daymade/claude-code-skills${NC}"
+        echo -e "${YELLOW}claude plugin install skill-creator@daymade-skills${NC}"
         echo ""
         echo -e "${GREEN}After installation, ask Claude Code:${NC}"
         echo "  \"Create a new skill called my-awesome-skill in ~/my-skills\""
@@ -80,10 +80,10 @@ case $choice in
         echo ""
         echo "Run these commands in Claude Code:"
         echo ""
-        echo -e "${YELLOW}claude plugin marketplace add daymade/claude-code-skills${NC}"
+        echo -e "${YELLOW}claude plugin marketplace add https://github.com/daymade/claude-code-skills${NC}"
         echo ""
         for skill in skill-creator github-ops markdown-tools mermaid-tools statusline-generator teams-channel-post-writer repomix-unmixer llm-icon-finder; do
-            echo -e "${YELLOW}claude plugin install ${skill}@daymade/claude-code-skills${NC}"
+            echo -e "${YELLOW}claude plugin install ${skill}@daymade-skills${NC}"
         done
         ;;
     3)
@@ -109,13 +109,13 @@ case $choice in
         echo ""
         echo "Run these commands in Claude Code:"
         echo ""
-        echo -e "${YELLOW}claude plugin marketplace add daymade/claude-code-skills${NC}"
+        echo -e "${YELLOW}claude plugin marketplace add https://github.com/daymade/claude-code-skills${NC}"
         echo ""
         SKILLS=(skill-creator github-ops markdown-tools mermaid-tools statusline-generator teams-channel-post-writer repomix-unmixer llm-icon-finder)
         for num in $selections; do
             idx=$((num-1))
             if [ $idx -ge 0 ] && [ $idx -lt 8 ]; then
-                echo -e "${YELLOW}claude plugin install ${SKILLS[$idx]}@daymade/claude-code-skills${NC}"
+                echo -e "${YELLOW}claude plugin install ${SKILLS[$idx]}@daymade-skills${NC}"
             fi
         done
         ;;

--- a/skill-creator/SKILL.md
+++ b/skill-creator/SKILL.md
@@ -110,6 +110,24 @@ Skills use a three-level loading system to manage context efficiently:
 
 Anthropic has wrote skill authoring best practices, you SHOULD retrieve it before you create or update any skills, the link is https://docs.claude.com/en/docs/agents-and-tools/agent-skills/best-practices.md
 
+## ⚠️ CRITICAL: Edit Skills at Source Location
+
+**NEVER edit skills in `~/.claude/plugins/cache/`** — that's a read-only cache directory. All changes there are:
+- Lost when cache refreshes
+- Not synced to source control
+- Wasted effort requiring manual re-merge
+
+**ALWAYS verify you're editing the source repository:**
+```bash
+# WRONG - cache location (read-only copy)
+~/.claude/plugins/cache/daymade-skills/my-skill/1.0.0/my-skill/SKILL.md
+
+# RIGHT - source repository
+/path/to/your/claude-code-skills/my-skill/SKILL.md
+```
+
+**Before any edit**, confirm the file path does NOT contain `/cache/` or `/plugins/cache/`.
+
 ## Skill Creation Process
 
 To create a skill, follow the "Skill Creation Process" in order, skipping steps only if there is a clear reason why they are not applicable.

--- a/skill-creator/SKILL.md
+++ b/skill-creator/SKILL.md
@@ -108,7 +108,7 @@ Skills use a three-level loading system to manage context efficiently:
 
 ### Skill Creation Best Practice
 
-Anthropic has wrote skill authoring best practices, you SHOULD retrieve it before you create or update any skills, the link is https://docs.claude.com/en/docs/agents-and-tools/agent-skills/best-practices.md
+Anthropic has wrote skill authoring best practices, you SHOULD retrieve it before you create or update any skills, the link is https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices.md
 
 ## ⚠️ CRITICAL: Edit Skills at Source Location
 

--- a/skill-creator/scripts/quick_validate.py
+++ b/skill-creator/scripts/quick_validate.py
@@ -18,9 +18,11 @@ def find_path_references(content: str) -> list[str]:
     - Placeholder paths (xxx, example, etc.)
     - Paths in example contexts (lines containing "Example:", "e.g.", etc.)
     - Generic documentation examples
+    - Paths prefixed with file:// (e.g., file://scripts/xxx) - these are external tool references, not skill-internal paths
     """
     # Pattern to match bundled resource paths (scripts/, references/, assets/)
-    pattern = r'(?:scripts|references|assets)/[\w./-]+'
+    # Use negative lookbehind to exclude file:// prefixed paths
+    pattern = r'(?<!file://)(?:scripts|references|assets)/[\w./-]+'
 
     # Find all matches with their line context
     unique_paths = set()

--- a/skills-search/.security-scan-passed
+++ b/skills-search/.security-scan-passed
@@ -1,0 +1,4 @@
+Security scan passed
+Scanned at: 2025-11-30T03:26:12.206682
+Tool: gitleaks + pattern-based validation
+Content hash: 493826cb21eefb61a82bf0a81dbccec44888e7b68b21bfdd02a2dd301805a695

--- a/skills-search/SKILL.md
+++ b/skills-search/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: skills-search
+description: This skill should be used when users want to search, discover, install, or manage Claude Code skills from the CCPM registry. Triggers include requests like "find skills for PDF", "search for code review skills", "install cloudflare-troubleshooting", "list my installed skills", "what does skill-creator do", or any mention of finding/installing/managing Claude Code skills or plugins.
+---
+
+# Skills Search
+
+## Overview
+
+Search, discover, and manage Claude Code skills from the CCPM (Claude Code Plugin Manager) registry. This skill wraps the `ccpm` CLI to provide seamless skill discovery and installation.
+
+## Quick Start
+
+```bash
+# Search for skills
+ccpm search <query>
+
+# Install a skill
+ccpm install <skill-name>
+
+# List installed skills
+ccpm list
+
+# Get skill details
+ccpm info <skill-name>
+```
+
+## Commands Reference
+
+### Search Skills
+
+Search the CCPM registry for skills matching a query.
+
+```bash
+ccpm search <query> [options]
+
+Options:
+  --limit <n>    Maximum results (default: 10)
+  --json         Output as JSON
+```
+
+**Examples:**
+```bash
+ccpm search pdf              # Find PDF-related skills
+ccpm search "code review"    # Find code review skills
+ccpm search cloudflare       # Find Cloudflare tools
+ccpm search --limit 20 react # Find React skills, show 20 results
+```
+
+### Install Skills
+
+Install a skill to make it available in Claude Code.
+
+```bash
+ccpm install <skill-name> [options]
+
+Options:
+  --project      Install to current project only (default: user-level)
+  --force        Force reinstall even if already installed
+```
+
+**Examples:**
+```bash
+ccpm install pdf-processor                    # Install pdf-processor skill
+ccpm install @daymade/skill-creator           # Install namespaced skill
+ccpm install cloudflare-troubleshooting       # Install troubleshooting skill
+ccpm install react-component-builder --project # Install for current project only
+```
+
+**Important:** After installing a skill, Claude Code must be restarted for the skill to become available.
+
+### List Installed Skills
+
+Show all currently installed skills.
+
+```bash
+ccpm list [options]
+
+Options:
+  --json         Output as JSON
+```
+
+**Output includes:**
+- Skill name and version
+- Installation scope (user/project)
+- Installation path
+
+### Get Skill Information
+
+Show detailed information about a skill from the registry.
+
+```bash
+ccpm info <skill-name>
+```
+
+**Output includes:**
+- Name, description, version
+- Author and repository
+- Download count and tags
+- Dependencies (if any)
+
+**Example:**
+```bash
+ccpm info skill-creator
+```
+
+### Uninstall Skills
+
+Remove an installed skill.
+
+```bash
+ccpm uninstall <skill-name> [options]
+
+Options:
+  --global       Uninstall from user-level installation
+  --project      Uninstall from project-level installation
+```
+
+**Example:**
+```bash
+ccpm uninstall pdf-processor
+```
+
+## Workflow: Finding and Installing Skills
+
+When a user needs functionality that might be available as a skill:
+
+1. **Search** for relevant skills:
+   ```bash
+   ccpm search <relevant-keywords>
+   ```
+
+2. **Review** the search results - check download counts and descriptions
+
+3. **Get details** on promising skills:
+   ```bash
+   ccpm info <skill-name>
+   ```
+
+4. **Install** the chosen skill:
+   ```bash
+   ccpm install <skill-name>
+   ```
+
+5. **Inform user** to restart Claude Code to use the new skill
+
+## Popular Skills
+
+Common skills users may want:
+
+| Skill | Purpose |
+|-------|---------|
+| `skill-creator` | Create new Claude Code skills |
+| `pdf-processor` | PDF manipulation and analysis |
+| `docx` | Word document processing |
+| `xlsx` | Excel spreadsheet operations |
+| `pptx` | PowerPoint presentation creation |
+| `cloudflare-troubleshooting` | Debug Cloudflare issues |
+| `prompt-optimizer` | Improve prompt quality |
+
+## Troubleshooting
+
+### "ccpm: command not found"
+
+Install CCPM globally:
+```bash
+npm install -g @anthropic/ccpm
+```
+
+### Skill not available after install
+
+Restart Claude Code - skills are loaded at startup.
+
+### Permission errors
+
+Try installing with user scope (default) or check write permissions to `~/.claude/skills/`.

--- a/transcript-fixer/SKILL.md
+++ b/transcript-fixer/SKILL.md
@@ -65,6 +65,15 @@ uv run scripts/fix_transcription.py --review-learned
 - `*_stage2.md` - AI corrections applied (final version)
 - `*_对比.html` - Visual diff (open in browser for best experience)
 
+**Generate word-level diff** (recommended for reviewing corrections):
+```bash
+uv run scripts/generate_word_diff.py original.md corrected.md output.html
+```
+
+This creates an HTML file showing word-by-word differences with clear highlighting:
+- 🔴 `japanese 3 pro` → 🟢 `Gemini 3 Pro` (complete word replacements)
+- Easy to spot exactly what changed without character-level noise
+
 ## Example Session
 
 **Input transcript** (`meeting.md`):
@@ -153,6 +162,7 @@ sqlite3 ~/.transcript-fixer/corrections.db "SELECT value FROM system_config WHER
 - `ensure_deps.py` - Initialize shared virtual environment (run once, optional)
 - `fix_transcript_enhanced.py` - Enhanced wrapper (recommended for interactive use)
 - `fix_transcription.py` - Core CLI (for automation)
+- `generate_word_diff.py` - Generate word-level diff HTML for reviewing corrections
 - `examples/bulk_import.py` - Bulk import example
 
 **References** (load as needed):

--- a/transcript-fixer/references/database_schema.md
+++ b/transcript-fixer/references/database_schema.md
@@ -1,0 +1,190 @@
+# Database Schema Reference
+
+**MUST read this before any database operations.**
+
+Database location: `~/.transcript-fixer/corrections.db`
+
+## Core Tables
+
+### corrections
+
+Main storage for correction mappings.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | INTEGER | Primary key |
+| from_text | TEXT | Error text to match (NOT NULL) |
+| to_text | TEXT | Correct replacement (NOT NULL) |
+| domain | TEXT | Domain: general, embodied_ai, finance, medical |
+| source | TEXT | 'manual', 'learned', 'imported' |
+| confidence | REAL | 0.0-1.0 |
+| added_by | TEXT | Username |
+| added_at | TIMESTAMP | Creation time |
+| usage_count | INTEGER | Times this correction was applied |
+| last_used | TIMESTAMP | Last time used |
+| notes | TEXT | Optional notes |
+| is_active | BOOLEAN | Active flag (1=active, 0=disabled) |
+
+**Constraint**: `UNIQUE(from_text, domain)`
+
+### context_rules
+
+Regex-based context-aware correction rules.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | INTEGER | Primary key |
+| pattern | TEXT | Regex pattern (UNIQUE) |
+| replacement | TEXT | Replacement text |
+| description | TEXT | Rule description |
+| priority | INTEGER | Higher = processed first |
+| is_active | BOOLEAN | Active flag |
+
+### learned_suggestions
+
+AI-learned patterns pending user review.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | INTEGER | Primary key |
+| from_text | TEXT | Detected error |
+| to_text | TEXT | Suggested correction |
+| domain | TEXT | Domain |
+| frequency | INTEGER | Occurrence count (≥1) |
+| confidence | REAL | AI confidence (0.0-1.0) |
+| first_seen | TIMESTAMP | First occurrence |
+| last_seen | TIMESTAMP | Last occurrence |
+| status | TEXT | 'pending', 'approved', 'rejected' |
+| reviewed_at | TIMESTAMP | Review time |
+| reviewed_by | TEXT | Reviewer |
+
+**Constraint**: `UNIQUE(from_text, to_text, domain)`
+
+### correction_history
+
+Audit log for all correction runs.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | INTEGER | Primary key |
+| filename | TEXT | Input file name |
+| domain | TEXT | Domain used |
+| run_timestamp | TIMESTAMP | When run |
+| original_length | INTEGER | Original text length |
+| stage1_changes | INTEGER | Dictionary changes count |
+| stage2_changes | INTEGER | AI changes count |
+| model | TEXT | AI model used |
+| execution_time_ms | INTEGER | Processing time |
+| success | BOOLEAN | Success flag |
+| error_message | TEXT | Error if failed |
+
+### correction_changes
+
+Detailed changes made in each correction run.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | INTEGER | Primary key |
+| history_id | INTEGER | FK → correction_history.id |
+| line_number | INTEGER | Line where change occurred |
+| from_text | TEXT | Original text |
+| to_text | TEXT | Corrected text |
+| rule_type | TEXT | 'context', 'dictionary', 'ai' |
+| rule_id | INTEGER | Reference to rule used |
+| context_before | TEXT | Text before change |
+| context_after | TEXT | Text after change |
+
+### system_config
+
+Key-value configuration store.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| key | TEXT | Config key (PRIMARY KEY) |
+| value | TEXT | Config value |
+| value_type | TEXT | 'string', 'int', 'float', 'boolean', 'json' |
+| description | TEXT | What this config does |
+| updated_at | TIMESTAMP | Last update |
+
+**Default configs**:
+- `schema_version`: '2.0'
+- `api_model`: 'GLM-4.6'
+- `learning_frequency_threshold`: 3
+- `learning_confidence_threshold`: 0.8
+- `history_retention_days`: 90
+
+### audit_log
+
+Comprehensive operations trail.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | INTEGER | Primary key |
+| timestamp | TIMESTAMP | When occurred |
+| action | TEXT | Action type |
+| entity_type | TEXT | Table affected |
+| entity_id | INTEGER | Row ID |
+| user | TEXT | Who did it |
+| details | TEXT | JSON details |
+| success | BOOLEAN | Success flag |
+| error_message | TEXT | Error if failed |
+
+## Views
+
+### active_corrections
+
+Active corrections only, ordered by domain and from_text.
+
+```sql
+SELECT * FROM active_corrections;
+```
+
+### pending_suggestions
+
+Suggestions awaiting review, with example count.
+
+```sql
+SELECT * FROM pending_suggestions WHERE confidence > 0.8;
+```
+
+### correction_statistics
+
+Statistics per domain.
+
+```sql
+SELECT * FROM correction_statistics;
+```
+
+## Common Queries
+
+```sql
+-- List all active corrections
+SELECT from_text, to_text, domain FROM active_corrections;
+
+-- Check pending high-confidence suggestions
+SELECT * FROM pending_suggestions WHERE confidence > 0.8 ORDER BY frequency DESC;
+
+-- Domain statistics
+SELECT domain, total_corrections, total_usage FROM correction_statistics;
+
+-- Recent correction history
+SELECT filename, stage1_changes, stage2_changes, run_timestamp
+FROM correction_history
+ORDER BY run_timestamp DESC LIMIT 10;
+
+-- Add new correction (use CLI instead for safety)
+INSERT INTO corrections (from_text, to_text, domain, source, confidence, added_by)
+VALUES ('错误词', '正确词', 'general', 'manual', 1.0, 'tiansheng');
+
+-- Disable a correction
+UPDATE corrections SET is_active = 0 WHERE id = ?;
+```
+
+## Schema Version
+
+Check current version:
+```sql
+SELECT value FROM system_config WHERE key = 'schema_version';
+```
+
+For complete schema including indexes and constraints, see `scripts/core/schema.sql`.

--- a/transcript-fixer/references/iteration_workflow.md
+++ b/transcript-fixer/references/iteration_workflow.md
@@ -1,0 +1,124 @@
+# Dictionary Iteration Workflow
+
+The core value of transcript-fixer is building a personalized correction dictionary that improves over time.
+
+## The Core Loop
+
+```
+┌─────────────────────────────────────────────────┐
+│  1. Fix transcript (manual or Stage 3)          │
+│                    ↓                            │
+│  2. Identify new ASR errors during fixing       │
+│                    ↓                            │
+│  3. IMMEDIATELY save to dictionary              │
+│                    ↓                            │
+│  4. Next time: Stage 1 auto-corrects these      │
+└─────────────────────────────────────────────────┘
+```
+
+**Key principle**: Every correction you make should be saved to the dictionary. This transforms one-time work into permanent value.
+
+## Workflow Checklist
+
+Copy this checklist when correcting transcripts:
+
+```
+Correction Progress:
+- [ ] Run correction: --input file.md --stage 3
+- [ ] Review output file for remaining ASR errors
+- [ ] Fix errors manually with Edit tool
+- [ ] Save EACH correction to dictionary with --add
+- [ ] Verify with --list that corrections were saved
+- [ ] Next time: Stage 1 handles these automatically
+```
+
+## Save Corrections Immediately
+
+After fixing any transcript, save corrections:
+
+```bash
+# Single correction
+uv run scripts/fix_transcription.py --add "错误词" "正确词" --domain general
+
+# Multiple corrections - run command for each
+uv run scripts/fix_transcription.py --add "片片总" "翩翩总" --domain general
+uv run scripts/fix_transcription.py --add "姐弟" "结业" --domain general
+uv run scripts/fix_transcription.py --add "自杀性" "自嗨性" --domain general
+uv run scripts/fix_transcription.py --add "被看" "被砍" --domain general
+uv run scripts/fix_transcription.py --add "单反过" "单访过" --domain general
+```
+
+## Verify Dictionary
+
+Always verify corrections were saved:
+
+```bash
+# List all corrections in current domain
+uv run scripts/fix_transcription.py --list
+
+# Direct database query
+sqlite3 ~/.transcript-fixer/corrections.db \
+  "SELECT from_text, to_text, domain FROM active_corrections ORDER BY added_at DESC LIMIT 10;"
+```
+
+## Domain Selection
+
+Choose the right domain for corrections:
+
+| Domain | Use Case |
+|--------|----------|
+| `general` | Common ASR errors, names, general vocabulary |
+| `embodied_ai` | 具身智能、机器人、AI 相关术语 |
+| `finance` | 财务、投资、金融术语 |
+| `medical` | 医疗、健康相关术语 |
+| `火星加速器` | Custom Chinese domain name (any valid name works) |
+
+```bash
+# Domain-specific correction
+uv run scripts/fix_transcription.py --add "股价系统" "框架系统" --domain embodied_ai
+uv run scripts/fix_transcription.py --add "片片总" "翩翩总" --domain 火星加速器
+```
+
+## Common ASR Error Patterns
+
+Build your dictionary with these common patterns:
+
+| Type | Examples |
+|------|----------|
+| **Homophones** | 赢→营, 减→剪, 被看→被砍, 营业→营的 |
+| **Names** | 片片→翩翩, 亮亮→亮哥 |
+| **Technical** | 巨升智能→具身智能, 股价→框架 |
+| **English** | log→vlog |
+| **Broken words** | 姐弟→结业, 单反→单访 |
+
+## When GLM API Fails
+
+If you see `[CLAUDE_FALLBACK]` output, the GLM API is unavailable.
+
+Steps:
+1. Claude Code should analyze the text directly for ASR errors
+2. Fix using Edit tool
+3. **MUST save corrections to dictionary** - this is critical
+4. Dictionary corrections work even without AI
+
+## Auto-Learning Feature
+
+After running Stage 3 multiple times:
+
+```bash
+# Check learned patterns
+uv run scripts/fix_transcription.py --review-learned
+
+# Approve high-confidence patterns
+uv run scripts/fix_transcription.py --approve "错误词" "正确词"
+```
+
+Patterns appearing ≥3 times at ≥80% confidence are suggested for review.
+
+## Best Practices
+
+1. **Save immediately**: Don't batch corrections - save each one right after fixing
+2. **Be specific**: Use exact phrases, not partial words
+3. **Use domains**: Organize corrections by topic for better precision
+4. **Verify**: Always run --list to confirm saves
+5. **Review suggestions**: Periodically check --review-learned for auto-detected patterns

--- a/transcript-fixer/scripts/core/ai_processor_async.py
+++ b/transcript-fixer/scripts/core/ai_processor_async.py
@@ -352,6 +352,13 @@ class AIProcessorAsync:
                             exc_info=True
                         )
 
+                # CLAUDE_FALLBACK: Signal Claude Code to take over manual correction
+                print("[CLAUDE_FALLBACK] GLM API unavailable. Claude Code should analyze this text for ASR errors:")
+                print("---")
+                print(chunk[:2000] if len(chunk) > 2000 else chunk)
+                print("---")
+                print("After fixing, MUST save corrections: --add \"错误词\" \"正确词\" --domain general")
+
                 logger.warning(
                     f"Using original text for chunk {chunk_index} after all retries failed",
                     chunk_index=chunk_index

--- a/transcript-fixer/scripts/core/correction_service.py
+++ b/transcript-fixer/scripts/core/correction_service.py
@@ -32,7 +32,11 @@ class ValidationRules:
     max_text_length: int = 1000
     min_text_length: int = 1
     max_domain_length: int = 50
-    allowed_domain_pattern: str = r'^[a-zA-Z0-9_-]+$'
+    # Support Chinese, Japanese, Korean characters in domain names
+    # \u4e00-\u9fff: CJK Unified Ideographs (Chinese)
+    # \u3040-\u309f: Hiragana, \u30a0-\u30ff: Katakana (Japanese)
+    # \uac00-\ud7af: Hangul Syllables (Korean)
+    allowed_domain_pattern: str = r'^[\w\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af-]+$'
     max_confidence: float = 1.0
     min_confidence: float = 0.0
 

--- a/transcript-fixer/scripts/ensure_deps.py
+++ b/transcript-fixer/scripts/ensure_deps.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Initialize shared virtual environment for transcript-fixer.
+
+Handles errors explicitly rather than letting Claude guess (per best practices).
+Creates a shared venv at ~/.transcript-fixer/.venv that can be reused across
+different working directories.
+"""
+import subprocess
+import sys
+from pathlib import Path
+
+DEPS_DIR = Path.home() / ".transcript-fixer"
+VENV_DIR = DEPS_DIR / ".venv"
+REQUIREMENTS = ["httpx[http2]>=0.24.0", "filelock>=3.13.0", "aiofiles>=23.0.0"]
+
+
+def main():
+    """Initialize shared dependencies for transcript-fixer."""
+    # Create base directory
+    try:
+        DEPS_DIR.mkdir(parents=True, exist_ok=True)
+    except PermissionError:
+        print(f"❌ Cannot create {DEPS_DIR}. Check permissions.")
+        sys.exit(1)
+
+    # Create virtual environment if not exists
+    if not VENV_DIR.exists():
+        print("🔧 Creating virtual environment...")
+        result = subprocess.run(
+            ["uv", "venv", str(VENV_DIR)],
+            capture_output=True,
+            text=True
+        )
+        if result.returncode != 0:
+            print(f"❌ Failed to create venv: {result.stderr}")
+            print("   Install uv first: curl -LsSf https://astral.sh/uv/install.sh | sh")
+            sys.exit(1)
+    else:
+        print(f"✓ Virtual environment exists at {VENV_DIR}")
+
+    # Install dependencies
+    print("📦 Installing dependencies...")
+    result = subprocess.run(
+        ["uv", "pip", "install", "--python", str(VENV_DIR / "bin" / "python")]
+        + REQUIREMENTS,
+        capture_output=True,
+        text=True
+    )
+    if result.returncode != 0:
+        print(f"❌ Failed to install: {result.stderr}")
+        sys.exit(1)
+
+    print(f"✅ Dependencies ready at {VENV_DIR}")
+    print()
+    print("Usage:")
+    print(f"  {VENV_DIR}/bin/python scripts/fix_transcription.py --input file.md --stage 3")
+    print()
+    print("Or add alias to ~/.zshrc:")
+    print(f'  alias tf="{VENV_DIR}/bin/python scripts/fix_transcription.py"')
+
+
+if __name__ == "__main__":
+    main()

--- a/transcript-fixer/scripts/generate_word_diff.py
+++ b/transcript-fixer/scripts/generate_word_diff.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""
+Generate Word-Level Diff HTML Comparison
+
+Creates an HTML file showing word-by-word differences between original and corrected transcripts.
+This helps users review corrections more easily than character-level or line-level diffs.
+
+Usage:
+    python scripts/generate_word_diff.py <original_file> <corrected_file> [output_file]
+
+Example:
+    python scripts/generate_word_diff.py original.md corrected.md comparison.html
+"""
+
+import difflib
+import html
+import re
+import sys
+from pathlib import Path
+
+
+def tokenize(text):
+    """
+    Split text into tokens (words) while preserving Chinese, English, numbers, and punctuation.
+
+    Pattern explanation:
+    - [\\u4e00-\\u9fff]+  : Chinese characters (one or more)
+    - [a-zA-Z0-9]+        : English words and numbers (one or more)
+    - [^\\u4e00-\\u9fffa-zA-Z0-9\\s] : Single punctuation/special chars
+    - \\s+                : Whitespace sequences
+
+    Returns:
+        List of token strings
+    """
+    pattern = r'[\u4e00-\u9fff]+|[a-zA-Z0-9]+|[^\u4e00-\u9fffa-zA-Z0-9\s]|\s+'
+    return re.findall(pattern, text)
+
+
+def get_word_diff(old, new):
+    """
+    Generate word-level diff with HTML highlighting.
+
+    Args:
+        old: Original text line
+        new: Corrected text line
+
+    Returns:
+        HTML string with word-level diff highlighting
+    """
+    old_tokens = tokenize(old)
+    new_tokens = tokenize(new)
+
+    s = difflib.SequenceMatcher(None, old_tokens, new_tokens)
+    result = []
+
+    for tag, i1, i2, j1, j2 in s.get_opcodes():
+        old_part = ''.join(old_tokens[i1:i2])
+        new_part = ''.join(new_tokens[j1:j2])
+
+        if tag == 'equal':
+            result.append(html.escape(old_part))
+        elif tag == 'delete':
+            result.append(f'<del class="word-del" title="删除: {html.escape(old_part)}">{html.escape(old_part)}</del>')
+        elif tag == 'insert':
+            result.append(f'<ins class="word-ins" title="添加: {html.escape(new_part)}">{html.escape(new_part)}</ins>')
+        elif tag == 'replace':
+            result.append(f'<span class="word-change"><del class="word-del" title="原文">{html.escape(old_part)}</del> → <ins class="word-ins" title="修正后">{html.escape(new_part)}</ins></span>')
+
+    return ''.join(result)
+
+
+def generate_html_header(total_lines, total_changes):
+    """Generate HTML header with statistics and styling."""
+    change_rate = total_changes / total_lines * 100 if total_lines > 0 else 0
+
+    return f'''<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>录音转写修正对比（词语级别）</title>
+    <style>
+        body {{
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', sans-serif;
+            font-size: 16px;
+            line-height: 2;
+            max-width: 1400px;
+            margin: 20px auto;
+            padding: 20px;
+            background: #f8f9fa;
+        }}
+        h1 {{
+            color: #1a1a1a;
+            border-bottom: 3px solid #007aff;
+            padding-bottom: 15px;
+            margin-bottom: 25px;
+        }}
+        .summary {{
+            background: white;
+            padding: 20px;
+            border-radius: 8px;
+            margin-bottom: 25px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }}
+        .summary h2 {{
+            margin: 0 0 15px 0;
+            color: #007aff;
+            font-size: 18px;
+        }}
+        .stat {{
+            display: inline-block;
+            margin-right: 25px;
+            padding: 8px 15px;
+            background: #f0f0f0;
+            border-radius: 5px;
+            font-weight: 500;
+        }}
+        .legend {{
+            background: #fff9e6;
+            padding: 15px;
+            border-radius: 8px;
+            margin-bottom: 20px;
+            border-left: 4px solid #ffc107;
+        }}
+        .legend-item {{
+            display: inline-block;
+            margin-right: 20px;
+            margin-bottom: 5px;
+        }}
+        .diff-container {{
+            background: white;
+            padding: 25px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }}
+        .diff-line {{
+            padding: 12px 15px;
+            margin: 10px 0;
+            border-left: 4px solid transparent;
+            border-radius: 4px;
+            background: #fafafa;
+        }}
+        .diff-line.changed {{
+            background: #fff;
+            border-left-color: #ff9800;
+        }}
+        .diff-line.unchanged {{
+            opacity: 0.5;
+            font-size: 14px;
+        }}
+        del.word-del {{
+            background-color: #ffcdd2;
+            color: #c62828;
+            text-decoration: line-through;
+            padding: 3px 6px;
+            border-radius: 4px;
+            font-weight: 700;
+            margin: 0 2px;
+        }}
+        ins.word-ins {{
+            background-color: #c8e6c9;
+            color: #2e7d32;
+            text-decoration: none;
+            padding: 3px 6px;
+            border-radius: 4px;
+            font-weight: 700;
+            margin: 0 2px;
+        }}
+        .word-change {{
+            display: inline-block;
+            background: #fff3e0;
+            padding: 4px 8px;
+            border-radius: 4px;
+            margin: 0 2px;
+        }}
+        .line-number {{
+            display: inline-block;
+            min-width: 60px;
+            color: #999;
+            font-size: 13px;
+            margin-right: 15px;
+            user-select: none;
+            font-family: 'SF Mono', 'Monaco', monospace;
+        }}
+    </style>
+</head>
+<body>
+    <h1>🎙️ 录音转写修正对比（词语级别）</h1>
+
+    <div class="summary">
+        <h2>📊 修正统计</h2>
+        <span class="stat">总行数: <strong>{total_lines}</strong></span>
+        <span class="stat" style="color: #ff9800;">修改行数: <strong>{total_changes}</strong></span>
+        <span class="stat" style="color: #4caf50;">修改率: <strong>{change_rate:.1f}%</strong></span>
+    </div>
+
+    <div class="legend">
+        <strong>📖 图例说明：</strong><br>
+        <span class="legend-item"><del class="word-del">删除的词</del> 原文中的错误</span>
+        <span class="legend-item"><ins class="word-ins">添加的词</ins> 修正后的内容</span>
+        <span class="legend-item"><span class="word-change"><del class="word-del">错误</del> → <ins class="word-ins">正确</ins></span> 词语替换</span>
+    </div>
+
+    <div class="diff-container">
+'''
+
+
+def generate_diff_content(original_lines, corrected_lines, context_lines=1):
+    """
+    Generate diff content HTML showing changed lines with context.
+
+    Args:
+        original_lines: List of original text lines
+        corrected_lines: List of corrected text lines
+        context_lines: Number of context lines to show around changes
+
+    Returns:
+        HTML string with diff content
+    """
+    html_parts = []
+    last_change_idx = -999
+
+    for i, (old_line, new_line) in enumerate(zip(original_lines, corrected_lines), 1):
+        old_line = old_line.rstrip('\n')
+        new_line = new_line.rstrip('\n')
+
+        if old_line.strip() != new_line.strip():
+            # Show separator if gap is large
+            if i - last_change_idx > context_lines + 1:
+                if last_change_idx > 0:
+                    html_parts.append('<div style="text-align: center; color: #999; margin: 20px 0; font-size: 18px;">⋯ ⋯ ⋯</div>\n')
+
+            # Show changed line
+            diff_html = get_word_diff(old_line, new_line)
+            html_parts.append(f'<div class="diff-line changed"><span class="line-number">第 {i} 行</span>{diff_html}</div>\n')
+            last_change_idx = i
+        elif abs(i - last_change_idx) <= context_lines and last_change_idx > 0:
+            # Show context line
+            escaped = html.escape(old_line)
+            html_parts.append(f'<div class="diff-line unchanged"><span class="line-number">第 {i} 行</span>{escaped}</div>\n')
+
+    return ''.join(html_parts)
+
+
+def generate_html_footer():
+    """Generate HTML footer."""
+    return '''
+    </div>
+</body>
+</html>
+'''
+
+
+def main():
+    """Main entry point for the script."""
+    if len(sys.argv) < 3:
+        print("Usage: python generate_word_diff.py <original_file> <corrected_file> [output_file]")
+        print("\nExample:")
+        print("  python generate_word_diff.py original.md corrected.md comparison.html")
+        sys.exit(1)
+
+    original_path = Path(sys.argv[1])
+    corrected_path = Path(sys.argv[2])
+
+    # Determine output path
+    if len(sys.argv) >= 4:
+        output_path = Path(sys.argv[3])
+    else:
+        # Default: save next to original file with _对比_词语级.html suffix
+        output_path = original_path.parent / f"{original_path.stem}_对比_词语级.html"
+
+    # Validate input files
+    if not original_path.exists():
+        print(f"❌ Error: Original file not found: {original_path}")
+        sys.exit(1)
+
+    if not corrected_path.exists():
+        print(f"❌ Error: Corrected file not found: {corrected_path}")
+        sys.exit(1)
+
+    # Read files
+    try:
+        with open(original_path, 'r', encoding='utf-8') as f:
+            original_lines = f.readlines()
+
+        with open(corrected_path, 'r', encoding='utf-8') as f:
+            corrected_lines = f.readlines()
+    except Exception as e:
+        print(f"❌ Error reading files: {e}")
+        sys.exit(1)
+
+    # Count changes
+    total_changes = sum(1 for old, new in zip(original_lines, corrected_lines)
+                       if old.strip() != new.strip())
+
+    # Generate HTML
+    html_content = generate_html_header(len(original_lines), total_changes)
+    html_content += generate_diff_content(original_lines, corrected_lines)
+    html_content += generate_html_footer()
+
+    # Write output
+    try:
+        with open(output_path, 'w', encoding='utf-8') as f:
+            f.write(html_content)
+
+        print(f"✅ 词语级 diff HTML 已生成: {output_path}")
+        print(f"📊 共修改了 {total_changes} 行，占总行数的 {total_changes/len(original_lines)*100:.1f}%")
+
+        return 0
+    except Exception as e:
+        print(f"❌ Error writing output file: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/transcript-fixer/scripts/tests/test_correction_service.py
+++ b/transcript-fixer/scripts/tests/test_correction_service.py
@@ -84,6 +84,14 @@ class TestCorrectionService(unittest.TestCase):
         self.service.validate_domain_name("embodied_ai")
         self.service.validate_domain_name("test-domain-123")
 
+    def test_validate_chinese_domain(self):
+        """Test acceptance of Chinese domain names."""
+        # Should not raise - Chinese characters are valid
+        self.service.validate_domain_name("火星加速器")
+        self.service.validate_domain_name("具身智能")
+        self.service.validate_domain_name("中文域名-123")
+        self.service.validate_domain_name("混合domain中文")
+
     # ==================== Correction Operations Tests ====================
 
     def test_add_correction(self):


### PR DESCRIPTION
## Summary

- Adds mcp-skills-plugin that converts MCP servers to Claude Skills with progressive disclosure pattern
- Reduces context usage by 90%+ compared to native MCP loading
- Includes session start hook for auto-loading MCP Skills Registry

## Features

- **mcp-to-skill-converter skill**: Converts MCP servers (stdio, http, sse) to Claude Skills
- **Session start hook**: Automatically loads MCP Skills Registry on startup
- **Python CLI**: List, convert single, or batch convert all MCP servers
- **Auto-updates**: Updates index.json and removes converted servers from .mcp.json

## Test plan

- [x] Plugin validated: plugin.json, hooks.json are valid JSON
- [x] Shell script validated: bash syntax check passed
- [x] Python script validated: py_compile check passed
- [x] YAML frontmatter validated: SKILL.md has valid YAML

## Context Savings

| Scenario | Native MCP | As Skill | Savings |
|----------|------------|----------|---------|
| Idle | 30-50k tokens | ~100 tokens | 99%+ |
| Active | 30-50k tokens | ~5k tokens | 85%+ |
| Executing | 30-50k tokens | 0 tokens | 100% |

## Standalone Repository

Also available at: https://github.com/bjornslib/mcp-skills-plugin

---
Author: Bjorn Schliebitz

🤖 Generated with [Claude Code](https://claude.com/claude-code)