### PR TITLE
fix(feishu-doc-scraper): correct cells-get CSV behavior for lark-cli 1.0.55 (v1.2.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -306,7 +306,7 @@
       "description": "Extract Feishu (Lark) Docs, Wiki pages, Wiki collections/hubs, spreadsheets, and Minutes (妙记) transcripts into clean high-fidelity local Markdown. The primary path is the lark-cli API — programmatic extraction with no LLM rewriting of the body — which recursively follows a collection's reference graph (mention-doc / sheet / cross-tenant links) and uses error codes to resolve permission boundaries precisely; a browser-DOM path is the fallback only when lark-cli cannot reach the content. Use this whenever the source is a Feishu/Lark URL and fidelity matters — including 导出飞书文档/合集/妙记转写, 把飞书 wiki/知识库转 markdown, scraping or archiving a Feishu collection, exporting a Feishu Minutes/妙记 transcript, or saving a Feishu page locally — even if the user only says clipping, archiving, converting, or \"save this\". Also covers the permission-denied path (owner-exported .docx → faithful Markdown with heading/highlight restoration).",
       "source": "./feishu-doc-scraper",
       "strict": false,
-      "version": "1.2.0",
+      "version": "1.2.1",
       "category": "productivity",
       "keywords": [
         "feishu",

--- a/feishu-doc-scraper/references/lark-cli-api-extraction.md
+++ b/feishu-doc-scraper/references/lark-cli-api-extraction.md
@@ -97,13 +97,15 @@ A `<sheet token="<SP>_<SID>"/>` tag (or a `…/sheets/<SP>` URL) carries the spr
 lark-cli sheets +info --spreadsheet-token <SP> \
   --jq '(.data.sheets.sheets // .data.sheets)[]? | {sheet_id, title}'
 
-# read one tab. 1.0.55 uses +cells-get with --format csv (clean CSV straight out):
-lark-cli sheets +cells-get --spreadsheet-token <SP> --sheet-id <SID> \
-  --range A1:AZ800 --format csv > "<tab-title>.csv"
+# read one tab. ⚠️ `--format csv` does NOT emit CSV for cells-get (verified 1.0.55) —
+# it returns a JSON cell grid (.data.ranges[].cells[][].value) regardless. Convert with jq:
+lark-cli sheets +cells-get --spreadsheet-token <SP> --sheet-id <SID> --range A1:AZ800 \
+  | jq -r '.data.ranges[0].cells[] | map(.value // "" | tostring) | @csv' > "<tab-title>.csv"
 ```
 
+- The cell grid carries border/style objects too; `.value` is the text, empty cells are `{}` → `.value // ""`. `tostring` guards numeric cells.
 - A tab `title` can contain newlines (`\n`); strip them (`tr -d '\n\r'`) before using it as a filename.
-- `--format csv` writes ready-to-file CSV; if you need a Markdown table instead, render the CSV. Size `--range` generously (`A1:AZ800`) — an over-wide range just returns the populated cells, while an under-sized one silently truncates rows.
+- **Check `.data.has_more`** — cells-get caps one response at ~4000–6000 cells (~200 rows); if `has_more:true` the grid was truncated — page with a smaller range / offset. `.data.ranges[0].actual_range` reports what you actually got.
 - Older builds exposed this as `sheets +read … --value-render-option ToString --jq '.data.valueRange.values'` (a 2-D array). If `+cells-get` is absent on your version, fall back to `+read`.
 
 ## Step 5: the reference-graph recursion (collections/hubs)


### PR DESCRIPTION
## What
Correct the lark-cli 1.0.55 `sheets +cells-get` documentation in feishu-doc-scraper, and bump to v1.2.1.

## Why
`--format csv` does not actually emit CSV for `cells-get` (verified on 1.0.55) — it returns a JSON cell grid regardless. The reference now shows the correct `jq` conversion and adds a `.data.has_more` pagination check (cells-get caps ~4000-6000 cells per response).

## Changes
- `references/lark-cli-api-extraction.md`: corrected cells-get usage + pagination note
- `marketplace.json`: feishu-doc-scraper 1.2.0 → 1.2.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)