### PR TITLE
fix(macos-cleaner): harden deletion safety checks

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -452,7 +452,7 @@
       "description": "Intelligent macOS disk space analysis and cleanup with safety-first philosophy. Use when users report disk space issues, need to clean their Mac, or want to understand storage consumption. Analyzes system caches, application remnants, large files, and development environments (Docker, Homebrew, npm, pip) with risk categorization (Safe/Caution/Keep) and requires explicit user confirmation before any deletions. Includes Mole visual tool integration for hybrid workflow",
       "source": "./macos-cleaner",
       "strict": false,
-      "version": "1.1.0",
+      "version": "1.1.1",
       "category": "utilities",
       "keywords": [
         "macos",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **macos-cleaner** v1.1.0 → v1.1.1: Hardened `safe_delete.py` with forced high-risk path blocking before confirmation and inside `delete_path()`, and updated `find_app_remnants.py` to match installed apps by Bundle Identifier as well as display name. Fixes [#70](https://github.com/daymade/claude-code-skills/issues/70).
+
 ## [1.60.0] - 2026-05-31
 
 ### Added

--- a/macos-cleaner/.security-scan-passed
+++ b/macos-cleaner/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-01-11T17:48:10.512079
+Scanned at: 2026-06-05T00:05:02.933101
 Tool: gitleaks + pattern-based validation
-Content hash: de94268166b88b2b704930f641a401a1eddcf2ea957ca6185533203b9e13fb04
+Content hash: 28f309886109b9ebe630bff04bfdbe3fb91ddb162218bfd78c36561ba5a0eeb0

--- a/macos-cleaner/references/safety_rules.md
+++ b/macos-cleaner/references/safety_rules.md
@@ -35,11 +35,20 @@ If uncertain about safety: **DON'T DELETE**.
 
 Ask user to verify instead.
 
-### Rule 4: Suggest Backups for Large Deletions
+### Rule 4: High-Risk Paths Are Hard Blocks
+
+`safe_delete.py` must refuse dangerous system and credential paths before confirmation and inside the delete function. A warning is not enough for:
+- `/`, `/System`, `/usr`, `/bin`, `/etc`
+- `~/.ssh`, `~/.aws`, `~/.gnupg`
+- `~/Library/Keychains`
+
+These paths and their descendants are blocked even when the user selects `all` in batch mode.
+
+### Rule 5: Suggest Backups for Large Deletions
 
 Before deleting >10 GB, recommend Time Machine backup.
 
-### Rule 5: Docker Prune Prohibition
+### Rule 6: Docker Prune Prohibition
 
 **NEVER use any Docker prune command.** This includes:
 - `docker image prune` / `docker image prune -a`
@@ -61,7 +70,7 @@ docker rm container-name-1 container-name-2
 docker volume rm project-mysql-data project-redis-data
 ```
 
-### Rule 6: Double-Check Verification Protocol
+### Rule 7: Double-Check Verification Protocol
 
 Before deleting ANY Docker object, perform independent cross-verification. This applies to images, volumes, and containers.
 
@@ -73,7 +82,7 @@ Before deleting ANY Docker object, perform independent cross-verification. This 
 
 See **SKILL.md Step 4** for the complete verification commands and database volume inspection workflow.
 
-### Rule 7: Use Trash When Possible
+### Rule 8: Use Trash When Possible
 
 Prefer moving to Trash over permanent deletion:
 
@@ -93,7 +102,7 @@ rm -rf /path/to/file
 |------|-----|-------------------|
 | `/System` | macOS core | System unbootable |
 | `/Library/Apple` | Apple frameworks | Apps won't launch |
-| `/private/etc` | System config | System unstable |
+| `/etc`, `/private/etc` | System config | System unstable |
 | `/private/var/db` | System databases | System unstable |
 | `/usr` | Unix utilities | Commands won't work |
 | `/bin`, `/sbin` | System binaries | System unusable |
@@ -114,6 +123,8 @@ rm -rf /path/to/file
 | Path | Why | Impact if Deleted |
 |------|-----|-------------------|
 | `~/.ssh` | SSH keys | Cannot access servers |
+| `~/.aws` | Cloud credentials | Cannot access cloud resources |
+| `~/.gnupg` | GPG keys | Cannot decrypt or sign data |
 | `~/Library/Keychains` | Passwords, certificates | Cannot access accounts/services |
 | Any file with "credential", "password", "key" in name | Security data | Cannot authenticate |
 
@@ -179,7 +190,7 @@ Please run this command manually:
 
 ### Docker Objects (Images, Containers, Volumes)
 
-**Action**: List every object individually. Use precision deletion only (see Rule 5 and Rule 6).
+**Action**: List every object individually. Use precision deletion only (see Rule 6 and Rule 7).
 
 **NEVER use prune commands.** Always specify exact IDs/names.
 
@@ -235,17 +246,24 @@ if not os.path.exists(path):
     return False
 ```
 
-### Check 2: Not a System Path
+### Check 2: Not a Blocked Path
 
 ```python
-system_paths = [
-    '/System', '/Library/Apple', '/private/etc',
-    '/usr', '/bin', '/sbin', '/private/var/db'
+blocked_paths = [
+    '/System', '/Library/Apple', '/etc', '/private/etc',
+    '/usr', '/bin', '/sbin', '/private/var/db',
+    '~/.ssh', '~/.aws', '~/.gnupg', '~/Library/Keychains',
 ]
 
-for sys_path in system_paths:
-    if path.startswith(sys_path):
-        print(f"❌ Cannot delete system path: {path}")
+expanded_path = os.path.realpath(os.path.expanduser(path))
+if expanded_path == '/':
+    print("❌ Cannot delete root path")
+    return False
+
+for blocked_path in blocked_paths:
+    expanded_blocked = os.path.realpath(os.path.expanduser(blocked_path))
+    if expanded_path == expanded_blocked or expanded_path.startswith(expanded_blocked + os.sep):
+        print(f"❌ Cannot delete blocked path: {path}")
         return False
 ```
 
@@ -254,7 +272,7 @@ for sys_path in system_paths:
 ```python
 user_data_paths = [
     '~/Documents', '~/Desktop', '~/Pictures',
-    '~/Movies', '~/Music', '~/.ssh'
+    '~/Movies', '~/Music'
 ]
 
 expanded_path = os.path.expanduser(path)

--- a/macos-cleaner/scripts/find_app_remnants.py
+++ b/macos-cleaner/scripts/find_app_remnants.py
@@ -16,6 +16,7 @@ import os
 import sys
 import subprocess
 import argparse
+import plistlib
 from pathlib import Path
 
 
@@ -45,24 +46,73 @@ def get_dir_size(path):
         return 0
 
 
+def get_bundle_identifier(app_path):
+    """Read CFBundleIdentifier from an app bundle when available."""
+    info_plist = app_path / 'Contents' / 'Info.plist'
+    try:
+        with info_plist.open('rb') as f:
+            info = plistlib.load(f)
+    except Exception:
+        return None
+
+    bundle_id = info.get('CFBundleIdentifier')
+    if isinstance(bundle_id, str) and bundle_id.strip():
+        return bundle_id.strip()
+    return None
+
+
+def _empty_installed_apps():
+    return {
+        'names': set(),
+        'bundle_ids': set(),
+    }
+
+
+def _coerce_installed_apps(installed_apps):
+    if isinstance(installed_apps, dict):
+        return {
+            'names': set(installed_apps.get('names', set())),
+            'bundle_ids': set(installed_apps.get('bundle_ids', set())),
+        }
+    return {
+        'names': set(installed_apps),
+        'bundle_ids': set(),
+    }
+
+
+def _add_app_bundle(installed_apps, app_path):
+    installed_apps['names'].add(app_path.stem)
+    bundle_id = get_bundle_identifier(app_path)
+    if bundle_id:
+        installed_apps['bundle_ids'].add(bundle_id)
+
+
+def _matches_bundle_identifier(dir_name, bundle_id):
+    dir_lower = dir_name.lower()
+    bundle_lower = bundle_id.lower()
+    if dir_lower == bundle_lower or dir_lower.startswith(bundle_lower + '.'):
+        return True
+
+    return normalize_name(dir_name) == normalize_name(bundle_id)
+
+
 def get_installed_apps():
-    """Get list of installed application names."""
-    apps = set()
+    """Get installed application names and bundle identifiers."""
+    apps = _empty_installed_apps()
 
     # System applications
     system_app_dir = Path('/Applications')
     if system_app_dir.exists():
         for app in system_app_dir.iterdir():
             if app.suffix == '.app':
-                # Remove .app suffix
-                apps.add(app.stem)
+                _add_app_bundle(apps, app)
 
     # User applications
     user_app_dir = Path.home() / 'Applications'
     if user_app_dir.exists():
         for app in user_app_dir.iterdir():
             if app.suffix == '.app':
-                apps.add(app.stem)
+                _add_app_bundle(apps, app)
 
     return apps
 
@@ -94,12 +144,22 @@ def is_likely_orphaned(dir_name, installed_apps):
         (is_orphaned, confidence, reason)
         confidence: 'high' | 'medium' | 'low'
     """
+    installed = _coerce_installed_apps(installed_apps)
     norm_dir = normalize_name(dir_name)
 
-    # Check exact matches
-    for app in installed_apps:
+    # Bundle identifiers are common in Containers and Saved Application State.
+    for bundle_id in installed['bundle_ids']:
+        if _matches_bundle_identifier(dir_name, bundle_id):
+            return (
+                False,
+                None,
+                f"Matches installed app bundle identifier: {bundle_id}"
+            )
+
+    # Check display-name matches.
+    for app in installed['names']:
         norm_app = normalize_name(app)
-        if norm_app in norm_dir or norm_dir in norm_app:
+        if norm_app and (norm_app in norm_dir or norm_dir in norm_app):
             return (False, None, f"Matches installed app: {app}")
 
     # System/common directories to always keep
@@ -124,7 +184,7 @@ def analyze_library_dir(library_path, min_size_bytes, installed_apps):
     Args:
         library_path: Path to scan (e.g., ~/Library/Application Support)
         min_size_bytes: Minimum size to report
-        installed_apps: Set of installed app names
+        installed_apps: Dict with installed app names and bundle identifiers
 
     Returns:
         List of (name, path, size, confidence, reason) tuples
@@ -180,7 +240,10 @@ def main():
     # Get installed apps
     print("Scanning installed applications...")
     installed_apps = get_installed_apps()
-    print(f"Found {len(installed_apps)} installed applications\n")
+    print(
+        f"Found {len(installed_apps['names'])} installed applications "
+        f"and {len(installed_apps['bundle_ids'])} bundle identifiers\n"
+    )
 
     # Directories to check
     library_dirs = {

--- a/macos-cleaner/scripts/safe_delete.py
+++ b/macos-cleaner/scripts/safe_delete.py
@@ -18,6 +18,63 @@ import subprocess
 from pathlib import Path
 
 
+def _canonical_path(path):
+    """Return a canonical path for safety comparisons."""
+    return Path(os.path.realpath(os.path.expanduser(str(path))))
+
+
+ROOT_PATH = _canonical_path('/')
+
+HIGH_RISK_PATHS = frozenset(
+    _canonical_path(path)
+    for path in [
+        '/System',
+        '/Library/Apple',
+        '/usr',
+        '/bin',
+        '/sbin',
+        '/etc',
+        '/private/var/db',
+        '~/.ssh',
+        '~/.aws',
+        '~/.gnupg',
+        '~/Library/Keychains',
+    ]
+)
+
+
+def _is_same_or_child(path, parent):
+    try:
+        path.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def get_high_risk_match(path):
+    """Return the denied ancestor path when path is too dangerous to delete."""
+    canonical = _canonical_path(path)
+    if canonical == ROOT_PATH:
+        return ROOT_PATH
+
+    for denied_path in HIGH_RISK_PATHS:
+        if _is_same_or_child(canonical, denied_path):
+            return denied_path
+    return None
+
+
+def is_high_risk_path(path):
+    """Check whether a path is blocked by the forced-delete denylist."""
+    return get_high_risk_match(path) is not None
+
+
+def format_blocked_message(path, denied_path):
+    return (
+        "BLOCKED: high-risk path refused by safety denylist "
+        f"({path} matches or is inside {denied_path})"
+    )
+
+
 def format_size(bytes_size):
     """Convert bytes to human-readable format."""
     for unit in ['B', 'KB', 'MB', 'GB', 'TB']:
@@ -86,6 +143,12 @@ def confirm_delete(path, size, description):
     Returns:
         True if user confirms, False otherwise
     """
+    denied_path = get_high_risk_match(path)
+    if denied_path:
+        print(f"\n⛔ {format_blocked_message(path, denied_path)}")
+        print("   Refusing to ask for confirmation for this target.")
+        return False
+
     print(f"\n🗑️  Confirm Deletion")
     print("━" * 50)
     print(f"Path:        {path}")
@@ -180,6 +243,10 @@ def delete_path(path):
         (success, message)
     """
     try:
+        denied_path = get_high_risk_match(path)
+        if denied_path:
+            return (False, format_blocked_message(path, denied_path))
+
         path_obj = Path(path)
 
         if not path_obj.exists():
@@ -237,6 +304,17 @@ def main():
     if not paths:
         parser.print_help()
         return 1
+
+    # Block high-risk paths before sizing or confirmation.
+    allowed_paths = []
+    for path in paths:
+        denied_path = get_high_risk_match(path)
+        if denied_path:
+            print(f"⛔ {format_blocked_message(path, denied_path)}")
+        else:
+            allowed_paths.append(path)
+
+    paths = allowed_paths
 
     # Prepare items
     items = []

--- a/tests/test_macos_cleaner_safety.py
+++ b/tests/test_macos_cleaner_safety.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Regression tests for macos-cleaner safety checks."""
+
+import importlib.util
+import plistlib
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_script(name):
+    script_path = REPO_ROOT / 'macos-cleaner' / 'scripts' / f'{name}.py'
+    spec = importlib.util.spec_from_file_location(name, str(script_path))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+safe_delete = load_script('safe_delete')
+find_app_remnants = load_script('find_app_remnants')
+
+
+class SafeDeleteTests(unittest.TestCase):
+    def test_blocks_high_risk_descendants(self):
+        self.assertTrue(safe_delete.is_high_risk_path('/System/Library'))
+        success, message = safe_delete.delete_path('/System/Library')
+        self.assertFalse(success)
+        self.assertIn('BLOCKED', message)
+
+    def test_blocks_documented_system_paths(self):
+        for path in [
+            '/Library/Apple/System',
+            '/sbin/launchd',
+            '/private/var/db/example',
+        ]:
+            with self.subTest(path=path):
+                self.assertTrue(safe_delete.is_high_risk_path(path))
+
+    def test_blocks_credential_paths(self):
+        home = Path.home()
+        for path in [
+            home / '.ssh' / 'id_ed25519',
+            home / '.aws' / 'credentials',
+            home / '.gnupg' / 'private-keys-v1.d',
+            home / 'Library' / 'Keychains' / 'login.keychain-db',
+        ]:
+            with self.subTest(path=path):
+                self.assertTrue(safe_delete.is_high_risk_path(path))
+
+    def test_blocks_root_without_blocking_everything(self):
+        self.assertTrue(safe_delete.is_high_risk_path('/'))
+        self.assertFalse(safe_delete.is_high_risk_path('/tmp'))
+
+    def test_allows_temp_file_deletion(self):
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+        self.addCleanup(lambda: tmp_path.exists() and tmp_path.unlink())
+
+        success, message = safe_delete.delete_path(tmp_path)
+
+        self.assertTrue(success, message)
+        self.assertFalse(tmp_path.exists())
+
+    def test_confirm_delete_blocks_without_prompting(self):
+        with patch('builtins.input', side_effect=AssertionError('no prompt')):
+            with redirect_stdout(StringIO()) as output:
+                confirmed = safe_delete.confirm_delete(
+                    '/System/Library',
+                    0,
+                    'Directory',
+                )
+
+        self.assertFalse(confirmed)
+        self.assertIn('BLOCKED', output.getvalue())
+
+
+class AppRemnantTests(unittest.TestCase):
+    def test_reads_bundle_identifier_from_app_bundle(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            app_path = Path(tmpdir) / 'Example.app'
+            contents = app_path / 'Contents'
+            contents.mkdir(parents=True)
+            with (contents / 'Info.plist').open('wb') as f:
+                plistlib.dump({'CFBundleIdentifier': 'com.example.App'}, f)
+
+            self.assertEqual(
+                find_app_remnants.get_bundle_identifier(app_path),
+                'com.example.App',
+            )
+
+    def test_malformed_plist_does_not_abort_scan(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            app_path = Path(tmpdir) / 'Broken.app'
+            contents = app_path / 'Contents'
+            contents.mkdir(parents=True)
+            (contents / 'Info.plist').write_text('<plist><broken>', encoding='utf-8')
+
+            self.assertIsNone(find_app_remnants.get_bundle_identifier(app_path))
+
+    def test_bundle_identifier_prevents_false_orphan(self):
+        installed = {
+            'names': {'GitHub Desktop'},
+            'bundle_ids': {'com.github.GitHub'},
+        }
+
+        is_orphaned, confidence, reason = find_app_remnants.is_likely_orphaned(
+            'com.github.GitHub',
+            installed,
+        )
+
+        self.assertFalse(is_orphaned)
+        self.assertIsNone(confidence)
+        self.assertIn('bundle identifier', reason)
+
+    def test_short_bundle_identifier_does_not_protect_unrelated_dir(self):
+        installed = {
+            'names': set(),
+            'bundle_ids': {'com.ex'},
+        }
+
+        is_orphaned, confidence, reason = find_app_remnants.is_likely_orphaned(
+            'com.example.App',
+            installed,
+        )
+
+        self.assertTrue(is_orphaned)
+        self.assertEqual(confidence, 'medium')
+        self.assertEqual(reason, 'No matching application found')
+
+    def test_legacy_installed_app_name_set_still_matches(self):
+        is_orphaned, confidence, reason = find_app_remnants.is_likely_orphaned(
+            'GitHub Desktop',
+            {'GitHub Desktop'},
+        )
+
+        self.assertFalse(is_orphaned)
+        self.assertIsNone(confidence)
+        self.assertIn('Matches installed app', reason)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- block high-risk system and credential paths in safe_delete.py before confirmation and inside delete_path()
- read CFBundleIdentifier from installed .app bundles and use bundle IDs when deciding whether app remnants are orphaned
- document the hard-block rule, bump macos-cleaner to v1.1.1, and add regression tests

## Verification
- python3 -m unittest tests/test_macos_cleaner_safety.py
- python3 -m py_compile macos-cleaner/scripts/safe_delete.py macos-cleaner/scripts/find_app_remnants.py tests/test_macos_cleaner_safety.py
- uv run --with PyYAML python -m scripts.quick_validate ../../macos-cleaner
- uv run --with PyYAML python -m scripts.security_scan ../../macos-cleaner --verbose
- bash daymade-claude-code/marketplace-dev/scripts/check_marketplace.sh
- python3 macos-cleaner/scripts/safe_delete.py /System

Fixes #70