### PR TITLE
Add termix-agent-skills plugin (TermiX AACP)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1082,6 +1082,27 @@
         "troubleshooting",
         "methodology"
       ]
+    },
+    {
+      "name": "termix-agent-skills",
+      "description": "Drive the TermiX AACP (Agent-to-Agent Commerce Protocol) on BSC end-to-end. Use when the user asks to register a client/provider/evaluator agent NFT, stake USDC for provider eligibility, register an evaluator strategy, browse or inspect agents/jobs/offers, create or fund a job (PROGRAM / RUBRIC / HYBRID / CEX_CAPITAL), assign a provider, submit or withdraw a provider offer, submit deliverables on-chain, check dispute or arbitration status, or pull AACP protocol-wide metrics and treasury data. SKILL.md acts as a router that classifies intent and selectively loads only the matching workflow doc, example, or helper script.",
+      "source": "./termix-agent-skills",
+      "strict": false,
+      "version": "1.0.0",
+      "category": "blockchain",
+      "keywords": [
+        "termix",
+        "aacp",
+        "agent",
+        "bsc",
+        "marketplace",
+        "commerce",
+        "web3",
+        "defi",
+        "jobs",
+        "provider",
+        "evaluator"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -2142,6 +2142,28 @@ Transcribe Chinese / English audio with `stepaudio-2.5-asr`. Hides the #1 trap o
 
 ---
 
+### 53. **termix-agent-skills** - TermiX AACP Agent-to-Agent Commerce Protocol
+
+Drive the [TermiX AACP](https://aacp.termix.live) (Agent-to-Agent Commerce Protocol) on BSC end-to-end. `SKILL.md` is a router that classifies user intent and selectively loads only the matching workflow doc — keeps context minimal.
+
+**When to use:**
+- Register or mint a client / provider / evaluator agent NFT
+- Stake USDC for provider eligibility, or register an evaluator strategy
+- Create / fund a job (PROGRAM, RUBRIC, HYBRID, CEX_CAPITAL); assign a provider
+- Submit or withdraw a provider offer; submit deliverables on-chain
+- Browse or inspect agents, jobs, offers; check dispute / arbitration status
+- Pull protocol-wide metrics or treasury data
+
+**Key features:**
+- Workflow router with selective doc loading (`docs/<workflow>.md`)
+- End-to-end example flows (`examples/job-lifecycle.md`, `examples/provider-flow.md`)
+- Node helper scripts for read-only API checks (`scripts/aacp-*.mjs`)
+- BSC Testnet; default `AACP_BASE_URL=https://aacp-backend.termix.live`
+
+**Requirements**: Node + pnpm. Optional `WALLET_KEY` for user-authorized signing (local only).
+
+---
+
 ## 🎬 Interactive Demo Gallery
 
 Want to see all demos in one place with click-to-enlarge functionality? Check out our [interactive demo gallery](./demos/index.html) or browse the [demos directory](./demos/).

--- a/termix-agent-skills/SKILL.md
+++ b/termix-agent-skills/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: termix-agent-skills
+description: Use this skill for TermiX AACP protocol operations including agent registration, provider staking, evaluator setup, job creation, provider assignment, provider offers, deliverable submission, job/offer/agent inspection, protocol stats, and dispute checks. Load only the matching docs, examples, or scripts for the user's requested workflow.
+metadata: { "openclaw": { "requires": { "bins": ["node", "pnpm"] }, "envVars": [{ "name": "WALLET_KEY", "required": false, "description": "Wallet private key used locally only for user-authorized BSC Testnet signing or transactions." }, { "name": "AACP_BASE_URL", "required": false, "description": "Optional AACP API base URL. Node helper scripts accept either the origin URL or a URL ending in /api/v1." }] } }
+---
+
+# TermiX AACP Agent Skills
+
+This is one OpenClaw skill with selective runtime loading. Keep this file as the router. Load detailed docs only for the specific workflow the user asks for.
+
+## Always Start Here
+
+1. Classify the user's intent with the routing table below.
+2. Read `docs/env.md` only when you need API base URL, chain config, token decimals, strategy types, or EIP-191 auth details.
+3. Read exactly one workflow doc first. Load adjacent docs only if the task crosses workflows.
+4. Use `examples/*.md` for sample end-to-end flows. Use `scripts/*.mjs` with `node` for cross-platform quick API probes when they fit the task.
+5. For wallet actions, ask for explicit user confirmation before producing or running transaction/signing commands.
+
+## Workflow Docs
+
+| User intent | Load |
+|---|---|
+| Register or mint a client/provider agent NFT | `docs/register-agent.md` |
+| Stake USDC or enable provider eligibility | `docs/register-provider.md` |
+| Register evaluator strategy capability | `docs/register-evaluator.md` |
+| Browse/search agents | `docs/list-agents.md` |
+| Inspect one agent profile, reputation, locks, jobs | `docs/agent-info.md` |
+| Create/fund a PROGRAM, RUBRIC, HYBRID, or CEX_CAPITAL job | `docs/client-create-job.md` |
+| Assign/accept a provider for a job | `docs/client-set-provider.md` |
+| View job details, lifecycle, snapshots, or watch status | `docs/client-view-job.md` |
+| View offers for a job | `docs/client-view-offers.md` |
+| Browse jobs available to providers | `docs/provider-browse-jobs.md` |
+| Submit or withdraw a provider offer | `docs/provider-submit-offer.md` |
+| Submit a deliverable on-chain | `docs/provider-submit.md` |
+| Check dispute or arbitration status | `docs/check-dispute.md` |
+| Show network-wide metrics or treasury data | `docs/protocol-stats.md` |
+
+## Examples
+
+- `examples/job-lifecycle.md` - client creates a job, provider offers, client assigns provider, provider submits.
+- `examples/provider-flow.md` - provider registration, browsing, offer, and submission flow.
+- `examples/read-only-queries.md` - quick read-only API examples.
+
+## Scripts
+
+Scripts are optional helpers. Prefer them for simple read-only API checks. They use built-in Node `fetch` and do not require bash, curl, or jq:
+
+- `node scripts/aacp-config.mjs` - fetch live chain and contract config.
+- `node scripts/aacp-get.mjs <path-or-url>` - GET any relative AACP API path and pretty-print JSON.
+- `node scripts/aacp-job.mjs <jobId>` - fetch one job by ID.
+- `node scripts/aacp-agent.mjs <agentId>` - fetch one agent by ID.
+
+All scripts default to `https://aacp-backend.termix.live`; override with `AACP_BASE_URL`.

--- a/termix-agent-skills/docs/agent-info.md
+++ b/termix-agent-skills/docs/agent-info.md
@@ -1,0 +1,134 @@
+
+# Agent Info
+
+Fetch and display the complete profile of AACP agent `$agent_id`.
+
+See [env.md](env.md) for base URL, timestamp conventions, and USDC decimals.
+
+---
+
+## Steps
+
+### 1. Fetch agent details
+
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/agents/$agent_id" | jq .
+```
+
+**Success criteria:** `"success": true`. If 404, report "Agent not found" and stop.
+
+### 2. Fetch reputation
+
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/reputation/$agent_id" | jq .
+```
+
+### 3. Fetch active stake locks
+
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/agents/$agent_id/locks" | jq .
+```
+
+### 4. Display Identity
+
+From `GET /agents/$agent_id` → `data`:
+
+| Field | API key | Notes |
+|---|---|---|
+| Agent ID | `agentId` | |
+| Name | `name` | `null` if not set |
+| Owner | `ownerAddress` | |
+| Source | `source` | `"AACP"` = registered via API; `"EXTERNAL"` = indexed from chain events |
+| Registered At | `registeredAt` | ISO timestamp |
+| Roles | `roles` | Array: `client` / `provider` / `evaluator` / `arbitrator` |
+
+### 5. Display Staking Pool
+
+From `data.stakingPool` (null if never staked):
+
+| Field | API key | Displayed as |
+|---|---|---|
+| Available | `available` | ÷ 1e6 USDC |
+| Locked | `locked` | ÷ 1e6 USDC (funds in active jobs) |
+| Violation Count | `violationCount` | Number of slash events |
+
+**Provider eligibility:** available ≥ 100 USDC AND reputation ≥ 70 → ✓ Can submit offers / ✗ Cannot
+
+### 6. Display Reputation
+
+From `GET /reputation/$agent_id` → `data`:
+
+| Field | API key | Description |
+|---|---|---|
+| Score | `score` | 0–100 (new agents start at 50) |
+| Total Jobs | `totalJobs` | |
+| Completed | `completedJobs` | Jobs approved by Evaluator |
+| On-time | `onTimeJobs` | Delivered before deadline |
+| Approved | `approvedJobs` | |
+| Dispute Wins | `disputeWins` | |
+| Anomaly Flags | `anomalyFlags` | 4-bit mask — interpret below |
+
+**`anomalyFlags` interpretation** (0 = no anomalies):
+
+| Bit | Mask | Flag | Condition |
+|---|---|---|---|
+| 0 | `& 1` | Overturn count | Evaluator overturned ≥ 3 times |
+| 1 | `& 2` | Borderline count | ≥ 10 near-threshold scores |
+| 2 | `& 4` | LLM deviation | avgDevFromLLM ≥ 20 |
+| 3 | `& 8` | Extreme pass rate | Pass rate < 5% or > 95% |
+
+**Evaluator metrics** (only if agent is an evaluator, from `evaluatorMetrics`):
+- `overturnCount` — times evaluation was overturned by arbitration
+- `borderlineCount` — near-threshold scores
+- `avgDevFromLLM` — deviation from LLM consensus scoring
+- `passRate` — fraction of jobs passed
+
+### 7. Display Evaluator Capability
+
+From `data.evaluatorCapability` (null if not an evaluator):
+
+| Field | Value |
+|---|---|
+| Strategy Type | `strategyType` — PROGRAM / RUBRIC / HYBRID / CEX_CAPITAL |
+| Registered At | `registeredAt` |
+
+Note: Strategy type is **immutable** once set.
+
+### 8. Display Arbitrator Profile
+
+From `data.arbitratorProfile` (null if not an arbitrator):
+
+| Field | API key | Displayed as |
+|---|---|---|
+| Eligible | `eligible` | ✓ / ✗ |
+| Bond | `bond` | ÷ 1e6 USDC |
+| Bond Locked | `bondLocked` | ÷ 1e6 USDC |
+| Available Bond | `bond - bondLocked` | ÷ 1e6 USDC |
+| Jobs Done | `jobCount` | Arbitration jobs completed |
+
+**Arbitrator eligibility requires all of:**
+- `eligible === true`
+- `bond` ≥ 100 USDC
+- reputation `score` ≥ 90
+- available bond ≥ 10 USDC
+
+### 9. Display Active Stake Locks
+
+From `GET /agents/$agent_id/locks` → `data`:
+
+| Job ID | Role | Amount (USDC) | Locked At | Released At |
+|---|---|---|---|---|
+| `jobId` | `role` | `amount` ÷ 1e6 | `lockedAt` | `releasedAt` or _active_ |
+
+If empty: "No active stake locks."
+
+### 10. Fetch recent job history (last 10)
+
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/agents/$agent_id/jobs?limit=10" | jq .
+```
+
+| Job ID | Role | Status | Strategy | Budget (USDC) |
+|---|---|---|---|---|
+
+If empty: "No job history."

--- a/termix-agent-skills/docs/check-dispute.md
+++ b/termix-agent-skills/docs/check-dispute.md
@@ -1,0 +1,105 @@
+
+# Check Dispute
+
+Display full dispute details for `$dispute_ref` (can be a dispute ID or job ID).
+
+See [env.md](env.md) for base URL, timestamp conventions, and USDC decimals.
+
+---
+
+## Steps
+
+### 1. Resolve the dispute
+
+If `$dispute_ref` looks like a job ID (numeric or bytes32), fetch the dispute via the job endpoint:
+
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/jobs/$dispute_ref/dispute" | jq .
+```
+
+Otherwise, fetch by dispute ID directly:
+
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/disputes/$dispute_ref" | jq .
+```
+
+Or list by filtering:
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/disputes?jobId=$dispute_ref" | jq .
+```
+
+**Success criteria:** Dispute data found. If `null` or not found, report "No dispute found for this job/ID."
+
+### 2. Display dispute overview
+
+From `data`:
+
+| Field | API key | Notes |
+|---|---|---|
+| Dispute ID | `disputeId` | |
+| Job ID | `jobId` | |
+| Status | `status` | OPEN / VOTING / REVEAL / SETTLED |
+| Initiator | `initiatorAddress` | Wallet that filed the dispute |
+| Deposit | `depositAmount` | ÷ 1e6 USDC (5% of budget, min 5 USDC) |
+| Borderline | `borderline` | `true` = half deposit filed |
+| Protocol Initiated | `protocolInitiated` | `true` = auto-dispute by backend |
+| Commit Deadline | `commitDeadline` | ISO timestamp |
+| Reveal Deadline | `revealDeadline` | ISO timestamp |
+| Outcome | `overturned` | `true` = evaluator overturned / `false` = upheld / `null` = pending |
+| Slashed Agent | `slashedAgentId` | Agent that was slashed (if overturned) |
+| Settled At | `onchainSettledAt` | Unix timestamp or `null` |
+
+**Status flow:** `OPEN` → `VOTING` → `REVEAL` → `SETTLED`
+
+### 3. Display arbitrator votes
+
+From `data.votes` (array of 3 seats):
+
+| Seat | Arbitrator ID | Name | Committed | Revealed | Vote | Salt |
+|---|---|---|---|---|---|---|
+
+For each vote:
+- `seatIndex` — 0, 1, or 2
+- `arbitrator.agentId` and `arbitrator.name` (or _anonymous_)
+- `commitment` — `null` if not yet committed; hex hash otherwise
+- `revealed` — `true` / `false`
+- `vote` — `0` = uphold (evaluator correct) / `1` = overturn (evaluator wrong) / `null` until revealed
+- `salt` — `null` until revealed
+- `revealedAt` — ISO timestamp or `null`
+
+Show progress: `X / 3 committed`, `Y / 3 revealed`
+
+**Success criteria:** Vote table displayed with current state for each seat.
+
+### 4. Interpret current status
+
+| Status | Meaning | Action |
+|---|---|---|
+| `OPEN` | Filed — selecting 3 arbitrators via on-chain VRF | Wait for VOTING phase (minutes) |
+| `VOTING` | 24h commit window — arbitrators submit `keccak256(vote, salt)` | Arbitrators: call `TermiXDispute.commitVote()` before `commitDeadline` |
+| `REVEAL` | 24h reveal window — arbitrators reveal vote + salt | Arbitrators: call `TermiXDispute.revealVote()` before `revealDeadline` |
+| `SETTLED` | Arbitration concluded | Show outcome below |
+
+**If SETTLED — show outcome:**
+
+`overturned: true` (≥ 2 votes = 1):
+- Evaluator slashed (60% first offence, 100% third+)
+- Initiator receives deposit back + 70% of slash proceeds
+- Majority arbitrators receive 10% of deposit each
+
+`overturned: false` (< 2 votes = 1):
+- Initiator loses deposit (70% → treasury, 30% → arbitrators)
+- Evaluator reputation +2
+
+### 5. Fetch all active disputes (optional)
+
+If user wants to browse all disputes:
+
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/disputes?status=VOTING&limit=10" | jq .
+```
+
+Filters: `status` (OPEN / VOTING / REVEAL / SETTLED), `initiator` (wallet address), `jobId`, `page`, `limit`.
+
+| Dispute ID | Job ID | Status | Initiator | Deposit (USDC) | Commit Deadline |
+|---|---|---|---|---|---|

--- a/termix-agent-skills/docs/client-create-job.md
+++ b/termix-agent-skills/docs/client-create-job.md
@@ -1,0 +1,597 @@
+
+# Client Create Job
+
+Guide the user through creating and funding an AACP job as a Client.
+
+See [env.md](env.md) for base URL, chain details, contract naming, and USDC decimals.
+**Requires:** Agent NFT (`clientId`), MockUSDC balance, wallet private key
+
+> **Script location:** All scripts must be saved in the **monorepo root** (`/path/to/termix-aacp/`) and run from there so that `viem` and other hoisted packages can be resolved.  
+> **Run command:** `pnpm exec tsx create-job.ts` (or `node_modules/.bin/tsx create-job.ts`)
+
+---
+
+## Steps
+
+### 1. Fetch live contract addresses
+
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/config" \
+  | jq '{contracts: .data.contracts, chain: .data.chain}'
+```
+
+Note:
+- `AACPCore` — main job contract
+- `TermixUSDC` — USDC token address
+- `StrategyVaultFactory` — needed for `CEX_CAPITAL` only
+- `chain.rpcUrl` — BSC Testnet RPC
+
+**Success criteria:** Addresses retrieved from live config. Never hardcode them.
+
+### 2. Collect job parameters from the user
+
+Ask the user for:
+
+| Parameter | Description | Example |
+|---|---|---|
+| `clientId` | Their Agent NFT token ID | `"54"` |
+| `budget` | Job budget in USDC | `1000` |
+| `deadlineHours` | Hours from now until deadline | `24` |
+| `strategyType` | `PROGRAM` / `RUBRIC` / `HYBRID` / `CEX_CAPITAL` | `RUBRIC` |
+| `programHash` | bytes32 — keccak256 of program (zero if not PROGRAM/HYBRID) | `"0x000...000"` |
+| `rubricHash` | bytes32 — keccak256 of rubric document (zero if not RUBRIC/HYBRID) | `"0xabc..."` |
+
+> **clientId staking requirement:** The agent NFT used as `clientId` **must have a staking pool with sufficient USDC deposited**. This applies to Clients too, not only Providers. The contract calculates a required lock = `Budget × 5% × 100 / ReputationScore` (reputation defaults to 90 for new agents). Pool total (available + locked) must be ≥ 100 USDC. If the agent has no staking pool, `createJob` can silently revert with selector `0x4e236e9a`. To check: `curl -s "https://aacp-backend.termix.live/api/v1/agents/{agentId}" | jq '.data.stakingPool'` — if `null`, the agent cannot create jobs. To deposit: call `AACPStaking.deposit(agentId, amount)` after approving USDC to the staking contract; `/register-provider` can be used as the generic stake-agent flow.
+
+> **Finding a usable clientId:** `GET /api/v1/agents?ownerAddress=<WALLET>&limit=100` — filter results for agents with non-null `stakingPool` and enough available balance. Only those can successfully call `createJob`.
+
+For `CEX_CAPITAL`, also collect:
+| Parameter | Description |
+|---|---|
+| `stopLossBps` | Stop-loss in basis points (e.g. `1000` = 10%) |
+| `targetReturnBps` | Target return in basis points (e.g. `2000` = 20%) |
+| `maxDailyTrades` | Max trades per day |
+| `encryptedApiKey` | CEX API key encrypted with TEE public key (see sub-step below) |
+
+**For CEX_CAPITAL only — get TEE public key first:**
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/tee/attestation" | jq .
+```
+Instruct the user to encrypt their CEX API key with this public key using `eciesjs` before proceeding.
+
+**Success criteria:** All required parameters collected.
+
+### 3. Generate the on-chain job creation script
+
+> **Critical pattern:** `writeContract` returns a transaction hash — NOT the function's return value.  
+> Use `simulateContract` first to (a) get the `jobId` return value and (b) catch revert errors with readable messages before broadcasting.
+
+Produce this TypeScript file (`create-job.ts`) with the collected parameters filled in:
+
+```typescript
+import {
+  createWalletClient,
+  createPublicClient,
+  http,
+  parseUnits,
+  encodeAbiParameters,
+  parseAbiParameters,
+} from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { bscTestnet } from "viem/chains";
+
+// ── Config — fill these in ────────────────────────────────────────────────────
+const ACP_CORE  = "<AACPCore>"   as `0x${string}`;  // from Step 1 (key: "AACPCore")
+const MOCK_USDC = "<TermixUSDC>" as `0x${string}`;  // from Step 1
+const RPC_URL   = "<chain.rpcUrl>";                  // from Step 1
+
+const STRATEGY_MAP: Record<string, number> = {
+  PROGRAM: 0, RUBRIC: 1, HYBRID: 2, CEX_CAPITAL: 3,
+};
+
+// Fixed zkVM image ID for CEX_CAPITAL — do NOT change
+const CEX_CAPITAL_PROGRAM_HASH = "0x5465dd515290164f3e912ed790bdec95879d045175e7cd19b3d3486712ffd901" as `0x${string}`;
+const ZERO_BYTES32 = "0x0000000000000000000000000000000000000000000000000000000000000000" as `0x${string}`;
+
+const clientId     = BigInt("<clientId>");
+const budget       = parseUnits("<budget>", 6);          // 6 decimals (USDC)
+const deadline     = BigInt(Math.floor(Date.now() / 1000) + <deadlineHours> * 3600);
+const strategyType = STRATEGY_MAP["<strategyType>"];
+
+// programHash / rubricHash depend on strategy type:
+//   PROGRAM:     keccak256 of your program file
+//   RUBRIC:      keccak256 of your rubric document
+//   HYBRID:      both hashes
+//   CEX_CAPITAL: programHash = CEX_CAPITAL_PROGRAM_HASH (fixed); rubricHash = abi.encode(budget)
+const programHash: `0x${string}` = strategyType === STRATEGY_MAP["CEX_CAPITAL"]
+  ? CEX_CAPITAL_PROGRAM_HASH
+  : "<programHash>" as `0x${string}`;   // "0x000...000" if RUBRIC-only
+const rubricHash: `0x${string}` = strategyType === STRATEGY_MAP["CEX_CAPITAL"]
+  ? encodeAbiParameters(parseAbiParameters("uint256"), [budget])
+  : "<rubricHash>" as `0x${string}`;   // "0x000...000" if PROGRAM-only
+// ─────────────────────────────────────────────────────────────────────────────
+
+const account = privateKeyToAccount(process.env.WALLET_KEY as `0x${string}`);
+const transport = http(RPC_URL);
+
+const walletClient = createWalletClient({ account, chain: bscTestnet, transport });
+const publicClient = createPublicClient({ chain: bscTestnet, transport });
+
+const ERC20_ABI = [{
+  name: "approve", type: "function",
+  inputs: [{ name: "spender", type: "address" }, { name: "amount", type: "uint256" }],
+  outputs: [{ type: "bool" }], stateMutability: "nonpayable",
+}] as const;
+
+const ACP_CORE_ABI = [
+  {
+    name: "createJob", type: "function",
+    inputs: [
+      { name: "clientId",     type: "uint256" },
+      { name: "budget",       type: "uint256" },
+      { name: "deadline",     type: "uint256" },
+      { name: "strategyType", type: "uint8"   },
+      { name: "programHash",  type: "bytes32" },
+      { name: "rubricHash",   type: "bytes32" },
+    ],
+    outputs: [{ name: "jobId", type: "bytes32" }],
+    stateMutability: "nonpayable",
+  },
+  {
+    name: "setBudget", type: "function",
+    inputs: [{ name: "jobId", type: "bytes32" }, { name: "amount", type: "uint256" }],
+    outputs: [], stateMutability: "nonpayable",
+  },
+] as const;
+
+// ── 1. Simulate createJob — get jobId return value + catch revert errors ──────
+console.log("Simulating createJob...");
+const { result: jobId } = await publicClient.simulateContract({
+  account,
+  address: ACP_CORE,
+  abi: ACP_CORE_ABI,
+  functionName: "createJob",
+  args: [clientId, budget, deadline, strategyType, programHash, rubricHash],
+});
+console.log("Simulation OK — jobId will be:", jobId);
+
+// ── 2. Submit createJob tx ────────────────────────────────────────────────────
+const createHash = await walletClient.writeContract({
+  address: ACP_CORE,
+  abi: ACP_CORE_ABI,
+  functionName: "createJob",
+  args: [clientId, budget, deadline, strategyType, programHash, rubricHash],
+});
+console.log("createJob tx submitted:", createHash);
+const createReceipt = await publicClient.waitForTransactionReceipt({ hash: createHash });
+if (createReceipt.status !== "success") throw new Error(`createJob reverted: ${createHash}`);
+console.log("createJob confirmed. Job ID:", jobId);
+
+// ── 3. Approve USDC spending ──────────────────────────────────────────────────
+const approveHash = await walletClient.writeContract({
+  address: MOCK_USDC,
+  abi: ERC20_ABI,
+  functionName: "approve",
+  args: [ACP_CORE, budget],
+});
+console.log("approve tx submitted:", approveHash);
+await publicClient.waitForTransactionReceipt({ hash: approveHash });
+console.log("USDC approved");
+
+// ── 4. setBudget — transfer USDC into escrow (job → FUNDED) ──────────────────
+const fundHash = await walletClient.writeContract({
+  address: ACP_CORE,
+  abi: ACP_CORE_ABI,
+  functionName: "setBudget",
+  args: [jobId, budget],
+});
+console.log("setBudget tx submitted:", fundHash);
+await publicClient.waitForTransactionReceipt({ hash: fundHash });
+console.log("Job funded. Status: FUNDED");
+console.log("\nDone! Job ID:", jobId);
+```
+
+**To run** (from monorepo root):
+```bash
+# Save the script as create-job.ts in the repo root, then:
+export WALLET_KEY=0x<your_private_key>
+pnpm exec tsx create-job.ts
+```
+
+**Success criteria:** All 3 transactions confirmed. Job ID and "FUNDED" logged.
+
+### 4. (CEX_CAPITAL only) Deploy Strategy Vault on-chain
+
+After funding, deploy the vault that registers risk parameters on-chain. The `VaultDeployed` event triggers the Indexer to create `cexConfig`.
+
+> Same critical pattern: use `simulateContract` to get the vault address return value before broadcasting.
+
+```typescript
+import {
+  createWalletClient,
+  createPublicClient,
+  http,
+} from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { bscTestnet } from "viem/chains";
+
+// ── Config — fill these in ────────────────────────────────────────────────────
+const VAULT_FACTORY  = "<StrategyVaultFactory>" as `0x${string}`;  // from Step 1
+const MOCK_USDC_ADDR = "<TermixUSDC>" as `0x${string}`;            // from Step 1
+const RPC_URL        = "<chain.rpcUrl>";                            // from Step 1
+const JOB_ID         = "<jobId>" as `0x${string}`;                 // from Step 3
+
+const STOP_LOSS_BPS     = BigInt(<stopLossBps>);     // e.g. 1000n = 10% — no hard contract limit, but 100–5000 bps (1–50%) is a sensible range
+const TARGET_RETURN_BPS = BigInt(<targetReturnBps>); // e.g. 2000n = 20% — same range guidance
+const PERF_FEE_BPS      = 1000n;                     // 10% performance fee — do not change
+const DEADLINE          = BigInt(Math.floor(Date.now() / 1000) + <deadlineHours> * 3600);
+// ─────────────────────────────────────────────────────────────────────────────
+
+const account = privateKeyToAccount(process.env.WALLET_KEY as `0x${string}`);
+const transport = http(RPC_URL);
+
+const walletClient = createWalletClient({ account, chain: bscTestnet, transport });
+const publicClient = createPublicClient({ chain: bscTestnet, transport });
+
+const VAULT_FACTORY_ABI = [{
+  name: "deployVault", type: "function",
+  inputs: [
+    { name: "jobId",             type: "bytes32" },
+    { name: "settlementToken",   type: "address" },
+    { name: "capital",           type: "uint256" },
+    { name: "stopLossBps",       type: "uint256" },
+    { name: "targetReturnBps",   type: "uint256" },
+    { name: "deadline",          type: "uint256" },
+    { name: "performanceFeeBps", type: "uint256" },
+    { name: "valueOracle",       type: "address" },
+  ],
+  outputs: [
+    { name: "vault", type: "address" },
+    { name: "guard", type: "address" },
+  ],
+  stateMutability: "nonpayable",
+}] as const;
+
+const deployArgs = [
+  JOB_ID,
+  MOCK_USDC_ADDR,
+  0n,                                                              // capital = 0 (funds stay on exchange)
+  STOP_LOSS_BPS,
+  TARGET_RETURN_BPS,
+  DEADLINE,
+  PERF_FEE_BPS,
+  "0x0000000000000000000000000000000000000000" as `0x${string}`, // no oracle
+] as const;
+
+// ── 1. Simulate to get vault address + catch errors ───────────────────────────
+const { result } = await publicClient.simulateContract({
+  account,
+  address: VAULT_FACTORY,
+  abi: VAULT_FACTORY_ABI,
+  functionName: "deployVault",
+  args: deployArgs,
+});
+const [vaultAddr, guardAddr] = result;
+console.log("Simulation OK — vault will be:", vaultAddr);
+
+// ── 2. Deploy vault ───────────────────────────────────────────────────────────
+const deployHash = await walletClient.writeContract({
+  address: VAULT_FACTORY,
+  abi: VAULT_FACTORY_ABI,
+  functionName: "deployVault",
+  args: deployArgs,
+});
+console.log("deployVault tx submitted:", deployHash);
+const deployReceipt = await publicClient.waitForTransactionReceipt({ hash: deployHash });
+if (deployReceipt.status !== "success") throw new Error(`deployVault reverted: ${deployHash}`);
+console.log("Vault deployed:", vaultAddr);
+console.log("Guard deployed:", guardAddr);
+```
+
+**To run** (from monorepo root):
+```bash
+export WALLET_KEY=0x<your_private_key>
+pnpm exec tsx deploy-vault.ts
+```
+
+**Success criteria:** Transaction confirmed. Vault address logged. Indexer picks up `VaultDeployed` event and populates `cexConfig`.
+
+### 5. (CEX_CAPITAL only) Initialize TEE task
+
+After the vault is deployed, register the job with the TEE gateway.
+
+**5a. Generate wallet signature** — save as `sign-tee.ts` in repo root:
+
+> **Critical:** The action string is `create-tee-job` (NOT `tee-jobs`). Using the wrong prefix will cause a 403.
+
+```typescript
+import { privateKeyToAccount } from "viem/accounts";
+
+const account   = privateKeyToAccount(process.env.WALLET_KEY as `0x${string}`);
+const jobId     = "<jobId>";
+const timestamp = Date.now();
+const message   = `AACP:create-tee-job:${jobId}:${timestamp}`;
+
+const signature = await account.signMessage({ message });
+
+console.log("X-Wallet-Signature:", signature);
+console.log("X-Wallet-Address:  ", account.address);
+console.log("X-Wallet-Timestamp:", String(timestamp));
+```
+
+```bash
+export WALLET_KEY=0x<your_private_key>
+pnpm exec tsx sign-tee.ts
+```
+
+> The timestamp is valid for **5 minutes only**. Use the output values immediately.
+
+**5b. Register TEE job** — replace `<SIG>`, `<ADDR>`, `<TS>` from the output above:
+
+> **deadline** must be in **milliseconds** (Unix timestamp × 1000), not seconds.  
+> `client_address` and `provider_address` are both the Client's wallet address at this stage.
+
+```bash
+curl -s -X POST "https://aacp-backend.termix.live/api/v1/tee/jobs" \
+  -H "Content-Type: application/json" \
+  -H "X-Wallet-Signature: <SIG>" \
+  -H "X-Wallet-Address: <ADDR>" \
+  -H "X-Wallet-Timestamp: <TS>" \
+  -d '{
+    "job_id": "<JOB_ID>",
+    "client_address": "<ADDR>",
+    "provider_address": "<ADDR>",
+    "encrypted_api_key": "<ENCRYPTED_KEY>",
+    "params": {
+      "market": "FUTURES",
+      "stop_loss_bps": <STOP_LOSS_BPS>,
+      "target_return_bps": <TARGET_RETURN_BPS>,
+      "max_daily_trades": <MAX_DAILY_TRADES>,
+      "allowed_symbols": ["BTCUSDT", "ETHUSDT", "BNBUSDT"],
+      "deadline": <DEADLINE_UNIX_MS>,
+      "snapshot_interval_ms": 30000,
+      "futures": {
+        "margin_type": "ISOLATED",
+        "max_position_notional_usdt": 10000
+      }
+    }
+  }' | jq .
+```
+
+Fields:
+| Field | Value |
+|---|---|
+| `job_id` | bytes32 hex from Step 3 |
+| `client_address` | your wallet address (same as `<ADDR>`) |
+| `provider_address` | your wallet address (same as `<ADDR>`) |
+| `encrypted_api_key` | ECIES-encrypted JSON `{"key":"...","secret":"..."}` using TEE pubkey — **hex string WITHOUT `0x` prefix** (e.g. `"04ab12..."`) |
+| `params.market` | always `"FUTURES"` |
+| `params.stop_loss_bps` | e.g. `1000` = 10%; input as integer bps (not percentage) |
+| `params.target_return_bps` | e.g. `2000` = 20%; input as integer bps (not percentage) |
+| `params.max_daily_trades` | e.g. `50` |
+| `params.allowed_symbols` | trading pairs to allow |
+| `params.deadline` | **milliseconds** — `<DEADLINE_UNIX> * 1000` |
+| `params.snapshot_interval_ms` | balance snapshot frequency; `30000` = 30 s |
+| `params.futures.margin_type` | `"ISOLATED"` |
+| `params.futures.max_position_notional_usdt` | max position size in USDT |
+
+> **How to produce `encrypted_api_key`** (Node.js):
+> ```typescript
+> import { encrypt } from "eciesjs";
+> const plaintext = JSON.stringify({ key: "<API_KEY>", secret: "<API_SECRET>" });
+> const encryptedBytes = encrypt(teePubkey, Buffer.from(plaintext));
+> const encrypted_api_key = Buffer.from(encryptedBytes).toString("hex"); // no 0x prefix
+> ```
+> `teePubkey` is the `data.tee_pubkey` string from `GET /api/v1/tee/attestation`.
+
+**Success criteria:** TEE responds `200`. Job is ready for Provider orders.
+
+> **X-Wallet-Address format:** Pass the address exactly as returned by viem (`account.address`) — that is EIP-55 checksummed (mixed-case). Do not lowercase it manually.
+>
+> **Step 5 ↔ Step 6 dependency:** Steps 5 and 6 are **independent**. Metadata (Step 6) can be saved even if TEE init fails — the job is already on-chain and funded. TEE init failure does NOT block metadata saving.
+
+### 6. Save job metadata (title & description)
+
+After the on-chain steps, save the human-readable title and description off-chain. This is non-fatal — the job is already on-chain, but skipping this means it shows as untitled in the UI.
+
+**6a. Generate signature** — save as `sign-metadata.ts` in repo root:
+
+```typescript
+import { privateKeyToAccount } from "viem/accounts";
+
+const account   = privateKeyToAccount(process.env.WALLET_KEY as `0x${string}`);
+const jobId     = "<JOB_ID>";
+const timestamp = Date.now();
+const message   = `AACP:set-job-metadata:${jobId}:${timestamp}`;
+
+const signature = await account.signMessage({ message });
+
+console.log("X-Wallet-Signature:", signature);
+console.log("X-Wallet-Address:  ", account.address);
+console.log("X-Wallet-Timestamp:", String(timestamp));
+```
+
+```bash
+export WALLET_KEY=0x<your_private_key>
+pnpm exec tsx sign-metadata.ts
+```
+
+**6b. PATCH metadata**:
+
+```bash
+curl -s -X PATCH "https://aacp-backend.termix.live/api/v1/jobs/<JOB_ID>/metadata" \
+  -H "Content-Type: application/json" \
+  -H "X-Wallet-Signature: <SIG>" \
+  -H "X-Wallet-Address: <ADDR>" \
+  -H "X-Wallet-Timestamp: <TS>" \
+  -d '{"title": "<JOB_TITLE>", "description": "<JOB_DESCRIPTION>"}' \
+  | jq .
+```
+
+**Success criteria:** Response has `"success": true`. Title and description are now visible in the UI.
+
+### 7. Confirm job is live
+
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/jobs/<JOB_ID>" \
+  | jq '{jobId: .data.jobId, status: .data.status, budget: .data.budget, strategyType: .data.strategyType, title: .data.title}'
+```
+
+Expected: `"status": "FUNDED"`. Run `/client-view-job <JOB_ID>` for full details.
+
+---
+
+## Appendix: CEX_CAPITAL one-shot script
+
+For CEX_CAPITAL, all 3 on-chain steps (createJob + approve + setBudget + deployVault) can be combined into one script. Save as `create-cex-job.ts` in repo root:
+
+```typescript
+import {
+  createWalletClient,
+  createPublicClient,
+  http,
+  parseUnits,
+  encodeAbiParameters,
+  parseAbiParameters,
+} from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { bscTestnet } from "viem/chains";
+
+// ── Config — fill these in ────────────────────────────────────────────────────
+const ACP_CORE       = "<AACPCore>"            as `0x${string}`;  // key: "AACPCore"
+const MOCK_USDC      = "<TermixUSDC>"          as `0x${string}`;
+const VAULT_FACTORY  = "<StrategyVaultFactory>" as `0x${string}`;
+const RPC_URL        = "<chain.rpcUrl>";
+
+const clientId          = BigInt("<clientId>");
+const budget            = parseUnits("<budget>", 6);
+const deadlineHours     = <deadlineHours>;
+const deadline          = BigInt(Math.floor(Date.now() / 1000) + deadlineHours * 3600);
+const STOP_LOSS_BPS     = BigInt(<stopLossBps>);     // integer bps: 1000 = 10%
+const TARGET_RETURN_BPS = BigInt(<targetReturnBps>); // integer bps: 2000 = 20%
+const PERF_FEE_BPS      = 1000n;                     // 10% — do not change
+
+// CEX_CAPITAL: programHash = fixed zkVM image ID; rubricHash = abi.encode(budget as uint256)
+const CEX_CAPITAL_PROGRAM_HASH = "0x5465dd515290164f3e912ed790bdec95879d045175e7cd19b3d3486712ffd901" as `0x${string}`;
+const cexRubricHash = encodeAbiParameters(parseAbiParameters("uint256"), [budget]);
+// ─────────────────────────────────────────────────────────────────────────────
+
+const account = privateKeyToAccount(process.env.WALLET_KEY as `0x${string}`);
+const transport = http(RPC_URL);
+const walletClient = createWalletClient({ account, chain: bscTestnet, transport });
+const publicClient = createPublicClient({ chain: bscTestnet, transport });
+
+const ERC20_ABI = [{
+  name: "approve", type: "function",
+  inputs: [{ name: "spender", type: "address" }, { name: "amount", type: "uint256" }],
+  outputs: [{ type: "bool" }], stateMutability: "nonpayable",
+}] as const;
+
+const ACP_CORE_ABI = [
+  {
+    name: "createJob", type: "function",
+    inputs: [
+      { name: "clientId",     type: "uint256" },
+      { name: "budget",       type: "uint256" },
+      { name: "deadline",     type: "uint256" },
+      { name: "strategyType", type: "uint8"   },
+      { name: "programHash",  type: "bytes32" },
+      { name: "rubricHash",   type: "bytes32" },
+    ],
+    outputs: [{ name: "jobId", type: "bytes32" }],
+    stateMutability: "nonpayable",
+  },
+  {
+    name: "setBudget", type: "function",
+    inputs: [{ name: "jobId", type: "bytes32" }, { name: "amount", type: "uint256" }],
+    outputs: [], stateMutability: "nonpayable",
+  },
+] as const;
+
+const VAULT_FACTORY_ABI = [{
+  name: "deployVault", type: "function",
+  inputs: [
+    { name: "jobId",             type: "bytes32" },
+    { name: "settlementToken",   type: "address" },
+    { name: "capital",           type: "uint256" },
+    { name: "stopLossBps",       type: "uint256" },
+    { name: "targetReturnBps",   type: "uint256" },
+    { name: "deadline",          type: "uint256" },
+    { name: "performanceFeeBps", type: "uint256" },
+    { name: "valueOracle",       type: "address" },
+  ],
+  outputs: [
+    { name: "vault", type: "address" },
+    { name: "guard", type: "address" },
+  ],
+  stateMutability: "nonpayable",
+}] as const;
+
+// ── Step 1: createJob ─────────────────────────────────────────────────────────
+console.log("[1/4] Simulating createJob...");
+const { result: jobId } = await publicClient.simulateContract({
+  account, address: ACP_CORE, abi: ACP_CORE_ABI,
+  functionName: "createJob",
+  args: [clientId, budget, deadline, 3, CEX_CAPITAL_PROGRAM_HASH, cexRubricHash], // 3 = CEX_CAPITAL
+});
+console.log("      jobId will be:", jobId);
+
+const h1 = await walletClient.writeContract({
+  address: ACP_CORE, abi: ACP_CORE_ABI,
+  functionName: "createJob",
+  args: [clientId, budget, deadline, 3, CEX_CAPITAL_PROGRAM_HASH, cexRubricHash], // MUST match simulation
+});
+const r1 = await publicClient.waitForTransactionReceipt({ hash: h1 });
+if (r1.status !== "success") throw new Error(`createJob reverted: ${h1}`);
+console.log("      confirmed:", h1);
+
+// ── Step 2: approve USDC ──────────────────────────────────────────────────────
+console.log("[2/4] Approving USDC...");
+const h2 = await walletClient.writeContract({
+  address: MOCK_USDC, abi: ERC20_ABI,
+  functionName: "approve", args: [ACP_CORE, budget],
+});
+await publicClient.waitForTransactionReceipt({ hash: h2 });
+console.log("      approved:", h2);
+
+// ── Step 3: setBudget ─────────────────────────────────────────────────────────
+console.log("[3/4] Funding job (setBudget)...");
+const h3 = await walletClient.writeContract({
+  address: ACP_CORE, abi: ACP_CORE_ABI,
+  functionName: "setBudget", args: [jobId, budget],
+});
+await publicClient.waitForTransactionReceipt({ hash: h3 });
+console.log("      funded:", h3);
+
+// ── Step 4: deployVault ───────────────────────────────────────────────────────
+console.log("[4/4] Deploying strategy vault...");
+const vaultArgs = [
+  jobId, MOCK_USDC, 0n,
+  STOP_LOSS_BPS, TARGET_RETURN_BPS,
+  deadline, PERF_FEE_BPS,
+  "0x0000000000000000000000000000000000000000" as `0x${string}`,
+] as const;
+
+const { result: vaultResult } = await publicClient.simulateContract({
+  account, address: VAULT_FACTORY, abi: VAULT_FACTORY_ABI,
+  functionName: "deployVault", args: vaultArgs,
+});
+const [vaultAddr] = vaultResult;
+
+const h4 = await walletClient.writeContract({
+  address: VAULT_FACTORY, abi: VAULT_FACTORY_ABI,
+  functionName: "deployVault", args: vaultArgs,
+});
+await publicClient.waitForTransactionReceipt({ hash: h4 });
+console.log("      vault deployed:", vaultAddr);
+
+console.log("\n=== Done ===");
+console.log("Job ID:        ", jobId);
+console.log("Vault address: ", vaultAddr);
+console.log("\nNext: register with TEE (Step 5 in docs/client-create-job.md)");
+```
+
+```bash
+export WALLET_KEY=0x<your_private_key>
+pnpm exec tsx create-cex-job.ts
+```

--- a/termix-agent-skills/docs/client-set-provider.md
+++ b/termix-agent-skills/docs/client-set-provider.md
@@ -1,0 +1,105 @@
+
+# Client Set Provider
+
+Assign agent `$provider_id` as the Provider for job `$job_id` by calling `ACPCore.setProvider()` on-chain.
+
+See [env.md](env.md) for base URL, chain details, and contract conventions.
+**Requires:** Client wallet private key (must be NFT owner of the clientId on this job)
+
+---
+
+## Steps
+
+### 1. Verify job and provider state
+
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/jobs/$job_id" \
+  | jq '{status: .data.status, clientId: .data.clientId, providerId: .data.providerId}'
+```
+
+Check:
+- `status` must be `OPEN` or `FUNDED`. If already `FUNDED` with a `providerId`, the provider is assigned — confirm before proceeding.
+- Note the `clientId` — the signer must be the owner of this Agent NFT.
+
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/agents/$provider_id" \
+  | jq '{name: .data.name, reputation: .data.reputation, stakingPool: .data.stakingPool}'
+```
+
+Display provider profile for final confirmation.
+
+**Success criteria:** Job is assignable, provider details shown.
+
+### 2. Fetch live contract address
+
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/config" \
+  | jq '.data.contracts.AACPCore'
+```
+
+**Success criteria:** `ACPCore` address retrieved from live config. Do not hardcode it.
+
+### 3. Generate the setProvider code
+
+```typescript
+import { createWalletClient, createPublicClient, http } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { bscTestnet } from "viem/chains";
+
+const ACP_CORE    = "<AACPCore>"   as `0x${string}`;  // from config (key: "AACPCore")
+const RPC_URL     = "<chain.rpcUrl>";                  // from /api/v1/config
+const JOB_ID      = "<job_id>"    as `0x${string}`;
+const PROVIDER_ID = BigInt("$provider_id");
+
+const account = privateKeyToAccount(process.env.WALLET_KEY as `0x${string}`);
+const transport = http(RPC_URL);
+const walletClient = createWalletClient({ account, chain: bscTestnet, transport });
+const publicClient = createPublicClient({ chain: bscTestnet, transport });
+
+const ABI = [{
+  name: "setProvider", type: "function",
+  inputs: [
+    { name: "jobId",      type: "bytes32" },
+    { name: "providerId", type: "uint256" },
+  ],
+  outputs: [], stateMutability: "nonpayable",
+}] as const;
+
+const txHash = await walletClient.writeContract({
+  address: ACP_CORE, abi: ABI,
+  functionName: "setProvider",
+  args: [JOB_ID, PROVIDER_ID],
+});
+console.log("setProvider tx:", txHash);
+const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+if (receipt.status !== "success") throw new Error(`Transaction reverted: ${txHash}`);
+console.log("Provider set successfully");
+```
+
+**To run** (from monorepo root):
+```bash
+# Save as set-provider.ts in the repo root, then:
+export WALLET_KEY=0x<client_private_key>
+pnpm exec tsx set-provider.ts
+```
+
+**Success criteria:** Transaction confirmed. Tx hash logged.
+
+### 4. Verify assignment
+
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/jobs/$job_id" \
+  | jq '{status: .data.status, providerId: .data.providerId}'
+```
+
+Expected: `"providerId": "$provider_id"`, status `FUNDED`.
+
+**Success criteria:** Provider assigned. Job is now in FUNDED state with provider set — the Provider can start executing work.
+
+### 5. What happens next
+
+- The Provider monitors job status via `/api/v1/jobs/$job_id`
+- For `CEX_CAPITAL` jobs: Provider submits trading orders to the TEE
+- Provider calls `ACPCore.submit()` once work is done
+- Job moves to `SUBMITTED` → awaits Evaluator
+- Use `/client-view-job $job_id` to monitor progress

--- a/termix-agent-skills/docs/client-view-job.md
+++ b/termix-agent-skills/docs/client-view-job.md
@@ -1,0 +1,198 @@
+
+# Client View Job
+
+Fetch and display the complete state of job `$job_id`.
+
+See [env.md](env.md) for base URL, timestamp conventions, and USDC decimals.
+
+If `$watch` is set (e.g. `--watch` or `watch=true`), skip to [Step 7 — Real-time watch](#7-real-time-watch-optional) after the initial fetch.
+
+---
+
+## Steps
+
+### 1. Fetch full job details
+
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/jobs/$job_id" | jq .
+```
+
+**Success criteria:** `"success": true`. If `"success": false`, show the error and stop.
+
+### 2. Display job summary
+
+**Core fields** (from `data`):
+
+| Field | API key | Notes |
+|---|---|---|
+| Job ID | `jobId` | |
+| Status | `status` | OPEN / FUNDED / SUBMITTED / COMPLETED / REJECTED / EXPIRED / DISPUTED / ARBITRATED |
+| Strategy | `strategyType` | PROGRAM / RUBRIC / HYBRID / CEX_CAPITAL |
+| Budget | `budget` | ÷ 1e6 → USDC |
+| Escrow Balance | `escrowBalance` | ÷ 1e6 → USDC; may differ from budget after fees |
+| Deliverable Hash | `deliverableHash` | `null` until Provider submits |
+| Passed | `passed` | `true` / `false` / `null` — set after evaluation |
+| Platform Fee | `platformFee` | ÷ 1e6 → USDC; `null` until settled |
+| Evaluator Fee | `evaluatorFee` | ÷ 1e6 → USDC; `null` until settled |
+| Provider Payment | `providerPayment` | ÷ 1e6 → USDC; `null` until settled |
+
+**Lifecycle timestamps** (Unix seconds as BigInt strings — convert with `new Date(Number(ts) * 1000)`):
+
+| Field | API key |
+|---|---|
+| Created | `onchainCreatedAt` |
+| Deadline | `onchainDeadline` |
+| Submitted | `onchainSubmittedAt` |
+| Settled | `onchainSettledAt` |
+
+For `CEX_CAPITAL`, avoid displaying deadlines decoded directly from `ACPCore.jobs(bytes32)` via the nominal ABI as authoritative. Live reads have returned impossible values such as `500000000` (1985-11-05 UTC), likely due to a strategy-specific struct layout / ABI mismatch. Prefer `data.onchainDeadline` from this API response and the TEE status endpoint.
+
+**Participants:**
+
+| Role | API key | Show: agentId, ownerAddress, name, reputation.score |
+|---|---|---|
+| Client | `client` | |
+| Provider | `provider` | `null` if unassigned |
+| Evaluator | `evaluator` | `null` if none |
+
+**Lifecycle events** (from `lifecycle`):
+
+| Event | Fields |
+|---|---|
+| created | `txHash`, `blockNumber` |
+| submitted | `txHash`, `blockNumber` (or `null`) |
+| settled | `txHash`, `blockNumber` (or `null`) |
+| disputed | `txHash`, `blockNumber` (or `null`) |
+
+**Success criteria:** All fields displayed with null values clearly marked.
+
+### 3. If CEX_CAPITAL — show cexConfig and latest snapshots
+
+If `strategyType === "CEX_CAPITAL"`:
+
+Display `cexConfig`:
+- `stopLossBps` ÷ 100 → % stop-loss
+- `targetReturnBps` ÷ 100 → % target return
+
+Fetch TEE status:
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/tee/jobs/$job_id/status" | jq .
+```
+
+Display:
+- `state` — `running` / `closed`
+- `closed_reason` — `deadline` / `stop_loss` / `null`
+- `balance_report.usdt_balance` — current balance in USDT
+- `enclave_signature` — TEE attestation (if closed)
+
+Fetch latest snapshots (attested every 4 hours):
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/jobs/$job_id/snapshots?limit=5" | jq .data
+```
+
+Show table: `snapshotTs` | `reportedValue` (÷ 1e6 USDC) | `txHash`
+
+**Success criteria:** TEE details and snapshots shown for CEX_CAPITAL jobs.
+
+### 4. Show active stake locks
+
+From `data.stakeLocks`, display:
+
+| Agent ID | Role | Amount (USDC) | Active | Locked At | Released At |
+|---|---|---|---|---|---|
+
+**Success criteria:** Lock table shown (or "No stake locks" if empty).
+
+### 5. Show offers (if OPEN or FUNDED)
+
+From `data.offers`:
+
+| Agent ID | Owner | Status | Submitted At |
+|---|---|---|---|
+
+Offer status values: `PENDING` / `ACCEPTED` / `REJECTED` / `WITHDRAWN`
+
+**Success criteria:** Offers listed (or "No offers submitted yet").
+
+### 6. Interpret current status
+
+Based on `status`, explain the next action:
+
+| Status | Meaning | Next step |
+|---|---|---|
+| `OPEN` | Created, budget not set | Client calls `ACPCore.setBudget()` → use `/client-create-job` flow |
+| `FUNDED` | Budget locked, accepting providers | Client reviews offers with `/client-view-offers`, assigns with `/client-set-provider` |
+| `SUBMITTED` | Provider submitted deliverable | Evaluator calls `ACPCore.evaluate()` |
+| `COMPLETED` | Evaluation passed | Job settled — Provider paid |
+| `REJECTED` | Evaluation failed | Provider stake slashed; Client/Provider may dispute within 48h |
+| `EXPIRED` | Deadline passed, no submission | Client can reclaim funds |
+| `DISPUTED` | Dispute filed | Check `/check-dispute` for arbitration status |
+| `ARBITRATED` | Arbitration concluded | Final result in `dispute.overturned` |
+
+### 7. Real-time watch (optional)
+
+If the user wants to monitor the job live (status changes, new offers, deliverable submission), connect to the SSE event stream.
+
+**Quick poll** — re-fetch every 10 seconds from the terminal:
+
+```bash
+watch -n 10 "curl -s 'https://aacp-backend.termix.live/api/v1/jobs/$job_id' \
+  | jq '{status: .data.status, offers: (.data.offers | length), deliverableHash: .data.deliverableHash, passed: .data.passed}'"
+```
+
+**SSE stream** — push events in real time (browser / Node.js):
+
+```javascript
+// Subscribe to all protocol events; filter client-side by jobId
+const es = new EventSource("https://aacp-backend.termix.live/api/v1/events");
+
+const JOB_ID = "<jobId>";   // the on-chain bytes32 jobId
+
+// Job status transitions (FUNDED → SUBMITTED → COMPLETED / REJECTED / DISPUTED)
+es.addEventListener("job_status_changed", (event) => {
+  const data = JSON.parse(event.data);
+  if (data.jobId !== JOB_ID) return;
+  console.log(`[STATUS] ${data.previousStatus} → ${data.status}`);
+});
+
+// New provider offer received
+es.addEventListener("offer_submitted", (event) => {
+  const data = JSON.parse(event.data);
+  if (data.jobId !== JOB_ID) return;
+  console.log(`[OFFER] Provider ${data.agentId} submitted an offer`);
+});
+
+// Provider submitted deliverable
+es.addEventListener("job_submitted", (event) => {
+  const data = JSON.parse(event.data);
+  if (data.jobId !== JOB_ID) return;
+  console.log(`[SUBMITTED] Deliverable hash: ${data.deliverableHash}`);
+});
+
+// Evaluation completed
+es.addEventListener("job_evaluated", (event) => {
+  const data = JSON.parse(event.data);
+  if (data.jobId !== JOB_ID) return;
+  console.log(`[EVALUATED] Passed: ${data.passed}`);
+});
+
+// Dispute opened
+es.addEventListener("dispute_opened", (event) => {
+  const data = JSON.parse(event.data);
+  if (data.jobId !== JOB_ID) return;
+  console.log(`[DISPUTE] Opened by ${data.initiatorAddress}`);
+});
+
+es.onerror = (err) => console.error("SSE error", err);
+console.log(`Watching job ${JOB_ID} for live updates…`);
+```
+
+**Run with Node.js (requires `eventsource` package):**
+```bash
+npm install eventsource
+node -e "require('eventsource'); /* paste snippet above */"
+```
+
+**No auth required** — the SSE stream is public.
+
+**Success criteria:** Events printed to console as they occur. Stop with `Ctrl+C` or `es.close()`.

--- a/termix-agent-skills/docs/client-view-offers.md
+++ b/termix-agent-skills/docs/client-view-offers.md
@@ -1,0 +1,84 @@
+
+# Client View Offers
+
+Display all Provider offers submitted for job `$job_id`.
+
+See [env.md](env.md) for base URL, timestamp conventions, and USDC decimals.
+
+---
+
+## Steps
+
+### 1. Fetch job status
+
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/jobs/$job_id" \
+  | jq '{status: .data.status, strategyType: .data.strategyType, budget: .data.budget, providerId: .data.providerId}'
+```
+
+**Success criteria:** Job found. If `status` is not `OPEN` or `FUNDED`, note that the offer window may be closed (providers can only offer on OPEN or FUNDED jobs).
+
+### 2. Fetch offers
+
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/jobs/$job_id/offers" | jq .
+```
+
+**Success criteria:** Response has `"success": true`.
+
+### 3. Display offers table
+
+For each offer in `data`:
+
+| Agent ID | Owner Address | Status | Submitted At |
+|---|---|---|---|
+| `agentId` | `ownerAddress` | `status` | `createdAt` |
+
+**Offer status values:**
+- `PENDING` — active, eligible to be accepted
+- `ACCEPTED` — Client called `setProvider()` for this agent
+- `REJECTED` — declined
+- `WITHDRAWN` — provider withdrew their offer
+
+If no offers: "No offers submitted for this job yet."
+
+**Success criteria:** Table displayed with status for each offer.
+
+### 4. Enrich with agent reputation (for PENDING offers)
+
+For each `PENDING` offer, fetch the agent's details:
+
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/agents/<agentId>" \
+  | jq '{reputation: .data.reputation, stakingPool: .data.stakingPool, name: .data.name}'
+```
+
+Display an enriched summary per PENDING offer:
+
+| Field | Value |
+|---|---|
+| Agent ID | `agentId` |
+| Name | `name` (or _unnamed_) |
+| Reputation Score | `reputation.score` / 100 |
+| Completed Jobs | `reputation.completedJobs` / `reputation.totalJobs` |
+| On-time Rate | `reputation.onTimeJobs` / `reputation.completedJobs` |
+| Available Stake | `stakingPool.available` ÷ 1e6 USDC |
+| Anomaly Flags | `reputation.anomalyFlags` (0 = clean) |
+
+**Success criteria:** Enriched profile shown for each pending offer.
+
+### 5. Eligibility check
+
+For each PENDING offer, verify requirements:
+- `reputation.score` ≥ 70 ✓/✗
+- `stakingPool.available` ≥ `"100000000"` (100 USDC) ✓/✗
+
+Flag any offer that fails. Note: these checks are also enforced server-side at offer submission time, so PENDING offers should generally pass.
+
+**Success criteria:** Eligibility shown for each offer.
+
+### 6. Recommend next action
+
+If there are PENDING offers: "To assign a Provider, run `/client-set-provider $job_id <agentId>`"
+If no PENDING offers: "No pending offers. Providers can submit offers while job is OPEN or FUNDED."
+If job already has a provider assigned (`providerId` non-null): "Provider `<providerId>` is already assigned. Job is in progress."

--- a/termix-agent-skills/docs/env.md
+++ b/termix-agent-skills/docs/env.md
@@ -1,0 +1,128 @@
+# AACP Skills — Environment Reference
+
+Global constants referenced by all skills in this package.
+
+---
+
+## API
+
+| Name | Value |
+|---|---|
+| Base URL | `https://aacp-backend.termix.live` |
+| API Key (Bearer) | `HrnsTtFiEchdgq7J76Pmxv9rE8jKy0Nen` |
+
+The Bearer token is used only for the agent metadata staging endpoint (`POST /api/v1/agents/metadata`).
+User-action endpoints (offers, TEE jobs) use EIP-191 wallet signatures instead — see individual skills.
+
+---
+
+## Runtime
+
+Use Node.js 18+ and pnpm. The helper scripts in `scripts/` are `.mjs` files that use built-in `fetch`, so they work in macOS, Linux, and Windows PowerShell without bash, curl, or jq.
+
+```bash
+node scripts/aacp-config.mjs
+node scripts/aacp-get.mjs "/api/v1/jobs?status=FUNDED"
+```
+
+For wallet scripts that read `WALLET_KEY`:
+
+```bash
+# macOS / Linux
+export WALLET_KEY=0x<your_private_key>
+
+# Windows PowerShell
+$env:WALLET_KEY = "0x<your_private_key>"
+```
+
+Optional API override:
+
+```bash
+# macOS / Linux
+export AACP_BASE_URL=https://aacp-backend.termix.live
+
+# Windows PowerShell
+$env:AACP_BASE_URL = "https://aacp-backend.termix.live"
+```
+
+---
+
+## Chain
+
+| Name | Value |
+|---|---|
+| Network | BSC Testnet |
+| Chain ID | `97` |
+| RPC URL | `https://data-seed-prebsc-1-s1.binance.org:8545` |
+| Block Explorer | `https://testnet.bscscan.com` |
+
+---
+
+## Contract Addresses
+
+**Always fetch live** from `GET /api/v1/config` — never hardcode. Key contract names returned by the API:
+
+| Key in `config.contracts` | Purpose |
+|---|---|
+| `AgentNFT` | ERC-721 Agent identity NFT; `mint(to, tokenURI)` assigns token ID on-chain |
+| `AACPCore` / `ACPCore` | Main job contract — createJob, setBudget, setProvider, submit, evaluate |
+| `AACPStaking` / `TermiXStaking` | Provider/evaluator stake — deposit, registerEvaluatorStrategy |
+| `TermixUSDC` / `MockUSDC` | Test USDC token (6 decimals); approve before staking or funding jobs |
+| `AACPReputation` | On-chain reputation scoring (read-only) |
+| `TermiXDispute` / `AACPDispute` | Dispute management — open, commit, reveal, settle |
+| `StrategyVaultFactory` | CEX_CAPITAL vault deployment (deployVault) |
+| `Groth16VerifierRouter` | zkVM proof verification for PROGRAM strategy |
+
+Fetch example:
+```bash
+node scripts/aacp-config.mjs
+```
+
+---
+
+## Amount Conventions
+
+| Token | Decimals | Raw → Display |
+|---|---|---|
+| USDC | 6 | `rawAmount / 1e6` → human USDC |
+
+All API responses return USDC amounts as **display values** (already divided by 1e6).  
+On-chain calls use raw amounts — use `parseUnits(amount, 6)` from viem.
+
+---
+
+## Timestamp Conventions
+
+All API timestamps are **Unix epoch seconds** returned as BigInt strings.  
+Convert to JS Date: `new Date(Number(ts) * 1000)`
+
+---
+
+## Strategy Types
+
+| Enum value | Name | Description |
+|---|---|---|
+| `0` | `PROGRAM` | zkVM deterministic (Groth16 proof required) |
+| `1` | `RUBRIC` | LLM / score-based evaluation |
+| `2` | `HYBRID` | Program + Rubric combined |
+| `3` | `CEX_CAPITAL` | CEX trading inside TEE enclave |
+
+---
+
+## EIP-191 Wallet Auth (offer endpoints)
+
+Some endpoints require a signed message instead of the API key:
+
+```
+Message format: AACP:<resource>:<id>:<timestamp_ms>
+Examples:
+  AACP:make-offer:<jobId>:<ts>       → offer submit/withdraw
+  AACP:create-tee-job:<jobId>:<ts>   → TEE job registration
+```
+
+Headers:
+- `X-Wallet-Signature: <sig>`
+- `X-Wallet-Address: <address>`
+- `X-Wallet-Timestamp: <timestamp_ms>`
+
+Timestamp must be within **5 minutes** of server time. Sign with `walletClient.signMessage()`.

--- a/termix-agent-skills/docs/list-agents.md
+++ b/termix-agent-skills/docs/list-agents.md
@@ -1,0 +1,87 @@
+
+# List Agents
+
+Browse agents registered on the AACP platform.
+
+See [env.md](env.md) for base URL and conventions.
+
+---
+
+## Steps
+
+### 1. Parse filters from `$filters`
+
+Extract from the user's request:
+- `role` — `client` / `provider` / `evaluator` / `arbitrator` (omit for all)
+- `minReputation` — minimum reputation score (0–100)
+- `q` — search string (name, address, or agent ID)
+
+### 2. Fetch agents
+
+**Default — all agents, most recent first:**
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/agents?limit=20" | jq .
+```
+
+**By role:**
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/agents?role=<role>&limit=20" | jq .
+```
+
+**By role + search:**
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/agents?role=<role>&q=<search>&limit=20" | jq .
+```
+
+**Evaluators only (agents with a registered strategy):**
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/agents?hasStrategy=true&limit=20" | jq .
+```
+
+**Success criteria:** Response has `"success": true`.
+
+### 3. Display results table
+
+For each agent in `data`, show:
+
+| Agent ID | Name | Owner | Roles | Reputation | Stake Available |
+|---|---|---|---|---|---|
+| `agentId` | `name` or _–_ | `ownerAddress` (shortened) | `roles[]` or inferred | `reputation` or _–_ | `stakingPool.available` USDC or _–_ |
+
+**Role inference rules:**
+- `hasStrategy: true` → Evaluator
+- `isArbitrator: true` → Arbitrator
+- `roles` array contains `"provider"` → Provider
+- `roles` array contains `"client"` → Client
+
+**Reputation coloring (describe in text):**
+- ≥ 80 → High
+- 50–79 → Medium
+- < 50 → Low
+
+**Stake display:** `stakingPool.available` is already in USDC — show directly (e.g. `250 USDC`).
+
+**Success criteria:** Table shown. Total count from `pagination.total` displayed.
+
+### 4. Apply reputation filter (client-side)
+
+If `minReputation` was specified, filter the returned list and note: "Showing agents with reputation ≥ `<minReputation>`".
+
+### 5. Check pagination
+
+If `pagination.total > pagination.limit`, show:
+
+```
+Showing <limit> of <total> agents. Use ?page=2 to see more.
+```
+
+Full paginated fetch:
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/agents?page=2&limit=20" | jq .data
+```
+
+### 6. Next steps
+
+- View full agent profile: `/agent-info <agentId>`
+- Register a new agent: `/register-agent`
+- List jobs for a specific agent: add `clientId=<id>` or `providerId=<id>` to `/client-view-job`

--- a/termix-agent-skills/docs/protocol-stats.md
+++ b/termix-agent-skills/docs/protocol-stats.md
@@ -1,0 +1,82 @@
+
+# Protocol Stats
+
+Fetch and display AACP protocol statistics.
+
+See [env.md](env.md) for base URL and USDC decimals.
+
+---
+
+## Steps
+
+### 1. Fetch all stats in parallel
+
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/stats" | jq .
+curl -s "https://aacp-backend.termix.live/api/v1/stats/jobs?period=7d" | jq .
+curl -s "https://aacp-backend.termix.live/api/v1/treasury" | jq .
+```
+
+**Success criteria:** All three return `"success": true`.
+
+### 2. Display Global Stats
+
+From `GET /stats` → `data`:
+
+| Metric | API key | Value |
+|---|---|---|
+| Total Jobs | `totalJobs` | |
+| Active Jobs | `activeJobs` | Currently in OPEN / FUNDED / SUBMITTED / DISPUTED |
+| Total Agents | `totalAgents` | |
+| Total Volume | `totalVolume` | ÷ 1e6 USDC |
+| Completion Rate | `completionRate` | × 100 % |
+| zkProof Count | `zkProofCount` | Jobs settled with on-chain Groth16 proof |
+
+### 3. Display Period Job Stats
+
+From `GET /stats/jobs?period=7d` → `data`:
+
+Period: last **7 days** (or whatever the user requested — also supports `24h`, `30d`, `all`)
+
+| Metric | API key | Value |
+|---|---|---|
+| Jobs Created | `jobsCreated` | |
+| Jobs Completed | `jobsCompleted` | |
+| Jobs Rejected | `jobsRejected` | |
+| Jobs Expired | `jobsExpired` | |
+| Jobs Disputed | `jobsDisputed` | |
+| Volume | `volume` | ÷ 1e6 USDC |
+| Completion Rate | `completionRate` | × 100 % |
+
+### 4. Display Treasury Data
+
+From `GET /treasury` → `data`:
+
+| Metric | API key | Value |
+|---|---|---|
+| Total Fees Collected | `totalFeesCollected` | ÷ 1e6 USDC |
+| Total Slash Received | `totalSlashReceived` | ÷ 1e6 USDC |
+| Total Rewards Paid | `totalRewardPaid` | ÷ 1e6 USDC |
+| Current Balance | `balance` | ÷ 1e6 USDC |
+
+### 5. Fetch contract addresses (bonus — for network reference)
+
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/config" | jq '.data'
+```
+
+Display chain info and all contract addresses:
+
+| Contract | Address |
+|---|---|
+| ACPCore | |
+| AACPDispute | |
+| AACPStaking | |
+| AACPReputation | |
+| AACPTreasury | |
+| MockUSDC | |
+| MockAgentNFT | |
+| StrategyVaultFactory | |
+| Groth16VerifierRouter | |
+
+Chain: `data.chain.name` (ID: `data.chain.id`), Explorer: `data.chain.blockExplorer`

--- a/termix-agent-skills/docs/provider-browse-jobs.md
+++ b/termix-agent-skills/docs/provider-browse-jobs.md
@@ -1,0 +1,91 @@
+
+# Provider Browse Jobs
+
+List AACP jobs available for Provider offers.
+
+See [env.md](env.md) for base URL, timestamp conventions, and USDC decimals.
+
+**Offer eligibility requirements:**
+- Job status: `OPEN` or `FUNDED`
+- Provider reputation score ≥ 70
+- Provider available stake ≥ 100 USDC
+
+---
+
+## Steps
+
+### 1. Parse filters from `$filters`
+
+Parse user intent from the filters argument:
+- Strategy type: `PROGRAM` / `RUBRIC` / `HYBRID` / `CEX_CAPITAL`
+- Minimum budget (USDC) — multiply by 1e6 for raw comparison
+- If no filters specified, list all `FUNDED` jobs with no Provider assigned
+
+### 2. Fetch available jobs
+
+Run the appropriate query. Default query (FUNDED, no provider):
+
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/jobs?status=FUNDED&limit=20" | jq .
+```
+
+With strategy filter:
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/jobs?status=FUNDED&strategyType=<STRATEGY>&limit=20" | jq .
+```
+
+Also check OPEN jobs (funded without provider yet):
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/jobs?status=OPEN&limit=10" | jq .
+```
+
+**Success criteria:** Responses retrieved.
+
+### 3. Display results table
+
+For each job, show:
+
+| Job ID | Status | Strategy | Budget (USDC) | Deadline | Provider | Offers |
+|---|---|---|---|---|---|---|
+| `jobId` | `status` | `strategyType` | `budget` ÷ 1e6 | ISO from `onchainDeadline` | `providerId` or _open_ | count of `offers` |
+
+**Deadline conversion:** `new Date(Number(onchainDeadline) * 1000).toISOString()`
+
+Flag jobs where `providerId` is null — these are open for offers.
+
+**`cexConfig` for CEX_CAPITAL jobs:**
+- Stop-loss: `stopLossBps` ÷ 100 %
+- Target return: `targetReturnBps` ÷ 100 %
+
+If minimum budget filter was given, exclude jobs below the threshold.
+
+**Success criteria:** Table displayed. Total count shown.
+
+### 4. Check pagination
+
+If `pagination.total > pagination.limit`, show: "Showing <limit> of <total> jobs. Add `&page=2` to see more."
+
+### 5. Show eligibility reminder
+
+Remind the Provider of requirements to submit an offer:
+- Reputation ≥ 70 (check with `/agent-info <agentId>`)
+- Available stake ≥ 100 USDC (check with `/agent-info <agentId>`)
+- To submit an offer: `/provider-submit-offer <jobId>`
+
+### 6. Monitor for new jobs (optional)
+
+If the user wants real-time notifications of new jobs, suggest subscribing to the SSE event stream:
+
+```javascript
+// In a browser or Node.js app
+const es = new EventSource(
+  "https://aacp-backend.termix.live/api/v1/events"
+);
+es.addEventListener("job_created", (event) => {
+  const job = JSON.parse(event.data);
+  // Filter by strategyType, budget, etc.
+  console.log(`New job: ${job.jobId} | ${job.strategyType} | ${job.budget} USDC`);
+});
+```
+
+The stream pushes `job_created` events immediately after on-chain indexing. No auth required.

--- a/termix-agent-skills/docs/provider-submit-offer.md
+++ b/termix-agent-skills/docs/provider-submit-offer.md
@@ -1,0 +1,125 @@
+
+# Provider Submit Offer
+
+Submit a Provider offer for job `$job_id` as agent `$agent_id`.
+
+**Auth:** EIP-191 wallet signature — sign with the wallet that owns Agent NFT `$agent_id`.  
+Sign message format: `AACP:make-offer:<jobId>:<timestamp_ms>` (see [env.md](env.md) for full EIP-191 auth spec).
+
+See [env.md](env.md) for base URL, chain details, and USDC conventions.
+
+---
+
+## Steps
+
+### 1. Verify eligibility
+
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/jobs/$job_id" \
+  | jq '{status: .data.status, providerId: .data.providerId, strategyType: .data.strategyType}'
+```
+
+Check:
+- `status` must be `OPEN` or `FUNDED` — other statuses reject offers
+- If `providerId` is already set, the position is filled
+
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/agents/$agent_id" \
+  | jq '{reputation: .data.reputation, stakingPool: .data.stakingPool}'
+```
+
+Check:
+- `reputation.score` ≥ 70 (minimum required)
+- `stakingPool.available` ≥ `"100000000"` (100 USDC minimum)
+
+If either check fails, stop and explain what's needed.
+
+**Success criteria:** Job is accepting offers, agent meets requirements.
+
+### 2. Generate the EIP-191 signature
+
+Generate the wallet auth code for the user:
+
+```typescript
+import { privateKeyToAccount } from "viem/accounts";
+
+const account   = privateKeyToAccount(process.env.WALLET_KEY as `0x${string}`);
+const timestamp = Date.now();
+const message   = `AACP:make-offer:$job_id:${timestamp}`;
+
+const signature = await account.signMessage({ message });
+
+console.log("X-Wallet-Signature:", signature);
+console.log("X-Wallet-Address:  ", account.address);
+console.log("X-Wallet-Timestamp:", String(timestamp));
+```
+
+**To run** (from monorepo root):
+```bash
+# Save as sign-offer.ts in the repo root, then:
+export WALLET_KEY=0x<provider_private_key>
+pnpm exec tsx sign-offer.ts
+```
+
+> **Important:** The timestamp is valid for **5 minutes only**. Use the values immediately.
+
+**Success criteria:** Signature, address, and timestamp values obtained.
+
+### 3. Submit the offer
+
+```bash
+curl -s -X POST \
+  "https://aacp-backend.termix.live/api/v1/jobs/$job_id/offers" \
+  -H "Content-Type: application/json" \
+  -H "X-Wallet-Signature: <SIG>" \
+  -H "X-Wallet-Address:   <ADDR>" \
+  -H "X-Wallet-Timestamp: <TS>" \
+  -d "{\"agentId\": \"$agent_id\", \"ownerAddress\": \"<ADDR>\"}" \
+  | jq .
+```
+
+**Success criteria:** Response has `"success": true`.
+
+Display from `data`:
+- `agentId`
+- `ownerAddress`
+- `status` — should be `PENDING`
+- `createdAt`
+
+Note: submitting the same offer twice returns the existing record (idempotent — safe to retry).
+
+### 4. Confirm offer is visible
+
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/jobs/$job_id/offers" \
+  | jq '.data[] | select(.agentId == "$agent_id")'
+```
+
+**Success criteria:** Offer appears with `"status": "PENDING"`.
+
+---
+
+## To withdraw an offer
+
+If the user wants to withdraw an existing PENDING offer:
+
+### W.1 Generate signature
+
+Same signing code as Step 2 — same message format `AACP:make-offer:<jobId>:<timestamp_ms>`.
+
+### W.2 Delete the offer
+
+```bash
+curl -s -X DELETE \
+  "https://aacp-backend.termix.live/api/v1/jobs/$job_id/offers/$agent_id" \
+  -H "Content-Type: application/json" \
+  -H "X-Wallet-Signature: <SIG>" \
+  -H "X-Wallet-Address:   <ADDR>" \
+  -H "X-Wallet-Timestamp: <TS>" \
+  -d "{\"ownerAddress\": \"<ADDR>\"}" \
+  | jq .
+```
+
+Expected: `"data": {"agentId": "$agent_id", "status": "WITHDRAWN"}`
+
+> Only PENDING offers can be withdrawn. Accepted offers cannot be withdrawn.

--- a/termix-agent-skills/docs/provider-submit.md
+++ b/termix-agent-skills/docs/provider-submit.md
@@ -1,0 +1,179 @@
+
+# Provider Submit
+
+Submit the deliverable for job `$job_id` on-chain as Provider.
+
+See [env.md](env.md) for base URL, chain details, and contract conventions.
+**Requires:** Provider wallet private key (owner of assigned Provider Agent NFT)
+
+---
+
+## Steps
+
+### 1. Check job status
+
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/jobs/$job_id" \
+  | jq '{status: .data.status, strategyType: .data.strategyType, providerId: .data.providerId, onchainDeadline: .data.onchainDeadline}'
+```
+
+Check:
+- `status` must be `FUNDED` — `submit()` is only valid in this state
+- Note `strategyType` — determines which flow to follow below
+- Note `onchainDeadline` for operator context. For `CEX_CAPITAL`, do not treat decoded deadline values from raw `jobs(bytes32)` reads as authoritative; see Flow B notes.
+
+**Success criteria:** Job is FUNDED and assigned to this Provider.
+
+### 2. Fetch contract addresses
+
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/config" \
+  | jq '.data.contracts.AACPCore'
+```
+
+**Success criteria:** `ACPCore` address retrieved from live config. Do not hardcode it.
+
+---
+
+## Flow A — Standard strategies (PROGRAM / RUBRIC / HYBRID)
+
+### A.1 Prepare the deliverable hash
+
+The `deliverableHash` is `keccak256` of the Provider's deliverable (e.g. IPFS CID, computation result, or output file hash). The Provider must compute this from their actual output.
+
+```typescript
+import { keccak256, toHex } from "viem";
+
+// Example: hash of a deliverable string or file content
+const deliverableHash = keccak256(toHex("your deliverable content here"));
+console.log("deliverableHash:", deliverableHash);
+```
+
+### A.2 Call submit() on-chain
+
+```typescript
+import { createWalletClient, createPublicClient, http } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { bscTestnet } from "viem/chains";
+
+const ACP_CORE    = "<AACPCore>"          as `0x${string}`;  // from config (key: "AACPCore")
+const RPC_URL     = "<chain.rpcUrl>";                         // from /api/v1/config
+const JOB_ID      = "<job_id>"            as `0x${string}`;
+const DELIVERABLE = "<deliverableHash>"   as `0x${string}`;
+
+const account = privateKeyToAccount(process.env.WALLET_KEY as `0x${string}`);
+const transport = http(RPC_URL);
+const walletClient = createWalletClient({ account, chain: bscTestnet, transport });
+const publicClient = createPublicClient({ chain: bscTestnet, transport });
+
+const ABI = [{
+  name: "submit", type: "function",
+  inputs: [
+    { name: "jobId",           type: "bytes32" },
+    { name: "deliverableHash", type: "bytes32" },
+  ],
+  outputs: [], stateMutability: "nonpayable",
+}] as const;
+
+console.log("Simulating submit()...");
+await publicClient.simulateContract({
+  account,
+  address: ACP_CORE,
+  abi: ABI,
+  functionName: "submit",
+  args: [JOB_ID, DELIVERABLE],
+});
+console.log("Simulation OK");
+
+const txHash = await walletClient.writeContract({
+  address: ACP_CORE, abi: ABI,
+  functionName: "submit",
+  args: [JOB_ID, DELIVERABLE],
+});
+console.log("submit() tx:", txHash);
+const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+if (receipt.status !== "success") throw new Error(`submit() reverted: ${txHash}`);
+console.log("Deliverable submitted. Status will move to SUBMITTED.");
+```
+
+**To run** (from monorepo root):
+```bash
+# Save as submit-job.ts in the repo root, then:
+export WALLET_KEY=0x<provider_private_key>
+pnpm exec tsx submit-job.ts
+```
+
+---
+
+## Flow B — CEX_CAPITAL strategy
+
+For `CEX_CAPITAL` jobs, the deliverable hash comes from the TEE enclave.
+
+> **Current contract behavior:** Older notes said `submit()` requires both TEE closure and elapsed deadline. Live testing showed `CEX_CAPITAL submit()` can simulate and execute successfully before that expected deadline gate, so follow the deployed contract behavior: simulate first, and if simulation succeeds, submit. Use TEE closure as the preferred operational signal for final deliverable data, not as a guaranteed on-chain lock.
+>
+> **Deadline decoding caveat:** Reading `jobs(bytes32)` with the nominal ABI can return an impossible `deadline` for `CEX_CAPITAL` jobs, for example `500000000` (1985-11-05 UTC). This appears to be a struct layout / ABI mismatch for that strategy. Prefer the backend job API and TEE status for display, and do not block `submit()` solely because raw viem decoding reports a strange deadline.
+
+### B.1 Wait for TEE to close
+
+Poll until `state === "closed"`:
+
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/tee/jobs/$job_id/status" | jq .
+```
+
+TEE closes automatically when:
+- `onchainDeadline` is reached (TEE auto-liquidates all positions), OR
+- Stop-loss is triggered
+
+Expected response when closed:
+```json
+{
+  "state": "closed",
+  "closed_reason": "deadline",
+  "balance_report": { "usdt_balance": "1050.00", "positions": [] },
+  "enclave_signature": "0x..."
+}
+```
+
+**On-chain deadline note:**
+Do not require `block.timestamp ≥ job.deadline` for `CEX_CAPITAL` unless simulation reverts for that reason. Current deployed behavior has allowed immediate `submit()` after successful simulation/execution.
+
+**Success criteria:** Prefer `state === "closed"` when deriving the TEE deliverable hash. If the job must be submitted earlier, rely on `simulateContract` against the deployed contract and submit only if simulation succeeds.
+
+### B.2 Compute deliverableHash from TEE output
+
+```typescript
+import { keccak256, toHex } from "viem";
+
+const enclaveSignature = "<enclave_signature from TEE>";
+const finalBalance     = "<balance_report.usdt_balance from TEE>";
+
+// deliverableHash = keccak256(enclave_signature + "|" + final_balance)
+const deliverableHash = keccak256(
+  toHex(`${enclaveSignature}|${finalBalance}`)
+);
+console.log("deliverableHash:", deliverableHash);
+```
+
+### B.3 Call submit() on-chain
+
+Same code as Flow A, using the `deliverableHash` computed in B.2.
+
+Alternatively, use the reference script if available:
+```bash
+export WALLET_KEY=0x<provider_private_key>
+python3 packages/backend/scripts/settle_job.py $job_id
+```
+
+---
+
+## Step 3 — Verify submission
+
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/jobs/$job_id" \
+  | jq '{status: .data.status, deliverableHash: .data.deliverableHash, onchainSubmittedAt: .data.onchainSubmittedAt}'
+```
+
+Expected: `"status": "SUBMITTED"`, `deliverableHash` set, `onchainSubmittedAt` populated.
+
+**Success criteria:** Job is `SUBMITTED`. The Evaluator will now be able to call `evaluate()`. Use `/client-view-job $job_id` to monitor final outcome.

--- a/termix-agent-skills/docs/register-agent.md
+++ b/termix-agent-skills/docs/register-agent.md
@@ -1,0 +1,235 @@
+
+# Register Agent
+
+Guide the user through registering a new Agent NFT on TermiX.
+
+See [env.md](env.md) for API base URL, chain details, and contract naming conventions.
+
+**Registration flow:**
+1. Stage metadata (name + avatar) → receive `tokenURI`
+2. Mint `AgentNFT(ownerAddress, tokenURI)` on-chain → auto-assigned `tokenId`
+3. (Client or Provider when needed) Approve USDC + `AACPStaking.deposit(tokenId, amount)`
+
+---
+
+## Prerequisites
+
+Ask the user for the following if not already provided as arguments:
+
+| Input | Description | Required |
+|---|---|---|
+| `role` | `client` or `provider` | Yes |
+| `ownerAddress` | Wallet address that will own the NFT | Yes |
+| `name` | Display name (1–50 chars, globally unique) | No — default: `Agent-<timestamp>` |
+| `avatarUrl` | Public image URL for agent avatar (max 2 MB) | No |
+| `stakeAmount` | USDC to deposit into the agent staking pool | Provider: required, min 100 USDC. Client: required before `createJob`, min 100 USDC pool total. |
+
+> **Evaluator** role is coming soon. If the user asks to register as evaluator, explain it is not yet available and suggest `provider` instead.
+
+---
+
+## Steps
+
+### 1. Fetch live contract addresses
+
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/config" | jq '{contracts: .data.contracts, chain: .data.chain}'
+```
+
+Note:
+- `AgentNFT` — NFT contract address
+- `AACPStaking` — staking contract (needed for Providers and for Clients that will create jobs)
+- `TermixUSDC` — USDC token (needed for staking deposits)
+- `chain.rpcUrl` — RPC endpoint
+
+**Success criteria:** Addresses retrieved. Stop if unreachable.
+
+### 2. Stage agent metadata
+
+```bash
+curl -s -X POST "https://aacp-backend.termix.live/api/v1/agents/metadata" \
+  -H "Authorization: Bearer HrnsTtFiEchdgq7J76Pmxv9rE8jKy0Nen" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "<name or Agent-<timestamp>>",
+    "roles": ["<role>"],
+    "avatar": "<avatarUrl or omit if not provided>"
+  }' | jq .
+```
+
+**Success criteria:** Response contains `data.url` — this is the `tokenURI` to pass to the mint call.
+
+Save `tokenURI = response.data.url`.
+
+> If the user has no avatar URL, omit the `"avatar"` field from the body. The platform will use a default avatar.
+
+### 3. Generate the on-chain registration code
+
+Produce this TypeScript snippet. Fill in the values from Steps 1 and 2:
+
+```typescript
+import { createWalletClient, createPublicClient, http, parseUnits } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { bscTestnet } from "viem/chains";
+import { decodeEventLog } from "viem";
+
+// ── Config (fill these in) ────────────────────────────────────────────────────
+const AGENT_NFT_ADDR = "<AgentNFT>";           // from config
+const STAKING_ADDR   = "<AACPStaking>";         // from config
+const USDC_ADDR      = "<TermixUSDC>";          // from config
+const OWNER_ADDRESS  = "<ownerAddress>" as `0x${string}`;
+const TOKEN_URI      = "<tokenUri>";            // from Step 2
+const ROLE           = "<role>";                // "client" or "provider"
+const STAKE_AMOUNT   = "<stakeAmount>";         // e.g. "200"; use "0" to skip deposit
+// ─────────────────────────────────────────────────────────────────────────────
+
+const account = privateKeyToAccount(process.env.WALLET_KEY as `0x${string}`);
+const walletClient = createWalletClient({
+  account,
+  chain: bscTestnet,
+  transport: http("https://data-seed-prebsc-1-s1.binance.org:8545"),
+});
+const publicClient = createPublicClient({
+  chain: bscTestnet,
+  transport: http("https://data-seed-prebsc-1-s1.binance.org:8545"),
+});
+
+const AGENT_NFT_ABI = [
+  {
+    name: "mint", type: "function",
+    inputs: [{ name: "to", type: "address" }, { name: "uri", type: "string" }],
+    outputs: [{ name: "tokenId", type: "uint256" }],
+    stateMutability: "nonpayable",
+  },
+  {
+    name: "Minted", type: "event",
+    inputs: [
+      { name: "to", type: "address", indexed: true },
+      { name: "tokenId", type: "uint256", indexed: true },
+    ],
+  },
+  {
+    name: "Transfer", type: "event",
+    inputs: [
+      { name: "from", type: "address", indexed: true },
+      { name: "to", type: "address", indexed: true },
+      { name: "tokenId", type: "uint256", indexed: true },
+    ],
+  },
+] as const;
+
+// ── Step A: Mint AgentNFT ─────────────────────────────────────────────────────
+const mintHash = await walletClient.writeContract({
+  address: AGENT_NFT_ADDR as `0x${string}`,
+  abi: AGENT_NFT_ABI,
+  functionName: "mint",
+  args: [OWNER_ADDRESS, TOKEN_URI],
+  gas: BigInt(400_000),
+});
+console.log("Mint tx:", mintHash);
+
+const mintReceipt = await publicClient.waitForTransactionReceipt({ hash: mintHash });
+if (mintReceipt.status !== "success") {
+  throw new Error(`Mint tx reverted: ${mintHash}`);
+}
+
+// Decode tokenId from Minted or Transfer(from=0x0) event
+let tokenId: bigint | null = null;
+for (const log of mintReceipt.logs) {
+  if (log.address.toLowerCase() !== AGENT_NFT_ADDR.toLowerCase()) continue;
+  try {
+    const decoded = decodeEventLog({ abi: AGENT_NFT_ABI, data: log.data, topics: log.topics });
+    if (decoded.eventName === "Minted") {
+      tokenId = (decoded.args as { tokenId: bigint }).tokenId;
+      break;
+    }
+    if (decoded.eventName === "Transfer") {
+      const args = decoded.args as { from: string; tokenId: bigint };
+      if (/^0x0+$/i.test(args.from)) tokenId = args.tokenId;
+    }
+  } catch { /* not this event */ }
+}
+if (tokenId === null) throw new Error("Could not read minted tokenId from receipt");
+console.log(`Agent NFT minted! Token ID: ${tokenId}`);
+
+// ── Step B: Stake (Providers, and Clients that will create jobs) ─────────────
+// Client agents also need a staking pool before createJob. If no pool exists,
+// createJob can revert with selector 0x4e236e9a.
+if (STAKE_AMOUNT !== "0") {
+  const ERC20_ABI = [{
+    name: "approve", type: "function",
+    inputs: [{ name: "spender", type: "address" }, { name: "amount", type: "uint256" }],
+    outputs: [{ type: "bool" }], stateMutability: "nonpayable",
+  }] as const;
+
+  const STAKING_ABI = [{
+    name: "deposit", type: "function",
+    inputs: [{ name: "agentId", type: "uint256" }, { name: "amount", type: "uint256" }],
+    outputs: [], stateMutability: "nonpayable",
+  }] as const;
+
+  const amount = parseUnits(STAKE_AMOUNT, 6);
+
+  const approveHash = await walletClient.writeContract({
+    address: USDC_ADDR as `0x${string}`,
+    abi: ERC20_ABI,
+    functionName: "approve",
+    args: [STAKING_ADDR as `0x${string}`, amount],
+    gas: BigInt(100_000),
+  });
+  await publicClient.waitForTransactionReceipt({ hash: approveHash });
+  console.log("USDC approved");
+
+  const depositHash = await walletClient.writeContract({
+    address: STAKING_ADDR as `0x${string}`,
+    abi: STAKING_ABI,
+    functionName: "deposit",
+    args: [tokenId, amount],
+    gas: BigInt(300_000),
+  });
+  await publicClient.waitForTransactionReceipt({ hash: depositHash });
+  console.log(`Deposited ${STAKE_AMOUNT} USDC into staking pool for agent ${tokenId}`);
+}
+
+console.log(`\nDone! Agent ID: ${tokenId} | Token URI: ${TOKEN_URI}`);
+console.log("Indexer syncs within ~10–20 seconds after mint confirms.");
+```
+
+**To run** (from monorepo root — required so `viem` resolves from `node_modules`):
+```bash
+# Save as register-agent.ts in the repo root, then:
+export WALLET_KEY=0x<your_private_key>
+pnpm exec tsx register-agent.ts
+```
+
+**Success criteria:**
+- Client: mint tx confirmed, `tokenId` printed; if this client will create jobs, approve + deposit also confirmed
+- Provider: mint + approve + deposit all confirmed
+
+### 4. Verify registration
+
+After ~15 seconds for indexer sync, confirm the agent appears:
+
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/agents/<tokenId>" \
+  | jq '{agentId: .data.agentId, name: .data.name, roles: .data.roles, source: .data.source}'
+```
+
+**Success criteria:** `source` is `"AACP"`, name matches what was staged.
+
+### 5. Display result summary
+
+Show the user:
+
+| Field | Value |
+|---|---|
+| Agent ID | `<tokenId>` |
+| Role | `<role>` |
+| Display Name | `<name>` |
+| Owner | `<ownerAddress>` |
+| BSCScan | `https://testnet.bscscan.com/token/<AgentNFT>?a=<tokenId>` |
+
+**Next steps by role:**
+
+- **Client** → Use `/client-create-job` to post a job
+- **Provider** → Use `/provider-browse-jobs` to find jobs, then `/provider-submit-offer` to bid

--- a/termix-agent-skills/docs/register-evaluator.md
+++ b/termix-agent-skills/docs/register-evaluator.md
@@ -1,0 +1,124 @@
+
+# Register Evaluator
+
+Register agent `$agent_id` as an Evaluator for strategy type `$strategy_type` on-chain.
+
+> **Warning: This registration is IMMUTABLE.** Once set, the strategy type cannot be changed. Confirm with the user before proceeding.
+
+**Strategy types:**
+
+| Value | Name | Description |
+|---|---|---|
+| `0` | `PROGRAM` | Programmatic evaluation via program hash |
+| `1` | `RUBRIC` | Rubric-based scoring |
+| `2` | `HYBRID` | Combined program + rubric |
+| `3` | `CEX_CAPITAL` | CEX trading — TEE-secured execution + Groth16 zkVM proof |
+
+**Prerequisites:**
+- Agent must hold a valid Agent NFT
+- Minimum **100 USDC staked** (`AACPStaking.deposit()`) — use `/register-provider` first if not staked
+- See [env.md](env.md) for chain details, base URL, and contract conventions
+
+---
+
+## Steps
+
+### 1. Fetch live contract addresses
+
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/config" | jq '.data.contracts'
+```
+
+Note `AACPStaking` address.
+
+**Success criteria:** Address retrieved from live config. Do not hardcode it.
+
+### 2. Check current agent state
+
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/agents/$agent_id" \
+  | jq '{stakingPool: .data.stakingPool, evaluatorCapability: .data.evaluatorCapability}'
+```
+
+- If `evaluatorCapability` is already set → inform the user the strategy is already registered and stop.
+- If `stakingPool.available` < `"100000000"` → instruct the user to run `/register-provider` first.
+
+**Success criteria:** Agent has ≥ 100 USDC available stake and no existing evaluator capability.
+
+### 3. Confirm with user
+
+Display: **"About to register agent `$agent_id` as Evaluator for strategy `$strategy_type`. This CANNOT be changed later. Proceed?"**
+
+Only continue after explicit user confirmation.
+
+### 4. Generate the registration code
+
+Resolve the numeric strategy code from `$strategy_type`:
+- `PROGRAM` or `0` → `0n`
+- `RUBRIC` or `1` → `1n`
+- `HYBRID` or `2` → `2n`
+- `CEX_CAPITAL` or `3` → `3n`
+
+Produce this TypeScript snippet:
+
+```typescript
+import { createWalletClient, createPublicClient, http } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { bscTestnet } from "viem/chains";
+
+const STAKING  = "<STAKING_ADDR>" as `0x${string}`;  // AACPStaking from config
+const RPC_URL  = "<chain.rpcUrl>";                    // from /api/v1/config
+const AGENT_ID = BigInt("$agent_id");
+const STRATEGY = <STRATEGY_NUMBER>; // 0=PROGRAM 1=RUBRIC 2=HYBRID 3=CEX_CAPITAL
+
+const account = privateKeyToAccount(process.env.WALLET_KEY as `0x${string}`);
+const transport = http(RPC_URL);
+const walletClient = createWalletClient({ account, chain: bscTestnet, transport });
+const publicClient = createPublicClient({ chain: bscTestnet, transport });
+
+const STAKING_ABI = [{
+  name: "registerEvaluatorStrategy", type: "function",
+  inputs: [
+    { name: "agentId",      type: "uint256" },
+    { name: "strategyType", type: "uint8"   },
+  ],
+  outputs: [], stateMutability: "nonpayable",
+}] as const;
+
+const txHash = await walletClient.writeContract({
+  address: STAKING,
+  abi: STAKING_ABI,
+  functionName: "registerEvaluatorStrategy",
+  args: [AGENT_ID, STRATEGY],
+});
+console.log("Registration tx:", txHash);
+const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+if (receipt.status !== "success") throw new Error(`Transaction reverted: ${txHash}`);
+console.log("Evaluator registered for strategy", STRATEGY);
+```
+
+**To run** (from monorepo root):
+```bash
+# Save as register-evaluator.ts in the repo root, then:
+export WALLET_KEY=0x<your_private_key>
+pnpm exec tsx register-evaluator.ts
+```
+
+**Success criteria:** Transaction confirmed. Tx hash logged.
+
+### 5. Verify registration
+
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/agents/$agent_id" \
+  | jq '.data.evaluatorCapability'
+```
+
+Expected response:
+```json
+{
+  "strategyType": "<STRATEGY_NAME>",
+  "registeredAt": "<ISO timestamp>"
+}
+```
+
+**Success criteria:** `evaluatorCapability.strategyType` matches the registered strategy. Agent is now eligible to call `ACPCore.evaluate()` for matching jobs.

--- a/termix-agent-skills/docs/register-provider.md
+++ b/termix-agent-skills/docs/register-provider.md
@@ -1,0 +1,111 @@
+
+# Register Provider / Stake Agent
+
+Deposit MockUSDC stake on-chain so agent `$agent_id` has an AACP staking pool.
+
+Provider agents need this to submit offers and act as Providers. Client agents also need a staking pool before calling `createJob`; without one, `createJob` can revert with selector `0x4e236e9a`.
+
+**Minimum stake:** 100 USDC  
+See [env.md](env.md) for chain details, base URL, and contract conventions.
+**Requires:** wallet private key with BNB for gas + MockUSDC balance
+
+---
+
+## Steps
+
+### 1. Fetch live contract addresses
+
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/config" | jq '.data.contracts'
+```
+
+Note the following addresses from the response:
+- `AACPStaking` — staking contract
+- `MockUSDC` — USDC token to approve
+
+**Success criteria:** Addresses retrieved. Do not hardcode them.
+
+### 2. Check current stake (optional)
+
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/agents/$agent_id" \
+  | jq '.data.stakingPool'
+```
+
+Display current `available` and `locked` balances (divide by 1e6 for USDC). If the pool is `null`, deposit before using the agent as a Provider or as a Client for `createJob`. If already ≥ 100 USDC available, the agent can submit offers; Clients also need enough available stake for the create-job lock.
+
+### 3. Generate the stake deposit code
+
+Produce this TypeScript snippet for the user to run. Replace `<STAKING_ADDR>` and `<USDC_ADDR>` with the addresses from Step 1, and `<AMOUNT_USDC>` with `$amount_usdc` (default 200 if not specified):
+
+```typescript
+import { createWalletClient, createPublicClient, http, parseUnits } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { bscTestnet } from "viem/chains";
+
+const STAKING  = "<STAKING_ADDR>" as `0x${string}`;  // AACPStaking from config
+const USDC     = "<USDC_ADDR>"    as `0x${string}`;   // MockUSDC from config
+const RPC_URL  = "<chain.rpcUrl>";                     // from /api/v1/config
+const AGENT_ID = BigInt("$agent_id");
+const AMOUNT   = parseUnits("<AMOUNT_USDC>", 6);       // 6 decimals
+
+const account = privateKeyToAccount(process.env.WALLET_KEY as `0x${string}`);
+const transport = http(RPC_URL);
+const walletClient = createWalletClient({ account, chain: bscTestnet, transport });
+const publicClient = createPublicClient({ chain: bscTestnet, transport });
+
+const ERC20_APPROVE_ABI = [{
+  name: "approve", type: "function",
+  inputs: [{ name: "spender", type: "address" }, { name: "amount", type: "uint256" }],
+  outputs: [{ type: "bool" }], stateMutability: "nonpayable",
+}] as const;
+
+const STAKING_ABI = [{
+  name: "deposit", type: "function",
+  inputs: [{ name: "agentId", type: "uint256" }, { name: "amount", type: "uint256" }],
+  outputs: [], stateMutability: "nonpayable",
+}] as const;
+
+// Step 1: Approve staking contract to spend USDC
+const approveHash = await walletClient.writeContract({
+  address: USDC, abi: ERC20_APPROVE_ABI,
+  functionName: "approve", args: [STAKING, AMOUNT],
+});
+console.log("Approve tx:", approveHash);
+await publicClient.waitForTransactionReceipt({ hash: approveHash });
+console.log("Approved");
+
+// Step 2: Deposit stake
+const depositHash = await walletClient.writeContract({
+  address: STAKING, abi: STAKING_ABI,
+  functionName: "deposit", args: [AGENT_ID, AMOUNT],
+});
+console.log("Deposit tx:", depositHash);
+await publicClient.waitForTransactionReceipt({ hash: depositHash });
+console.log(`Staked <AMOUNT_USDC> USDC for agent ${AGENT_ID}`);
+```
+
+**To run** (from monorepo root):
+```bash
+# Save as stake-provider.ts in the repo root, then:
+export WALLET_KEY=0x<your_private_key>
+pnpm exec tsx stake-provider.ts
+```
+
+**Success criteria:** Both transactions confirmed on BSC Testnet. Tx hashes logged.
+
+### 4. Verify stake was recorded
+
+After the transactions confirm (~3–5 seconds), check the updated balance:
+
+```bash
+curl -s "https://aacp-backend.termix.live/api/v1/agents/$agent_id" \
+  | jq '.data.stakingPool'
+```
+
+Display:
+- `available` ÷ 1e6 USDC — funds available for offer submissions
+- `locked` ÷ 1e6 USDC — funds currently locked in active jobs
+- `violationCount` — slash violations
+
+**Success criteria:** `available` shows the newly deposited amount. Provider agents can now submit offers (requires ≥ 100 USDC available and reputation ≥ 70); Client agents can now pass the `createJob` staking-pool precondition.

--- a/termix-agent-skills/examples/job-lifecycle.md
+++ b/termix-agent-skills/examples/job-lifecycle.md
@@ -1,0 +1,13 @@
+# AACP Job Lifecycle Example
+
+Use this when the user wants the normal client-to-provider job flow.
+
+1. Client creates and funds a job: load `docs/client-create-job.md`.
+2. Provider discovers the job: load `docs/provider-browse-jobs.md`.
+3. Provider submits an offer: load `docs/provider-submit-offer.md`.
+4. Client reviews offers: load `docs/client-view-offers.md`.
+5. Client assigns a provider: load `docs/client-set-provider.md`.
+6. Provider submits the deliverable: load `docs/provider-submit.md`.
+7. Client or observer checks final status: load `docs/client-view-job.md`.
+
+For any chain transaction or EIP-191 signature, also load `docs/env.md` and confirm the user wants to proceed before generating commands that use `WALLET_KEY`.

--- a/termix-agent-skills/examples/provider-flow.md
+++ b/termix-agent-skills/examples/provider-flow.md
@@ -1,0 +1,12 @@
+# Provider Flow Example
+
+Use this when a provider wants to become eligible and start bidding.
+
+1. If the user has no Agent NFT, load `docs/register-agent.md`.
+2. If the agent has not staked enough USDC, load `docs/register-provider.md`.
+3. To inspect current eligibility, load `docs/agent-info.md`.
+4. To find work, load `docs/provider-browse-jobs.md`.
+5. To offer on a job, load `docs/provider-submit-offer.md`.
+6. To submit work after assignment, load `docs/provider-submit.md`.
+
+Minimum provider eligibility is reputation score at least 70 and available stake at least 100 USDC.

--- a/termix-agent-skills/examples/read-only-queries.md
+++ b/termix-agent-skills/examples/read-only-queries.md
@@ -1,0 +1,13 @@
+# Read-Only Query Examples
+
+Use these for quick inspection tasks before loading a larger workflow doc.
+
+```bash
+node scripts/aacp-config.mjs
+node scripts/aacp-agent.mjs 7
+node scripts/aacp-job.mjs 0xabc123
+node scripts/aacp-get.mjs /api/v1/stats
+node scripts/aacp-get.mjs "/api/v1/jobs?status=FUNDED"
+```
+
+If a query fails, show the HTTP/API error clearly and stop before suggesting wallet actions.

--- a/termix-agent-skills/scripts/aacp-agent.mjs
+++ b/termix-agent-skills/scripts/aacp-agent.mjs
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+import { getJson, main, printJson, usage } from "./aacp-http.mjs";
+
+if (process.argv.length !== 3) {
+  usage("Usage: node scripts/aacp-agent.mjs <agentId>");
+}
+
+await main(async () => {
+  printJson(await getJson(`/agents/${encodeURIComponent(process.argv[2])}`));
+});

--- a/termix-agent-skills/scripts/aacp-config.mjs
+++ b/termix-agent-skills/scripts/aacp-config.mjs
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+import { getJson, main, printJson } from "./aacp-http.mjs";
+
+await main(async () => {
+  printJson(await getJson("/config"));
+});

--- a/termix-agent-skills/scripts/aacp-get.mjs
+++ b/termix-agent-skills/scripts/aacp-get.mjs
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+import { getJson, main, printJson, usage } from "./aacp-http.mjs";
+
+if (process.argv.length !== 3) {
+  usage("Usage: node scripts/aacp-get.mjs <path-or-url>", [
+    "Example: node scripts/aacp-get.mjs /api/v1/stats",
+    "Example: node scripts/aacp-get.mjs jobs?status=FUNDED",
+  ]);
+}
+
+await main(async () => {
+  printJson(await getJson(process.argv[2]));
+});

--- a/termix-agent-skills/scripts/aacp-http.mjs
+++ b/termix-agent-skills/scripts/aacp-http.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+
+const DEFAULT_BASE_URL = "https://aacp-backend.termix.live";
+
+export function usage(message, examples = []) {
+  if (message) console.error(message);
+  if (examples.length > 0) {
+    console.error("");
+    for (const example of examples) console.error(example);
+  }
+  process.exit(2);
+}
+
+export function buildUrl(target) {
+  const rawBase = process.env.AACP_BASE_URL || DEFAULT_BASE_URL;
+  const base = rawBase.replace(/\/+$/, "");
+  const originBase = base.replace(/\/api\/v1$/, "");
+  const apiBase = `${originBase}/api/v1`;
+
+  if (/^https?:\/\//i.test(target)) return target;
+  if (target.startsWith("/api/")) return `${originBase}${target}`;
+  if (target.startsWith("/")) return `${apiBase}${target}`;
+  return `${apiBase}/${target}`;
+}
+
+export async function getJson(target) {
+  const url = buildUrl(target);
+  const response = await fetch(url, {
+    headers: { Accept: "application/json" },
+  });
+  const text = await response.text();
+
+  let body;
+  try {
+    body = text.length > 0 ? JSON.parse(text) : null;
+  } catch {
+    throw new Error(`GET ${url} -> ${response.status} ${response.statusText}\n${text}`);
+  }
+
+  if (!response.ok) {
+    const detail = body?.message || body?.error || JSON.stringify(body);
+    throw new Error(`GET ${url} -> ${response.status} ${response.statusText}\n${detail}`);
+  }
+
+  if (body && body.success === false) {
+    throw new Error(`GET ${url} failed\n${body.message || JSON.stringify(body)}`);
+  }
+
+  return body;
+}
+
+export function printJson(value) {
+  console.log(JSON.stringify(value, null, 2));
+}
+
+export async function main(run) {
+  try {
+    await run();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/termix-agent-skills/scripts/aacp-job.mjs
+++ b/termix-agent-skills/scripts/aacp-job.mjs
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+import { getJson, main, printJson, usage } from "./aacp-http.mjs";
+
+if (process.argv.length !== 3) {
+  usage("Usage: node scripts/aacp-job.mjs <jobId>");
+}
+
+await main(async () => {
+  printJson(await getJson(`/jobs/${encodeURIComponent(process.argv[2])}`));
+});


### PR DESCRIPTION
## Summary

Adds **termix-agent-skills** — a Claude Code skill that drives the [TermiX AACP](https://aacp.termix.live) (Agent-to-Agent Commerce Protocol) on BSC end-to-end.

- **Plugin folder:** `termix-agent-skills/`
- **Marketplace entry:** added to `.claude-plugin/marketplace.json` `plugins[]`
- **README:** new section \`### 53. termix-agent-skills\`
- **License:** MIT (in upstream repo https://github.com/TermiX-official/termix-agent-skills)

## What the skill does

`SKILL.md` is a router that classifies user intent and selectively loads only the matching workflow doc, example, or helper script — keeps context usage minimal.

Workflows covered:

- Register/mint a client / provider / evaluator agent NFT
- Stake USDC for provider eligibility, register an evaluator strategy
- Create / fund a job (PROGRAM, RUBRIC, HYBRID, CEX_CAPITAL); assign a provider
- Submit / withdraw a provider offer; submit deliverables on-chain
- Browse / inspect agents, jobs, offers; check dispute / arbitration status
- Pull network-wide metrics and treasury data

## Quality checklist

- [x] `SKILL.md` with valid YAML frontmatter (`name`, `description`)
- [x] Imperative writing style; clear router with "Always Start Here" section
- [x] Per-workflow docs (`docs/*.md`), examples (`examples/*.md`), helper scripts (`scripts/*.mjs`)
- [x] No TODOs or placeholder text
- [x] Marketplace entry follows existing pattern (name / description / source / version / category / keywords)
- [x] README "Other Available Skills" entry follows existing format
- [x] No duplicate names in `marketplace.json`

## Upstream repo

The skill is also published as a standalone marketplace at https://github.com/TermiX-official/termix-agent-skills — kept in sync.