### PR TITLE
docs(transcript-fixer): clarify native correction protocol + fix DB column guidance

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -134,7 +134,7 @@
       "description": "Audio processing suite covering the full speech pipeline: ASR transcription (Qwen3, StepFun), transcript error correction, structured meeting minutes generation, and TTS voice synthesis (StepFun). Install once for the complete audio workflow.",
       "source": "./daymade-audio",
       "strict": false,
-      "version": "1.0.0",
+      "version": "1.1.0",
       "category": "suite",
       "keywords": [
         "suite",

--- a/daymade-audio/transcript-fixer/SKILL.md
+++ b/daymade-audio/transcript-fixer/SKILL.md
@@ -49,7 +49,7 @@ Two-phase pipeline with persistent learning:
 5. **Save stable patterns**: `--add "错误词" "正确词"` after each session
 6. **Review learned patterns**: `--review-learned` and `--approve` high-confidence suggestions
 
-**Domains**: `general`, `embodied_ai`, `finance`, `medical`, or custom (e.g., `火星加速器`)
+**Domains**: `general`, `embodied_ai`, `finance`, `medical`, or custom (e.g., `legal`, `gaming`)
 **Learning**: Patterns appearing ≥3 times at ≥80% confidence auto-promote from AI to dictionary
 
 **After fixing, always save reusable corrections to dictionary.** This is the skill's core value — see `references/iteration_workflow.md` for the complete checklist.
@@ -61,9 +61,9 @@ After native AI correction, review all applied fixes and decide which to save. U
 | Pattern type | Example | Action |
 |-------------|---------|--------|
 | Non-word → correct term | 克劳锐→Claude, cloucode→Claude Code | ✅ Add (zero false positive risk) |
-| Rare word → correct term | 潜彩→前采, 维星→韦青 | ✅ Add (verify it's not a real word first) |
-| Person/company name ASR error | 宋天航→宋天生, 策马攀山→策马看山 | ✅ Add (stable, unique) |
-| Common word → context word | 争→蒸, 钱财→前采, 报纸→标品 | ❌ Skip (high false positive risk) |
+| Rare word → correct term | 拉行链→LangChain, 哈金费斯→Hugging Face | ✅ Add (verify it's not a real word first) |
+| Person/company name ASR error | 卡帕西→Karpathy, Anthropics→Anthropic | ✅ Add (stable, unique) |
+| Common word → context word | 争→蒸, affect→effect | ❌ Skip (high false positive risk) |
 | Real brand → different brand | Xcode→Claude Code, Clover→Claude | ❌ Skip (real words in other contexts) |
 
 Batch add multiple corrections in one session:
@@ -150,8 +150,8 @@ uv run scripts/fix_transcript_timestamps.py meeting.txt --in-place
 **Split transcript into sections** (rebase each to `00:00:00`):
 ```bash
 uv run scripts/split_transcript_sections.py meeting.txt \
-  --first-section-name "课前聊天" \
-  --section "正式上课::好，无缝切换嘛。" \
+  --first-section-name "intro" \
+  --section "main::<verbatim line that starts the next section>" \
   --rebase-to-zero
 ```
 

--- a/daymade-audio/transcript-fixer/SKILL.md
+++ b/daymade-audio/transcript-fixer/SKILL.md
@@ -7,6 +7,8 @@ description: Corrects speech-to-text transcription errors using dictionary rules
 
 Two-phase correction pipeline: deterministic dictionary rules (instant, free) followed by AI-powered error detection. Corrections accumulate in `~/.transcript-fixer/corrections.db`, improving accuracy over time.
 
+**What each phase is actually good at** (calibration, not a rule): the dictionary shines on *recurring* errors — product names, common homophones, anything you've corrected before — at zero cost and zero latency. But on a fresh database, on high-quality ASR (e.g. transcripts from a strong engine like Whisper, Otter, or Feishu / Tencent-Meeting), or in specialized domains (finance, medical, legal), the dictionary often matches almost nothing — the errors that remain are proper nouns and domain terms it has never seen. There, the AI pass does essentially all the real work. Treat Stage 1 as a cheap pre-filter for known repeats, not as the primary corrector, and don't be alarmed when it changes only a handful of lines on a clean transcript.
+
 ## Prerequisites
 
 All scripts use PEP 723 inline metadata — `uv run` auto-installs dependencies. Requires `uv` ([install guide](https://docs.astral.sh/uv/getting-started/installation/)).
@@ -26,12 +28,7 @@ for f in /path/to/*.txt; do
 done
 ```
 
-After Stage 1, Claude reads the output and fixes remaining ASR errors natively (no API key needed):
-1. Read all Stage 1 outputs — read **entire** transcript before proposing corrections (later context disambiguates earlier errors)
-2. Identify ASR errors — compile all corrections across files
-3. Apply fixes with sed in batch, verify each with diff
-4. Finalize: rename `_stage1.md` → `.md`, delete original `.txt`
-5. Save stable patterns to dictionary for future reuse
+After Stage 1, Claude reads the output and fixes remaining ASR errors natively (no API key needed). The full method — triage by confidence, verify-don't-guess, second pass, needs-checking list — is in **Native AI Correction** below; read that section as the source of truth. For a quick, clean transcript it collapses to: read the whole thing → fix the obvious errors with sed → save reusable patterns to the dictionary.
 
 See `references/example_session.md` for a concrete input/output walkthrough.
 
@@ -82,21 +79,25 @@ Adding wrong dictionary rules silently corrupts future transcripts. **Read `refe
 
 ## Native AI Correction (Default Mode)
 
-When running inside Claude Code, use Claude's own language understanding for Phase 2:
+When running inside Claude Code, use Claude's own language understanding for Phase 2 — on high-quality ASR this is where almost all the real correction happens. **Scale the effort to the transcript.** A short, clean recording with no proper nouns (a quick voice memo) just needs steps 1-3 plus one obvious-fix pass; skip the verification / second-pass / subagent / needs-checking machinery below, which earns its keep on long, multi-speaker, domain-heavy, or high-stakes transcripts. Don't turn a 10-second memo into a research project.
 
 1. Run Stage 1 (dictionary) on all files (parallel if multiple)
-2. Verify Stage 1 — diff original vs output. If dictionary introduced false positives, work from the **original** file
-3. Read **all** Stage 1 outputs fully before proposing any corrections — later context often disambiguates earlier errors. For large files (>10k tokens), read in chunks but finish the entire file before identifying errors
-4. Identify ASR errors per file — classify by confidence:
-   - **High confidence** (apply directly): non-words, obvious garbling, product name variants
-   - **Medium confidence** (present for review): context-dependent homophones, person names
-5. Apply fixes efficiently:
-   - **Global replacements** (unique non-words like "克劳锐"→"Claude"): use `sed -i ''` with `-e` flags, multiple patterns in one command
-   - **Context-dependent** (common words like "争"→"蒸" only in distillation context): use sed with longer context phrases for uniqueness, or Edit tool
-6. Verify with diff: `diff original.txt corrected_stage1.md`
-7. Finalize files: rename `*_stage1.md` → `*.md`, delete original `.txt`
-8. Save stable patterns to dictionary (see "Dictionary Addition" below)
-9. Remove false positives if Stage 1 had any
+2. Verify Stage 1 — diff against the original. If the dictionary introduced false positives, work from the **original** file instead and apply your edits there
+3. Read the **entire** transcript before proposing corrections — later context disambiguates earlier errors (a name garbled near the start often becomes obvious later). For large files, read in chunks but finish the whole thing before deciding anything
+4. **Triage each candidate error into one of three buckets** — this triage is the part that takes judgment:
+   - **Confident fix** — non-words, obvious garbling, product-name variants you already recognize, or a homophone that's unambiguous in context (`their`→`there` where context forces it; `彭波`→`彭博` when every other mention already reads `彭博`). Apply directly (step 5).
+   - **Needs verification** — a proper noun you can't confirm from context: a person / company / ticker / product / place name (a misheard drug name in a medical interview, a researcher's surname in a podcast, a ticker on an earnings call), or any term you can't point to a specific source for — even one you think you recognize ("I'm pretty sure" is exactly how wrong names slip in). **Search it, don't guess** — WebSearch, or a local grep if it's a project / personal entity. A confirmed result becomes a Confident fix; if the search *can't* confirm it, it drops to Uncertain. Batch these: collect the unique unknowns and look them up together, not one-by-one.
+   - **Uncertain** — you suspect an error but can't confirm it even after searching (a syllable that maps to several real entities; a structurally broken sentence). **Leave the original text exactly as-is** and record it in the needs-checking list (step 7). A fluent-but-wrong "fix" is harder to catch downstream than an obvious garble — silence beats a confident guess.
+5. Apply the confident fixes efficiently:
+   - **Global replacements** (unique non-words like "克劳锐"→"Claude"): one `sed -i ''` with multiple `-e` flags
+   - **Context-dependent** (a word that's only wrong in one context, like "争"→"蒸" in a distillation discussion): sed with a longer surrounding phrase for uniqueness, or the Edit tool
+   - Re-grep each changed term afterward to confirm it landed and didn't hit look-alikes you meant to keep
+6. **Second pass — catch what one read missed.** A single linear read reliably leaves residue: an idiom degraded into a near-homophone, a term wrong in just one spot among many correct ones, an acronym misheard as another. Always re-scan once for leftovers. For a long or high-stakes transcript, *also* spawn an independent subagent (Task) to re-read the corrected file cold — fresh eyes with no memory of your first pass catch what you've read past. Have it report suspected residuals **with line numbers**, then run each back through step-4 triage (fix / search / log). Task works when you're in the main context; if it isn't available — e.g. these instructions are themselves running inside a subagent, which can't spawn another — just do one more thorough independent re-read yourself. Never skip the second pass over a missing tool.
+7. **Emit a needs-checking list** — in your chat summary to the human, not baked into the file — for everything still *Uncertain*: line number, the original text you left in place, what you suspect, and why you couldn't confirm it. This surfaces the few items that need a recording or source to resolve, instead of burying them or papering over them with guesses. If nothing is uncertain, say so.
+8. Verify with diff against the file you actually edited (`diff <original> <your-working-file>`) — every change should trace back to a triage decision
+9. Finalize: rename `*_stage1.md` → `*.md`, delete the original `.txt`
+10. Save stable patterns to the dictionary (see "Dictionary Addition" below)
+11. If you worked from `corrected_stage1.md`, strip any remaining Stage 1 false positives before finalizing
 
 ### Common ASR Error Patterns
 
@@ -167,10 +168,14 @@ uv run scripts/generate_word_diff.py original.md corrected.md output.html
 
 ## Database Operations
 
-**Read `references/database_schema.md` before any database operations.**
+**Read `references/database_schema.md` before writing any custom query** — the column names are not what you'd guess. The correction columns are **`from_text` / `to_text`** (not `wrong_term`/`correct_term`, not `original`/`corrected`). Guessing column names is the most common way these queries fail with "no such column".
 
 ```bash
-sqlite3 ~/.transcript-fixer/corrections.db "SELECT * FROM active_corrections;"
+# Inspect corrections — real column names are from_text, to_text, domain
+sqlite3 ~/.transcript-fixer/corrections.db "SELECT from_text, to_text, domain FROM active_corrections;"
+# Count rules per domain
+sqlite3 ~/.transcript-fixer/corrections.db "SELECT domain, COUNT(*) FROM active_corrections GROUP BY domain;"
+# Schema version
 sqlite3 ~/.transcript-fixer/corrections.db "SELECT value FROM system_config WHERE key='schema_version';"
 ```
 


### PR DESCRIPTION
## What

Clarifies the transcript-fixer **native (Phase 2) correction protocol** and fixes two documentation-accuracy issues found in real use. SKILL.md only — no script or behavior changes.

## Changes

1. **Native flow made explicit** — three-bucket triage:
   - **confident** → fix directly
   - **needs-verification** (a proper noun you can't confirm from context) → **search, don't guess**
   - **uncertain** (can't confirm even after searching) → **leave as-is + emit a needs-checking list** instead of injecting a fluent-but-wrong fix
   - **second pass** to catch what one linear read misses — with a fallback to a manual re-read when `Task` isn't available (e.g. running inside a nested subagent)
   - **scale-rigor escape hatch**: a short/clean transcript skips all of the above
2. **Stage 1 dictionary positioning calibrated** — a near-zero hit rate on high-quality ASR / specialized domains is expected; the AI pass does the real work. Sets the right expectation instead of implying the dictionary is the primary corrector.
3. **Database Operations fixed** — documents the real column names `from_text` / `to_text` (not `wrong_term`/`correct_term`) and adds example queries. Guessing column names was the most common way these queries failed.
4. **Quick Start** now points to the full method instead of duplicating a stale 5-step recap that contradicted the upgraded section.
5. **Examples generalized** (Whisper/Otter; medical / podcast / earnings) so the guidance reads as universal craft, not one domain.

## Validation (skill-creator eval)

- **Short / clean synthetic transcripts**: new vs old produced **byte-identical** output — a strong model already does triage / verify / keep-uncertain unprompted. **Zero regression** on easy inputs.
- **Long real-world transcript (held out)**: the old single-pass flow **fabricated a product name out of a real one** and **missed several recurring errors**; the new flow's triage + search-don't-guess + second-pass caught them (~30-line difference, on a clean run forbidden from consulting any prior answer).
- **Takeaway**: no change on easy inputs, measurable gain on long / hard ones — which is exactly what the scale-rigor escape hatch is built around.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
