### PR TITLE
feat(daymade-claude-code): add read-claude-web-conversation skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -123,10 +123,10 @@
     },
     {
       "name": "daymade-claude-code",
-      "description": "Claude Code operations suite that bundles session history recovery, interrupted-work continuation, plugin/skill troubleshooting, CLAUDE.md progressive disclosure optimization, statusline configuration, exported .txt repair, plugin marketplace development, multi-provider profile isolation for running Kimi/GLM/DeepSeek/StepFun/Anthropic in separate windows, and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
+      "description": "Claude Code operations suite that bundles session history recovery, interrupted-work continuation, plugin/skill troubleshooting, CLAUDE.md progressive disclosure optimization, statusline configuration, exported .txt repair, full web-conversation extraction from claude.ai, plugin marketplace development, multi-provider profile isolation for running Kimi/GLM/DeepSeek/StepFun/Anthropic in separate windows, and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
       "source": "./daymade-claude-code",
       "strict": false,
-      "version": "1.5.0",
+      "version": "1.6.0",
       "category": "suite",
       "keywords": [
         "suite",
@@ -137,7 +137,8 @@
         "troubleshooting",
         "marketplace-dev",
         "terminal-screenshot",
-        "usage-analyst"
+        "usage-analyst",
+        "web-conversation-export"
       ],
       "skills": [
         "./claude-code-history-files-finder",
@@ -149,7 +150,8 @@
         "./marketplace-dev",
         "./terminal-screenshot",
         "./claude-usage-analyst",
-        "./claude-switch-models-setup"
+        "./claude-switch-models-setup",
+        "./read-claude-web-conversation"
       ]
     },
     {

--- a/daymade-claude-code/read-claude-web-conversation/.security-scan-passed
+++ b/daymade-claude-code/read-claude-web-conversation/.security-scan-passed
@@ -1,0 +1,4 @@
+Security scan passed
+Scanned at: 2026-06-26T19:16:37.245952
+Tool: gitleaks + pattern-based validation
+Content hash: a401ff0da94ffc8b8d160b00f8172d7648a7e45f5b0e9b1763e4799248933c89

--- a/daymade-claude-code/read-claude-web-conversation/.security-scan-passed
+++ b/daymade-claude-code/read-claude-web-conversation/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-06-26T19:16:37.245952
+Scanned at: 2026-06-26T20:06:19.691905
 Tool: gitleaks + pattern-based validation
-Content hash: a401ff0da94ffc8b8d160b00f8172d7648a7e45f5b0e9b1763e4799248933c89
+Content hash: 93f09726a0b2c9774a17b09594855b5ab86d0da04f45e34de6a96ae7f09b9ffe

--- a/daymade-claude-code/read-claude-web-conversation/SKILL.md
+++ b/daymade-claude-code/read-claude-web-conversation/SKILL.md
@@ -92,15 +92,32 @@ const conv = await fetch(
   { headers: { accept: 'application/json' } }
 ).then(r => r.json());
 
-const msgs = conv.chat_messages || [];
-// Body is either top-level m.text or a content[] block array. Keep the non-text
-// blocks too — thinking / tool_use / tool_result carry real content (common in
-// Claude Code / agent conversations); dropping them holes out the transcript.
-const textOf = (m) => m.text || (m.content || []).map(b =>
+// tree=True returns the WHOLE message tree, including branches abandoned by edits
+// or regenerations. Walk the active path from the current leaf up its parents so
+// the transcript is the conversation as actually read — not dead branches in array
+// order. Falls back to raw order if these fields aren't present.
+const raw = conv.chat_messages || [];
+const byId = Object.fromEntries(raw.map(m => [m.uuid, m]));
+const path = [];
+for (let id = conv.current_leaf_message_uuid; id && byId[id]; id = byId[id].parent_message_uuid) {
+  path.unshift(byId[id]);
+}
+const msgs = path.length ? path : raw;          // fallback: leaf walk unavailable → raw order
+
+// A message can carry a top-level m.text AND a content[] array at once (agent turns:
+// thinking + tool_use blocks PLUS a final text answer). Build from content[] first so
+// nothing is dropped, then fold in m.text if not already there — never short-circuit
+// on m.text alone (that silently discards every block whenever m.text is set).
+const blockText = (b) =>
   b.text || b.thinking
   || (b.type === 'tool_use'    ? `[tool_use ${b.name || ''}] ${JSON.stringify(b.input || {})}` : '')
-  || (b.type === 'tool_result' ? `[tool_result] ${typeof b.content === 'string' ? b.content : JSON.stringify(b.content || '')}` : '')
-).filter(Boolean).join('\n');
+  || (b.type === 'tool_result' ? `[tool_result] ${typeof b.content === 'string' ? b.content : JSON.stringify(b.content || '')}` : '');
+const textOf = (m) => {
+  const blocks = (m.content || []).map(blockText).filter(Boolean);
+  const joined = blocks.join('\n');
+  if (m.text && !joined.includes(m.text)) return joined ? `${joined}\n${m.text}` : m.text;
+  return joined || m.text || '';
+};
 
 const transcript = msgs
   .map(m => `## ${m.sender === 'human' ? 'User' : 'Claude'}\n\n${textOf(m)}`)
@@ -132,15 +149,21 @@ larger risks hitting the truncation limit again.
 ## Gotchas
 
 - **`sender` values are `'human'` and `'assistant'`** (not `'user'`/`'claude'`).
-- **Text lives in `m.text` OR `m.content[].text`.** Older/streamed messages put
-  the body in a `content` block array; blocks may be `text`, `thinking`,
-  `tool_use`, or `tool_result`. The `textOf()` above keeps all of them — don't
-  simplify it back to `.text`-only or tool-heavy conversations export with holes.
-  If you get blank messages, inspect one raw: `Object.keys(msgs[0])` and
+- **A message can have `m.text` AND `m.content[]` at the same time.** Agent turns
+  often carry the final answer in `m.text` plus `thinking` / `tool_use` /
+  `tool_result` blocks in `content[]`. `textOf()` above builds from `content[]`
+  first and folds in `m.text` — do NOT reduce it to `m.text || (content…)`, which
+  short-circuits and silently drops every block whenever `m.text` is set. If a
+  message comes back blank, inspect one raw: `Object.keys(msgs[0])` and
   `msgs[0].content?.map(b => b.type)`.
 - **If `rendering_mode=raw` returns empty or short bodies, retry with
   `rendering_mode=messages`.** The two modes expose slightly different fields;
   `messages` is the usual fallback when `raw` looks incomplete.
+- **`tree=True` returns the whole tree, including abandoned edit/regeneration
+  branches.** The code walks the active path from `conv.current_leaf_message_uuid`
+  via `parent_message_uuid`, so dead branches don't leak into the transcript or
+  inflate the `messages` count. If a payload lacks those fields the walk falls back
+  to raw array order — correct for never-edited (single-chain) conversations.
 - **Multiple organizations:** `orgs[0]` may be the wrong one. If the conversation
   404s, list them — `orgs.map(o => ({ uuid: o.uuid, name: o.name }))` — and try
   the org whose name matches the user's account, or loop the fetch across orgs.

--- a/daymade-claude-code/read-claude-web-conversation/SKILL.md
+++ b/daymade-claude-code/read-claude-web-conversation/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: read-claude-web-conversation
+description: >-
+  Read or export the COMPLETE transcript of a Claude.ai web conversation (a
+  claude.ai/chat/... link) by driving the user's already-logged-in Chrome and
+  calling Claude.ai's own internal conversation API from inside the page. Use
+  this whenever the user pastes a claude.ai conversation link and asks to read,
+  summarize, export, or extract it — "read this Claude conversation", "what did
+  that other chat say", "导出这个网页版对话", "读一下这个 claude.ai 链接". Plain curl
+  / WebFetch FAIL (login-gated) and get_page_text returns only the last visible
+  message (Claude.ai uses virtual scrolling), so naive approaches silently lose
+  most of a long conversation — this skill returns every message. Scope: ONLINE
+  conversations on claude.ai. For LOCAL Claude Code session history
+  (~/.claude/projects/*.jsonl) use claude-code-history-files-finder; for an
+  already-exported .txt/.json file use claude-export-txt-better.
+---
+
+# Read Claude.ai Web Conversation
+
+Pull a Claude.ai **web** conversation into a full, structured transcript — every
+message, not just what is currently on screen.
+
+Verified against Claude.ai's web API as of June 2026. The endpoints below are the
+same private JSON API the Claude.ai front-end itself calls; they are not a
+documented/stable public API, so if a request 404s, re-derive the shape from the
+Network tab (see `references/claude-web-api-extraction.md`).
+
+## This skill vs. its siblings
+
+Pick by the *source you are holding*, not by the word "conversation":
+
+| Source | Use |
+|--------|-----|
+| A live **`claude.ai/chat/…`** URL (online, login-gated) | **This skill** |
+| Local Claude Code sessions (`~/.claude/projects/*.jsonl`) | `claude-code-history-files-finder` |
+| An already-exported `.txt` / `.json` conversation file | `claude-export-txt-better` |
+
+## Why the obvious approaches fail (read this first)
+
+Two traps make this deceptively hard, and both fail *silently* — they return
+partial data that looks complete, so you only notice the loss if you happen to
+know the conversation was longer:
+
+1. **Login wall.** `curl`, `WebFetch`, and headless browsers get an auth
+   redirect or an empty SPA shell. A Claude.ai conversation is private and gated
+   on the session cookie that lives in the user's logged-in Chrome. You have to
+   run inside *their* browser session.
+2. **Virtual scrolling.** Even with the conversation open, `get_page_text` and
+   DOM scraping only see the few messages currently rendered — often just the
+   last one. A 40-message thread comes back as 1. Programmatically scrolling to
+   force-render every message is slow, flaky, and order-fragile.
+
+**The reliable path:** open the conversation in the user's Chrome, then from
+*inside the page* `fetch` Claude.ai's own conversation JSON (the request inherits
+the login cookie automatically). One call returns the entire message tree.
+
+## Method
+
+### Step 1 — Load the browser tools
+
+Load the core claude-in-chrome set in one ToolSearch call:
+
+```
+ToolSearch: select:mcp__claude-in-chrome__tabs_context_mcp,mcp__claude-in-chrome__navigate,mcp__claude-in-chrome__javascript_tool
+```
+
+(No `get_page_text` / `read_page` needed — the API path bypasses the DOM.)
+
+### Step 2 — Open the conversation in the user's Chrome
+
+`tabs_context_mcp` with `{ "createIfEmpty": true }` to get a tab, then
+`navigate` that tab to the conversation URL. Confirm it loaded **logged-in**: the
+returned tab title should be the conversation's name, not "Log in" / "Claude".
+If it shows a login page, stop and tell the user to sign into claude.ai in Chrome
+first — do not try to automate the login.
+
+### Step 3 — Pull the full transcript via the internal API
+
+Run this with `mcp__claude-in-chrome__javascript_tool` (`action: javascript_exec`)
+on that tab. It executes in the page, so `fetch` carries the user's auth. It
+derives the conversation id from the open URL — **never hard-code an id**:
+
+```js
+// Runs inside the claude.ai page; fetch inherits the logged-in session cookie.
+const orgs = await fetch('/api/organizations', { headers: { accept: 'application/json' } })
+  .then(r => r.json());
+const org = orgs[0].uuid;                            // first org — see Gotchas if the user has several
+const convId = location.pathname.split('/').pop();  // from the open URL; do NOT hard-code
+
+const conv = await fetch(
+  `/api/organizations/${org}/chat_conversations/${convId}?tree=True&rendering_mode=raw`,
+  { headers: { accept: 'application/json' } }
+).then(r => r.json());
+
+const msgs = conv.chat_messages || [];
+// Body is either top-level m.text or a content[] block array. Keep the non-text
+// blocks too — thinking / tool_use / tool_result carry real content (common in
+// Claude Code / agent conversations); dropping them holes out the transcript.
+const textOf = (m) => m.text || (m.content || []).map(b =>
+  b.text || b.thinking
+  || (b.type === 'tool_use'    ? `[tool_use ${b.name || ''}] ${JSON.stringify(b.input || {})}` : '')
+  || (b.type === 'tool_result' ? `[tool_result] ${typeof b.content === 'string' ? b.content : JSON.stringify(b.content || '')}` : '')
+).filter(Boolean).join('\n');
+
+const transcript = msgs
+  .map(m => `## ${m.sender === 'human' ? 'User' : 'Claude'}\n\n${textOf(m)}`)
+  .join('\n\n');
+
+// Return a small summary + the first window of text (large returns get truncated — see Step 4).
+({ title: conv.name, messages: msgs.length, chars: transcript.length, text: transcript.slice(0, 14000) });
+```
+
+You now have the title, the exact message count, and the transcript. Use the
+count to verify completeness (it is the ground truth — if `get_page_text` earlier
+showed 1 message and this says 40, the API path just saved you 39).
+
+### Step 4 — Page through large conversations
+
+`javascript_tool` truncates very large return values, so a long transcript comes
+back cut off. The `chars` field from Step 3 tells you the true length. If
+`chars` exceeds what you received, re-run the snippet but return a later window —
+keep the fetch identical and only change the final line:
+
+```js
+// ... identical fetch + transcript build as Step 3 ...
+transcript.slice(14000, 32000);   // next window; repeat (32000, 50000) … until you've covered `chars`
+```
+
+Stitch the windows together in order. Prefer ~14–18k-char windows; going much
+larger risks hitting the truncation limit again.
+
+## Gotchas
+
+- **`sender` values are `'human'` and `'assistant'`** (not `'user'`/`'claude'`).
+- **Text lives in `m.text` OR `m.content[].text`.** Older/streamed messages put
+  the body in a `content` block array; blocks may be `text`, `thinking`,
+  `tool_use`, or `tool_result`. The `textOf()` above keeps all of them — don't
+  simplify it back to `.text`-only or tool-heavy conversations export with holes.
+  If you get blank messages, inspect one raw: `Object.keys(msgs[0])` and
+  `msgs[0].content?.map(b => b.type)`.
+- **If `rendering_mode=raw` returns empty or short bodies, retry with
+  `rendering_mode=messages`.** The two modes expose slightly different fields;
+  `messages` is the usual fallback when `raw` looks incomplete.
+- **Multiple organizations:** `orgs[0]` may be the wrong one. If the conversation
+  404s, list them — `orgs.map(o => ({ uuid: o.uuid, name: o.name }))` — and try
+  the org whose name matches the user's account, or loop the fetch across orgs.
+- **`/share/…` links are different.** A public share link is not login-gated and
+  has its own payload; try `get_page_text` or a plain fetch of the share JSON
+  first. The API path above is for private `/chat/…` conversations. (Not deeply
+  verified here — fall back to reading the rendered page if the share API shape
+  differs.)
+- **Just read — don't click.** This skill never needs to interact with the
+  conversation UI; avoid triggering navigation or dialogs mid-fetch.
+
+For the full reusable script (every block type, an automatic paging loop, and a
+markdown-file export variant) plus the response schema field-by-field, see
+[references/claude-web-api-extraction.md](references/claude-web-api-extraction.md).
+
+## Next Step
+
+Once you have the transcript, suggest the natural follow-up — opt-in, never
+automatic:
+
+```
+Got the full conversation (<N> messages, "<title>").
+
+Options:
+A) Clean it up — run transcript-fixer if it's ASR/garbled (only if relevant)
+B) Summarize / extract the decisions and action items
+C) Save it to a file — tell me where
+D) Nothing else — you just needed it read
+```

--- a/daymade-claude-code/read-claude-web-conversation/references/claude-web-api-extraction.md
+++ b/daymade-claude-code/read-claude-web-conversation/references/claude-web-api-extraction.md
@@ -1,0 +1,163 @@
+# Claude.ai Web Conversation — API Extraction Reference
+
+The complete, copy-pasteable version of the method in SKILL.md: the full export
+script, the response schema field-by-field, the paging strategy, and a
+troubleshooting table.
+
+All snippets here are meant to run **inside the claude.ai page** via
+`mcp__claude-in-chrome__javascript_tool` (`action: javascript_exec`), on a tab
+that has navigated to the conversation and is logged in. `fetch` inside the page
+inherits the session cookie, which is the whole reason this works where `curl`
+does not.
+
+## Table of contents
+
+- [Endpoints](#endpoints)
+- [Response schema](#response-schema)
+- [Full export script](#full-export-script)
+- [Paging long conversations](#paging-long-conversations)
+- [Saving to a file](#saving-to-a-file)
+- [Troubleshooting](#troubleshooting)
+
+## Endpoints
+
+These are the private JSON endpoints the Claude.ai front-end itself calls. They
+are not a documented or version-stable public API — treat them as "verified to
+work in June 2026", and if one 404s, open the Network tab on a working
+conversation and copy the current request.
+
+| Purpose | Request |
+|---------|---------|
+| List the organizations the logged-in user belongs to | `GET /api/organizations` |
+| Fetch one full conversation (all messages) | `GET /api/organizations/{orgUuid}/chat_conversations/{convId}?tree=True&rendering_mode=raw` |
+
+- `{orgUuid}` comes from `organizations[0].uuid` (see Troubleshooting for the
+  multi-org case).
+- `{convId}` is the last path segment of the open URL
+  (`location.pathname.split('/').pop()`), e.g. for
+  `https://claude.ai/chat/<id>` it is `<id>`.
+- `tree=True&rendering_mode=raw` returns the raw message bodies; this is the
+  variant verified to carry the complete text. If `raw` ever comes back with
+  empty/short bodies, retry with `rendering_mode=messages` — the two modes expose
+  slightly different fields.
+
+## Response schema
+
+Only the fields this skill relies on are listed; the payload contains more.
+
+**Conversation object**
+
+| Field | Meaning |
+|-------|---------|
+| `name` | Conversation title (the auto-generated or user-set name) |
+| `uuid` | Conversation id (matches `{convId}`) |
+| `chat_messages` | Array of message objects, in order |
+
+**Message object** (`chat_messages[i]`)
+
+| Field | Meaning |
+|-------|---------|
+| `sender` | `'human'` or `'assistant'` — note: NOT `'user'`/`'claude'` |
+| `text` | The message body as a plain string (present on most messages) |
+| `content` | Block array (present when `text` is empty). Each block has a `type`: `text`, `thinking`, `tool_use` (carries `name` + `input`), or `tool_result` (carries `content`) |
+
+The robust extractor keeps **every** block type — dropping `tool_use` /
+`thinking` would silently hole out agent / Claude-Code conversations:
+
+```js
+const blockToText = (b) =>
+  b.text || b.thinking
+  || (b.type === 'tool_use'    ? `[tool_use ${b.name || ''}] ${JSON.stringify(b.input || {})}` : '')
+  || (b.type === 'tool_result' ? `[tool_result] ${typeof b.content === 'string' ? b.content : JSON.stringify(b.content || '')}` : '');
+const textOf = (m) => m.text || (m.content || []).map(blockToText).filter(Boolean).join('\n');
+```
+
+## Full export script
+
+Fetches the conversation and assembles the entire transcript as markdown, both
+speakers and all block types included. Returns a summary plus the first window
+(large single returns get truncated by the tool — see paging next):
+
+```js
+// Run inside the claude.ai conversation page.
+const orgs = await fetch('/api/organizations', { headers: { accept: 'application/json' } })
+  .then(r => r.json());
+const org = orgs[0].uuid;                            // multi-org? see Troubleshooting
+const convId = location.pathname.split('/').pop();   // derive from URL; never hard-code
+
+const conv = await fetch(
+  `/api/organizations/${org}/chat_conversations/${convId}?tree=True&rendering_mode=raw`,
+  { headers: { accept: 'application/json' } }
+).then(r => r.json());
+
+const msgs = conv.chat_messages || [];
+const blockToText = (b) =>
+  b.text || b.thinking
+  || (b.type === 'tool_use'    ? `[tool_use ${b.name || ''}] ${JSON.stringify(b.input || {})}` : '')
+  || (b.type === 'tool_result' ? `[tool_result] ${typeof b.content === 'string' ? b.content : JSON.stringify(b.content || '')}` : '');
+const textOf = (m) => m.text || (m.content || []).map(blockToText).filter(Boolean).join('\n');
+
+// Cache the assembled transcript on the page so paging calls don't re-fetch.
+window.__claudeTranscript = msgs
+  .map(m => `## ${m.sender === 'human' ? 'User' : 'Claude'}\n\n${textOf(m)}`)
+  .join('\n\n');
+
+({
+  title: conv.name,
+  messages: msgs.length,
+  chars: window.__claudeTranscript.length,
+  text: window.__claudeTranscript.slice(0, 16000),
+});
+```
+
+`messages` is the ground-truth count — use it to confirm you got everything (and
+to show the user how much `get_page_text` would have missed).
+
+## Paging long conversations
+
+`javascript_tool` truncates very large return values. When `chars` is bigger
+than the `text` you received, pull the rest in windows. Because the script above
+cached the transcript on `window`, each follow-up call is a cheap slice with no
+re-fetch:
+
+```js
+window.__claudeTranscript.slice(16000, 32000);   // then (32000, 48000), (48000, 64000) …
+```
+
+Repeat until you've covered `chars`, then concatenate the windows in order.
+
+> Caching on `window` persists across `javascript_exec` calls **as long as the
+> tab isn't reloaded**. If a later call returns `undefined` (tab was navigated or
+> refreshed), just re-run the full export script — it's a single API round-trip —
+> or inline the fetch and change only the trailing `.slice(...)`, which is the
+> reload-proof fallback.
+
+Keep windows around 14–18k chars; much larger and you risk re-hitting the limit.
+
+## Saving to a file
+
+To hand the user a file instead of pasting the transcript into chat, return the
+full markdown in windows (as above), stitch them together in the main context,
+and write the result with the `Write` tool to a path the user names. Keep the
+`## User` / `## Claude` headers — they make the export readable and round-trip
+cleanly into other tools.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Only 1 (or a few) messages came back | You used `get_page_text` / DOM scraping; virtual scrolling only renders the tail | Switch to the API script above |
+| Auth redirect / empty shell / "Log in" title | Not running in the user's logged-in session (e.g. curl/headless), or they're signed out | Use the user's Chrome via claude-in-chrome; ask them to sign in if needed |
+| `404` on the conversation fetch | Wrong org, or wrong `convId` | List orgs: `(await fetch('/api/organizations').then(r=>r.json())).map(o=>({uuid:o.uuid,name:o.name}))`; verify `convId` against `location.pathname` |
+| 200 OK but bodies are empty/short | `rendering_mode=raw` doesn't expose the text for these messages | Retry the fetch with `rendering_mode=messages` |
+| Messages present but `text` empty | Body is in the `content[]` block array, not `text` | Use `textOf()` (handles every block type); inspect `msgs[0].content?.map(b=>b.type)` |
+| Return value looks cut off | Tool truncated a large response | Page it with `.slice()` windows |
+| It's a `/share/...` link | Public share payload differs from private `/chat/...` | Try `get_page_text` or fetch the share JSON directly; the private-conversation endpoint may not apply |
+
+## Sanitization note for maintainers
+
+This method was distilled from a real session that pulled private conversations.
+Everything user-specific (real names, conversation ids, org ids, business data,
+local paths) was stripped — ids are derived at runtime from the open URL, and the
+examples carry no real content. Keep it that way: this skill ships in a public
+marketplace.

--- a/daymade-claude-code/read-claude-web-conversation/references/claude-web-api-extraction.md
+++ b/daymade-claude-code/read-claude-web-conversation/references/claude-web-api-extraction.md
@@ -51,25 +51,33 @@ Only the fields this skill relies on are listed; the payload contains more.
 |-------|---------|
 | `name` | Conversation title (the auto-generated or user-set name) |
 | `uuid` | Conversation id (matches `{convId}`) |
-| `chat_messages` | Array of message objects, in order |
+| `current_leaf_message_uuid` | Tip of the active path — start here and walk `parent_message_uuid` to recover the live conversation |
+| `chat_messages` | All message nodes. Under `tree=True` this is the WHOLE tree (including abandoned edit/regen branches), NOT a linear reading order — reconstruct order via the leaf/parent walk |
 
 **Message object** (`chat_messages[i]`)
 
 | Field | Meaning |
 |-------|---------|
+| `uuid` / `parent_message_uuid` | This node's id and its parent — used to walk the active path |
 | `sender` | `'human'` or `'assistant'` — note: NOT `'user'`/`'claude'` |
-| `text` | The message body as a plain string (present on most messages) |
-| `content` | Block array (present when `text` is empty). Each block has a `type`: `text`, `thinking`, `tool_use` (carries `name` + `input`), or `tool_result` (carries `content`) |
+| `text` | Top-level body string. MAY coexist with `content[]` — an agent turn can have both a final-answer `text` AND a `content[]` of thinking/tool blocks — so do not treat `text` as authoritative on its own |
+| `content` | Block array. Each block has a `type`: `text`, `thinking`, `tool_use` (carries `name` + `input`), or `tool_result` (carries `content`) |
 
-The robust extractor keeps **every** block type — dropping `tool_use` /
-`thinking` would silently hole out agent / Claude-Code conversations:
+The robust extractor builds from `content[]` first and then folds in the top-level
+`text` — short-circuiting on `m.text` would silently drop every block whenever
+`m.text` is set (the common agent-turn shape):
 
 ```js
 const blockToText = (b) =>
   b.text || b.thinking
   || (b.type === 'tool_use'    ? `[tool_use ${b.name || ''}] ${JSON.stringify(b.input || {})}` : '')
   || (b.type === 'tool_result' ? `[tool_result] ${typeof b.content === 'string' ? b.content : JSON.stringify(b.content || '')}` : '');
-const textOf = (m) => m.text || (m.content || []).map(blockToText).filter(Boolean).join('\n');
+const textOf = (m) => {
+  const blocks = (m.content || []).map(blockToText).filter(Boolean);
+  const joined = blocks.join('\n');
+  if (m.text && !joined.includes(m.text)) return joined ? `${joined}\n${m.text}` : m.text;
+  return joined || m.text || '';
+};
 ```
 
 ## Full export script
@@ -90,12 +98,28 @@ const conv = await fetch(
   { headers: { accept: 'application/json' } }
 ).then(r => r.json());
 
-const msgs = conv.chat_messages || [];
+// tree=True returns the whole tree (incl. abandoned edit/regen branches). Walk the
+// active path from the current leaf up its parents; fall back to raw order if the
+// leaf/parent fields are absent.
+const raw = conv.chat_messages || [];
+const byId = Object.fromEntries(raw.map(m => [m.uuid, m]));
+const path = [];
+for (let id = conv.current_leaf_message_uuid; id && byId[id]; id = byId[id].parent_message_uuid) {
+  path.unshift(byId[id]);
+}
+const msgs = path.length ? path : raw;
+
 const blockToText = (b) =>
   b.text || b.thinking
   || (b.type === 'tool_use'    ? `[tool_use ${b.name || ''}] ${JSON.stringify(b.input || {})}` : '')
   || (b.type === 'tool_result' ? `[tool_result] ${typeof b.content === 'string' ? b.content : JSON.stringify(b.content || '')}` : '');
-const textOf = (m) => m.text || (m.content || []).map(blockToText).filter(Boolean).join('\n');
+// content[] first, then fold in m.text — never short-circuit on m.text alone.
+const textOf = (m) => {
+  const blocks = (m.content || []).map(blockToText).filter(Boolean);
+  const joined = blocks.join('\n');
+  if (m.text && !joined.includes(m.text)) return joined ? `${joined}\n${m.text}` : m.text;
+  return joined || m.text || '';
+};
 
 // Cache the assembled transcript on the page so paging calls don't re-fetch.
 window.__claudeTranscript = msgs
@@ -152,6 +176,7 @@ cleanly into other tools.
 | 200 OK but bodies are empty/short | `rendering_mode=raw` doesn't expose the text for these messages | Retry the fetch with `rendering_mode=messages` |
 | Messages present but `text` empty | Body is in the `content[]` block array, not `text` | Use `textOf()` (handles every block type); inspect `msgs[0].content?.map(b=>b.type)` |
 | Return value looks cut off | Tool truncated a large response | Page it with `.slice()` windows |
+| Transcript has duplicated / out-of-order / contradictory turns | The conversation was edited or regenerated; `tree=True` returned dead branches | Use the active-path walk (`current_leaf_message_uuid` → `parent_message_uuid`) from the export script — it drops dead branches and fixes ordering |
 | It's a `/share/...` link | Public share payload differs from private `/chat/...` | Try `get_page_text` or fetch the share JSON directly; the private-conversation endpoint may not apply |
 
 ## Sanitization note for maintainers


### PR DESCRIPTION
## What

Adds **`read-claude-web-conversation`** to the `daymade-claude-code` suite (bumps it to **1.6.0**).

It pulls the **complete** transcript of a Claude.ai web conversation (`claude.ai/chat/…`) by driving the user's already-logged-in Chrome and calling Claude.ai's own internal conversation API from inside the page.

## Why

Two obvious approaches fail *silently* on web conversations — they return partial data that looks complete:

- `curl` / `WebFetch` → login wall (conversations are private, gated on the session cookie in the user's Chrome)
- `get_page_text` / DOM scraping → returns only the last message (Claude.ai uses virtual scrolling, so a 40-message thread comes back as 1)

Running `fetch` *inside the logged-in page* sidesteps both: the request inherits the session cookie, and the conversation API returns the entire message tree in one call.

## Where it fits

Completes the three conversation-source readers in the suite:

| Source you have | Skill |
|-----------------|-------|
| Live `claude.ai/chat/…` (online) | **read-claude-web-conversation** _(new)_ |
| Local Claude Code sessions (`~/.claude/projects/*.jsonl`) | `claude-code-history-files-finder` |
| An exported `.txt` / `.json` file | `claude-export-txt-better` |

## Notes

- `SKILL.md` + `references/claude-web-api-extraction.md` (full script, response schema, paging strategy, troubleshooting table).
- Handles every message block type (text / thinking / tool_use / tool_result), large-response paging, multi-org accounts, and the `rendering_mode=messages` fallback.
- Validated (skill structure + security scan); no secrets / PII; conversation ids are derived at runtime from the open URL (never hard-coded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177kBsKH8fXi51UGaCy7qoh
