### PR TITLE
docs(skill-creator): Add comprehensive YAML frontmatter reference with context: fork

### DIFF
--- a/skill-creator/scripts/init_skill.py
+++ b/skill-creator/scripts/init_skill.py
@@ -18,6 +18,13 @@ from pathlib import Path
 SKILL_TEMPLATE = """---
 name: {skill_name}
 description: [TODO: Complete and informative explanation of what the skill does and when to use it. Include WHEN to use this skill - specific scenarios, file types, or tasks that trigger it.]
+# ─── OPTIONAL FIELDS (uncomment as needed) ───
+# context: fork                    # Run in subagent context. IMPORTANT: Required for skills that subagents should use via Task tool
+# agent: Explore                   # Subagent type when context: fork (Explore, Plan, general-purpose, or custom)
+# disable-model-invocation: true   # Only allow manual /skill-name invocation, prevent auto-triggering
+# user-invocable: false            # Hide from / menu (for background knowledge only)
+# allowed-tools: Read, Grep        # Tools allowed without permission prompts
+# argument-hint: [filename]        # Autocomplete hint for arguments
 ---
 
 # {skill_title}


### PR DESCRIPTION
## Summary

- Add complete YAML frontmatter reference documentation to skill-creator SKILL.md
- Document `context: fork` field which is **critical for subagent-accessible skills**
- Update init_skill.py template with commented optional frontmatter fields

## Problem

Skills created without `context: fork` cannot be used by subagents spawned via the Task tool. This was undocumented in skill-creator, causing users to create skills that only work in the main conversation context.

## What's Changed

### SKILL.md
- Added **YAML Frontmatter Reference** section with complete field table
- Documented all available fields: `name`, `description`, `context`, `agent`, `disable-model-invocation`, `user-invocable`, `allowed-tools`, `model`, `argument-hint`, `hooks`
- Added **When to Use `context: fork`** guidance with examples
- Added **Invocation Control** comparison table showing how different frontmatter combinations affect skill accessibility

### init_skill.py
- Updated template to include commented examples of optional frontmatter fields
- Prominently features `context: fork` with explanation that it's required for subagent access

## What's NOT Changed

- No existing functionality removed
- No breaking changes to skill structure
- All existing skills continue to work unchanged

## Test Plan

- [ ] Verify init_skill.py generates valid SKILL.md with new template
- [ ] Verify new documentation renders correctly in SKILL.md
- [ ] Create a test skill with `context: fork` and confirm subagent can use it

🤖 Generated with [Claude Code](https://claude.com/claude-code)