### PR TITLE
Add product-manager-skills to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1749,6 +1749,14 @@ claude plugin install capture-screen@daymade-skills
 
 ---
 
+### Community Skills
+
+| Name | Description | Link |
+|------|-------------|------|
+| **product-manager-skills** | Senior PM agent with 6 knowledge domains, 12 templates, 30+ frameworks — discovery, strategy, delivery, SaaS metrics, PM career coaching (IC to CPO), AI product craft. Install via `clawhub install product-manager-skills` | [Source](https://github.com/Digidai/product-manager-skills) |
+
+---
+
 ## 🎬 Interactive Demo Gallery
 
 Want to see all demos in one place with click-to-enlarge functionality? Check out our [interactive demo gallery](./demos/index.html) or browse the [demos directory](./demos/).


### PR DESCRIPTION
## Summary

- Adds a **Community Skills** section to the README with an entry for **product-manager-skills** by [Digidai](https://github.com/Digidai)
- Senior PM agent skill with 6 knowledge domains, 12 templates, and 30+ frameworks
- Covers product discovery, strategy, delivery, 32 SaaS metrics with formulas, PM career coaching (IC to CPO), and AI product craft
- Pure Markdown, zero scripts — installs via `clawhub install product-manager-skills`

**Source:** https://github.com/Digidai/product-manager-skills
**ClawHub:** https://clawhub.ai/Digidai/product-manager-skills