### PR TITLE
fix(wecom): address PR #95 review nits

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -182,7 +182,7 @@
       "description": "Audio processing suite covering the full speech pipeline: ASR transcription (Qwen3, StepFun), transcript error correction, structured meeting minutes generation, and TTS voice synthesis (StepFun). Install once for the complete audio workflow.",
       "source": "./daymade-audio",
       "strict": false,
-      "version": "1.2.2",
+      "version": "1.2.1",
       "category": "suite",
       "keywords": [
         "suite",
@@ -928,7 +928,7 @@
       "description": "Set up and send technical status notifications through WeCom (Enterprise WeChat) webhooks. Use this skill whenever the user needs to send notifications, alerts, backup completion reports, or status updates via WeCom; when they mention 企业微信, 企微机器人, webhook, or alerting; or when a message needs to be clear, unambiguous, and technically precise rather than vague or condescending.",
       "source": "./setup-notifications-via-wecom",
       "strict": false,
-      "version": "1.1.0",
+      "version": "1.0.0",
       "category": "developer-tools",
       "keywords": [
         "wecom",

--- a/setup-notifications-via-wecom/scripts/send_wecom.py
+++ b/setup-notifications-via-wecom/scripts/send_wecom.py
@@ -150,7 +150,7 @@ def main():
 
     if result.get("errcode") != 0:
         print(
-            f"WeCom returned an error: {result.get('errmsg')}",
+            f"WeCom returned an error: {result.get('errmsg', 'unknown error')}",
             file=sys.stderr,
         )
         sys.exit(1)


### PR DESCRIPTION
Address review nits from PR #95:

- Revert accidental `daymade-audio` version bump (`1.2.2` → `1.2.1`) that had no associated plugin changes.
- Set `setup-notifications-via-wecom` initial version to `1.0.0` instead of `1.1.0`.
- Handle missing `errmsg` in WeCom error response to avoid printing `"None"`.

🤖 Generated with [Claude Code](https://claude.com/code)
