### PR TITLE
docs(skill-creator): AI semantic read-through as the primary sanitization method

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -160,7 +160,7 @@
       "description": "Daymade skills core suite. Bundles skill creation, quality review, search, and marketplace development tooling under one shared namespace.",
       "source": "./daymade-skill",
       "strict": false,
-      "version": "1.0.1",
+      "version": "1.1.0",
       "category": "suite",
       "keywords": [
         "suite",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,11 +127,12 @@ Skills for public distribution must NOT contain:
 - OneDrive paths or environment-specific absolute paths
 - Use relative paths within skill bundle or standard placeholders (`<workspace>/`, `<user_id>`)
 
-**Four-layer defense system:**
+**Five-layer defense system:**
 1. **CLAUDE.md rules** (this section) — Claude avoids generating sensitive content
 2. **Global PII Guard pre-commit hook** (`~/scripts/git-pii-guard/pre-commit`) — blocks staged PII/secrets and generated/local artifact paths
 3. **Global PII Guard pre-push hook** (`~/scripts/git-pii-guard/pre-push`) — scans commits about to be pushed, catching bad local history before it hits GitHub
 4. **gitleaks** (`.gitleaks.toml`) — deep scan with custom rules for this repo
+5. **AI semantic read-through** (the gate the other four structurally cannot be) — layers 1-4 are keyword/regex/gitleaks: they only match patterns someone listed, and are blind to private content with **no keyword** — a real name in another language (gitleaks doesn't cover CJK), a verbatim line from a real transcript, a real example dropped into an illustration. Before publishing, **read the whole skill yourself and judge each concrete name/example/snippet semantically** ("generic placeholder / public entity, or lifted from a real project / person / transcript?"). A green scan is **not** a clean bill of health; "grep found nothing" only means your word list didn't fire. Method: [`daymade-skill/skill-creator/references/sanitization_checklist.md`](./daymade-skill/skill-creator/references/sanitization_checklist.md).
 
 PII Guard is enabled via `~/scripts/git-pii-guard/manage.sh enable <repo-path>`, which sets `core.hooksPath` to `~/scripts/git-pii-guard`.
 For repo-specific additions:

--- a/daymade-skill/skill-creator/SKILL.md
+++ b/daymade-skill/skill-creator/SKILL.md
@@ -919,31 +919,29 @@ When editing, remember that the skill is being created for another instance of C
 
 **Pipeline check**: Consider whether this skill's output naturally feeds into another skill. If so, add a "Next Step" handoff section (see "Pipeline Handoff" in the Skill Writing Guide). Also check if any existing skill should chain *into* this one.
 
-### Step 5: Sanitization Review (Optional)
+### Step 5: Sanitization Review (mandatory for any public skill)
 
-Use **AskUserQuestion** before executing this step:
+**Not optional for a skill going to a public repo.** Private content leaks into public skills all the time, and the leaks a scanner misses are the dangerous ones — a real name in a non-English language, a verbatim line from a real transcript, a real example dropped into an illustration. Skip only if the skill is genuinely internal-only.
+
+Use **AskUserQuestion** to confirm the depth (not whether to do it):
 
 ```
-This skill appears to contain content from a real project.
-Before distribution, I should check for business-specific details
-(company names, internal paths, product names) that shouldn't be public.
-
-RECOMMENDATION: Run selective sanitization — review each finding before removing.
+This skill will be public. I'll do a sanitization pass — the core of it is
+me reading the whole skill and judging each name/example/snippet, because
+scanners miss real content that has no keyword to match.
 
 Options:
-A) Full sanitization — automatically remove all business-specific content
-B) Selective sanitization — show me each finding and let me decide (Recommended)
-C) Skip — this is for internal use only, no sanitization needed
+A) Full — I replace everything that looks lifted from a real project/person
+B) Selective — I show you each finding and you decide (Recommended)
+C) This skill is genuinely internal-only — skip
 ```
 
-Skip if: skill was created from scratch for public use, user declines, or skill is for internal use.
+**Sanitization process — the read-through is the method, the scan is a helper:**
 
-**Sanitization process:**
-
-1. **Load the checklist**: Read [references/sanitization_checklist.md](references/sanitization_checklist.md) for detailed guidance
-2. **Run automated scans** to identify potential sensitive content
-3. **Review and replace** each category (product names, person names, entity names, paths, jargon)
-4. **Verify completeness**: Re-run patterns, read through skill, confirm functionality
+1. **Read the entire skill yourself and judge semantically** (this is the real check): SKILL.md + every reference + every example. For each concrete noun / example / snippet ask "generic-placeholder-or-public-entity, or lifted-from-a-real-project/person/transcript?" Replace the latter — even if no scanner flagged it. This is the only thing that catches no-keyword leaks. Full guidance + the semantic question in [references/sanitization_checklist.md](references/sanitization_checklist.md).
+2. **Run scanners as a cheap first pass**: the checklist's grep patterns + `security_scan.py` (Step 6). They catch obvious secrets / paths / known names fast — but "no matches" is not a pass.
+3. **Replace** each finding with a generic equivalent that keeps the teaching point (real name → public figure or `<placeholder>`, real snippet → `<placeholder>`).
+4. **Verify by re-reading, not by re-grepping**: re-read the changed sections and confirm no broken references.
 
 ### Step 6: Security Review
 
@@ -961,6 +959,8 @@ python scripts/security_scan.py <path/to/skill-folder> --verbose
 - Hardcoded secrets (API keys, passwords, tokens) via gitleaks
 - Personal information (usernames, emails, company names) in verbose mode
 - Unsafe code patterns (command injection risks) in verbose mode
+
+**What it does NOT cover** — why Step 5's read-through is still required: gitleaks and the regex rules only match *known secret formats and patterns you listed*. They are structurally blind to private content with no keyword — a real person/project name in a non-English language, a verbatim line from a real transcript, a real example lifted from your own work. A green `security_scan` means "no known-format secret was found", **not** "the skill is sanitized". Never treat it as the latter.
 
 **First-time setup:** Install gitleaks if not present:
 

--- a/daymade-skill/skill-creator/references/sanitization_checklist.md
+++ b/daymade-skill/skill-creator/references/sanitization_checklist.md
@@ -2,16 +2,28 @@
 
 When extracting a skill from a business project for public distribution, systematically remove all business-specific content to make it generic and reusable.
 
+## The rule that matters most: read it yourself, don't just grep
+
+Scanners — gitleaks, the grep patterns below, `security_scan.py` — only match what you **thought to list**: known secret formats, a name list you wrote, specific path shapes. They are blind to the most dangerous leak of all: **real content with no proper noun to catch.** A verbatim spoken line from a real transcript (a casual aside with no name in it), a specific real-world example dropped into an illustration, a real meeting or project mentioned in passing, a codename you simply forgot to add to the word list — none of these have a keyword for grep to hit, so every scanner sails right past them.
+
+The primary sanitization method is therefore **you reading the entire skill** — SKILL.md, every reference file, every example, every bundled doc — and judging each concrete noun, example, and snippet semantically:
+
+> "Does this read like a generic placeholder or a public entity (Claude, GitHub, LangChain, `<project>`), or like it was lifted from a real project / person / transcript?"
+
+Anything in the second category gets replaced — **even if no scanner flagged it.**
+
+**"grep returned no matches" is not a clean bill of health.** It only means the word list you guessed didn't fire. Run the scanners below as a cheap first pass for the obvious stuff, then do the read-through as the actual gate. If you only do one, do the read-through.
+
 ## Quick Scan Commands
 
 Run these grep patterns to identify potential sensitive content:
 
 ```bash
 # Business/product names (case-insensitive)
-grep -rniE "mercury|portal|underwriting|glean|[company-name]|[product-name]" skill-folder/
+grep -rniE "acme|globex|[company-name]|[product-name]" skill-folder/
 
 # Person names (look for capitalized names)
-grep -rniE "\b(Oliver|John|Alice|Bob|建斌|小明)\b" skill-folder/
+grep -rniE "\b(Carol|John|Alice|Bob|小华|小明)\b" skill-folder/
 
 # Absolute paths and usernames
 grep -rniE "/Users/|/home/|/mnt/c/Users|OneDrive|username" skill-folder/
@@ -28,9 +40,9 @@ grep -rniE "ultrathink|internal-only|confidential" skill-folder/
 ### 1. Product and Project Names
 
 **What to find:**
-- Project codenames (e.g., "Mercury Prepared", "Project Phoenix")
-- Internal product names (e.g., "Reviewer Portal", "Admin Dashboard")
-- Tool-specific names (e.g., "Glean Gemini" → just "Gemini")
+- Project codenames (e.g., "Acme Prepared", "Project Phoenix")
+- Internal product names (e.g., "Ops Console", "Admin Dashboard")
+- Tool-specific names (e.g., "Globex Gemini" → just "Gemini")
 
 **How to replace:**
 - Use generic terms: "the system", "the application", "the service"
@@ -40,7 +52,7 @@ grep -rniE "ultrathink|internal-only|confidential" skill-folder/
 ### 2. Person Names
 
 **What to find:**
-- Real employee names in examples: "Oliver will handle...", "建斌你来..."
+- Real employee names in examples: "Carol will handle...", "小华你来..."
 - Team member references in action items
 - Author attributions that reveal identity
 
@@ -65,7 +77,7 @@ grep -rniE "ultrathink|internal-only|confidential" skill-folder/
 
 **What to find:**
 - Team-specific folders: `10-team-collaboration/Meeting Minutes`
-- Project-specific paths: `reviewer-portal-api-design`
+- Project-specific paths: `ops-console-api-design`
 - Environment-specific paths: user home directory project paths
 
 **How to replace:**
@@ -77,7 +89,7 @@ grep -rniE "ultrathink|internal-only|confidential" skill-folder/
 
 **What to find:**
 - Internal slang: "ultrathink", "deep dive session"
-- Company-specific processes: "Mercury standup", "Portal review"
+- Company-specific processes: "Acme standup", "Portal review"
 - Abbreviations without context: "MP", "RP", "UW"
 
 **How to replace:**
@@ -114,7 +126,7 @@ grep -rniE "ultrathink|internal-only|confidential" skill-folder/
 **What to find:**
 - Internal APIs: `POST /evaluate (push to Risk Model)`
 - Company-specific integrations: "Sync with Underwriting system"
-- Internal tool names: "Glean search", "Internal Wiki"
+- Internal tool names: "Globex search", "Internal Wiki"
 
 **How to replace:**
 - Use generic services: `POST /process (send to External Service)`
@@ -139,19 +151,19 @@ For each match:
 3. Check if replacement maintains meaning
 4. Verify no broken references
 
-### Phase 3: Verification
+### Phase 3: Verification (the read-through is the real gate)
 
 After sanitization:
-1. Re-run all grep patterns - should return no matches
-2. Read through skill to ensure coherence
-3. Test skill functionality still works
-4. Have someone unfamiliar with the original project review
+1. **Read the whole skill again yourself** — SKILL.md + every reference + every example — re-asking the semantic question above on each concrete noun and snippet. This is what catches the no-keyword leaks (a verbatim transcript line, a real spoken example) that scanners structurally cannot see. **This step, not the grep, is what "passes" sanitization.**
+2. Re-run the grep patterns + `security_scan.py` as a secondary check — but read "no matches" as "the obvious stuff is gone", never as "it's clean"
+3. Test skill functionality still works (no broken references after replacements)
+4. If you can, have a fresh reader — a person, or a subagent with no prior context — read it cold; fresh eyes catch what you've already read past
 
 ## Common Pitfalls
 
 | Pitfall | Solution |
 |---------|----------|
-| Over-sanitizing generic terms | "reviewer" as a role is fine; "Reviewer Portal" is not |
+| Over-sanitizing generic terms | "reviewer" as a role is fine; "Ops Console" is not |
 | Breaking examples by removing context | Replace with equivalent generic examples |
 | Leaving orphaned references | Check all cross-references after renaming |
 | Inconsistent replacements | Use find-and-replace for consistency |


### PR DESCRIPTION
## What

Makes **AI semantic read-through the primary sanitization method** for any public skill, after a real private leak slipped past keyword scanning.

## Why

The flow leaned on scanners — `gitleaks`, grep patterns, `security_scan.py` — plus an **Optional** sanitization step. But scanners only match patterns you thought to list (known secret formats, a name list, path shapes). They are **structurally blind to private content with no keyword**:
- a real person/project name in a non-English language (gitleaks doesn't cover it)
- a verbatim line from a real transcript (no name to grep for)
- a real example dropped into an illustration

A real leak got through exactly this way — caught only by *reading* the file, not by any scan.

## Changes

1. **`sanitization_checklist.md`** — leads with the rule that matters: *read it yourself, don't just grep*. grep is a cheap first pass, not the gate; **"grep returned no matches" is explicitly not a clean bill of health**. Phase 3 now makes the read-through (re-asking a semantic question on each concrete noun/snippet), not re-grepping, the step that actually passes sanitization.
2. **SKILL.md Step 5** — sanitization is now **mandatory for public skills** (was `Optional`); the semantic read-through is the method, the scan is a helper.
3. **SKILL.md Step 6** — spells out what gitleaks does **not** cover, so a green `security_scan` is never mistaken for "sanitized".
4. **The checklist's own examples** — ironically used real company/product/person/project names as "sanitization examples". Replaced with generic placeholders. A sanitization guide shouldn't itself leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
