### PR TITLE
feat(frontend-visual-qa): add rendered-frontend visual QA skill (v1.70.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional Claude Code skills marketplace — production-ready skills spanning GitHub and git operations, document conversion and generation (Markdown, PDF, PPTX, DOCX), diagram and UI-design extraction, the full audio pipeline (ASR transcription, TTS, transcript correction, meeting minutes), financial and investment-research data, web scraping and content capture, security/PII tooling and secure repomix packaging, macOS and iOS development, CLI demo and terminal automation, prompt and skill engineering, deep research and fact-checking, QA and LLM-evaluation infrastructure, internationalization, network/Tailscale and remote-desktop diagnostics, and Claude Code operations (session recovery, CLAUDE.md optimization, statusline, multi-provider profile isolation, troubleshooting, marketplace development, repo health-check). Suite plugins (daymade-audio, daymade-claude-code, daymade-docs, daymade-skill) bundle related skills under shared namespaces, including the StepFun StepAudio 2.5 audio family. See the Available Skills list in the README for the authoritative per-skill breakdown.",
-    "version": "1.69.0"
+    "version": "1.70.0"
   },
   "plugins": [
     {
@@ -997,6 +997,25 @@
         "generated_images",
         "gpt-image",
         "image-review"
+      ]
+    },
+    {
+      "name": "frontend-visual-qa",
+      "description": "Reviews rendered frontends, dashboards, HTML slides, design-system specimens, and generated UIs for visual quality defects that lint/build miss: awkward line breaks, orphan Chinese characters, wrapped buttons/tags/nav, horizontal overflow, double scrollbars, repeated card piles, page-type drift such as design systems becoming fake workbenches, missing images, generic AI slop, and Chrome DevTools viewport mistakes. Use after frontend-design or ui-designer work and alongside qa-expert release gates.",
+      "source": "./frontend-visual-qa",
+      "strict": false,
+      "version": "1.0.0",
+      "category": "design",
+      "keywords": [
+        "frontend",
+        "visual-qa",
+        "layout",
+        "line-breaks",
+        "responsive",
+        "chrome",
+        "playwright",
+        "ai-slop",
+        "design-review"
       ]
     }
   ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository Overview
 
-This is a Claude Code skills marketplace containing 71 production-ready skills organized in a plugin marketplace structure. Most plugins expose one skill for narrow installs; suite plugins expose related skills under shared namespaces for combined installation workflows.
+This is a Claude Code skills marketplace containing 72 production-ready skills organized in a plugin marketplace structure. Most plugins expose one skill for narrow installs; suite plugins expose related skills under shared namespaces for combined installation workflows.
 
 **Essential Skill**: `skill-creator` is the most important skill in this marketplace - it's a meta-skill that enables users to create their own skills. Always recommend it first for users interested in extending Claude Code.
 
@@ -153,7 +153,7 @@ If it fires, fix the issue — do NOT use `--no-verify` to bypass.
 ## Marketplace Configuration
 
 The marketplace is configured in `.claude-plugin/marketplace.json`:
-- Contains 50 plugin entries: single-skill plugins point `source` directly at the skill directory (no `skills` field); suite plugins (`daymade-audio`, `daymade-claude-code`, `daymade-docs`, `daymade-skill`) use explicit `skills` arrays for multi-skill routing
+- Contains 51 plugin entries: single-skill plugins point `source` directly at the skill directory (no `skills` field); suite plugins (`daymade-audio`, `daymade-claude-code`, `daymade-docs`, `daymade-skill`) use explicit `skills` arrays for multi-skill routing
 - Each plugin has: name, description, source, version, category, keywords
 - Marketplace metadata: name, owner, version
 - Single-skill plugins follow the official pattern (167/168 plugins in `anthropics/claude-plugins-official`): `source` points to skill directory, `skills` omitted
@@ -270,6 +270,7 @@ This applies when you change ANY file under a skill directory:
 69. **notify-wecom** - Send a single one-off WeCom group-bot message without setting up a reusable notification workflow
 70. **github-sensitive-data-cleanup** - Scan and remove secrets, API keys, private domains/IPs, and PII from GitHub repository history with force-push safety gates
 71. **codex-image-gallery** - Start a self-contained local web gallery for browsing Codex-generated images from `~/.codex/generated_images` or a custom `GALLERY_ROOT`
+72. **frontend-visual-qa** - Reviews rendered frontends, dashboards, HTML slides, and generated UIs for visual quality defects that lint/build miss (awkward line breaks, wrapped controls, horizontal overflow, double scrollbars, AI slop, Chrome DevTools viewport mistakes); use after frontend-design/ui-designer and alongside qa-expert
 
 **Recommendation**: Always suggest `skill-creator` first for users interested in creating skills or extending Claude Code.
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@
 [![简体中文](https://img.shields.io/badge/语言-简体中文-red)](./README.zh-CN.md)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Skills](https://img.shields.io/badge/skills-71-blue.svg)](https://github.com/daymade/claude-code-skills)
-[![Version](https://img.shields.io/badge/version-1.69.0-green.svg)](https://github.com/daymade/claude-code-skills)
+[![Skills](https://img.shields.io/badge/skills-72-blue.svg)](https://github.com/daymade/claude-code-skills)
+[![Version](https://img.shields.io/badge/version-1.70.0-green.svg)](https://github.com/daymade/claude-code-skills)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-2.0.13+-purple.svg)](https://claude.com/code)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./CONTRIBUTING.md)
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/daymade/claude-code-skills/graphs/commit-activity)
 
 </div>
 
-Professional Claude Code skills marketplace featuring 71 production-ready skills for enhanced development workflows.
+Professional Claude Code skills marketplace featuring 72 production-ready skills for enhanced development workflows.
 
 ## 📑 Table of Contents
 
@@ -2774,6 +2774,26 @@ Start a self-contained local web gallery for Codex-generated image outputs. The 
 - Optional `GALLERY_ROOT`, `PORT`, and `HOST`
 
 **Requirements**: Node.js 18+ and access to the image folder.
+
+### 74. **frontend-visual-qa** - Rendered Frontend Visual QA Gate
+
+```bash
+claude plugin install frontend-visual-qa@daymade-skills
+```
+
+Catch embarrassing rendered UI defects that normal lint/build checks miss.
+
+**When to use:**
+- Reviewing or shipping a frontend, website, dashboard, design-system specimen, or HTML slide page
+- User flags awkward line breaks, cramped text, double scrollbars, overlap, or generic AI slop aesthetics
+- User says the artifact has the wrong type, such as a design system turning into a fake app/workbench
+- Need Chrome/Playwright evidence across desktop and mobile viewports
+- Need to complement `ui-designer`, `frontend-design`, and `qa-expert`
+
+**Key features:**
+- History-derived checklist for recurring line-break, overflow, and typography failures
+- Chrome DevTools first-pass for the user-visible browser viewport, including stale mobile emulation checks
+- Playwright-core audit script for desktop-wide, desktop, and mobile viewports
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,15 +6,15 @@
 [![简体中文](https://img.shields.io/badge/语言-简体中文-red)](./README.zh-CN.md)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Skills](https://img.shields.io/badge/skills-71-blue.svg)](https://github.com/daymade/claude-code-skills)
-[![Version](https://img.shields.io/badge/version-1.69.0-green.svg)](https://github.com/daymade/claude-code-skills)
+[![Skills](https://img.shields.io/badge/skills-72-blue.svg)](https://github.com/daymade/claude-code-skills)
+[![Version](https://img.shields.io/badge/version-1.70.0-green.svg)](https://github.com/daymade/claude-code-skills)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-2.0.13+-purple.svg)](https://claude.com/code)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./CONTRIBUTING.md)
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/daymade/claude-code-skills/graphs/commit-activity)
 
 </div>
 
-专业的 Claude Code 技能市场，提供 71 个生产就绪的技能，用于增强开发工作流。
+专业的 Claude Code 技能市场，提供 72 个生产就绪的技能，用于增强开发工作流。
 
 ## 📑 目录
 
@@ -2816,6 +2816,26 @@ claude plugin install codex-image-gallery@daymade-skills
 - 支持可选 `GALLERY_ROOT`、`PORT`、`HOST`
 
 **要求**：Node.js 18+，并能访问目标图片目录。
+
+### 74. **frontend-visual-qa** - 渲染后前端视觉 QA 门禁
+
+```bash
+claude plugin install frontend-visual-qa@daymade-skills
+```
+
+捕捉普通 lint/build 检查发现不了的低级界面排版和视觉错误。
+
+**使用场景：**
+- 审核或交付前端、网站、dashboard、设计系统样张或 HTML 演示页
+- 用户指出不恰当换行、文字挤、双滚动条、重叠或 AI slop 审美
+- 用户指出产物类型错位，例如把设计系统做成假的工作台/业务界面
+- 需要在桌面和移动端用 Chrome/Playwright 留证
+- 需要补足 `ui-designer`、`frontend-design` 和 `qa-expert` 之间的空档
+
+**主要功能：**
+- 基于本地历史反馈沉淀的换行、溢出、排版错误清单
+- 优先用 Chrome DevTools 检查用户当前可见浏览器视口，包括残留移动端 emulation
+- Playwright-core 脚本覆盖宽桌面、常规桌面和移动端视口
 
 ---
 

--- a/frontend-visual-qa/.security-scan-passed
+++ b/frontend-visual-qa/.security-scan-passed
@@ -1,0 +1,4 @@
+Security scan passed
+Scanned at: 2026-06-28T11:44:15.806052
+Tool: gitleaks + pattern-based validation
+Content hash: a00b8ea6f58f8aa0aea5828af8150837f70451bf94147dec882017989a54888a

--- a/frontend-visual-qa/SKILL.md
+++ b/frontend-visual-qa/SKILL.md
@@ -1,0 +1,324 @@
+---
+name: frontend-visual-qa
+description: >-
+  Reviews rendered frontends, websites, dashboards, HTML slides, design-system
+  specimens, live-artifact design systems, and generated UIs for visual quality
+  defects that lint/build miss.
+  Use when shipping or reviewing UI, especially after frontend-design or
+  ui-designer work, or when the user mentions awkward line breaks, orphan
+  Chinese characters, cramped text, wrapped buttons/tags/nav, horizontal
+  overflow, double scrollbars, overlapping elements, repeated card piles,
+  wrong page type such as a design system turning into an app dashboard, tiny
+  dense typography, wrong font/spacing/width/type-scale choices, generic AI
+  slop, screenshot QA, Chrome DevTools, or "look at the page yourself."
+  Prioritizes the user's real Chrome viewport when
+  available, then runs scriptable desktop/mobile sweeps.
+---
+
+# Frontend Visual QA
+
+## Purpose
+
+This skill turns recurring frontend review failures into a repeatable rendered visual QA gate. The core lesson: passing `lint`, `build`, or a scripted screenshot is not enough. The agent must prove that the UI the user can actually see has no embarrassing layout defects.
+
+Use it after implementation and before saying a UI is done. Also use it during review when the user says things like "不恰当的换行", "断行", "挤在一起", "滚动条不对", "低级排版错误", "AI slop", "use frontend-design to review", "自己用 Chrome 看", or "为什么你检查不出来".
+
+## Relationship To Other Skills
+
+- `ui-designer`: use first when reference screenshots or brand examples exist. It extracts design-system direction from images; it does not verify a live page.
+- `frontend-design`: use while designing/implementing. It sets taste, hierarchy, visual assets, and anti-slop direction; it is not a deterministic QA gate.
+- `qa-expert`: use for full QA process, test cases, bug tracking, and release gates; it does not specialize in typography/layout line-break defects.
+- `frontend-visual-qa`: use after there is something rendered. It checks the actual UI in Chrome and produces fixable findings.
+
+## Required Workflow
+
+1. **Load Project Intent**
+   - Read the product/design context, current route/page, and any design-system docs.
+   - Identify the page type: real app, dashboard, landing page, deck-like HTML, static design-system reference, live-artifact design system, game/tool.
+   - If reference images or official brand materials exist, use them before judging aesthetics.
+   - Write down the page's anti-goals before reviewing. Examples:
+     - A design-system specimen is not a real app screen.
+     - A live-artifact design system is not a static documentation page; interactive controls are allowed when they demonstrate variants, states, chart behavior, responsive behavior, or component anatomy.
+     - A landing page is not an internal dashboard.
+     - A dashboard is not a marketing poster.
+   - Treat page-type drift as a defect, not a taste preference.
+   - For design systems, decide whether the intended artifact is:
+     - **Static reference**: a rendered specification page focused on rules, tokens, examples, and governance.
+     - **Live artifact**: an interactive design-system artifact where buttons, tabs, drawers, chart hover states, filters, and state toggles let reviewers test the system in place.
+   - Do not remove useful interactivity from a live-artifact design system merely because it resembles product UI. Instead, check whether each interactive module is explicitly framed as a specimen, state demo, pattern, or component contract.
+
+2. **Check The User-Visible Chrome First**
+   - If Chrome DevTools tools are available and the user is looking at the page, inspect that page before running headless scripts.
+   - Establish the viewport contract before judging layout. Record all four widths because they answer different questions:
+     - `outerWidth`: the user's visible Chrome window.
+     - `innerWidth`: the CSS layout viewport the page is rendered into.
+     - `visualViewport.width`: the post-emulation/zoom viewport the user is actually seeing.
+     - `documentElement.clientWidth`: the page viewport after scrollbar subtraction.
+   - Record the real browser state with DevTools:
+
+```js
+() => ({
+  href: location.href,
+  title: document.title,
+  innerWidth,
+  innerHeight,
+  outerWidth,
+  outerHeight,
+  clientWidth: document.documentElement.clientWidth,
+  scrollWidth: document.documentElement.scrollWidth,
+  overflowX: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+  dpr: devicePixelRatio,
+  visualViewport: window.visualViewport
+    ? { width: visualViewport.width, height: visualViewport.height, scale: visualViewport.scale }
+    : null,
+  h1: document.querySelector("h1")?.textContent?.replace(/\s+/g, " ").trim() || null,
+  metaViewport: document.querySelector('meta[name="viewport"]')?.content || null
+})
+```
+
+   - If a normal desktop Chrome window is still reporting a mobile viewport such as `390x844`, DevTools emulation is probably still enabled. Reset it to a desktop viewport such as `1440x900x1`, then re-check before judging the page.
+   - Also catch subtler desktop emulation drift: if `outerWidth - innerWidth > 120` while the user says the Chrome window is full-size, the page is being judged inside a smaller emulated viewport. Do not judge "right-side blank space" or max-width until the emulated viewport matches the visible browser window or the mismatch is explicitly stated.
+   - After unplugging/plugging an external display, changing display scaling, or moving Chrome between displays, treat the existing Chrome window as contaminated until proven clean. Old zoom, stale DevTools emulation, and inherited window bounds can make a correct page look broken or hide a real bug. Prefer restarting a clean Chrome test window/profile, then record `outerWidth`, `innerWidth`, `visualViewport`, and zoom-sensitive geometry again.
+   - Measure the first viewport geometry in the same DevTools pass:
+
+```js
+() => {
+  const content = document.querySelector("main") || document.body;
+  const heroImage = [...document.images]
+    .filter((img) => img.complete && img.naturalWidth)
+    .map((img) => {
+      const rect = img.getBoundingClientRect();
+      return { img, rect, area: rect.width * rect.height };
+    })
+    .filter((item) => item.rect.bottom > 0 && item.rect.top < innerHeight)
+    .sort((a, b) => b.area - a.area)[0];
+  const contentRect = content.getBoundingClientRect();
+  return {
+    content: {
+      left: Math.round(contentRect.left),
+      right: Math.round(contentRect.right),
+      leftBlank: Math.round(Math.max(0, contentRect.left)),
+      rightBlank: Math.round(Math.max(0, innerWidth - contentRect.right)),
+    },
+    heroImage: heroImage ? {
+      displayed: `${Math.round(heroImage.rect.width)}x${Math.round(heroImage.rect.height)}`,
+      displayedRatio: +(heroImage.rect.width / heroImage.rect.height).toFixed(3),
+      naturalRatio: +(heroImage.img.naturalWidth / heroImage.img.naturalHeight).toFixed(3),
+      objectFit: getComputedStyle(heroImage.img).objectFit,
+    } : null,
+  };
+}
+```
+
+   - Treat a large right blank area as a viewport-contract problem until proven otherwise: first check `outerWidth - innerWidth`; then compare first-viewport `leftBlank` and `rightBlank`; only then decide whether it is an intentional max-width layout.
+   - Do not leave the user's browser stuck in mobile emulation after the review. End on the viewport the user expects, or state exactly what viewport remains active.
+
+3. **Run Mechanical Checks**
+   - Start or identify the dev server.
+   - Run the app's normal checks first: `lint`, `build`, unit/e2e tests when present.
+   - Run the bundled visual audit script when a URL is available:
+
+```bash
+cd /path/to/project
+npm install -D playwright-core   # if the project does not already have it
+node <path-to-this-skill>/scripts/visual_layout_audit.mjs --url http://127.0.0.1:5173/
+```
+
+   - If the artifact has a known page type, pass it explicitly:
+
+```bash
+node <path-to-this-skill>/scripts/visual_layout_audit.mjs \
+  --url http://127.0.0.1:5173/ \
+  --page-type design-system
+```
+
+   - If the intended deliverable is an interactive rendered design system, use the live artifact page type:
+
+```bash
+node <path-to-this-skill>/scripts/visual_layout_audit.mjs \
+  --url http://127.0.0.1:5173/ \
+  --page-type live-artifact-design-system
+```
+
+   - For long pages, design systems, and live artifacts, capture lower-section screenshots as part of the same run:
+
+```bash
+node <path-to-this-skill>/scripts/visual_layout_audit.mjs \
+  --url http://127.0.0.1:5173/ \
+  --page-type live-artifact-design-system \
+  --screenshot-sections
+```
+
+   - Section screenshots should include representative component/specimen, chart/data-viz, pattern/state, and governance/usage areas when those areas exist. A first-viewport-only pass is not enough for a design system.
+   - Pass product-specific forbidden rendered terms only when the project has known stale names:
+
+```bash
+node <path-to-this-skill>/scripts/visual_layout_audit.mjs \
+  --url http://127.0.0.1:5173/ \
+  --forbid "Old Product Name|Deprecated Font|staging-only label"
+```
+
+   - If the user is looking at a wider Chrome window than the scripted viewport, pass the visible window width so the script can flag a mismatch:
+
+```bash
+node <path-to-this-skill>/scripts/visual_layout_audit.mjs \
+  --url http://127.0.0.1:5173/ \
+  --expected-window-width 1920
+```
+
+   - Do not "fix" script failures by renaming classes, hiding overflow, or removing selectable text. If the script misclassifies a container as a control, fix the script rule or record the false positive with evidence.
+   - The script is a sweep, not proof by itself. DevTools evidence and screenshot inspection still decide user-visible correctness.
+
+4. **Use Real Browser Evidence**
+   - Verify at least one desktop viewport and one mobile viewport.
+   - Record: `outerWidth`, `innerWidth`, `visualViewport.width`, `outerWidth - innerWidth`, `innerHeight`, `overflowX`, document title/H1, important image load status.
+   - For the first viewport, also record the effective content bounds, left/right blank space, primary image displayed ratio versus natural ratio, and whether any label/caption overlaps important image content.
+   - Record enough typography evidence to answer whether the font, spacing, width, text size, and style are right: body font family, H1 size, body size, sidebar/rail width, repeated text-column width, and smallest important text size.
+   - Take screenshots. Inspect them. Do not treat the screenshot file as proof until you actually look at it.
+   - If the user complained about a specific area, scroll to that area and screenshot it, not just the top of the page.
+   - For long pages or design systems, inspect at least the first viewport plus representative lower sections. Do not stop after a clean hero/cover screenshot.
+   - For a live artifact design system, exercise at least one interactive specimen: variant/tab/segmented switch, drawer/modal open-close, chart state, filter state, or responsive/state demo. Record what changed and whether text, overlay, scroll ownership, or overflow broke while the state was active.
+   - If no meaningful interaction can be exercised in a live artifact, report that as a finding rather than silently treating it as static documentation.
+
+5. **Classify Findings**
+   - `P0`: page unusable, blank, primary action blocked, text unreadable, severe overlap.
+   - `P1`: horizontal page overflow, double/incorrect scroll container, modal/toolbar blocks content, major responsive failure.
+   - `P2`: awkward heading line break, orphan Chinese character/word, wrapped button/tag, cramped card text, important image missing.
+   - `P3`: minor spacing, weak contrast, inconsistent alignment, non-critical polish.
+   - `Intent`: wrong artifact type, such as a design system presented as a fake app, a dashboard presented as a poster, or a landing page presented as a component catalog.
+   - `Taste`: generic AI slop aesthetic, wrong domain style, unmotivated gradient/glow/card pile, not enough brand/product signal.
+
+6. **Fix And Re-run**
+   - Do not say "fixed" after editing CSS. Re-run the visual checks and inspect screenshots again.
+   - For awkward line breaks, prefer structural fixes over random width tweaks:
+     - shorten copy;
+     - split title into intentional spans;
+     - change layout tracks;
+     - widen the semantic column;
+     - move metadata into a second line;
+     - use `white-space: nowrap` only for short labels/buttons/tags;
+     - use `text-wrap: balance` for headings where supported;
+     - use container-specific font sizes, not viewport-wide scaling.
+
+## What To Check
+
+Load `references/history-derived-checklist.md` for the detailed checklist. Minimum checks:
+
+- awkward Chinese or mixed Chinese/English line breaks;
+- semantic Chinese word splits across rendered line boundaries in high-visibility copy, such as `这|里`, `这|个`, `不|是`, or `我|们`;
+- orphan lines where high-visibility text ends with one or two Chinese characters;
+- short-tail lines in ordinary body copy are context-dependent: do not mechanically fail every 2-3 character tail. Judge by visibility, semantic break, repeated occurrence, and whether the container is unnecessarily narrow.
+- wrapped controls: buttons, tabs, pills, tags, nav items, menu labels;
+- typography system mismatch: font family, type scale, line height, text-column width, and density do not match the artifact type or domain;
+- cramped text in cards/tables/timelines;
+- text clipped by fixed heights;
+- horizontal page overflow;
+- viewport/window mismatch that makes a normal desktop Chrome render through a smaller emulated viewport;
+- excessive or asymmetric blank space in the first viewport;
+- lower-section layout failures that are hidden by a clean first viewport;
+- scroll container mistakes: double scrollbars, page scroll when a panel should scroll, sticky controls blocking content;
+- overlapping elements;
+- images not loaded, distorted, stretched, too cropped, wrong aspect ratio, overlaid by labels/captions, or not representative of the product/domain;
+- title/H1/visible system name drift;
+- page-type drift: design system vs app/workbench/dashboard/landing/deck;
+- live-artifact drift: useful interactive specimens are wrongly removed, or live controls appear without specimen labels, state/variant framing, or usage rules;
+- unexercised live-artifact interactions: controls exist, but nobody checked the changed state for overflow, clipping, overlay, stale chart data, or scroll problems;
+- repeated card/panel grids that replace information architecture;
+- generic AI slop aesthetics: purple/blue gradient default, glass cards, decorative orbs/glow, card grids everywhere, vague "AI empowers" copy.
+
+## Page-Type Contracts
+
+Use this section before judging the UI. A visually polished page can still be wrong if it is the wrong artifact.
+
+### Design System / Specimen
+
+Expected signals:
+- scope and version;
+- design principles;
+- foundations/tokens: color, typography, spacing, radius, elevation, motion;
+- component anatomy, variants, states, usage, do/don't;
+- patterns that combine components;
+- accessibility, content, data-viz, responsive, and governance rules.
+
+Red flags:
+- the page reads as a real workbench/dashboard instead of a specification;
+- business metrics, competitor notes, or roadmap content dominate the first screen;
+- many repeated cards replace component anatomy and usage guidance;
+- fake data modules look like product features rather than specimens;
+- the artifact lacks do/don't, states, or governance.
+
+### Live Artifact Design System
+
+Expected signals:
+- visible system scope, version, and artifact status;
+- interactive specimens for components, charts, states, tokens, responsive behavior, or patterns;
+- each live module is labelled as a specimen, pattern, state demo, or component contract;
+- interactions expose design behavior: variant switching, state changes, empty/error/loading cases, chart tooltip/selection, drawer/modal behavior, responsive collapse, or governance rules;
+- sample business data is clearly specimen data and does not pretend that the real app/workbench is complete.
+
+Red flags:
+- treating all controls, tabs, buttons, drawers, or charts as "fake app" and stripping the artifact into a dead static document;
+- app-like panels dominate without anatomy, variants, state names, usage rules, or do/don't guidance;
+- the page becomes an operational workbench where the reviewer cannot tell what design rule is being demonstrated;
+- repeated business cards replace component contracts and interaction specimens;
+- live interactions change content but do not reveal any design-system behavior.
+- controls cannot be exercised, or the exercised state creates overflow, clipped text, modal/drawer scroll mistakes, or stale chart labels.
+
+### Real App / Dashboard
+
+Expected signals:
+- task-first layout, real navigation, meaningful data states, one scroll owner;
+- controls have stable dimensions and do not wrap;
+- data visualizations show units, source, time range, and empty/error states.
+
+Red flags:
+- marketing hero composition inside an operations tool;
+- decorative cards around every section;
+- chart-like visuals without units or source;
+- global page scroll competing with panel scroll.
+
+## Evidence Format
+
+When reporting, be concrete:
+
+```markdown
+Findings:
+- P2 awkward heading break: `.hero-title` renders as `客户增长分析 / 系统` at 1700px. Fix: split H1 into intentional semantic spans.
+- P1 horizontal overflow: mobile 390px has `overflowX=42`; source `.toolbar`.
+- Taste: hero uses generic purple gradient and no real product/domain visual; replace with domain-specific image.
+
+Verified:
+- desktop 1700x1000: `overflowX=0`, title/H1 correct, primary image loaded.
+- mobile 390x844: `overflowX=0`, no wrapped controls.
+- screenshots: `/tmp/page-desktop.png`, `/tmp/page-mobile.png`.
+```
+
+## Anti-Patterns
+
+- Checking only code and not rendered output.
+- Using a narrow desktop window and calling it mobile or desktop validation.
+- Leaving DevTools mobile emulation active, then mistaking the page for a broken desktop layout.
+- Leaving a desktop emulated viewport active inside a larger Chrome window, then missing a large blank area the user can see.
+- Trusting a Chrome window after display changes without restarting or revalidating zoom/emulation/window bounds.
+- Judging only `innerWidth` while the user is reacting to the full visible Chrome `outerWidth`.
+- Calling a centered max-width layout "fine" before checking whether the right blank area is symmetric and intentional.
+- Taking a screenshot but not opening it.
+- Reviewing only the first viewport of a long page and missing broken lower sections.
+- Leaving tabs/drawers/modals/chart states unclicked in a live artifact.
+- Fixing one visible line break without scanning other headings/buttons/tables.
+- Overcorrecting Chinese short-tail lines by forcing every 2-3 character final line to disappear.
+- Answering "font/spacing/width/size/style are fine" without computed values and screenshot evidence.
+- Gaming the QA script by renaming classes or hiding overflow instead of fixing the visual defect or the detector.
+- Treating a design-system specimen as permission to build a fake product screen.
+- Turning "avoid repeated cards" into a mechanical "remove all cards" rule. The real issue is whether cards serve component specimens or replace information architecture.
+- Adding `overflow: hidden` to hide the problem.
+- Shrinking all text until it fits.
+- Letting labels or table first columns break character-by-character.
+- Saying "responsive" because CSS has media queries.
+- Treating `frontend-design` as a substitute for actual Chrome verification.
+- Treating a headless Playwright pass as proof that the user's current Chrome window is correct.
+
+## Bundled Resources
+
+- `scripts/visual_layout_audit.mjs`: Playwright-core script that loads a URL at desktop/mobile viewports and reports bad terms, horizontal overflow, section overflow, orphan heading lines, wrapped controls, clipped text, image defects, and optional lower-section screenshots.
+- `references/history-derived-checklist.md`: distilled checklist from local Claude/Codex history and recurring user corrections.

--- a/frontend-visual-qa/references/history-derived-checklist.md
+++ b/frontend-visual-qa/references/history-derived-checklist.md
@@ -1,0 +1,122 @@
+# History-Derived Frontend Visual QA Checklist
+
+This checklist was distilled from local Claude/Codex history where the user repeatedly corrected rendered frontend artifacts. The raw histories contain private project details; this file keeps the reusable patterns and removes project-specific content.
+
+## Recurring Failure Patterns
+
+| Pattern | What It Looked Like | Detection Heuristic | Preferred Fix |
+|---|---|---|---|
+| Awkward heading break | A title breaks into a final line with one or two Chinese characters, or a semantic phrase is split apart. | In Chrome, inspect rendered text lines for headings and titles. Flag final lines with <=2 non-space chars. | Split the heading intentionally, shorten copy, widen the column, or use `text-wrap: balance`. |
+| Semantic word split | High-visibility Chinese copy breaks a common two-character word across lines, such as `这|里`, `这|个`, `不|是`, `我|们`, or `需|要`. It looks careless even when neither line is a short tail. | Inspect rendered line boundaries for key headings, hero/lead copy, labels, spec cells, and repeated component text. Do not apply this mechanically to every ordinary paragraph. | Rewrite the sentence, widen the semantic column, use intentional spans for short phrases, or move the clause to a new line. |
+| Over-strict short-tail policing | A reviewer tries to eliminate every two- or three-character final line in normal body copy, creating needless rewrites or over-wide layouts. | Treat short tails as contextual. Prioritize headings, controls, labels, table/spec cells, first viewport copy, and repeated obvious cases. | Fix visible semantic breaks and cramped containers; do not chase every ordinary body-copy short tail. |
+| Table first-column break | A short label, date, name, or module title breaks character-by-character in a narrow table column. | Scan table cells and row headers for multi-line short strings. | Change column widths, use `white-space: nowrap` for short labels, or restructure the table for mobile. |
+| Wrapped controls | Button/tag/nav text wraps onto two lines, making the control look cheap or ambiguous. | Flag buttons, tabs, nav items, tags, pills with more than one rendered line. | Shorten label, increase control width, use icon+tooltip, or change layout. |
+| Text block crowding | Cards contain too much prose, causing dense grey text and poor hierarchy. | Count lines and visual density; screenshot review catches this better than DOM alone. | Rewrite copy, split into bullets, promote only high-value text, add hierarchy and spacing. |
+| Double or wrong scrollbar | Page scrolls when a panel/sidebar should scroll, or two scrollbars appear on the right. | Check scroll containers and user interaction path; verify with Chrome. | Define one owner for scroll. Use `min-height: 0`, stable panel heights, and scoped overflow. |
+| DevTools viewport drift | Browser window looks normal, but the page renders as mobile because DevTools emulation was left at `390x844` or another device profile. | In Chrome DevTools, compare `outerWidth/outerHeight` to `innerWidth/innerHeight`, `visualViewport`, and `devicePixelRatio`. | Reset emulation to a desktop viewport before desktop review; after mobile checks, return to the user's expected viewport. |
+| Contaminated browser state after display changes | After unplugging an external monitor or changing display scale, the old Chrome window keeps stale zoom, emulation, or window bounds. The page appears broken until Chrome is restarted. | When the user changes displays, do not trust prior screenshots. Re-read `outerWidth`, `innerWidth`, `visualViewport`, DPR, and zoom-sensitive layout geometry in a restarted or explicitly reset Chrome window. | Restart a clean Chrome test window/profile, or explicitly reset zoom/emulation/window bounds before visual QA. Treat earlier evidence as invalid unless it is reproduced after reset. |
+| Desktop viewport mismatch | Chrome is a wide desktop window, but DevTools still emulates a narrower desktop viewport such as `1440` inside a `1920` outer window, creating a large blank area on the user's visible screen. | In Chrome DevTools, flag `outerWidth - innerWidth > 120` when the user is looking at a normal desktop window. Also compare the right edge of the main container against both `innerWidth` and `outerWidth`. | Match the emulated viewport to the actual visible browser window, or explicitly state the mismatch before judging layout. |
+| Asymmetric first-viewport blank space | A hero or design-system cover leaves a visibly huge empty area on the right while the content appears pinned left or underfilled. | Measure the first viewport content bounds: `leftBlank`, `rightBlank`, content width ratio, and `rightBlank - leftBlank`. Compare against `outerWidth - innerWidth` before blaming CSS. | Fix the viewport contract first. If the viewport is correct, rebalance the grid/container, widen the content area, or intentionally center the composition. |
+| First-viewport-only QA | The cover/hero passes, but lower component, chart, pattern, or governance sections still have bad wrapping, overflow, repeated cards, or broken images. | For long pages/design systems, capture and inspect representative lower-section screenshots. Use section overflow checks, not just page-level `overflowX`. | Add a section sweep to the review: first viewport, component/specimen area, chart/data-viz area, pattern/state area, governance/end area where present. |
+| Image aspect or crop mismatch | A hero/product image looks stretched, squeezed, or cropped into a shape that hides the useful content. | Compare displayed image ratio to natural image ratio and inspect `object-fit`. Flag `object-fit: fill` or default stretching with a ratio mismatch; warn on heavy `cover` cropping. | Use the correct asset ratio, set a matching container `aspect-ratio`, or choose `object-fit: contain/cover` deliberately with safe focal positioning. |
+| Image overlay collision | Labels, badges, or captions sit on top of useful content inside an image, covering cards, product UI, faces, or readable details. | Check text element rectangles against primary image rectangles, especially absolutely positioned captions inside `figure`/hero/media wrappers. | Move captions outside the image, reserve a non-critical overlay zone, or use a separate legend/control area. |
+| Page-type drift | The user asks for a design system, but the artifact becomes a fake app dashboard/workbench; or a dashboard becomes a marketing page. | Before reviewing, write the page type and anti-goals. For design systems, check for principles, foundations, components, patterns, do/don't, and governance. | Rebuild the information architecture around the artifact type; do not merely restyle cards. |
+| Live artifact misread as fake app | A live design-system artifact uses buttons, tabs, drawers, charts, or state toggles to demonstrate component behavior, but the reviewer treats all interactivity as page-type drift and strips it back to a dead static page. | Ask whether the interaction is labelled as a specimen, state demo, pattern, or component contract. Check whether it exposes variants, states, chart behavior, responsive behavior, or governance rules. | Keep the interaction when it demonstrates the design system. Add labels, anatomy, states, and usage framing so it cannot be mistaken for a finished workbench. |
+| Unframed live artifact | Interactive modules exist, but nothing says what component, pattern, state, or rule they demonstrate. The page feels like a half-built product. | Scan nearby headings and labels for specimen/pattern/component/state/variant/token/anatomy/usage language. Check whether sample data is marked as specimen data. | Convert app-like modules into live specimens: add component names, state labels, usage rules, do/don't notes, and explicit sample-data framing. |
+| Unexercised live interaction | Buttons, tabs, drawers, or chart controls are visible, but the review never clicks them. The default state looks acceptable while alternate states overflow, clip, or show stale labels. | In Chrome, exercise at least one representative interaction per live specimen family. Record before/after state and inspect overflow, text wrapping, overlay, and scroll ownership while the state is active. | Treat live artifact review like a small interaction QA pass: click variant/state controls, open/close overlays, hover/select charts when possible, then re-screenshot the changed state. |
+| Repeated card pile | Many identical cards/panels appear because the agent translated every idea into a card. The page feels generated rather than designed. | Count repeated card/panel/tile containers and inspect whether they express hierarchy or just duplicate a template. | Use tables, rules, specimens, side notes, bands, and structured lists. Keep cards for repeated items, examples, modals, and genuine component specimens. |
+| QA script gaming | A detector flags an issue, then the implementation is changed to avoid the selector rather than fixing the visual problem or detector. | Compare the user's complaint, screenshot, and code change. Renaming `.tag-sample` to avoid a wrapped-control warning is a smell unless the detector logic is also corrected. | Fix the detector if it misclassifies, or fix the layout if it is real. Record the reason. |
+| Overlap | Calendar/timeline/event labels collide, or blocks overlap after data changes. | Use viewport screenshots around dense areas and inspect bounding boxes when possible. | Reserve dimensions, use collision-aware layout, reduce competing columns, or stack on small widths. |
+| Hidden/clipped content | Screenshot/section/page is not fully visible; fixed-height panels cut off text. | Compare `scrollHeight` vs `clientHeight`; inspect screenshots across viewports. | Remove arbitrary fixed heights or provide intentional scroll area with affordance. |
+| Low-value copy causing layout damage | Vague slogans or redundant labels make the page longer while adding no decision value. | Ask whether each visible sentence changes user action or understanding. | Cut vague copy. Replace with object/state/action labels. |
+| Generic AI slop | Purple gradients, glow, glass cards, decorative blobs, card grids everywhere, "AI empowers" copy. | Compare against domain references and product purpose. | Use domain-specific visuals, brand tokens, real objects/states, and restrained composition. |
+| Screenshot not actually reviewed | Agent claims done after build/lint, but browser view still has obvious line breaks. | Require screenshot paths and a short visual finding summary. | Open and inspect screenshots before final response. |
+| Staged viewport not restored | A mobile or narrow emulation profile remains active after testing, so later reviewers see a phone-sized page inside a desktop window. | End the review by reading `outerWidth`, `innerWidth`, `visualViewport`, and DPR again in the user's Chrome. | Reset to the expected desktop viewport or explicitly report the remaining emulation state. |
+
+## Mandatory Viewports
+
+Use real browser rendering, not mental simulation.
+
+- Desktop wide: around `1700x1000`.
+- Desktop common: around `1440x900`.
+- Mobile: around `390x844`.
+- If the target is a projection/demo page, also test the intended projection size.
+
+For each viewport record:
+
+- `document.title`
+- first `h1`
+- `innerWidth` / `innerHeight`
+- `outerWidth` / `outerHeight` when using the user's visible Chrome
+- `outerWidth - innerWidth` when using the user's visible Chrome
+- `visualViewport.width` / `visualViewport.scale` when DevTools emulation may be active
+- `documentElement.scrollWidth - clientWidth`
+- first viewport content `leftBlank` / `rightBlank` / width ratio
+- primary image load status
+- primary image displayed ratio / natural ratio / object-fit
+- text overlays that intersect important image content
+- typography evidence: font family, key text sizes, line heights, sidebar/rail width, repeated text-column width, smallest important text size
+- screenshot path
+- lower-section screenshot paths when the page is long, a design system, or a live artifact
+
+## Text And Line-Break Rules
+
+- Chinese headings must not end with a final line of one or two characters.
+- High-visibility Chinese copy should not split common semantic two-character words across line boundaries, such as `这|里`, `这|个`, `我|们`, or `不|是`.
+- Domain terms should stay intact: product names, module names, dates, city/dealer names, labels.
+- Two- or three-character final lines in ordinary body text are not automatically defects. Flag them only when they are high visibility, split a semantic unit, occur repeatedly in the same component pattern, or reveal a too-narrow container.
+- Buttons/tags/nav labels should not wrap unless the control is explicitly designed for two lines.
+- Do not globally shrink font size to solve line breaks.
+- Do not hide overflow to suppress evidence.
+- Prefer rewriting content over forcing narrow containers to accept long text.
+- Treat product names, labels, dates, and domain phrases as semantic units. If a semantic unit breaks badly, fix the content or layout instead of accepting the browser's default wrap.
+
+## Layout Rules
+
+- Do not put every concept into identical cards.
+- Do not put cards inside cards unless it is a modal or repeated item structure.
+- Do not reduce "avoid cards" to "no cards anywhere." The question is whether the card has a job.
+- Preserve clear primary/secondary hierarchy.
+- Give repeated fixed-format elements stable dimensions.
+- A panel that scrolls must visibly own its scroll; the page must not hijack panel scrolling.
+- Sticky/floating controls must not cover content.
+- A wide desktop first viewport should not accidentally underfill one side. If there is a large blank area, classify whether it comes from viewport emulation, intentional max-width centering, or broken grid/container sizing.
+- Section containers must not have their own accidental horizontal overflow even when the whole document reports `overflowX=0`.
+- Font size, line height, spacing, and column width must be judged together. A readable font can still fail if the column is too narrow, and a wide layout can still fail if the type scale is too small for the artifact.
+
+## Design-System Artifact Rules
+
+When the page is a design system, review it as a design system, not as an app screen.
+
+- It should explain why the system exists, what it governs, and what it excludes.
+- It should contain foundations, component anatomy, variants, states, usage guidance, do/don't examples, responsive rules, and governance.
+- Component examples may use cards or panels, but the page's information architecture should not be a pile of business cards.
+- Fake data is acceptable only as a specimen. It must not make the page read like a real dashboard.
+- Business strategy, competitor notes, or roadmap context belong in supporting docs unless the design-system page explicitly frames them as product principles.
+- If the artifact lacks a do/don't section or state/variant rules, it is probably a showcase page, not a design system.
+
+## Live Artifact Design-System Rules
+
+Some projects intentionally ship the design system as a live artifact: a rendered, interactive page that lets reviewers test components and patterns directly. Do not downgrade it into a static documentation page.
+
+- Interactivity is allowed when it demonstrates design-system behavior: variants, states, token application, chart tooltip/selection, drawer/modal behavior, responsive collapse, empty/error/loading cases, or governance rules.
+- A live specimen must name what is being demonstrated. Nearby text should make the unit legible as a component, pattern, state demo, chart contract, shell specimen, or responsive rule.
+- Controls should feel like test harnesses for the design system, not unfinished business actions. If a button says "open case" or "assign lead," the surrounding frame must explain the component state or pattern being tested.
+- Sample business data must be visibly framed as specimen data. Otherwise the artifact will read as a fake workbench.
+- Do not remove useful live specimens just because they resemble product UI. Fix the framing first: add anatomy, variant/state labels, usage guidance, and do/don't examples.
+- Fail the artifact when interaction changes content without revealing a design rule. A live artifact earns its interactivity by making a rule testable.
+- Click representative controls during review. A live artifact is not verified until at least one changed state has been inspected for overflow, clipping, image/text collision, and scroll ownership.
+
+## Aesthetic Rules
+
+- First viewport must communicate the actual domain/product, not just generic SaaS competence.
+- Visual assets should reveal the product, place, object, gameplay, or state being discussed.
+- Avoid default AI visual tropes: purple/blue gradients, glassmorphism, floating orbs, excessive glow, decorative dashboards with fake data.
+- If a page belongs to a brand or industry, check official materials or reference images before choosing style.
+
+## How This Differs From Existing Skills
+
+- `ui-designer` extracts visual systems from reference images.
+- `frontend-design` guides distinctive implementation.
+- `qa-expert` sets up broad QA processes and bug tracking.
+- This checklist catches rendered visual defects after the UI exists.

--- a/frontend-visual-qa/scripts/visual_layout_audit.mjs
+++ b/frontend-visual-qa/scripts/visual_layout_audit.mjs
@@ -1,0 +1,962 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+function loadPlaywright() {
+  const requireFromProject = createRequire(`${process.cwd()}/package.json`);
+  try {
+    return requireFromProject("playwright-core");
+  } catch (projectError) {
+    try {
+      const requireFromSkill = createRequire(import.meta.url);
+      return requireFromSkill("playwright-core");
+    } catch {
+      throw new Error(
+        "playwright-core not found. Run `npm install -D playwright-core` in the frontend project, then re-run this script.\n" +
+        `Original error: ${projectError.message}`
+      );
+    }
+  }
+}
+
+function getArg(name, fallback = null) {
+  const idx = process.argv.indexOf(name);
+  return idx >= 0 && process.argv[idx + 1] ? process.argv[idx + 1] : fallback;
+}
+
+function findChrome() {
+  const candidates = [
+    process.env.CHROME_PATH,
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
+    "/Applications/Chromium.app/Contents/MacOS/Chromium",
+    "/usr/bin/google-chrome-stable",
+    "/usr/bin/google-chrome",
+    "/usr/bin/chromium",
+  ].filter(Boolean);
+  const found = candidates.find((candidate) => fs.existsSync(candidate));
+  if (!found) {
+    throw new Error("Chrome/Chromium not found. Set CHROME_PATH to the browser executable.");
+  }
+  return found;
+}
+
+const target = getArg("--url") || getArg("--file");
+const outDir = getArg("--out", "/tmp/frontend-visual-qa");
+const forbidPattern = getArg("--forbid", "");
+const requirePattern = getArg("--require", "");
+const pageType = getArg("--page-type", "auto");
+const expectedWindowWidth = parsePositiveInt(getArg("--expected-window-width", ""));
+const contentSelector = getArg("--content-selector", "");
+const mediaSelector = getArg("--media-selector", "");
+const sectionSelector = getArg("--section-selector", "section,[role='region'],main > div,main > article");
+const maxSectionScreenshots = parsePositiveInt(getArg("--max-section-screenshots", "4"));
+const screenshotSections = process.argv.includes("--screenshot-sections");
+const failOnWarning = process.argv.includes("--fail-on-warning");
+
+if (!target || process.argv.includes("--help")) {
+  console.error("Usage: visual_layout_audit.mjs --url <http://localhost:port/|local.html> [--page-type design-system|live-artifact-design-system|dashboard|app|landing|auto] [--forbid \"Old Name|Bad Term\"] [--require \"Required Term\"] [--expected-window-width 1920] [--content-selector main] [--media-selector .hero] [--section-selector \"section\"] [--screenshot-sections] [--max-section-screenshots 4] [--out /tmp/dir] [--fail-on-warning]");
+  process.exit(2);
+}
+
+const url = normalizeTarget(target);
+validateForbidPattern(forbidPattern);
+validateForbidPattern(requirePattern);
+validatePageType(pageType);
+validateSelector(sectionSelector, "--section-selector");
+
+const { chromium } = loadPlaywright();
+
+fs.mkdirSync(outDir, { recursive: true });
+
+const viewports = [
+  { name: "desktop-wide", width: 1700, height: 1000, deviceScaleFactor: 1, isMobile: false, hasTouch: false },
+  { name: "desktop", width: 1440, height: 900, deviceScaleFactor: 1, isMobile: false, hasTouch: false },
+  { name: "mobile", width: 390, height: 844, deviceScaleFactor: 2, isMobile: true, hasTouch: true },
+];
+
+const browser = await chromium.launch({
+  executablePath: findChrome(),
+  headless: true,
+});
+
+const report = {
+  url,
+  createdAt: new Date().toISOString(),
+  viewports: [],
+  issues: [],
+};
+
+for (const viewport of viewports) {
+  const page = await browser.newPage({
+    viewport: { width: viewport.width, height: viewport.height },
+    deviceScaleFactor: viewport.deviceScaleFactor,
+    isMobile: viewport.isMobile,
+    hasTouch: viewport.hasTouch,
+  });
+  await page.goto(url, { waitUntil: "networkidle", timeout: 30_000 });
+  await page.evaluate(() => window.scrollTo(0, 0));
+  const screenshot = `${outDir}/${viewport.name}.png`;
+  await page.screenshot({ path: screenshot, fullPage: false });
+  const result = await page.evaluate(auditPage, {
+    viewportName: viewport.name,
+    forbidPattern,
+    requirePattern,
+    pageType,
+    expectedWindowWidth,
+    contentSelector,
+    mediaSelector,
+    sectionSelector,
+  });
+  const sectionScreenshots = screenshotSections
+    ? await captureSectionScreenshots(page, viewport, outDir, sectionSelector, maxSectionScreenshots)
+    : [];
+  report.viewports.push({ ...result.meta, screenshot, sectionScreenshots });
+  report.issues.push(...result.issues);
+  await page.close();
+}
+
+await browser.close();
+
+const reportPath = `${outDir}/frontend-visual-qa-report.json`;
+fs.writeFileSync(reportPath, JSON.stringify(report, null, 2));
+
+const errors = report.issues.filter((issue) => issue.severity === "error");
+const warnings = report.issues.filter((issue) => issue.severity === "warning");
+
+for (const viewport of report.viewports) {
+  const visual = viewport.visualViewport ? `, visual=${viewport.visualViewport.width}x${viewport.visualViewport.height}@${viewport.visualViewport.scale}` : "";
+  const content = viewport.firstViewportContent
+    ? `, firstViewportBlank=${viewport.firstViewportContent.leftBlank}/${viewport.firstViewportContent.rightBlank}, contentRatio=${viewport.firstViewportContent.widthRatio}`
+    : "";
+  const primaryImage = viewport.primaryImage
+    ? `, primaryImage=${viewport.primaryImage.displayedWidth}x${viewport.primaryImage.displayedHeight} ratio=${viewport.primaryImage.displayedRatio}/${viewport.primaryImage.naturalRatio} fit=${viewport.primaryImage.objectFit}`
+    : "";
+  const typography = viewport.typography
+    ? `, type=${viewport.typography.bodySize}/${viewport.typography.h1Size}, minText=${viewport.typography.smallestImportantTextSize}, minCol=${viewport.typography.narrowestTextColumnWidth}`
+    : "";
+  const sections = viewport.sections
+    ? `sections=${viewport.sections.count}, worstSectionOverflowX=${viewport.sections.worstOverflowX}`
+    : "";
+  console.log(`${viewport.viewport}: outer=${viewport.outerWidth}x${viewport.outerHeight}, inner=${viewport.width}x${viewport.height}, outerMinusInner=${viewport.outerMinusInner}, client=${viewport.clientWidth}, scroll=${viewport.scrollWidth}, overflowX=${viewport.overflowX}${visual}${content}${primaryImage}${typography}, title="${viewport.title}", h1="${viewport.h1}", screenshot=${viewport.screenshot}`);
+  if (sections) console.log(`  sectionAudit: ${sections}`);
+  if (viewport.sectionScreenshots?.length) {
+    console.log(`  sectionScreenshots: ${viewport.sectionScreenshots.map((item) => item.screenshot).join(", ")}`);
+  }
+}
+
+if (report.issues.length) {
+  console.log(`\nIssues: ${errors.length} error(s), ${warnings.length} warning(s). Report: ${reportPath}`);
+  for (const issue of report.issues) {
+    console.log(`- ${issue.severity.toUpperCase()} ${issue.viewport} ${issue.type} ${issue.selector || ""}`);
+    if (issue.text) console.log(`  text: ${issue.text}`);
+    if (issue.detail) console.log(`  ${issue.detail}`);
+  }
+} else {
+  console.log(`\nNo mechanical layout issues found. Screenshots still require human visual review. Report: ${reportPath}`);
+}
+
+process.exit(errors.length || (failOnWarning && warnings.length) ? 1 : 0);
+
+function normalizeTarget(value) {
+  if (/^(https?:|file:)/i.test(value)) return value;
+  const resolved = path.resolve(value);
+  if (fs.existsSync(resolved)) return pathToFileURL(resolved).href;
+  return value;
+}
+
+function validateForbidPattern(pattern) {
+  if (!pattern) return;
+  try {
+    new RegExp(pattern, "g");
+  } catch (error) {
+    console.error(`Invalid --forbid regular expression: ${error.message}`);
+    process.exit(2);
+  }
+}
+
+function parsePositiveInt(value) {
+  if (!value) return null;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    console.error(`Invalid positive integer: ${value}`);
+    process.exit(2);
+  }
+  return parsed;
+}
+
+function validatePageType(value) {
+  const allowed = new Set(["auto", "design-system", "live-artifact-design-system", "dashboard", "app", "landing"]);
+  if (!allowed.has(value)) {
+    console.error(`Invalid --page-type "${value}". Expected one of: ${[...allowed].join(", ")}`);
+    process.exit(2);
+  }
+}
+
+function validateSelector(selector, flagName) {
+  if (!selector) return;
+  try {
+    globalThis.document?.querySelectorAll(selector);
+  } catch {
+    // No document in Node; validate with a tiny browser-side pass in auditPage.
+  }
+  if (/^\s*,|,\s*,|,\s*$/.test(selector)) {
+    console.error(`Invalid ${flagName}: "${selector}"`);
+    process.exit(2);
+  }
+}
+
+async function captureSectionScreenshots(page, viewport, outDir, sectionSelector, maxCount) {
+  const sections = await page.evaluate(collectScreenshotSections, {
+    sectionSelector,
+    maxCount: maxCount || 4,
+  });
+  const captures = [];
+  for (let index = 0; index < sections.length; index += 1) {
+    const section = sections[index];
+    const scrolled = await page.evaluate(({ selector, domIndex }) => {
+      const el = document.querySelectorAll(selector)[domIndex];
+      if (!el) return null;
+      el.scrollIntoView({ block: "start", inline: "nearest" });
+      return Math.round(window.scrollY);
+    }, { selector: sectionSelector, domIndex: section.domIndex });
+    if (scrolled === null) continue;
+    await page.waitForTimeout(80);
+    const file = `${outDir}/${viewport.name}-section-${String(index + 1).padStart(2, "0")}-${section.slug}.png`;
+    await page.screenshot({ path: file, fullPage: false });
+    captures.push({ ...section, scrollY: scrolled, screenshot: file });
+  }
+  await page.evaluate(() => window.scrollTo(0, 0));
+  return captures;
+}
+
+function collectScreenshotSections({ sectionSelector, maxCount }) {
+  const preferredPatterns = [
+    /component|组件|anatomy|解剖|specimen|样本/i,
+    /chart|data.?viz|visuali[sz]ation|图表|可视化/i,
+    /pattern|模式|state|状态|variant|变体/i,
+    /governance|治理|usage|用法|do\/?don't|禁忌|qa|质量/i,
+  ];
+
+  let elements = [];
+  try {
+    elements = [...document.querySelectorAll(sectionSelector)];
+  } catch {
+    return [];
+  }
+
+  const candidates = elements
+    .map((el, domIndex) => {
+      const rect = el.getBoundingClientRect();
+      const style = getComputedStyle(el);
+      const heading = el.querySelector("h1,h2,h3,h4")?.textContent?.replace(/\s+/g, " ").trim() || "";
+      const label = heading || el.id || (typeof el.className === "string" ? el.className.split(/\s+/).slice(0, 2).join(" ") : "") || `section ${domIndex + 1}`;
+      const haystack = `${label} ${el.id || ""} ${typeof el.className === "string" ? el.className : ""} ${el.textContent || ""}`;
+      const preferredIndex = preferredPatterns.findIndex((pattern) => pattern.test(haystack));
+      return {
+        domIndex,
+        top: Math.round(rect.top + window.scrollY),
+        height: Math.round(rect.height),
+        width: Math.round(rect.width),
+        preferredIndex,
+        label: label.slice(0, 80),
+        slug: slugify(label) || `section-${domIndex + 1}`,
+        visible: rect.width > 100 && rect.height > 80 && style.display !== "none" && style.visibility !== "hidden",
+      };
+    })
+    .filter((item) => item.visible)
+    .filter((item) => item.top > window.innerHeight * 0.25);
+
+  const selected = [];
+  for (let index = 0; index < preferredPatterns.length && selected.length < maxCount; index += 1) {
+    const match = candidates.find((item) => item.preferredIndex === index && !selected.some((picked) => picked.domIndex === item.domIndex));
+    if (match) selected.push(match);
+  }
+  for (const item of candidates) {
+    if (selected.length >= maxCount) break;
+    if (!selected.some((picked) => picked.domIndex === item.domIndex)) selected.push(item);
+  }
+
+  return selected.slice(0, maxCount);
+
+  function slugify(value) {
+    return value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 40);
+  }
+}
+
+function auditPage({ viewportName, forbidPattern, requirePattern, pageType, expectedWindowWidth, contentSelector, mediaSelector, sectionSelector }) {
+  const issues = [];
+  const forbiddenTerms = forbidPattern ? new RegExp(forbidPattern, "g") : null;
+  const requiredTerms = requirePattern ? new RegExp(requirePattern, "g") : null;
+  const textSelector = [
+    "h1", "h2", "h3", "h4", "p", "button", "a", "strong", "em", "td", "th",
+    "[class*='tag']", "[class*='badge']", "[class*='pill']", "[class*='nav']",
+    "[class*='title']", "[class*='label']", "[class*='note']", "[class*='eyebrow']",
+  ].join(",");
+
+  for (const [selector, flagName] of [[contentSelector, "--content-selector"], [mediaSelector, "--media-selector"], [sectionSelector, "--section-selector"]]) {
+    if (!selector) continue;
+    try {
+      document.querySelectorAll(selector);
+    } catch (error) {
+      issues.push({
+        viewport: viewportName,
+        type: "invalid-selector",
+        severity: "error",
+        detail: `${flagName} is not a valid CSS selector: ${error.message}`,
+      });
+    }
+  }
+
+  const meta = {
+    viewport: viewportName,
+    width: window.innerWidth,
+    height: window.innerHeight,
+    outerWidth: window.outerWidth,
+    outerHeight: window.outerHeight,
+    outerMinusInner: window.outerWidth - window.innerWidth,
+    clientWidth: document.documentElement.clientWidth,
+    scrollWidth: document.documentElement.scrollWidth,
+    title: document.title,
+    h1: document.querySelector("h1")?.textContent?.replace(/\s+/g, " ").trim() || null,
+    overflowX: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+    dpr: window.devicePixelRatio,
+    visualViewport: window.visualViewport ? {
+      width: Math.round(window.visualViewport.width),
+      height: Math.round(window.visualViewport.height),
+      scale: window.visualViewport.scale,
+    } : null,
+  };
+
+  meta.firstViewportContent = measureFirstViewportContent(contentSelector);
+  meta.primaryImage = measurePrimaryImage(mediaSelector);
+  meta.typography = measureTypography();
+  const sectionAudit = auditSections(sectionSelector);
+  meta.sections = sectionAudit.meta;
+  issues.push(...sectionAudit.issues);
+
+  if (meta.overflowX > 1) {
+    issues.push({ viewport: viewportName, type: "page-horizontal-overflow", severity: "error", detail: `Page overflows by ${meta.overflowX}px.` });
+  }
+
+  if (/^desktop/.test(viewportName) && Math.abs(meta.outerMinusInner) > 120) {
+    issues.push({
+      viewport: viewportName,
+      type: "viewport-emulation-mismatch",
+      severity: "warning",
+      detail: `outerWidth (${meta.outerWidth}) differs from innerWidth (${meta.width}) by ${meta.outerMinusInner}px. In user-visible Chrome, verify the emulated viewport matches the actual window before judging blank space.`,
+    });
+  }
+
+  if (/^desktop/.test(viewportName) && expectedWindowWidth && Math.abs(expectedWindowWidth - meta.width) > 120) {
+    issues.push({
+      viewport: viewportName,
+      type: "expected-window-viewport-mismatch",
+      severity: "warning",
+      detail: `Expected visible Chrome width is ${expectedWindowWidth}px, but this audit rendered a ${meta.width}px CSS viewport. Reproduce the user's real viewport before judging wide-screen blank space.`,
+    });
+  }
+
+  if (/^desktop/.test(viewportName) && meta.firstViewportContent) {
+    const blankDelta = meta.firstViewportContent.rightBlank - meta.firstViewportContent.leftBlank;
+    if (blankDelta > Math.max(160, meta.width * 0.12)) {
+      issues.push({
+        viewport: viewportName,
+        type: "first-viewport-asymmetric-blank",
+        severity: "warning",
+        detail: `First viewport has ${meta.firstViewportContent.leftBlank}px left blank and ${meta.firstViewportContent.rightBlank}px right blank. Check viewport emulation first, then container/grid sizing.`,
+      });
+    }
+    if (meta.firstViewportContent.widthRatio < 0.62 && meta.firstViewportContent.leftBlank > 180 && meta.firstViewportContent.rightBlank > 180) {
+      issues.push({
+        viewport: viewportName,
+        type: "first-viewport-underfilled",
+        severity: "warning",
+        detail: `First viewport content uses only ${Math.round(meta.firstViewportContent.widthRatio * 100)}% of the CSS viewport. Inspect whether this is intentional editorial whitespace or a broken container.`,
+      });
+    }
+  }
+
+  if (forbiddenTerms) {
+    const badMatches = [...(document.body.innerText || "").matchAll(forbiddenTerms)].map((match) => match[0]);
+    for (const term of [...new Set(badMatches)]) {
+      issues.push({ viewport: viewportName, type: "forbidden-rendered-term", severity: "error", text: term, detail: "A project-specific forbidden term appears in rendered UI." });
+    }
+  }
+
+  if (requiredTerms && !(document.body.innerText || "").match(requiredTerms)) {
+    issues.push({ viewport: viewportName, type: "required-rendered-term-missing", severity: "error", detail: `No rendered text matches required pattern: ${requiredTerms.source}` });
+  }
+
+  issues.push(...auditPageType({ viewportName, pageType }));
+
+  for (const el of [...document.querySelectorAll(textSelector)].filter(isVisible)) {
+    const text = clean(el.textContent || "");
+    if (!text || text.length < 2 || text.length > 180) continue;
+    const selector = describe(el);
+    const style = getComputedStyle(el);
+    const overflowX = el.scrollWidth - el.clientWidth;
+    const overflowY = el.scrollHeight - el.clientHeight;
+
+    if (overflowX > 2 && style.overflowX !== "visible") {
+      issues.push({ viewport: viewportName, selector, type: "element-horizontal-overflow", severity: "error", text, detail: `Element overflows by ${Math.round(overflowX)}px.` });
+    }
+    if (overflowY > 2 && style.overflowY !== "visible" && style.maxHeight !== "none") {
+      issues.push({ viewport: viewportName, selector, type: "text-clipped", severity: "error", text, detail: `Element is clipped by ${Math.round(overflowY)}px.` });
+    }
+
+    const lines = renderedLines(el);
+    if (lines.length < 2) continue;
+    const lastLine = lines.at(-1);
+    const lastCharCount = [...lastLine.replace(/\s+/g, "")].length;
+    const className = typeof el.className === "string" ? el.className : "";
+    const classTokens = className.split(/\s+/).filter(Boolean);
+    const isHeading = /^H[1-4]$/.test(el.tagName) || classTokens.some((token) => /(^|[-_])(title|heading)([-_]|$)/i.test(token));
+    const role = el.getAttribute("role") || "";
+    const isInteractiveAnchor = el.tagName === "A" && /button|tab|nav|menu|link/i.test(classTokens.join(" ") + " " + role);
+    const isControlClass = classTokens.some((token) => /^(tag|badge|pill|btn|button|tab|nav|seg__opt|qbadge|tier)$/.test(token));
+    const isControlRole = /^(button|tab|menuitem|switch|checkbox|radio|link)$/.test(role);
+    const isControl = el.tagName === "BUTTON" || isInteractiveAnchor || isControlRole || isControlClass;
+    const isTableLabel = /T[HD]/.test(el.tagName);
+    const rect = el.getBoundingClientRect();
+    const fontSize = Number.parseFloat(style.fontSize) || 0;
+    const highVisibilityText = isHeading
+      || isControl
+      || isTableLabel
+      || rect.top < window.innerHeight
+      || fontSize >= 16
+      || classTokens.some((token) => /(^|[-_])(hero|lead|dek|title|heading|label|spec|caption)([-_]|$)/i.test(token));
+
+    if (isHeading && lastCharCount <= 2 && /[\u4e00-\u9fffA-Za-z0-9]/.test(lastLine)) {
+      issues.push({ viewport: viewportName, selector, type: "orphan-heading-line", severity: "error", text, detail: `Last rendered line is "${lastLine}".` });
+    }
+    const awkwardBoundary = awkwardChineseBoundary(lines);
+    if (awkwardBoundary && highVisibilityText) {
+      issues.push({
+        viewport: viewportName,
+        selector,
+        type: "awkward-chinese-line-boundary",
+        severity: "warning",
+        text,
+        detail: `Rendered line boundary splits "${awkwardBoundary.pair}" as "${awkwardBoundary.boundary}". Previous line: "${awkwardBoundary.previousLine}". Next line: "${awkwardBoundary.nextLine}".`,
+      });
+    }
+    if (isControl && lines.length > 1) {
+      issues.push({ viewport: viewportName, selector, type: "wrapped-control", severity: "error", text, detail: `Control renders on ${lines.length} lines.` });
+    }
+    if (isTableLabel && text.length <= 12 && lines.length > 1) {
+      issues.push({ viewport: viewportName, selector, type: "wrapped-table-label", severity: "warning", text, detail: `Short table label renders on ${lines.length} lines.` });
+    }
+    if (!isHeading && !isControl && lastCharCount === 1 && text.length <= 40) {
+      issues.push({ viewport: viewportName, selector, type: "suspicious-orphan-line", severity: "warning", text, detail: `Last rendered line is "${lastLine}".` });
+    }
+  }
+
+  for (const img of selectedImages(mediaSelector).filter(isVisible)) {
+    if (!img.complete || img.naturalWidth === 0) {
+      issues.push({ viewport: viewportName, selector: describe(img), type: "image-not-loaded", severity: "error", text: img.alt || img.src });
+      continue;
+    }
+
+    const imageMetrics = measureImage(img);
+    if (!imageMetrics || imageMetrics.area < 10_000) continue;
+
+    const ratioDelta = Math.abs(imageMetrics.displayedRatio / imageMetrics.naturalRatio - 1);
+    if (!["cover", "contain", "scale-down"].includes(imageMetrics.objectFit) && ratioDelta > 0.08) {
+      issues.push({
+        viewport: viewportName,
+        selector: describe(img),
+        type: "image-aspect-mismatch",
+        severity: "error",
+        text: img.alt || img.src,
+        detail: `Image displays at ratio ${imageMetrics.displayedRatio} but natural ratio is ${imageMetrics.naturalRatio}; object-fit is "${imageMetrics.objectFit}".`,
+      });
+    } else if (imageMetrics.objectFit === "cover" && ratioDelta > 0.25) {
+      issues.push({
+        viewport: viewportName,
+        selector: describe(img),
+        type: "image-heavy-crop",
+        severity: "warning",
+        text: img.alt || img.src,
+        detail: `Image container ratio ${imageMetrics.displayedRatio} differs from natural ratio ${imageMetrics.naturalRatio}. Inspect whether important content is cropped.`,
+      });
+    }
+  }
+
+  issues.push(...auditImageOverlays({ viewportName, mediaSelector }));
+
+  return { meta, issues };
+
+  function clean(value) {
+    return value.replace(/\s+/g, " ").trim();
+  }
+
+  function isVisible(el) {
+    const rect = el.getBoundingClientRect();
+    const style = getComputedStyle(el);
+    return rect.width > 0 && rect.height > 0 && style.display !== "none" && style.visibility !== "hidden";
+  }
+
+  function selectedImages(selector) {
+    if (!selector) return [...document.images];
+    try {
+      const roots = [...document.querySelectorAll(selector)].filter(isVisible);
+      return [...new Set(roots.flatMap((root) => {
+        if (root.tagName === "IMG") return [root];
+        return [...root.querySelectorAll("img")];
+      }))];
+    } catch {
+      return [...document.images];
+    }
+  }
+
+  function measureImage(img) {
+    const rect = img.getBoundingClientRect();
+    if (!rect.width || !rect.height || !img.naturalWidth || !img.naturalHeight) return null;
+    return {
+      selector: describe(img),
+      displayedWidth: Math.round(rect.width),
+      displayedHeight: Math.round(rect.height),
+      displayedRatio: +(rect.width / rect.height).toFixed(3),
+      naturalRatio: +(img.naturalWidth / img.naturalHeight).toFixed(3),
+      objectFit: getComputedStyle(img).objectFit || "fill",
+      area: rect.width * rect.height,
+    };
+  }
+
+  function measurePrimaryImage(selector) {
+    const measured = selectedImages(selector)
+      .filter(isVisible)
+      .filter((img) => img.complete && img.naturalWidth)
+      .map((img) => ({ img, metrics: measureImage(img) }))
+      .filter((item) => item.metrics)
+      .filter(({ img }) => {
+        const rect = img.getBoundingClientRect();
+        return rect.bottom > 0 && rect.top < window.innerHeight;
+      })
+      .sort((a, b) => b.metrics.area - a.metrics.area)[0]?.metrics;
+    if (!measured) return null;
+    delete measured.area;
+    return measured;
+  }
+
+  function measureFirstViewportContent(selector) {
+    let elements = [];
+    if (selector) {
+      try {
+        elements = [...document.querySelectorAll(selector)];
+      } catch {
+        elements = [];
+      }
+    }
+    if (!elements.length) {
+      elements = [...document.querySelectorAll([
+        "h1", "h2", "h3", "h4", "p", "a", "button", "img", "canvas", "video",
+        "li", "td", "th", "input", "select", "textarea",
+        "[role='button']", "[role='tab']", "[class*='card']", "[class*='panel']",
+        "[class*='tile']", "[class*='media']", "[class*='hero']", "[class*='cover']",
+      ].join(","))];
+    }
+
+    const rects = elements
+      .filter(isVisible)
+      .map((el) => el.getBoundingClientRect())
+      .filter((rect) => rect.bottom > 0 && rect.top < window.innerHeight)
+      .filter((rect) => rect.width > 1 && rect.height > 1)
+      .filter((rect) => !(rect.width >= window.innerWidth * 0.98 && rect.height >= window.innerHeight * 0.98))
+      .map((rect) => ({
+        left: Math.max(0, rect.left),
+        right: Math.min(window.innerWidth, rect.right),
+        top: Math.max(0, rect.top),
+        bottom: Math.min(window.innerHeight, rect.bottom),
+      }));
+
+    if (!rects.length) return null;
+
+    const left = Math.min(...rects.map((rect) => rect.left));
+    const right = Math.max(...rects.map((rect) => rect.right));
+    const top = Math.min(...rects.map((rect) => rect.top));
+    const bottom = Math.max(...rects.map((rect) => rect.bottom));
+    const width = Math.max(0, right - left);
+
+    return {
+      left: Math.round(left),
+      right: Math.round(right),
+      top: Math.round(top),
+      bottom: Math.round(bottom),
+      width: Math.round(width),
+      widthRatio: +(width / window.innerWidth).toFixed(3),
+      leftBlank: Math.round(Math.max(0, left)),
+      rightBlank: Math.round(Math.max(0, window.innerWidth - right)),
+    };
+  }
+
+  function measureTypography() {
+    const bodyStyle = getComputedStyle(document.body);
+    const h1 = document.querySelector("h1");
+    const h1Style = h1 ? getComputedStyle(h1) : null;
+    const textElements = [...document.querySelectorAll("p,dd,li,td,th,button,a,span,strong,em")]
+      .filter(isVisible)
+      .map((el) => {
+        const rect = el.getBoundingClientRect();
+        const style = getComputedStyle(el);
+        return {
+          tag: el.tagName.toLowerCase(),
+          className: typeof el.className === "string" ? el.className : "",
+          width: Math.round(rect.width),
+          fontSize: Number.parseFloat(style.fontSize) || 0,
+          text: clean(el.textContent || ""),
+        };
+      })
+      .filter((item) => item.text.length >= 4 && item.width >= 20 && item.fontSize > 0);
+
+    const importantText = textElements.filter((item) => !/(eyebrow|mono|tag|badge|pill|qbadge|tier)/i.test(item.className));
+    const narrowTextColumns = importantText
+      .filter((item) => item.text.length >= 16)
+      .map((item) => item.width)
+      .sort((a, b) => a - b);
+    const smallestImportantTextSize = importantText
+      .map((item) => item.fontSize)
+      .sort((a, b) => a - b)[0] || null;
+
+    return {
+      bodyFont: bodyStyle.fontFamily,
+      bodySize: bodyStyle.fontSize,
+      bodyLineHeight: bodyStyle.lineHeight,
+      h1Size: h1Style?.fontSize || null,
+      h1LineHeight: h1Style?.lineHeight || null,
+      smallestImportantTextSize,
+      narrowestTextColumnWidth: narrowTextColumns[0] || null,
+    };
+  }
+
+  function auditImageOverlays({ viewportName, mediaSelector }) {
+    const found = [];
+    const images = selectedImages(mediaSelector)
+      .filter(isVisible)
+      .filter((img) => img.complete && img.naturalWidth)
+      .map((img) => ({ img, rect: img.getBoundingClientRect() }))
+      .filter((item) => item.rect.width * item.rect.height >= 10_000);
+
+    if (!images.length) return found;
+
+    const textElements = [...document.querySelectorAll("body *")]
+      .filter(isVisible)
+      .filter((el) => el.tagName !== "SCRIPT" && el.tagName !== "STYLE" && el.tagName !== "IMG")
+      .map((el) => ({ el, text: ownText(el), rect: el.getBoundingClientRect(), style: getComputedStyle(el) }))
+      .filter((item) => item.text.length > 0 && item.rect.width > 0 && item.rect.height > 0)
+      .filter((item) => ["absolute", "fixed", "sticky"].includes(item.style.position) || item.style.zIndex !== "auto");
+
+    for (const { img, rect: imageRect } of images) {
+      for (const item of textElements) {
+        if (item.el.contains(img) || img.contains(item.el)) continue;
+        const overlap = intersectionRatio(imageRect, item.rect);
+        if (overlap < 0.18) continue;
+        found.push({
+          viewport: viewportName,
+          selector: describe(item.el),
+          type: "image-overlay-collision",
+          severity: "warning",
+          text: clean(item.text).slice(0, 120),
+          detail: `Text overlays ${Math.round(overlap * 100)}% of its own box on image ${describe(img)}. Inspect whether it covers important image content.`,
+        });
+      }
+    }
+
+    return found;
+  }
+
+  function auditSections(selector) {
+    const found = [];
+    let sections = [];
+    try {
+      sections = [...document.querySelectorAll(selector)];
+    } catch {
+      return { meta: { count: 0, worstOverflowX: 0, widest: null }, issues: found };
+    }
+
+    const measured = sections
+      .filter(isVisible)
+      .filter((el) => {
+        const rect = el.getBoundingClientRect();
+        return rect.width > 100 && rect.height > 40;
+      })
+      .map((el) => {
+        const rect = el.getBoundingClientRect();
+        const overflowX = Math.max(0, Math.round(el.scrollWidth - el.clientWidth));
+        const widthOverflow = Math.max(0, Math.round(rect.width - document.documentElement.clientWidth));
+        return {
+          selector: describe(el),
+          top: Math.round(rect.top + window.scrollY),
+          width: Math.round(rect.width),
+          height: Math.round(rect.height),
+          overflowX,
+          widthOverflow,
+          text: clean(el.querySelector("h1,h2,h3,h4")?.textContent || ownText(el) || "").slice(0, 120),
+        };
+      });
+
+    for (const item of measured) {
+      if (item.overflowX > 2) {
+        found.push({
+          viewport: viewportName,
+          selector: item.selector,
+          type: "section-horizontal-overflow",
+          severity: "error",
+          text: item.text,
+          detail: `Section at y=${item.top} has internal horizontal overflow of ${item.overflowX}px.`,
+        });
+      }
+      if (item.widthOverflow > 2) {
+        found.push({
+          viewport: viewportName,
+          selector: item.selector,
+          type: "section-wider-than-viewport",
+          severity: "warning",
+          text: item.text,
+          detail: `Section box is ${item.widthOverflow}px wider than documentElement.clientWidth.`,
+        });
+      }
+    }
+
+    const worst = measured
+      .slice()
+      .sort((a, b) => b.overflowX - a.overflowX)[0] || null;
+    const widest = measured
+      .slice()
+      .sort((a, b) => b.width - a.width)[0] || null;
+
+    return {
+      meta: {
+        count: measured.length,
+        worstOverflowX: worst?.overflowX || 0,
+        worstOverflowSelector: worst?.overflowX ? worst.selector : null,
+        widest: widest ? { selector: widest.selector, width: widest.width } : null,
+      },
+      issues: found,
+    };
+  }
+
+  function ownText(el) {
+    return [...el.childNodes]
+      .filter((node) => node.nodeType === Node.TEXT_NODE)
+      .map((node) => node.nodeValue || "")
+      .join(" ")
+      .replace(/\s+/g, " ")
+      .trim();
+  }
+
+  function intersectionRatio(a, b) {
+    const left = Math.max(a.left, b.left);
+    const right = Math.min(a.right, b.right);
+    const top = Math.max(a.top, b.top);
+    const bottom = Math.min(a.bottom, b.bottom);
+    if (right <= left || bottom <= top) return 0;
+    const intersectionArea = (right - left) * (bottom - top);
+    const bArea = b.width * b.height || 1;
+    return intersectionArea / bArea;
+  }
+
+  function describe(el) {
+    if (el.id) return `${el.tagName.toLowerCase()}#${el.id}`;
+    const className = typeof el.className === "string"
+      ? el.className.split(/\s+/).filter(Boolean).slice(0, 2).join(".")
+      : "";
+    return `${el.tagName.toLowerCase()}${className ? `.${className}` : ""}`;
+  }
+
+  function auditPageType({ viewportName, pageType }) {
+    const found = [];
+    const isDesignSystemLike = pageType === "design-system" || pageType === "live-artifact-design-system";
+    const isLiveArtifactDesignSystem = pageType === "live-artifact-design-system";
+    const bodyText = clean(document.body.innerText || "");
+    const headingText = [...document.querySelectorAll("h1,h2,h3,h4")]
+      .map((el) => clean(el.textContent || ""))
+      .join(" ");
+    const cardLike = [...document.querySelectorAll("article, section, div")]
+      .filter(isVisible)
+      .filter((el) => {
+        const className = typeof el.className === "string" ? el.className : "";
+        return /\b(card|panel|tile|module|widget)\b/i.test(className) || /(^|[-_])(card|panel|tile|module|widget)([-_]|$)/i.test(className);
+      });
+
+    if (isDesignSystemLike) {
+      const designSignals = [
+        /principle|原则/i,
+        /foundation|token|基础|变量|颜色|字体|间距/i,
+        /component|组件/i,
+        /pattern|模式/i,
+        /state|variant|状态|变体/i,
+        /governance|accessibility|do\/?don't|治理|可访问性|禁忌|用法/i,
+      ];
+      const signalCount = designSignals.filter((pattern) => pattern.test(headingText + " " + bodyText)).length;
+      if (signalCount < 4) {
+        found.push({
+          viewport: viewportName,
+          type: "design-system-structure-missing",
+          severity: "error",
+          detail: `Only ${signalCount}/6 design-system signals found. Expected principles, foundations/tokens, components, patterns, states/variants, and governance/usage guidance.`,
+        });
+      }
+
+      const appDriftPattern = /工作台|真实工作台|数据大盘|运营大屏|dashboard|workbench|analytics workspace|control center/i;
+      const firstViewportText = visibleTextInViewport(0, window.innerHeight);
+      const hasSpecimenContext = /specimen|artifact|样本|规范|组件|状态|变体|pattern|模式|contract|anatomy|解剖|Design System|Live Artifact/i.test(firstViewportText);
+      const hardAppDrift = /真实工作台|运营大屏|数据大盘|production dashboard|real workbench/i.test(firstViewportText);
+      if (appDriftPattern.test(firstViewportText) && !(isLiveArtifactDesignSystem && hasSpecimenContext && !hardAppDrift)) {
+        found.push({
+          viewport: viewportName,
+          type: "page-type-drift",
+          severity: "warning",
+          text: firstViewportText.slice(0, 180),
+          detail: "A design-system artifact contains app/dashboard/workbench language in the first viewport.",
+        });
+      }
+
+      if (isLiveArtifactDesignSystem) {
+        const liveSignals = [
+          /live artifact|interactive|交互|可交互|状态切换/i,
+          /specimen|样本|pattern|模式|contract|anatomy|解剖/i,
+          /variant|state|状态|变体/i,
+          /usage|用法|do\/?don't|禁忌|治理/i,
+        ];
+        const liveSignalCount = liveSignals.filter((pattern) => pattern.test(headingText + " " + bodyText)).length;
+        const interactiveCount = [...document.querySelectorAll([
+          "button",
+          "select",
+          "input",
+          "textarea",
+          "details",
+          "summary",
+          "a[href]",
+          "[role='button']",
+          "[role='tab']",
+          "[role='switch']",
+          "[role='checkbox']",
+          "[tabindex]:not([tabindex='-1'])",
+        ].join(","))].filter(isVisible).length;
+
+        if (liveSignalCount < 2) {
+          found.push({
+            viewport: viewportName,
+            type: "live-artifact-framing-missing",
+            severity: "warning",
+            detail: `Only ${liveSignalCount}/4 live-artifact framing signals found. Interactive design systems should label specimens, states/variants, usage rules, or contracts so controls are not mistaken for a fake app.`,
+          });
+        }
+
+        if (interactiveCount < 3) {
+          found.push({
+            viewport: viewportName,
+            type: "live-artifact-interaction-thin",
+            severity: "warning",
+            detail: `${interactiveCount} visible interactive element(s) found. If this is intended as a live artifact, inspect whether reviewers can actually exercise component states and patterns.`,
+          });
+        }
+      }
+    }
+
+    if (cardLike.length >= 40) {
+      found.push({
+        viewport: viewportName,
+        type: "repeated-card-density",
+        severity: isDesignSystemLike ? "warning" : "info",
+        detail: `${cardLike.length} visible card/panel/tile-like containers found. Inspect whether cards express real structure or replace information architecture.`,
+      });
+    }
+
+    return found;
+  }
+
+  function visibleTextInViewport(top, bottom) {
+    return [...document.querySelectorAll("body *")]
+      .filter(isVisible)
+      .filter((el) => {
+        const rect = el.getBoundingClientRect();
+        return rect.bottom >= top && rect.top <= bottom;
+      })
+      .map((el) => clean(el.textContent || ""))
+      .filter(Boolean)
+      .join(" ")
+      .replace(/\s+/g, " ")
+      .trim();
+  }
+
+  function renderedLines(el) {
+    const chars = [];
+    const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT, {
+      acceptNode(node) {
+        return node.nodeValue && node.nodeValue.trim() ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT;
+      },
+    });
+
+    for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+      const value = node.nodeValue || "";
+      for (let offset = 0; offset < value.length;) {
+        const char = Array.from(value.slice(offset))[0];
+        const next = offset + char.length;
+        if (!/\s/.test(char)) {
+          const range = document.createRange();
+          range.setStart(node, offset);
+          range.setEnd(node, next);
+          const rect = range.getBoundingClientRect();
+          if (rect.width > 0 && rect.height > 0) chars.push({ char, top: rect.top, left: rect.left });
+          range.detach();
+        }
+        offset = next;
+      }
+    }
+
+    if (!chars.length) return [];
+    chars.sort((a, b) => a.top - b.top || a.left - b.left);
+    const rows = [];
+    for (const item of chars) {
+      const row = rows.find((candidate) => Math.abs(candidate.top - item.top) <= 3);
+      if (row) {
+        row.items.push(item);
+        row.top = (row.top + item.top) / 2;
+      } else {
+        rows.push({ top: item.top, items: [item] });
+      }
+    }
+    return rows
+      .sort((a, b) => a.top - b.top)
+      .map((row) => row.items.sort((a, b) => a.left - b.left).map((item) => item.char).join(""));
+  }
+
+  function awkwardChineseBoundary(lines) {
+    const commonPairs = new Set([
+      "这里", "这个", "这种", "这些", "这样",
+      "那个", "那些", "那种", "那样", "哪里",
+      "我们", "你们", "他们", "她们", "它们",
+      "不是", "不能", "不要", "不会", "不用",
+      "应该", "必须", "可以", "需要", "还有",
+      "以及", "因为", "所以", "如果", "但是",
+    ]);
+
+    for (let index = 0; index < lines.length - 1; index += 1) {
+      const previousLine = lines[index].trim();
+      const nextLine = lines[index + 1].trim();
+      if (!previousLine || !nextLine) continue;
+      const left = Array.from(previousLine).at(-1);
+      const right = Array.from(nextLine)[0];
+      const pair = `${left}${right}`;
+      if (commonPairs.has(pair) || (/^[这那哪]$/.test(left) && /^[个些种样里]$/.test(right))) {
+        return {
+          pair,
+          boundary: `${left}|${right}`,
+          previousLine,
+          nextLine,
+        };
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
## What
New skill **frontend-visual-qa**: catches rendered UI defects that lint/build checks miss — awkward line breaks, orphan Chinese characters, wrapped buttons/tags/nav, horizontal overflow, double scrollbars, repeated card piles, page-type drift, missing images, generic AI slop, and Chrome DevTools viewport mistakes. Bundles a history-derived checklist + Chrome-first pass + Playwright-core audit script.

## Changes
- marketplace: register frontend-visual-qa (50→51 plugins), metadata 1.69→1.70
- docs: README / README.zh-CN / CLAUDE skill lists synced 71→72, badges 1.70.0

## Safety
- `security_scan` passed — no secrets.
- `history-derived-checklist.md` explicitly removes project-specific content (generic patterns only); reviewed clean.
- doc-skill-list consistency check green (72 skills across all docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)