### PR TITLE
feat(codex-image-gallery): add skill + sync doc baseline to 71 skills (v1.69.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional Claude Code skills marketplace — production-ready skills spanning GitHub and git operations, document conversion and generation (Markdown, PDF, PPTX, DOCX), diagram and UI-design extraction, the full audio pipeline (ASR transcription, TTS, transcript correction, meeting minutes), financial and investment-research data, web scraping and content capture, security/PII tooling and secure repomix packaging, macOS and iOS development, CLI demo and terminal automation, prompt and skill engineering, deep research and fact-checking, QA and LLM-evaluation infrastructure, internationalization, network/Tailscale and remote-desktop diagnostics, and Claude Code operations (session recovery, CLAUDE.md optimization, statusline, multi-provider profile isolation, troubleshooting, marketplace development, repo health-check). Suite plugins (daymade-audio, daymade-claude-code, daymade-docs, daymade-skill) bundle related skills under shared namespaces, including the StepFun StepAudio 2.5 audio family. See the Available Skills list in the README for the authoritative per-skill breakdown.",
-    "version": "1.68.0"
+    "version": "1.69.0"
   },
   "plugins": [
     {
@@ -979,6 +979,24 @@
         "force-push",
         "cleanup",
         "claude-code"
+      ]
+    },
+    {
+      "name": "codex-image-gallery",
+      "description": "Start or reuse a self-contained local web gallery for browsing Codex-generated images. Use when the user asks to browse Codex generated images, open a local image gallery, inspect ~/.codex/generated_images, view a Codex image output folder, or browse image files produced by Codex.",
+      "source": "./codex-image-gallery",
+      "strict": false,
+      "version": "1.0.0",
+      "category": "utilities",
+      "keywords": [
+        "codex",
+        "generated-images",
+        "image-gallery",
+        "local-server",
+        "browser",
+        "generated_images",
+        "gpt-image",
+        "image-review"
       ]
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.69.0] - 2026-06-27
+
+### Added
+- **codex-image-gallery** v1.0.0: new self-contained skill for browsing Codex-generated images in a local web gallery. Bundles `scripts/server.mjs` and `assets/index.html`; scans `~/.codex/generated_images` by default; supports `GALLERY_ROOT`, `PORT`, and `HOST`; serves a dynamic `/api/images` index and protected `/images/<relative-path>` image routes.
+
+### Changed
+- Updated marketplace skills count from 70 to 71.
+- Updated marketplace plugin entry count from 49 to 50.
+- Updated marketplace version from 1.68.0 to 1.69.0.
+- Updated README.md / README.zh-CN.md badges and skill lists to include `codex-image-gallery`.
+- Backfilled existing doc-list drift for `read-claude-web-conversation`, `setup-notifications-via-wecom`, `notify-wecom`, and `github-sensitive-data-cleanup` so the human-facing lists match `marketplace.json`.
+- Updated CLAUDE.md repository overview count, marketplace plugin count, and Available Skills list.
+
 ## [1.67.0] - 2026-06-24
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository Overview
 
-This is a Claude Code skills marketplace containing 66 production-ready skills organized in a plugin marketplace structure. Most plugins expose one skill for narrow installs; suite plugins expose related skills under shared namespaces for combined installation workflows.
+This is a Claude Code skills marketplace containing 71 production-ready skills organized in a plugin marketplace structure. Most plugins expose one skill for narrow installs; suite plugins expose related skills under shared namespaces for combined installation workflows.
 
 **Essential Skill**: `skill-creator` is the most important skill in this marketplace - it's a meta-skill that enables users to create their own skills. Always recommend it first for users interested in extending Claude Code.
 
@@ -153,7 +153,7 @@ If it fires, fix the issue — do NOT use `--no-verify` to bypass.
 ## Marketplace Configuration
 
 The marketplace is configured in `.claude-plugin/marketplace.json`:
-- Contains 46 plugin entries: single-skill plugins point `source` directly at the skill directory (no `skills` field); suite plugins (`daymade-audio`, `daymade-claude-code`, `daymade-docs`, `daymade-skill`) use explicit `skills` arrays for multi-skill routing
+- Contains 50 plugin entries: single-skill plugins point `source` directly at the skill directory (no `skills` field); suite plugins (`daymade-audio`, `daymade-claude-code`, `daymade-docs`, `daymade-skill`) use explicit `skills` arrays for multi-skill routing
 - Each plugin has: name, description, source, version, category, keywords
 - Marketplace metadata: name, owner, version
 - Single-skill plugins follow the official pattern (167/168 plugins in `anthropics/claude-plugins-official`): `source` points to skill directory, `skills` omitted
@@ -265,6 +265,11 @@ This applies when you change ANY file under a skill directory:
 64. **marketplace-health-check** - Run a full 6-dimension health check of this skills marketplace repo (code/script safety, doc/SSOT consistency, security/PII, open-PR triage, open-issue triage, marketplace integrity) via a parallel fan-out Dynamic Workflow, then Counter-Review the serious findings and report by priority
 65. **claude-switch-models-setup** - Set up multiple isolated Claude Code CLI profiles so students and power users can run different LLM providers (Kimi, GLM, DeepSeek, StepFun, Anthropic) in separate terminal windows at the same time (daymade-claude-code suite member)
 66. **llm-eval-harness** - Evaluate any LLM behind an OpenAI- or Anthropic-compatible endpoint across four dimensions (speed with thinking-aware tok/s, concurrency/stability, Anthropic protocol compliance, and quality regression against your own use cases via blind judges); keys passed by env-var name only, use-case library kept outside the bundle
+67. **read-claude-web-conversation** - Extract full Claude.ai web conversations through the daymade-claude-code suite for recovery, audit, archival, or migration
+68. **setup-notifications-via-wecom** - Set up reusable WeCom / Enterprise WeChat webhook notifications for status reports, alerts, and completion messages
+69. **notify-wecom** - Send a single one-off WeCom group-bot message without setting up a reusable notification workflow
+70. **github-sensitive-data-cleanup** - Scan and remove secrets, API keys, private domains/IPs, and PII from GitHub repository history with force-push safety gates
+71. **codex-image-gallery** - Start a self-contained local web gallery for browsing Codex-generated images from `~/.codex/generated_images` or a custom `GALLERY_ROOT`
 
 **Recommendation**: Always suggest `skill-creator` first for users interested in creating skills or extending Claude Code.
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@
 [![简体中文](https://img.shields.io/badge/语言-简体中文-red)](./README.zh-CN.md)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Skills](https://img.shields.io/badge/skills-66-blue.svg)](https://github.com/daymade/claude-code-skills)
-[![Version](https://img.shields.io/badge/version-1.67.0-green.svg)](https://github.com/daymade/claude-code-skills)
+[![Skills](https://img.shields.io/badge/skills-71-blue.svg)](https://github.com/daymade/claude-code-skills)
+[![Version](https://img.shields.io/badge/version-1.69.0-green.svg)](https://github.com/daymade/claude-code-skills)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-2.0.13+-purple.svg)](https://claude.com/code)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./CONTRIBUTING.md)
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/daymade/claude-code-skills/graphs/commit-activity)
 
 </div>
 
-Professional Claude Code skills marketplace featuring 66 production-ready skills for enhanced development workflows.
+Professional Claude Code skills marketplace featuring 71 production-ready skills for enhanced development workflows.
 
 ## 📑 Table of Contents
 
@@ -2685,6 +2685,95 @@ uv run --with aiohttp python scripts/concurrency_probe.py \
 📚 **Documentation**: See [llm-eval-harness/references/evaluation_disciplines.md](./llm-eval-harness/references/evaluation_disciplines.md) for the reasoning behind each discipline and [llm-eval-harness/references/quality_blind_judge.md](./llm-eval-harness/references/quality_blind_judge.md) for the blind-judge method.
 
 **Requirements**: Python 3.8+, `uv`; `openai` and `aiohttp` (auto-installed via `uv run --with`); an API key for the endpoint under test. Optionally composes with **promptfoo-evaluation** for rubric-based gating.
+
+---
+
+### 69. **read-claude-web-conversation** - Extract Claude.ai Web Conversations
+
+> **Install**: `claude plugin install daymade-claude-code@daymade-skills` (suite-only — invoked as `daymade-claude-code:read-claude-web-conversation`)
+
+Extract full Claude.ai web conversation content through the Claude Code operations suite when local browser/export paths are needed for recovery, auditing, or migration.
+
+**When to use:**
+- Reading a Claude.ai web conversation that is not available in local Claude Code logs
+- Recovering a full web thread for handoff, audit, or archival
+- Comparing browser-visible content with exported or local session artifacts
+
+**Requirements**: Installed `daymade-claude-code` suite and access to the relevant browser/session context.
+
+---
+
+### 70. **setup-notifications-via-wecom** - Reusable WeCom Notification Setup
+
+```bash
+claude plugin install setup-notifications-via-wecom@daymade-skills
+```
+
+Set up reusable WeCom (Enterprise WeChat) webhook notifications for technical status reports, alerts, and completion messages.
+
+**When to use:**
+- Configuring a reusable 企业微信 / WeCom notification channel
+- Sending structured status notifications, backup reports, or alerts
+- Turning a one-off webhook into a repeatable notification workflow
+
+**Requirements**: WeCom bot webhook URL and shell access.
+
+---
+
+### 71. **notify-wecom** - One-Off WeCom Message
+
+```bash
+claude plugin install notify-wecom@daymade-skills
+```
+
+Send a single WeCom group-bot message without setting up a reusable notification workflow.
+
+**When to use:**
+- `/notify-wecom`
+- 临时发一条企业微信 / 企微通知一下
+- One-shot alerts that do not need templates or persistent setup
+
+**Requirements**: WeCom bot webhook URL.
+
+---
+
+### 72. **github-sensitive-data-cleanup** - GitHub Sensitive Data Cleanup
+
+```bash
+claude plugin install github-sensitive-data-cleanup@daymade-skills
+```
+
+Scan and remove sensitive data from GitHub repository history, with backup, visibility checks, and force-push safety gates.
+
+**When to use:**
+- A repo leaked secrets, private domains/IPs, API keys, or PII
+- Cleaning git history before or after a public exposure
+- Verifying safety before any force push to a public repository
+
+**Requirements**: `git`, GitHub access, and the relevant scanning/history-rewrite tools for the target repository.
+
+---
+
+### 73. **codex-image-gallery** - Local Browser for Codex Generated Images
+
+```bash
+claude plugin install codex-image-gallery@daymade-skills
+```
+
+Start a self-contained local web gallery for Codex-generated image outputs. The skill bundles its Node server and HTML UI, scans `~/.codex/generated_images` by default, and can point at another folder with `GALLERY_ROOT`.
+
+**When to use:**
+- Browsing Codex generated images in a local UI
+- Inspecting `~/.codex/generated_images`
+- Reviewing a custom image output directory with search, batches, and image detail view
+
+**Key features:**
+- Bundled `scripts/server.mjs` and `assets/index.html`
+- Dynamic `/api/images` scan; no hardcoded manifest
+- `/images/<relative-path>` image route with path traversal protection
+- Optional `GALLERY_ROOT`, `PORT`, and `HOST`
+
+**Requirements**: Node.js 18+ and access to the image folder.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,15 +6,15 @@
 [![简体中文](https://img.shields.io/badge/语言-简体中文-red)](./README.zh-CN.md)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Skills](https://img.shields.io/badge/skills-66-blue.svg)](https://github.com/daymade/claude-code-skills)
-[![Version](https://img.shields.io/badge/version-1.67.0-green.svg)](https://github.com/daymade/claude-code-skills)
+[![Skills](https://img.shields.io/badge/skills-71-blue.svg)](https://github.com/daymade/claude-code-skills)
+[![Version](https://img.shields.io/badge/version-1.69.0-green.svg)](https://github.com/daymade/claude-code-skills)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-2.0.13+-purple.svg)](https://claude.com/code)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./CONTRIBUTING.md)
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/daymade/claude-code-skills/graphs/commit-activity)
 
 </div>
 
-专业的 Claude Code 技能市场，提供 66 个生产就绪的技能，用于增强开发工作流。
+专业的 Claude Code 技能市场，提供 71 个生产就绪的技能，用于增强开发工作流。
 
 ## 📑 目录
 
@@ -2727,6 +2727,95 @@ uv run --with aiohttp python scripts/concurrency_probe.py \
 📚 **文档**：参见 [llm-eval-harness/references/evaluation_disciplines.md](./llm-eval-harness/references/evaluation_disciplines.md) 了解每条纪律背后的推理，以及 [llm-eval-harness/references/quality_blind_judge.md](./llm-eval-harness/references/quality_blind_judge.md) 了解独立盲审质量方法。
 
 **要求**：Python 3.8+、`uv`；`openai` 和 `aiohttp`（通过 `uv run --with` 自动安装）；被测端点的 API key。可与 **promptfoo-evaluation** 组合，用于基于 rubric 的门控。
+
+---
+
+### 69. **read-claude-web-conversation** - 提取 Claude.ai 网页会话
+
+> **安装**：`claude plugin install daymade-claude-code@daymade-skills`（套件专用——通过 `daymade-claude-code:read-claude-web-conversation` 调用）
+
+通过 Claude Code operations 套件提取 Claude.ai 网页会话全文，用于恢复、审计、归档或迁移。
+
+**使用场景：**
+- 需要读取本地 Claude Code 日志里没有的 Claude.ai 网页会话
+- 为交接、审计或归档恢复完整网页线程
+- 对比浏览器可见内容、导出文件和本地 session artifact
+
+**要求**：已安装 `daymade-claude-code` 套件，并能访问相关浏览器/session 上下文。
+
+---
+
+### 70. **setup-notifications-via-wecom** - 可复用企微通知配置
+
+```bash
+claude plugin install setup-notifications-via-wecom@daymade-skills
+```
+
+配置可复用的企业微信/WeCom webhook 通知，用于技术状态报告、告警和任务完成消息。
+
+**使用场景：**
+- 配置可复用的企业微信 / WeCom 通知通道
+- 发送结构化状态通知、备份报告或告警
+- 把一次性 webhook 变成可复用通知流程
+
+**要求**：企业微信机器人 webhook URL 和 shell 环境。
+
+---
+
+### 71. **notify-wecom** - 发送一次性企微消息
+
+```bash
+claude plugin install notify-wecom@daymade-skills
+```
+
+发送单条企业微信群机器人消息，不建立可复用通知工作流。
+
+**使用场景：**
+- `/notify-wecom`
+- 临时发一条企业微信 / 企微通知一下
+- 不需要模板或持久配置的一次性提醒
+
+**要求**：企业微信机器人 webhook URL。
+
+---
+
+### 72. **github-sensitive-data-cleanup** - GitHub 敏感数据清理
+
+```bash
+claude plugin install github-sensitive-data-cleanup@daymade-skills
+```
+
+扫描并清理 GitHub 仓库历史里的敏感数据，带备份、可见性检查和 force-push 安全门。
+
+**使用场景：**
+- 仓库泄露了 secrets、私有域名/IP、API key 或 PII
+- 公开暴露前后需要清理 git 历史
+- 对公共仓库 force push 前做安全验证
+
+**要求**：`git`、GitHub 访问权限，以及目标仓库所需的扫描/历史重写工具。
+
+---
+
+### 73. **codex-image-gallery** - Codex 生成图片本地浏览器
+
+```bash
+claude plugin install codex-image-gallery@daymade-skills
+```
+
+启动一个自包含的本地网页 gallery 浏览 Codex 生成图片。Skill 自带 Node server 和 HTML UI，默认扫描 `~/.codex/generated_images`，也可用 `GALLERY_ROOT` 指向其他目录。
+
+**使用场景：**
+- 用本地 UI 浏览 Codex 生成图片
+- 查看 `~/.codex/generated_images`
+- 用搜索、批次分组和详情视图检查自定义图片输出目录
+
+**主要功能：**
+- 内置 `scripts/server.mjs` 和 `assets/index.html`
+- 动态 `/api/images` 扫描，不维护手写 manifest
+- `/images/<relative-path>` 图片路由带路径穿越保护
+- 支持可选 `GALLERY_ROOT`、`PORT`、`HOST`
+
+**要求**：Node.js 18+，并能访问目标图片目录。
 
 ---
 

--- a/codex-image-gallery/.security-scan-passed
+++ b/codex-image-gallery/.security-scan-passed
@@ -1,0 +1,4 @@
+Security scan passed
+Scanned at: 2026-06-28T11:31:05.545773
+Tool: gitleaks + pattern-based validation
+Content hash: 89d30f2459796df12b29a92ac1b6c59948cdbcb9ba164b44bf38cebb9efa60b8

--- a/codex-image-gallery/SKILL.md
+++ b/codex-image-gallery/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: codex-image-gallery
+description: Start or reuse a self-contained local web gallery for browsing Codex-generated images. Use when the user asks to browse Codex generated images, open a local image gallery, inspect ~/.codex/generated_images, view a Codex image output folder, or browse image files produced by Codex.
+---
+
+# Codex Image Gallery
+
+Start a local browser gallery for Codex image outputs. This skill is self-contained: the server lives in `scripts/server.mjs`, and the UI template lives in `assets/index.html`.
+
+## Quick Start
+
+Run commands from this skill directory, the directory containing this `SKILL.md`.
+
+```bash
+node scripts/server.mjs
+```
+
+The server prints the actual URL. It starts at `http://127.0.0.1:8765/` and tries later ports if the default is occupied.
+
+## Workflow
+
+1. Check the default URL first:
+
+   ```bash
+   node -e 'fetch("http://127.0.0.1:8765/api/images").then(r => r.json()).then(j => console.log(j.rootPath, j.items.length)).catch(() => process.exit(1))'
+   ```
+
+   If this succeeds, reuse the running server at `http://127.0.0.1:8765/`.
+
+2. If the API check fails, check for a running server process:
+
+   ```bash
+   pgrep -fl 'node .*server\.mjs' || true
+   ```
+
+   When a process exists but the default URL fails, inspect its stdout or try likely later ports because the server auto-increments when a port is occupied.
+
+3. Verify any reused URL before reporting success:
+
+   ```bash
+   node -e 'fetch("http://127.0.0.1:8765/api/images").then(r => r.json()).then(j => console.log(j.rootPath, j.items.length))'
+   ```
+
+   If the server chose another port, use that port.
+
+4. Start the server if none is running:
+
+   ```bash
+   node scripts/server.mjs
+   ```
+
+   Keep the process running for the user and read stdout for the URL.
+
+5. Open the browser unless the user asks for URL-only:
+
+   ```bash
+   open http://127.0.0.1:8765/
+   ```
+
+## Image Root
+
+Default image root:
+
+```text
+~/.codex/generated_images
+```
+
+Use a different folder with:
+
+```bash
+GALLERY_ROOT=/path/to/images node scripts/server.mjs
+```
+
+## Validation
+
+Before declaring the skill healthy after edits, run:
+
+```bash
+node --check scripts/server.mjs
+```
+
+Then start the server and verify:
+
+- `GET /api/images` returns JSON with `rootPath` and `items`
+- `/images/<relative-path>` returns image content for at least one listed item
+- The page loads from the bundled `assets/index.html`
+
+## Response
+
+Report the URL, image root, whether the server was reused or newly started, and any verification failure. Keep the answer short.

--- a/codex-image-gallery/agents/openai.yaml
+++ b/codex-image-gallery/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Codex Image Gallery"
+  short_description: "Browse Codex generated images locally"
+  default_prompt: "Use $codex-image-gallery to open a local browser for Codex generated images."

--- a/codex-image-gallery/assets/index.html
+++ b/codex-image-gallery/assets/index.html
@@ -1,0 +1,1387 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Codex Images</title>
+  <style>
+    :root {
+      --ink: #171512;
+      --ink-2: #23211b;
+      --paper: #f3efe4;
+      --paper-2: #e5ddcd;
+      --muted: #8c877a;
+      --line: #3a362c;
+      --line-soft: rgba(23, 21, 18, 0.14);
+      --acid: #d8ff45;
+      --ember: #ff6b35;
+      --aqua: #68c7bd;
+      --shadow: 0 20px 50px rgba(0, 0, 0, 0.32);
+      --card-min: 236px;
+      --radius: 6px;
+      color-scheme: dark;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html {
+      min-height: 100%;
+      background: var(--ink);
+      color: var(--paper);
+      font-family: "Avenir Next", "Helvetica Neue", sans-serif;
+    }
+
+    body {
+      min-height: 100vh;
+      margin: 0;
+      background:
+        linear-gradient(116deg, rgba(216, 255, 69, 0.12), transparent 29%),
+        linear-gradient(242deg, rgba(104, 199, 189, 0.11), transparent 34%),
+        repeating-linear-gradient(0deg, rgba(255, 255, 255, 0.035) 0 1px, transparent 1px 18px),
+        repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.025) 0 1px, transparent 1px 18px),
+        var(--ink);
+      background-attachment: fixed;
+    }
+
+    button,
+    input,
+    select {
+      font: inherit;
+    }
+
+    button,
+    a.button {
+      min-height: 38px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--paper);
+      color: var(--ink);
+      cursor: pointer;
+      text-decoration: none;
+      transition: transform 140ms ease, border-color 140ms ease, box-shadow 140ms ease, background 140ms ease;
+    }
+
+    button:hover,
+    a.button:hover {
+      border-color: var(--acid);
+      box-shadow: 0 0 0 2px rgba(216, 255, 69, 0.28);
+      transform: translateY(-1px);
+    }
+
+    button:focus-visible,
+    a:focus-visible,
+    input:focus-visible,
+    select:focus-visible {
+      outline: 2px solid var(--acid);
+      outline-offset: 2px;
+    }
+
+    .shell {
+      display: grid;
+      grid-template-columns: minmax(248px, 304px) minmax(0, 1fr);
+      min-height: 100vh;
+    }
+
+    .rail {
+      position: sticky;
+      top: 0;
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+      gap: 18px;
+      padding: 24px 20px;
+      border-right: 1px solid rgba(255, 255, 255, 0.12);
+      background:
+        linear-gradient(180deg, rgba(35, 33, 27, 0.95), rgba(18, 17, 14, 0.95)),
+        var(--ink);
+      backdrop-filter: blur(18px);
+      box-shadow: 16px 0 50px rgba(0, 0, 0, 0.25);
+    }
+
+    .eyebrow {
+      margin: 0 0 8px;
+      color: var(--aqua);
+      font-size: 10px;
+      font-weight: 800;
+      letter-spacing: 0;
+      text-transform: uppercase;
+    }
+
+    h1 {
+      margin: 0;
+      font-family: "DIN Condensed", "Avenir Next Condensed", "Helvetica Neue", sans-serif;
+      font-size: clamp(40px, 4.8vw, 62px);
+      font-weight: 900;
+      line-height: 0.9;
+      letter-spacing: 0;
+      text-transform: uppercase;
+    }
+
+    .root-path {
+      margin: 10px 0 0;
+      color: var(--muted);
+      font-size: 11px;
+      line-height: 1.45;
+      overflow-wrap: anywhere;
+    }
+
+    .stat-grid {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 10px;
+    }
+
+    .stat {
+      position: relative;
+      min-height: 66px;
+      padding: 11px;
+      border: 1px solid rgba(255, 255, 255, 0.13);
+      border-radius: var(--radius);
+      background: linear-gradient(180deg, rgba(255, 255, 255, 0.075), rgba(255, 255, 255, 0.032));
+      overflow: hidden;
+    }
+
+    .stat::before {
+      content: "";
+      position: absolute;
+      inset: 0 auto auto 0;
+      width: 100%;
+      height: 2px;
+      background: linear-gradient(90deg, var(--acid), transparent 78%);
+      opacity: 0.7;
+    }
+
+    .stat dt {
+      margin: 0 0 7px;
+      color: var(--muted);
+      font-size: 10px;
+      font-weight: 800;
+      text-transform: uppercase;
+    }
+
+    .stat dd {
+      margin: 0;
+      color: var(--paper);
+      font-family: "DIN Alternate", "Avenir Next Condensed", sans-serif;
+      font-size: 27px;
+      font-weight: 800;
+      line-height: 1;
+    }
+
+    .rail-actions {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 10px;
+    }
+
+    .rail-actions button,
+    .rail-actions a {
+      display: grid;
+      place-items: center;
+      padding: 0 12px;
+      font-size: 13px;
+      font-weight: 800;
+    }
+
+    .source-note {
+      margin: auto 0 0;
+      color: var(--muted);
+      font-size: 11px;
+      line-height: 1.55;
+    }
+
+    .workspace {
+      min-width: 0;
+      padding: 24px;
+    }
+
+    .toolbar {
+      position: sticky;
+      top: 0;
+      z-index: 5;
+      display: grid;
+      grid-template-columns: minmax(220px, 1fr) 164px 126px;
+      gap: 12px;
+      padding: 0 0 14px;
+      background: linear-gradient(to bottom, rgba(23, 21, 18, 0.99) 72%, rgba(23, 21, 18, 0));
+    }
+
+    .search,
+    .select {
+      height: 44px;
+      border: 1px solid rgba(255, 255, 255, 0.16);
+      border-radius: var(--radius);
+      background: rgba(255, 255, 255, 0.095);
+      color: var(--paper);
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+    }
+
+    .search {
+      padding: 0 14px;
+    }
+
+    .search::placeholder {
+      color: rgba(243, 239, 228, 0.48);
+    }
+
+    .select {
+      padding: 0 12px;
+    }
+
+    .view-toggle {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 6px;
+      padding: 4px;
+      border: 1px solid rgba(255, 255, 255, 0.16);
+      border-radius: var(--radius);
+      background: rgba(255, 255, 255, 0.08);
+    }
+
+    .view-toggle button {
+      min-height: 34px;
+      border: 0;
+      background: transparent;
+      color: var(--paper);
+      font-size: 12px;
+      font-weight: 800;
+    }
+
+    .view-toggle button.is-active {
+      background: var(--acid);
+      color: var(--ink);
+    }
+
+    .session-bar {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 7px;
+      margin: 0 0 16px;
+    }
+
+    .chip {
+      min-height: 32px;
+      padding: 0 9px;
+      border-color: rgba(255, 255, 255, 0.18);
+      background: rgba(255, 255, 255, 0.07);
+      color: var(--paper);
+      font-size: 12px;
+      font-weight: 700;
+    }
+
+    .chip.is-active {
+      border-color: var(--acid);
+      background: var(--acid);
+      color: var(--ink);
+    }
+
+    .count-pill {
+      display: inline-grid;
+      min-width: 22px;
+      height: 18px;
+      place-items: center;
+      margin-left: 6px;
+      border-radius: 999px;
+      background: rgba(0, 0, 0, 0.18);
+      font-size: 10px;
+    }
+
+    .grid {
+      display: grid;
+      gap: 20px;
+      align-items: start;
+    }
+
+    .batch-section {
+      display: grid;
+      gap: 10px;
+    }
+
+    .batch-header {
+      display: flex;
+      align-items: end;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 2px 2px 0;
+      color: var(--paper);
+    }
+
+    .batch-title {
+      margin: 0;
+      font-size: 14px;
+      font-weight: 900;
+      line-height: 1.2;
+    }
+
+    .batch-meta {
+      color: var(--muted);
+      font-size: 11px;
+      font-weight: 800;
+      white-space: nowrap;
+    }
+
+    .batch-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(var(--card-min), 1fr));
+      gap: 14px;
+      align-items: start;
+    }
+
+    .grid.is-list .batch-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .card {
+      display: grid;
+      width: 100%;
+      padding: 0;
+      overflow: hidden;
+      border: 1px solid rgba(255, 255, 255, 0.16);
+      border-radius: var(--radius);
+      background: var(--paper);
+      color: var(--ink);
+      text-align: left;
+      box-shadow: 0 14px 34px rgba(0, 0, 0, 0.22);
+      transform: translateY(8px);
+      opacity: 0;
+      animation: cardIn 360ms cubic-bezier(0.2, 0.7, 0.2, 1) forwards;
+      animation-delay: calc(min(var(--i, 0), 16) * 24ms);
+      transition: transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
+    }
+
+    .card:hover {
+      border-color: rgba(216, 255, 69, 0.86);
+      box-shadow: 0 22px 46px rgba(0, 0, 0, 0.32), 0 0 0 2px rgba(216, 255, 69, 0.18);
+      transform: translateY(-3px);
+    }
+
+    @keyframes cardIn {
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    .thumb {
+      position: relative;
+      width: 100%;
+      aspect-ratio: 16 / 10;
+      display: grid;
+      place-items: center;
+      overflow: hidden;
+      background:
+        linear-gradient(45deg, rgba(0, 0, 0, 0.05) 25%, transparent 25% 75%, rgba(0, 0, 0, 0.05) 75%),
+        linear-gradient(45deg, rgba(0, 0, 0, 0.05) 25%, transparent 25% 75%, rgba(0, 0, 0, 0.05) 75%);
+      background-position: 0 0, 10px 10px;
+      background-size: 20px 20px;
+    }
+
+    .thumb img {
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+      display: block;
+      transition: transform 220ms ease, filter 220ms ease;
+    }
+
+    .card:hover .thumb img {
+      filter: saturate(1.03) contrast(1.02);
+      transform: scale(1.018);
+    }
+
+    .badge {
+      position: absolute;
+      left: 7px;
+      top: 7px;
+      max-width: calc(100% - 16px);
+      padding: 4px 7px;
+      border-radius: 999px;
+      background: rgba(23, 21, 18, 0.82);
+      color: var(--paper);
+      font-size: 9px;
+      font-weight: 800;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .meta {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      min-height: 42px;
+      padding: 8px 10px;
+      border-top: 1px solid rgba(0, 0, 0, 0.08);
+      background: rgba(243, 239, 228, 0.94);
+    }
+
+    .file-name {
+      margin: 0;
+      min-width: 0;
+      color: var(--ink);
+      font-family: "Avenir Next", "Helvetica Neue", sans-serif;
+      font-size: 12px;
+      font-weight: 800;
+      line-height: 1.28;
+      overflow-wrap: anywhere;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      overflow: hidden;
+    }
+
+    .sub-name {
+      color: rgba(23, 21, 18, 0.58);
+      font-size: 10px;
+      font-weight: 800;
+      text-transform: uppercase;
+      white-space: nowrap;
+    }
+
+    .facts {
+      display: none;
+      flex-wrap: wrap;
+      gap: 6px;
+      color: rgba(23, 21, 18, 0.72);
+      font-size: 10px;
+      font-weight: 700;
+    }
+
+    .fact {
+      padding: 4px 6px;
+      border-radius: 999px;
+      background: rgba(23, 21, 18, 0.07);
+      white-space: nowrap;
+    }
+
+    .grid.is-list .card {
+      grid-template-columns: 130px 1fr;
+    }
+
+    .grid.is-list .thumb {
+      aspect-ratio: 1 / 1;
+    }
+
+    .grid.is-list .meta {
+      align-content: center;
+      border-top: 0;
+      border-left: 1px solid rgba(0, 0, 0, 0.1);
+    }
+
+    .empty {
+      display: none;
+      min-height: 42vh;
+      place-items: center;
+      border: 1px dashed rgba(255, 255, 255, 0.22);
+      border-radius: var(--radius);
+      color: var(--muted);
+      font-weight: 800;
+    }
+
+    .empty.is-visible {
+      display: grid;
+    }
+
+    .lightbox {
+      position: fixed;
+      inset: 0;
+      z-index: 20;
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 360px;
+      background:
+        linear-gradient(135deg, rgba(216, 255, 69, 0.08), transparent 34%),
+        rgba(10, 9, 7, 0.93);
+      backdrop-filter: blur(12px);
+    }
+
+    .lightbox[hidden] {
+      display: none;
+    }
+
+    .stage {
+      display: grid;
+      place-items: center;
+      min-width: 0;
+      padding: 30px;
+      background:
+        linear-gradient(45deg, rgba(255, 255, 255, 0.025) 25%, transparent 25% 75%, rgba(255, 255, 255, 0.025) 75%),
+        linear-gradient(45deg, rgba(255, 255, 255, 0.025) 25%, transparent 25% 75%, rgba(255, 255, 255, 0.025) 75%);
+      background-position: 0 0, 14px 14px;
+      background-size: 28px 28px;
+    }
+
+    .stage img {
+      max-width: 100%;
+      max-height: calc(100vh - 60px);
+      object-fit: contain;
+      border: 1px solid rgba(255, 255, 255, 0.18);
+      box-shadow: var(--shadow);
+    }
+
+    .detail {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      min-width: 0;
+      padding: 24px;
+      border-left: 1px solid rgba(255, 255, 255, 0.14);
+      background: linear-gradient(180deg, var(--paper), var(--paper-2));
+      color: var(--ink);
+    }
+
+    .detail h2 {
+      margin: 0;
+      font-size: 16px;
+      line-height: 1.25;
+      overflow-wrap: anywhere;
+    }
+
+    .detail dl {
+      display: grid;
+      grid-template-columns: 82px 1fr;
+      gap: 9px 12px;
+      margin: 0;
+      font-size: 12px;
+    }
+
+    .detail dt {
+      color: rgba(23, 21, 18, 0.56);
+      font-weight: 800;
+      text-transform: uppercase;
+    }
+
+    .detail dd {
+      margin: 0;
+      min-width: 0;
+      overflow-wrap: anywhere;
+      font-weight: 700;
+    }
+
+    .tech-details {
+      border-top: 1px solid rgba(23, 21, 18, 0.16);
+      padding-top: 12px;
+    }
+
+    .tech-details summary {
+      cursor: pointer;
+      font-size: 12px;
+      font-weight: 900;
+      text-transform: uppercase;
+    }
+
+    .tech-details dl {
+      margin-top: 12px;
+    }
+
+    .detail-actions {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 10px;
+      margin-top: auto;
+    }
+
+    .detail-actions button,
+    .detail-actions a {
+      display: grid;
+      place-items: center;
+      padding: 0 12px;
+      font-size: 13px;
+      font-weight: 800;
+    }
+
+    .close {
+      background: var(--ink);
+      color: var(--paper);
+    }
+
+    .toast {
+      position: fixed;
+      left: 50%;
+      bottom: 22px;
+      z-index: 40;
+      transform: translateX(-50%) translateY(20px);
+      padding: 10px 14px;
+      border-radius: 999px;
+      background: var(--acid);
+      color: var(--ink);
+      font-size: 12px;
+      font-weight: 900;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 160ms ease, transform 160ms ease;
+    }
+
+    .toast.is-visible {
+      opacity: 1;
+      transform: translateX(-50%) translateY(0);
+    }
+
+    @media (max-width: 860px) {
+      .shell {
+        grid-template-columns: 1fr;
+      }
+
+      .rail {
+        position: relative;
+        height: auto;
+        border-right: 0;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+        gap: 14px;
+      }
+
+      .toolbar {
+        grid-template-columns: 1fr;
+        padding-top: 2px;
+      }
+
+      .workspace {
+        padding: 18px;
+      }
+
+      .lightbox {
+        grid-template-columns: 1fr;
+        grid-template-rows: minmax(0, 1fr) auto;
+      }
+
+      .stage {
+        padding: 16px;
+      }
+
+      .stage img {
+        max-height: 58vh;
+      }
+
+      .detail {
+        max-height: 42vh;
+        overflow: auto;
+        border-left: 0;
+        border-top: 1px solid rgba(255, 255, 255, 0.14);
+      }
+    }
+
+    @media (max-width: 520px) {
+      body {
+        overflow-x: hidden;
+      }
+
+      h1 {
+        font-size: 34px;
+      }
+
+      .rail {
+        padding: 16px;
+        gap: 11px;
+      }
+
+      .root-path {
+        margin-top: 7px;
+        font-size: 10px;
+      }
+
+      .detail-actions {
+        grid-template-columns: 1fr;
+      }
+
+      .stat-grid {
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        gap: 6px;
+      }
+
+      .stat {
+        min-height: 52px;
+        padding: 8px;
+      }
+
+      .stat dt {
+        margin-bottom: 5px;
+        font-size: 8px;
+      }
+
+      .stat dd {
+        font-size: 21px;
+      }
+
+      .rail-actions {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 8px;
+      }
+
+      .rail-actions button,
+      .rail-actions a {
+        min-height: 36px;
+        font-size: 12px;
+      }
+
+      .source-note {
+        display: none;
+      }
+
+      .workspace {
+        padding: 12px;
+      }
+
+      .toolbar {
+        gap: 8px;
+      }
+
+      .search,
+      .select {
+        height: 40px;
+      }
+
+      .view-toggle button {
+        min-height: 30px;
+      }
+
+      .session-bar {
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        padding-bottom: 6px;
+        scrollbar-width: thin;
+      }
+
+      .chip {
+        flex: 0 0 auto;
+      }
+
+      .grid {
+        grid-template-columns: 1fr;
+      }
+
+      .grid.is-list .card {
+        grid-template-columns: 104px 1fr;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      *,
+      *::before,
+      *::after {
+        animation-duration: 1ms !important;
+        scroll-behavior: auto !important;
+        transition-duration: 1ms !important;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="shell">
+    <aside class="rail" aria-label="Gallery controls">
+      <div>
+        <p class="eyebrow">Light table</p>
+        <h1>Codex Images</h1>
+        <p class="root-path" id="rootPath">Source: generated_images</p>
+      </div>
+
+      <dl class="stat-grid" aria-label="Gallery stats">
+        <div class="stat">
+          <dt>Images</dt>
+          <dd id="imageCount">0</dd>
+        </div>
+        <div class="stat">
+          <dt>Batches</dt>
+          <dd id="sessionCount">0</dd>
+        </div>
+        <div class="stat">
+          <dt>Visible</dt>
+          <dd id="shownCount">0</dd>
+        </div>
+        <div class="stat">
+          <dt>Storage</dt>
+          <dd id="totalSize">0</dd>
+        </div>
+      </dl>
+
+      <div class="rail-actions">
+        <button id="scanButton" type="button" title="Scan an image folder in this browser">Open another folder</button>
+        <a class="button" href="./" title="Reload the gallery">Reload</a>
+      </div>
+
+      <p class="source-note" id="sourceNote">Dynamic index.</p>
+      <input id="fileInput" type="file" accept="image/*" webkitdirectory multiple hidden>
+    </aside>
+
+    <section class="workspace" aria-label="Image gallery">
+      <header class="toolbar">
+        <input class="search" id="searchInput" type="search" placeholder="Search images" autocomplete="off">
+        <select class="select" id="sortSelect" aria-label="Sort images">
+          <option value="newest">Newest first</option>
+          <option value="oldest">Oldest first</option>
+          <option value="size">Largest first</option>
+          <option value="session">Batch order</option>
+        </select>
+        <div class="view-toggle" aria-label="View mode">
+          <button id="gridView" type="button" class="is-active">Grid</button>
+          <button id="listView" type="button">List</button>
+        </div>
+      </header>
+
+      <nav class="session-bar" id="sessionBar" aria-label="Session filter"></nav>
+      <div class="grid" id="grid"></div>
+      <div class="empty" id="empty">No matches</div>
+    </section>
+  </main>
+
+  <section class="lightbox" id="lightbox" hidden aria-label="Image detail">
+    <div class="stage" id="stage">
+      <img id="detailImage" alt="">
+    </div>
+    <aside class="detail">
+      <h2 id="detailTitle"></h2>
+      <dl>
+        <dt>Batch</dt>
+        <dd id="detailSession"></dd>
+        <dt>Modified</dt>
+        <dd id="detailDate"></dd>
+        <dt>Size</dt>
+        <dd id="detailSize"></dd>
+        <dt>Pixels</dt>
+        <dd id="detailPixels"></dd>
+      </dl>
+      <details class="tech-details">
+        <summary>Technical details</summary>
+        <dl>
+          <dt>Original filename</dt>
+          <dd id="detailFile"></dd>
+          <dt>Internal session ID</dt>
+          <dd id="detailRawSession"></dd>
+          <dt>Full path</dt>
+          <dd id="detailPath"></dd>
+        </dl>
+      </details>
+      <div class="detail-actions">
+        <button id="prevButton" type="button">Prev</button>
+        <button id="nextButton" type="button">Next</button>
+        <a id="openLink" class="button" href="#" target="_blank" rel="noreferrer">Open</a>
+        <button id="copyButton" type="button">Copy full path</button>
+        <button id="closeButton" class="close" type="button">Close</button>
+      </div>
+    </aside>
+  </section>
+
+  <div class="toast" id="toast">Copied</div>
+
+  <script>
+    const DEFAULT_ROOT_PATH = "";
+    const INITIAL_ITEMS = [];
+
+
+    const state = {
+      items: [],
+      visible: [],
+      session: "all",
+      query: "",
+      sort: "newest",
+      view: "grid",
+      activeIndex: -1,
+      rootPath: DEFAULT_ROOT_PATH,
+      objectUrls: []
+    };
+
+    const els = {
+      imageCount: document.getElementById("imageCount"),
+      sessionCount: document.getElementById("sessionCount"),
+      shownCount: document.getElementById("shownCount"),
+      totalSize: document.getElementById("totalSize"),
+      sourceNote: document.getElementById("sourceNote"),
+      rootPath: document.getElementById("rootPath"),
+      scanButton: document.getElementById("scanButton"),
+      fileInput: document.getElementById("fileInput"),
+      searchInput: document.getElementById("searchInput"),
+      sortSelect: document.getElementById("sortSelect"),
+      gridView: document.getElementById("gridView"),
+      listView: document.getElementById("listView"),
+      sessionBar: document.getElementById("sessionBar"),
+      grid: document.getElementById("grid"),
+      empty: document.getElementById("empty"),
+      lightbox: document.getElementById("lightbox"),
+      stage: document.getElementById("stage"),
+      detailImage: document.getElementById("detailImage"),
+      detailTitle: document.getElementById("detailTitle"),
+      detailSession: document.getElementById("detailSession"),
+      detailFile: document.getElementById("detailFile"),
+      detailRawSession: document.getElementById("detailRawSession"),
+      detailDate: document.getElementById("detailDate"),
+      detailSize: document.getElementById("detailSize"),
+      detailPixels: document.getElementById("detailPixels"),
+      detailPath: document.getElementById("detailPath"),
+      prevButton: document.getElementById("prevButton"),
+      nextButton: document.getElementById("nextButton"),
+      openLink: document.getElementById("openLink"),
+      copyButton: document.getElementById("copyButton"),
+      closeButton: document.getElementById("closeButton"),
+      toast: document.getElementById("toast")
+    };
+
+    function normalizeItem(item, index) {
+      const path = item.path.replace(/^\/+/, "");
+      return {
+        ...item,
+        path,
+        key: `${path}:${item.mtime || 0}:${index}`,
+        session: path.includes("/") ? path.split("/")[0] : "selected",
+        filename: path.split("/").pop(),
+        absolutePath: item.absolutePath || (state.rootPath ? `${state.rootPath}/${path}` : path)
+      };
+    }
+
+    function padNumber(value) {
+      return String(value).padStart(2, "0");
+    }
+
+    const GENERATED_SESSION_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    const GENERATED_FILE_RE = /^ig_[0-9a-f]{24,}\.(png|jpe?g|webp|gif)$/i;
+
+    function formatBatchDate(ms) {
+      if (!ms) return "Undated";
+      return new Intl.DateTimeFormat(undefined, {
+        month: "short",
+        day: "2-digit"
+      }).format(new Date(ms));
+    }
+
+    function formatTime(ms) {
+      if (!ms) return "-";
+      return new Intl.DateTimeFormat(undefined, {
+        hour: "2-digit",
+        minute: "2-digit"
+      }).format(new Date(ms));
+    }
+
+    function formatBatchRange(oldest, newest) {
+      if (!oldest && !newest) return "Undated";
+      const date = formatBatchDate(newest || oldest);
+      if (!oldest || !newest || oldest === newest) return `${date}, ${formatTime(newest || oldest)}`;
+      return `${date}, ${formatTime(oldest)}-${formatTime(newest)}`;
+    }
+
+    function isGeneratedSession(name) {
+      return GENERATED_SESSION_RE.test(name || "");
+    }
+
+    function isGeneratedFile(name) {
+      return GENERATED_FILE_RE.test(name || "");
+    }
+
+    function labelItems(items) {
+      const sessions = getSessions(items);
+      const sessionMap = new Map(sessions.map((session, index) => [
+        session.name,
+        {
+          batchIndex: index + 1,
+          label: session.label,
+          shortLabel: session.shortLabel,
+          contextLabel: session.contextLabel
+        }
+      ]));
+
+      sessions.forEach((session) => {
+        const meta = sessionMap.get(session.name);
+        items
+          .filter((item) => item.session === session.name)
+          .sort((a, b) => (b.mtime || 0) - (a.mtime || 0) || a.path.localeCompare(b.path))
+          .forEach((item, index) => {
+            item.batchIndex = meta.batchIndex;
+            item.batchLabel = meta.label;
+            item.batchShortLabel = meta.shortLabel;
+            item.batchContextLabel = meta.contextLabel;
+            item.imageLabel = isGeneratedFile(item.filename) ? `Image ${padNumber(index + 1)}` : item.filename;
+            item.imageShortLabel = isGeneratedFile(item.filename) ? padNumber(index + 1) : item.filename;
+            item.displayTitle = item.imageLabel;
+            item.searchText = [
+              item.displayTitle,
+              item.batchLabel,
+              item.batchContextLabel,
+              item.batchShortLabel,
+              item.filename,
+              item.session,
+              item.path,
+              formatDate(item.mtime)
+            ].join(" ").toLowerCase();
+          });
+      });
+
+      return items;
+    }
+
+    function encodedPath(path) {
+      return path.split("/").map(encodeURIComponent).join("/");
+    }
+
+    function srcFor(item) {
+      if (item.url) return item.url;
+      const encoded = encodedPath(item.path);
+      return location.protocol === "file:" ? encoded : `/images/${encoded}`;
+    }
+
+    function displayPath(item) {
+      if (item.url) return item.absolutePath || item.path;
+      return item.absolutePath || (state.rootPath ? `${state.rootPath}/${item.path}` : item.path);
+    }
+
+    function formatDate(ms) {
+      if (!ms) return "-";
+      return new Intl.DateTimeFormat(undefined, {
+        month: "short",
+        day: "2-digit",
+        hour: "2-digit",
+        minute: "2-digit"
+      }).format(new Date(ms));
+    }
+
+    function formatBytes(bytes) {
+      if (!Number.isFinite(bytes)) return "-";
+      if (bytes >= 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+      if (bytes >= 1024) return `${Math.round(bytes / 1024)} KB`;
+      return `${bytes} B`;
+    }
+
+    function escapeHtml(value) {
+      return String(value).replace(/[&<>"']/g, (char) => ({
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        '"': "&quot;",
+        "'": "&#39;"
+      }[char]));
+    }
+
+    function getSessions(items) {
+      const sessions = new Map();
+      items.forEach((item) => {
+        const current = sessions.get(item.session) || { name: item.session, count: 0, newest: 0, oldest: Infinity };
+        current.count += 1;
+        current.newest = Math.max(current.newest, item.mtime || 0);
+        current.oldest = Math.min(current.oldest, item.mtime || Infinity);
+        sessions.set(item.session, current);
+      });
+      return [...sessions.values()]
+        .sort((a, b) => b.newest - a.newest || a.name.localeCompare(b.name))
+        .map((session, index) => ({
+          ...session,
+          batchIndex: index + 1,
+          label: isGeneratedSession(session.name) ? formatBatchRange(session.oldest, session.newest) : session.name,
+          shortLabel: isGeneratedSession(session.name) ? `B${padNumber(index + 1)}` : session.name,
+          contextLabel: `${session.count} ${session.count === 1 ? "image" : "images"}`
+        }));
+    }
+
+    function applySort(items) {
+      const sorted = [...items];
+      if (state.sort === "oldest") {
+        sorted.sort((a, b) => (a.mtime || 0) - (b.mtime || 0) || a.path.localeCompare(b.path));
+      } else if (state.sort === "size") {
+        sorted.sort((a, b) => (b.size || 0) - (a.size || 0) || a.path.localeCompare(b.path));
+      } else if (state.sort === "session") {
+        sorted.sort((a, b) => (a.batchIndex || 0) - (b.batchIndex || 0) || (b.mtime || 0) - (a.mtime || 0));
+      } else {
+        sorted.sort((a, b) => (b.mtime || 0) - (a.mtime || 0) || a.path.localeCompare(b.path));
+      }
+      return sorted;
+    }
+
+    function getVisibleItems() {
+      const query = state.query.trim().toLowerCase();
+      return applySort(state.items.filter((item) => {
+        if (state.session !== "all" && item.session !== state.session) return false;
+        if (!query) return true;
+        const searchable = item.searchText || [item.path, item.session, item.filename].join(" ").toLowerCase();
+        return searchable.includes(query);
+      }));
+    }
+
+    function renderStats() {
+      const sessions = getSessions(state.items);
+      const totalBytes = state.items.reduce((sum, item) => sum + (item.size || 0), 0);
+      els.imageCount.textContent = state.items.length;
+      els.sessionCount.textContent = sessions.length;
+      els.shownCount.textContent = state.visible.length;
+      els.totalSize.textContent = (totalBytes / 1024 / 1024).toFixed(0);
+    }
+
+    function renderSessions() {
+      const sessions = getSessions(state.items);
+      const buttons = [
+        `<button class="chip ${state.session === "all" ? "is-active" : ""}" type="button" data-session="all">All<span class="count-pill">${state.items.length}</span></button>`,
+        ...sessions.map((session) => (
+          `<button class="chip ${state.session === session.name ? "is-active" : ""}" type="button" data-session="${escapeHtml(session.name)}" title="${escapeHtml(`${session.label} · ${session.contextLabel}`)}">${escapeHtml(session.label)}<span class="count-pill">${session.count}</span></button>`
+        ))
+      ];
+      els.sessionBar.innerHTML = buttons.join("");
+    }
+
+    function groupedVisibleItems() {
+      const groups = [];
+      const index = new Map();
+      state.visible.forEach((item, visibleIndex) => {
+        let group = index.get(item.session);
+        if (!group) {
+          group = {
+            session: item.session,
+            label: item.batchLabel,
+            contextLabel: item.batchContextLabel,
+            newest: item.mtime || 0,
+            items: []
+          };
+          index.set(item.session, group);
+          groups.push(group);
+        }
+        group.items.push({ item, visibleIndex });
+      });
+      return groups;
+    }
+
+    function renderGrid() {
+      els.grid.classList.toggle("is-list", state.view === "list");
+      els.empty.classList.toggle("is-visible", state.visible.length === 0);
+      els.grid.innerHTML = groupedVisibleItems().map((group) => `
+        <section class="batch-section">
+          <header class="batch-header">
+            <h2 class="batch-title">${escapeHtml(group.label)}</h2>
+            <span class="batch-meta">${escapeHtml(group.contextLabel)}</span>
+          </header>
+          <div class="batch-grid">
+            ${group.items.map(({ item, visibleIndex }) => `
+              <button class="card" type="button" data-index="${visibleIndex}" title="${escapeHtml(`${item.displayTitle} · ${formatDate(item.mtime)}`)}" aria-label="Open ${escapeHtml(item.displayTitle)}" style="--i: ${visibleIndex};">
+                <span class="thumb">
+                  <img src="${escapeHtml(srcFor(item))}" alt="" loading="${visibleIndex < 10 ? "eager" : "lazy"}" decoding="async" data-key="${escapeHtml(item.key)}">
+                  <span class="badge">${escapeHtml(`${item.batchShortLabel} · ${item.imageShortLabel}`)}</span>
+                </span>
+                <span class="meta">
+                  <span class="file-name">${escapeHtml(item.displayTitle)}</span>
+                  <span class="sub-name">${escapeHtml(formatDate(item.mtime))}</span>
+                  <span class="facts">
+                    <span class="fact">${formatBytes(item.size)}</span>
+                    <span class="fact" data-dim="${escapeHtml(item.key)}">...</span>
+                  </span>
+                </span>
+              </button>
+            `).join("")}
+          </div>
+        </section>
+      `).join("");
+
+      els.grid.querySelectorAll(".card").forEach((card) => {
+        card.addEventListener("click", () => openLightbox(Number(card.dataset.index)));
+      });
+
+      els.grid.querySelectorAll("img").forEach((img) => {
+        img.addEventListener("load", () => {
+          const item = state.items.find((candidate) => candidate.key === img.dataset.key);
+          if (!item) return;
+          item.width = img.naturalWidth;
+          item.height = img.naturalHeight;
+          document.querySelectorAll(`[data-dim="${CSS.escape(item.key)}"]`).forEach((node) => {
+            node.textContent = `${item.width} x ${item.height}`;
+          });
+          if (state.activeIndex >= 0 && state.visible[state.activeIndex]?.key === item.key) {
+            renderDetail();
+          }
+        });
+      });
+    }
+
+    function render() {
+      state.visible = getVisibleItems();
+      renderStats();
+      renderSessions();
+      renderGrid();
+    }
+
+    function renderDetail() {
+      const item = state.visible[state.activeIndex];
+      if (!item) return;
+      const source = srcFor(item);
+      els.detailImage.src = source;
+      els.detailImage.alt = item.displayTitle;
+      els.detailTitle.textContent = item.displayTitle;
+      els.detailSession.textContent = `${item.batchLabel} · ${item.batchContextLabel}`;
+      els.detailFile.textContent = item.filename;
+      els.detailRawSession.textContent = item.session;
+      els.detailDate.textContent = formatDate(item.mtime);
+      els.detailSize.textContent = formatBytes(item.size);
+      els.detailPixels.textContent = item.width && item.height ? `${item.width} x ${item.height}` : "-";
+      els.detailPath.textContent = displayPath(item);
+      els.openLink.href = source;
+      els.prevButton.disabled = state.visible.length < 2;
+      els.nextButton.disabled = state.visible.length < 2;
+    }
+
+    function openLightbox(index) {
+      state.activeIndex = index;
+      renderDetail();
+      els.lightbox.hidden = false;
+      els.closeButton.focus();
+    }
+
+    function closeLightbox() {
+      els.lightbox.hidden = true;
+      state.activeIndex = -1;
+      els.detailImage.removeAttribute("src");
+    }
+
+    function moveLightbox(step) {
+      if (state.activeIndex < 0 || state.visible.length === 0) return;
+      state.activeIndex = (state.activeIndex + step + state.visible.length) % state.visible.length;
+      renderDetail();
+    }
+
+    async function copyActivePath() {
+      const item = state.visible[state.activeIndex];
+      if (!item) return;
+      const text = displayPath(item);
+      try {
+        await navigator.clipboard.writeText(text);
+        showToast("Full path copied");
+      } catch {
+        window.prompt("Path", text);
+      }
+    }
+
+    function showToast(text) {
+      els.toast.textContent = text;
+      els.toast.classList.add("is-visible");
+      window.clearTimeout(showToast.timer);
+      showToast.timer = window.setTimeout(() => els.toast.classList.remove("is-visible"), 1200);
+    }
+
+    function resetObjectUrls() {
+      state.objectUrls.forEach((url) => URL.revokeObjectURL(url));
+      state.objectUrls = [];
+    }
+
+    function setItems(items, note, rootLabel, rootPath = "") {
+      resetObjectUrls();
+      state.objectUrls = items.map((item) => item.url).filter(Boolean);
+      state.rootPath = rootPath;
+      state.items = labelItems(items.map(normalizeItem));
+      state.session = "all";
+      state.query = "";
+      els.searchInput.value = "";
+      els.sourceNote.textContent = note;
+      els.rootPath.textContent = rootLabel.startsWith("Source:") ? rootLabel : `Source: ${rootLabel}`;
+      render();
+    }
+
+    async function loadInitialItems() {
+      if (location.protocol === "file:") {
+        state.rootPath = DEFAULT_ROOT_PATH;
+        state.items = labelItems(INITIAL_ITEMS.map(normalizeItem));
+        els.sourceNote.textContent = "No dynamic index on file://.";
+        render();
+        return;
+      }
+
+      try {
+        const response = await fetch("/api/images", { cache: "no-store" });
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const payload = await response.json();
+        const rootLabel = payload.rootLabel || "generated_images";
+        state.rootPath = payload.rootPath || DEFAULT_ROOT_PATH;
+        state.items = labelItems((payload.items || []).map(normalizeItem));
+        els.rootPath.textContent = `Source: ${rootLabel}`;
+        els.sourceNote.textContent = `Indexed ${state.items.length} images from ${rootLabel}.`;
+      } catch (error) {
+        state.rootPath = DEFAULT_ROOT_PATH;
+        state.items = labelItems(INITIAL_ITEMS.map(normalizeItem));
+        els.sourceNote.textContent = "Dynamic index unavailable.";
+      }
+
+      render();
+    }
+
+    async function walkDirectory(handle, prefix = "") {
+      const files = [];
+      for await (const [name, entry] of handle.entries()) {
+        const path = prefix ? `${prefix}/${name}` : name;
+        if (entry.kind === "directory") {
+          files.push(...await walkDirectory(entry, path));
+        } else if (/\.(png|jpe?g|webp|gif)$/i.test(name)) {
+          const file = await entry.getFile();
+          files.push(fileToItem(file, path));
+        }
+      }
+      return files;
+    }
+
+    function fileToItem(file, path) {
+      const url = URL.createObjectURL(file);
+      return {
+        path,
+        mtime: file.lastModified,
+        size: file.size,
+        url,
+        absolutePath: path
+      };
+    }
+
+    async function chooseFolder() {
+      if (window.showDirectoryPicker) {
+        try {
+          const handle = await window.showDirectoryPicker();
+          const items = await walkDirectory(handle);
+          setItems(
+            applySort(items),
+            `Browser scan: ${items.length} images.`,
+            handle.name
+          );
+          return;
+        } catch (error) {
+          if (error.name === "AbortError") return;
+        }
+      }
+      els.fileInput.click();
+    }
+
+    els.fileInput.addEventListener("change", () => {
+      const files = [...els.fileInput.files].filter((file) => /^image\//.test(file.type) || /\.(png|jpe?g|webp|gif)$/i.test(file.name));
+      const items = files.map((file) => fileToItem(file, file.webkitRelativePath || file.name));
+      setItems(applySort(items), `Browser scan: ${items.length} images.`, "Selected folder");
+      els.fileInput.value = "";
+    });
+
+    els.scanButton.addEventListener("click", chooseFolder);
+    els.searchInput.addEventListener("input", (event) => {
+      state.query = event.target.value;
+      render();
+    });
+    els.sortSelect.addEventListener("change", (event) => {
+      state.sort = event.target.value;
+      render();
+    });
+    els.gridView.addEventListener("click", () => {
+      state.view = "grid";
+      els.gridView.classList.add("is-active");
+      els.listView.classList.remove("is-active");
+      renderGrid();
+    });
+    els.listView.addEventListener("click", () => {
+      state.view = "list";
+      els.listView.classList.add("is-active");
+      els.gridView.classList.remove("is-active");
+      renderGrid();
+    });
+    els.sessionBar.addEventListener("click", (event) => {
+      const button = event.target.closest("button[data-session]");
+      if (!button) return;
+      state.session = button.dataset.session;
+      render();
+    });
+    els.prevButton.addEventListener("click", () => moveLightbox(-1));
+    els.nextButton.addEventListener("click", () => moveLightbox(1));
+    els.copyButton.addEventListener("click", copyActivePath);
+    els.closeButton.addEventListener("click", closeLightbox);
+    els.stage.addEventListener("click", closeLightbox);
+    document.addEventListener("keydown", (event) => {
+      if (els.lightbox.hidden) return;
+      if (event.key === "Escape") closeLightbox();
+      if (event.key === "ArrowLeft") moveLightbox(-1);
+      if (event.key === "ArrowRight") moveLightbox(1);
+    });
+
+    loadInitialItems();
+  </script>
+</body>
+</html>

--- a/codex-image-gallery/scripts/server.mjs
+++ b/codex-image-gallery/scripts/server.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+import { createReadStream } from "node:fs";
+import { readdir, stat } from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HOST = process.env.HOST || "127.0.0.1";
+const DEFAULT_PORT = Number(process.env.PORT || process.argv[2] || 8765);
+const SKILL_ROOT = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const APP_ROOT = path.join(SKILL_ROOT, "assets");
+const IMAGE_ROOT = path.resolve(process.env.GALLERY_ROOT || path.join(os.homedir(), ".codex/generated_images"));
+
+const MIME = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".webp": "image/webp",
+  ".gif": "image/gif"
+};
+
+function isImage(filePath) {
+  return /\.(png|jpe?g|webp|gif)$/i.test(filePath);
+}
+
+async function walkImages(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const out = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...await walkImages(fullPath));
+    } else if (entry.isFile() && isImage(entry.name)) {
+      const info = await stat(fullPath);
+      out.push({
+        path: path.relative(IMAGE_ROOT, fullPath).split(path.sep).join("/"),
+        mtime: Math.round(info.mtimeMs),
+        size: info.size
+      });
+    }
+  }
+
+  return out;
+}
+
+function safePath(root, relativePath) {
+  const fullPath = path.resolve(root, relativePath);
+  if (fullPath !== root && !fullPath.startsWith(`${root}${path.sep}`)) {
+    return null;
+  }
+  return fullPath;
+}
+
+function appPath(urlPath) {
+  if (urlPath === "/" || urlPath === "/index.html") {
+    return path.join(APP_ROOT, "index.html");
+  }
+  return null;
+}
+
+function imagePath(urlPath) {
+  if (!urlPath.startsWith("/images/")) return null;
+  try {
+    return safePath(IMAGE_ROOT, decodeURIComponent(urlPath.slice("/images/".length)));
+  } catch {
+    return null;
+  }
+}
+
+async function handler(req, res) {
+  const url = new URL(req.url, `http://${req.headers.host || `${HOST}:${DEFAULT_PORT}`}`);
+
+  if (url.pathname === "/api/images") {
+    const items = (await walkImages(IMAGE_ROOT)).sort((a, b) => b.mtime - a.mtime || a.path.localeCompare(b.path));
+    res.writeHead(200, {
+      "content-type": "application/json; charset=utf-8",
+      "cache-control": "no-store"
+    });
+    res.end(JSON.stringify({
+      rootLabel: path.basename(IMAGE_ROOT),
+      rootPath: IMAGE_ROOT,
+      items
+    }));
+    return;
+  }
+
+  let fullPath = appPath(url.pathname);
+  if (!fullPath && url.pathname.startsWith("/images/")) {
+    fullPath = imagePath(url.pathname);
+    if (!fullPath) {
+      res.writeHead(403);
+      res.end("Forbidden");
+      return;
+    }
+  }
+
+  if (!fullPath) {
+    res.writeHead(404);
+    res.end("Not found");
+    return;
+  }
+
+  try {
+    const info = await stat(fullPath);
+    if (!info.isFile()) throw new Error("Not a file");
+    const ext = path.extname(fullPath).toLowerCase();
+    res.writeHead(200, {
+      "content-type": MIME[ext] || "application/octet-stream",
+      "cache-control": ext === ".html" ? "no-store" : "public, max-age=60"
+    });
+    createReadStream(fullPath).pipe(res);
+  } catch {
+    res.writeHead(404);
+    res.end("Not found");
+  }
+}
+
+function listen(port) {
+  const server = http.createServer((req, res) => {
+    handler(req, res).catch((error) => {
+      res.writeHead(500, { "content-type": "text/plain; charset=utf-8" });
+      res.end(error.stack || String(error));
+    });
+  });
+
+  server.on("error", (error) => {
+    if (error.code === "EADDRINUSE" && port < DEFAULT_PORT + 20) {
+      listen(port + 1);
+      return;
+    }
+    throw error;
+  });
+
+  server.listen(port, HOST, () => {
+    console.log(`Codex image gallery: http://${HOST}:${port}/`);
+    console.log(`Image root: ${IMAGE_ROOT}`);
+  });
+}
+
+listen(DEFAULT_PORT);


### PR DESCRIPTION
## What
- **New skill `codex-image-gallery`**: self-contained local web gallery for browsing Codex image outputs (`~/.codex/generated_images`); bundled Node server + HTML UI.
- **Doc baseline sync**: the human-facing skill lists had drifted (showed 66) — now synced to the authoritative count, backfilling previously-merged skills that were missing from the docs (`read-claude-web-conversation`, `setup-notifications-via-wecom`, `notify-wecom`, `github-sensitive-data-cleanup`) plus `codex-image-gallery`.

## Counts (now consistent)
- marketplace: 50 plugin entries, 71 skills, metadata 1.69.0
- README / README.zh-CN / CLAUDE: all 71 skills, version badge 1.69.0 — verified green by `check_doc_skill_lists.py`

## Safety
- codex `security_scan` passed — no secrets.
- Integrates a concurrent session's codex + doc-backfill work, reviewed and verified here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)