### PR TITLE
feat(openclaw): add OpenClaw config manager skill (sanitized, v1.71.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional Claude Code skills marketplace — production-ready skills spanning GitHub and git operations, document conversion and generation (Markdown, PDF, PPTX, DOCX), diagram and UI-design extraction, the full audio pipeline (ASR transcription, TTS, transcript correction, meeting minutes), financial and investment-research data, web scraping and content capture, security/PII tooling and secure repomix packaging, macOS and iOS development, CLI demo and terminal automation, prompt and skill engineering, deep research and fact-checking, QA and LLM-evaluation infrastructure, internationalization, network/Tailscale and remote-desktop diagnostics, and Claude Code operations (session recovery, CLAUDE.md optimization, statusline, multi-provider profile isolation, troubleshooting, marketplace development, repo health-check). Suite plugins (daymade-audio, daymade-claude-code, daymade-docs, daymade-skill) bundle related skills under shared namespaces, including the StepFun StepAudio 2.5 audio family. See the Available Skills list in the README for the authoritative per-skill breakdown.",
-    "version": "1.70.0"
+    "version": "1.71.0"
   },
   "plugins": [
     {
@@ -1016,6 +1016,23 @@
         "playwright",
         "ai-slop",
         "design-review"
+      ]
+    },
+    {
+      "name": "openclaw",
+      "description": "Manage OpenClaw (龙虾 / lobster) instance configurations — audit, diff, copy, add-model, list, and switch models across openclaw.json files. Use when juggling multiple OpenClaw / Claude Code wrapper instances, applying DeepSeek model patches, managing default models and aliases, or validating config.",
+      "source": "./openclaw",
+      "strict": false,
+      "version": "1.0.0",
+      "category": "claude-code",
+      "keywords": [
+        "openclaw",
+        "lobster",
+        "config",
+        "model-management",
+        "deepseek",
+        "claude-code",
+        "config-validation"
       ]
     }
   ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository Overview
 
-This is a Claude Code skills marketplace containing 72 production-ready skills organized in a plugin marketplace structure. Most plugins expose one skill for narrow installs; suite plugins expose related skills under shared namespaces for combined installation workflows.
+This is a Claude Code skills marketplace containing 73 production-ready skills organized in a plugin marketplace structure. Most plugins expose one skill for narrow installs; suite plugins expose related skills under shared namespaces for combined installation workflows.
 
 **Essential Skill**: `skill-creator` is the most important skill in this marketplace - it's a meta-skill that enables users to create their own skills. Always recommend it first for users interested in extending Claude Code.
 
@@ -153,7 +153,7 @@ If it fires, fix the issue — do NOT use `--no-verify` to bypass.
 ## Marketplace Configuration
 
 The marketplace is configured in `.claude-plugin/marketplace.json`:
-- Contains 51 plugin entries: single-skill plugins point `source` directly at the skill directory (no `skills` field); suite plugins (`daymade-audio`, `daymade-claude-code`, `daymade-docs`, `daymade-skill`) use explicit `skills` arrays for multi-skill routing
+- Contains 52 plugin entries: single-skill plugins point `source` directly at the skill directory (no `skills` field); suite plugins (`daymade-audio`, `daymade-claude-code`, `daymade-docs`, `daymade-skill`) use explicit `skills` arrays for multi-skill routing
 - Each plugin has: name, description, source, version, category, keywords
 - Marketplace metadata: name, owner, version
 - Single-skill plugins follow the official pattern (167/168 plugins in `anthropics/claude-plugins-official`): `source` points to skill directory, `skills` omitted
@@ -271,6 +271,7 @@ This applies when you change ANY file under a skill directory:
 70. **github-sensitive-data-cleanup** - Scan and remove secrets, API keys, private domains/IPs, and PII from GitHub repository history with force-push safety gates
 71. **codex-image-gallery** - Start a self-contained local web gallery for browsing Codex-generated images from `~/.codex/generated_images` or a custom `GALLERY_ROOT`
 72. **frontend-visual-qa** - Reviews rendered frontends, dashboards, HTML slides, and generated UIs for visual quality defects that lint/build miss (awkward line breaks, wrapped controls, horizontal overflow, double scrollbars, AI slop, Chrome DevTools viewport mistakes); use after frontend-design/ui-designer and alongside qa-expert
+73. **openclaw** - Manage OpenClaw (龙虾/lobster) instance configs: audit, diff, copy, add-model, list, switch models across openclaw.json files; DeepSeek model patches, default-model/alias management, config validation
 
 **Recommendation**: Always suggest `skill-creator` first for users interested in creating skills or extending Claude Code.
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@
 [![简体中文](https://img.shields.io/badge/语言-简体中文-red)](./README.zh-CN.md)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Skills](https://img.shields.io/badge/skills-72-blue.svg)](https://github.com/daymade/claude-code-skills)
-[![Version](https://img.shields.io/badge/version-1.70.0-green.svg)](https://github.com/daymade/claude-code-skills)
+[![Skills](https://img.shields.io/badge/skills-73-blue.svg)](https://github.com/daymade/claude-code-skills)
+[![Version](https://img.shields.io/badge/version-1.71.0-green.svg)](https://github.com/daymade/claude-code-skills)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-2.0.13+-purple.svg)](https://claude.com/code)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./CONTRIBUTING.md)
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/daymade/claude-code-skills/graphs/commit-activity)
 
 </div>
 
-Professional Claude Code skills marketplace featuring 72 production-ready skills for enhanced development workflows.
+Professional Claude Code skills marketplace featuring 73 production-ready skills for enhanced development workflows.
 
 ## 📑 Table of Contents
 
@@ -2794,6 +2794,25 @@ Catch embarrassing rendered UI defects that normal lint/build checks miss.
 - History-derived checklist for recurring line-break, overflow, and typography failures
 - Chrome DevTools first-pass for the user-visible browser viewport, including stale mobile emulation checks
 - Playwright-core audit script for desktop-wide, desktop, and mobile viewports
+
+### 75. **openclaw** - OpenClaw (龙虾) Config Manager
+
+```bash
+claude plugin install openclaw@daymade-skills
+```
+
+Manage OpenClaw (龙虾/lobster) instance configurations — audit, diff, copy, add-model, list, and switch models across `openclaw.json` files.
+
+**When to use:**
+- Managing multiple OpenClaw / Claude Code wrapper instances
+- Applying DeepSeek model patches to an instance
+- Auditing, diffing, or copying provider/model config between instances
+- Managing default models and aliases, or validating config
+
+**Key features:**
+- Unified CLI: audit / diff / copy / add-model / list / switch
+- Auto-audit on mutating commands with a `--no-audit` escape hatch
+- Nickname registry for cross-config operations
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,15 +6,15 @@
 [![简体中文](https://img.shields.io/badge/语言-简体中文-red)](./README.zh-CN.md)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Skills](https://img.shields.io/badge/skills-72-blue.svg)](https://github.com/daymade/claude-code-skills)
-[![Version](https://img.shields.io/badge/version-1.70.0-green.svg)](https://github.com/daymade/claude-code-skills)
+[![Skills](https://img.shields.io/badge/skills-73-blue.svg)](https://github.com/daymade/claude-code-skills)
+[![Version](https://img.shields.io/badge/version-1.71.0-green.svg)](https://github.com/daymade/claude-code-skills)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-2.0.13+-purple.svg)](https://claude.com/code)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./CONTRIBUTING.md)
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/daymade/claude-code-skills/graphs/commit-activity)
 
 </div>
 
-专业的 Claude Code 技能市场，提供 72 个生产就绪的技能，用于增强开发工作流。
+专业的 Claude Code 技能市场，提供 73 个生产就绪的技能，用于增强开发工作流。
 
 ## 📑 目录
 
@@ -2836,6 +2836,25 @@ claude plugin install frontend-visual-qa@daymade-skills
 - 基于本地历史反馈沉淀的换行、溢出、排版错误清单
 - 优先用 Chrome DevTools 检查用户当前可见浏览器视口，包括残留移动端 emulation
 - Playwright-core 脚本覆盖宽桌面、常规桌面和移动端视口
+
+### 75. **openclaw** - OpenClaw (龙虾) 配置管理器
+
+```bash
+claude plugin install openclaw@daymade-skills
+```
+
+管理 OpenClaw (龙虾) 实例配置 —— 在 `openclaw.json` 文件间审计、对比、复制、加模型、列出和切换模型。
+
+**使用场景：**
+- 管理多个 OpenClaw / Claude Code wrapper 实例
+- 给实例打 DeepSeek 模型补丁
+- 在实例间审计、对比、复制 provider/模型配置
+- 管理默认模型和别名，或校验配置
+
+**主要功能：**
+- 统一 CLI：audit / diff / copy / add-model / list / switch
+- 变更命令自动审计，带 `--no-audit` 逃生口
+- 昵称注册表支持跨配置操作
 
 ---
 

--- a/openclaw/.security-scan-passed
+++ b/openclaw/.security-scan-passed
@@ -1,0 +1,4 @@
+Security scan passed
+Scanned at: 2026-06-28T11:53:01.443792
+Tool: gitleaks + pattern-based validation
+Content hash: aefa4064289f08f6167e7fa930746f65d7d68efd5fc3e68bcb9849fec2bc7d18

--- a/openclaw/SKILL.md
+++ b/openclaw/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: openclaw
+description: >-
+  Manage OpenClaw (龙虾) instance configurations. Use whenever the user wants
+  to audit, diff, copy, add-model, list, or switch models in an openclaw.json
+  file, or when they mention lobsters, 虾, 甲虾, 乙虾, DeepSeek patch,
+  default model, model aliases, or OpenClaw config validation.
+argument-hint: '[audit|diff|copy|add-model|list|switch] [options]'
+---
+
+# openclaw
+
+A unified skill for managing OpenClaw (龙虾) instance configs.
+
+## Subcommands
+
+```bash
+python3 scripts/cli.py [audit|diff|copy|add-model|list|switch] [options]
+```
+
+Each subcommand can also be run directly, e.g. `python3 scripts/audit.py ...`.
+
+`diff` is an alias for `compare`.
+
+## Shared behavior
+
+- **Default config discovery**: when `--config` / `--to` is omitted, the skill
+  searches these locations in order:
+  1. `~/workspace/.force/openclaw/openclaw.json`
+  2. `~/.kimi_openclaw/openclaw.json`
+  3. `~/.openclaw/openclaw.json`
+- **Lobster nicknames**: `--config`, `--from`, and `--to` can be either a file
+  path or a nickname registered in `lobsters.json` (see below). You can also use
+  `--from-lobster` and `--to-lobster` for explicit nickname arguments.
+- **Backups**: every write operation copies the config to
+  `config-backups/<stem>-<utc-timestamp>.json` before saving. The skill keeps
+  the 20 most recent backups.
+- **Dry run**: write subcommands (`copy`, `add-model`, `switch`) support
+  `--dry-run` to preview changes.
+- **Restart**: write subcommands support `--restart` to restart the OpenClaw
+  gateway after saving.
+- **Automatic audit**: `copy`, `add-model`, and `switch` run an audit before and
+  after the change by default. Use `--no-audit` to skip it.
+
+## Lobster nickname registry
+
+Create a JSON file at one of these locations:
+
+- `~/workspace/.force/openclaw/lobsters.json`
+- `~/.kimi_openclaw/lobsters.json`
+- `~/.openclaw/lobsters.json`
+
+Example:
+
+```json
+{
+  "甲虾": "/path/to/甲虾/openclaw.json",
+  "乙虾": "/path/to/乙虾/openclaw.json"
+}
+```
+
+Then use:
+
+```bash
+python3 scripts/cli.py copy gateway-provider --from 甲虾 --to 乙虾 --alias
+python3 scripts/cli.py switch gateway-provider/deepseek-v4-pro --config 乙虾 --restart
+```
+
+---
+
+## `audit` — validate a config
+
+```bash
+python3 scripts/cli.py audit [--config PATH|NICKNAME] [--json]
+```
+
+Checks providers, models, default model, aliases, and plugin consistency.
+
+Use when:
+
+- "帮我查一下这只虾的配置"
+- "audit 一下 openclaw.json"
+- Before applying a patch or copying a provider
+
+---
+
+## `diff` — semantic diff of two configs
+
+```bash
+python3 scripts/cli.py diff LEFT.json RIGHT.json [--json] [--include-cost]
+```
+
+Reports added/removed/changed providers, models, default model, aliases, and
+plugins. Skips cost fields by default; use `--include-cost` to diff them.
+
+Use when:
+
+- "为什么甲虾能用 DeepSeek，乙虾不行？"
+- "这两份龙虾配置哪里不一样？"
+
+---
+
+## `copy` — copy a provider between configs
+
+```bash
+python3 scripts/cli.py copy \
+  --from SOURCE|NICKNAME [--to TARGET|NICKNAME] \
+  provider-name [--model ID]... [--alias] [--restart] [--dry-run] [--no-audit]
+```
+
+Copies an entire provider from one config to another. If the target already has
+that provider, it merges models and updates `baseUrl` / `api` without deleting
+target-only models. `--alias` also copies aliases pointing to that provider.
+
+Use when:
+
+- "把甲虾的 gateway provider 复制到乙虾"
+- "把这个模型配置同步过去"
+
+---
+
+## `add-model` — add a model to a provider
+
+```bash
+python3 scripts/cli.py add-model provider model-id|model-json \
+  [--config PATH|NICKNAME] [--from SOURCE|NICKNAME] [--alias NAME] \
+  [--restart] [--dry-run] [--no-audit]
+```
+
+Adds a model definition and alias to a provider. If the provider is missing, it
+can be copied from `--from` first.
+
+Ways to specify the model:
+
+- Pass a model id and `--from SOURCE` containing that model in the same provider.
+- Pass a path to a JSON file with the model definition.
+
+Use when:
+
+- "给这只虾加上 DeepSeek"
+- "把甲虾的 DeepSeek 配置复制到乙虾"
+
+The canonical DeepSeek model definition lives in
+`references/deepseek_model.json`.
+
+### Critical pitfalls
+
+- **Do not create a separate `deepseek` provider.** The supported path is the
+  gateway provider with model id `deepseek-v4-pro`.
+- **Model id must not contain `[1m]`.** Use the suffixless `deepseek-v4-pro`;
+  the upstream gateway maps it to the 1M context variant.
+- **Cold restart required.** New providers are not reliably picked up by hot
+  reload.
+
+---
+
+## `list` — list providers, models, aliases, and default
+
+```bash
+python3 scripts/cli.py list [--config PATH|NICKNAME] [--json] [--validate]
+```
+
+Human-readable output by default; `--json` for piping to `jq`. Add `--validate`
+to check that the default model and aliases resolve.
+
+Use when:
+
+- "这只虾有哪些模型？"
+- "列出甲虾可用的模型"
+- "看看默认模型是什么"
+
+---
+
+## `switch` — change the default model
+
+```bash
+python3 scripts/cli.py switch provider/model-id \
+  [--config PATH|NICKNAME] [--restart] [--dry-run] [--no-audit]
+```
+
+This is the only subcommand that changes `agents.defaults.model`. It verifies
+that the provider and model exist, backs up the config, and updates the default.
+If the target is already the default, it exits without making another backup.
+
+Use when:
+
+- "把默认模型切成 DeepSeek"
+- "切回原来的模型"
+
+---
+
+## Typical workflows
+
+### Enable DeepSeek on a lobster
+
+```bash
+python3 scripts/cli.py audit --config 乙虾
+python3 scripts/cli.py add-model gateway-provider deepseek-v4-pro \
+  --config 乙虾 --from 甲虾 --alias "DeepSeek V4 Pro"
+python3 scripts/cli.py switch gateway-provider/deepseek-v4-pro --config 乙虾 --restart
+```
+
+### Clone a working config to a new lobster
+
+```bash
+python3 scripts/cli.py copy gateway-provider --from 甲虾 --to 乙虾 --alias --restart
+python3 scripts/cli.py audit --config 乙虾
+```
+
+### Diff two lobsters
+
+```bash
+python3 scripts/cli.py diff 甲虾 乙虾
+```
+
+## References
+
+- `references/openclaw_architecture.md` — config schema and terminology
+- `references/deepseek_patch_sop.md` — DeepSeek patch SOP (sanitized)
+- `references/deepseek_model.json` — canonical DeepSeek model definition loaded
+  by `add-model`
+- `references/lobster_registry.example.json` — example lobster nickname registry

--- a/openclaw/references/deepseek_model.json
+++ b/openclaw/references/deepseek_model.json
@@ -1,0 +1,20 @@
+{
+  "model": {
+    "id": "deepseek-v4-pro",
+    "name": "DeepSeek V4 Pro 1M",
+    "api": "anthropic-messages",
+    "input": ["text"],
+    "reasoning": true,
+    "cost": {
+      "input": 0,
+      "output": 0,
+      "cacheRead": 0,
+      "cacheWrite": 0
+    },
+    "contextWindow": 1000000,
+    "maxTokens": 32768
+  },
+  "alias": {
+    "alias": "DeepSeek V4 Pro"
+  }
+}

--- a/openclaw/references/deepseek_patch_sop.md
+++ b/openclaw/references/deepseek_patch_sop.md
@@ -1,0 +1,46 @@
+# SOP — Add DeepSeek V4 Pro 1M to an OpenClaw instance
+
+This document describes the canonical way to add the `deepseek-v4-pro` model to
+an OpenClaw config. The actual model definition is stored in
+`deepseek_model.json` next to this file and is loaded by the `add-model`
+subcommand.
+
+## Supported path
+
+Use the internal gateway provider with the model id `deepseek-v4-pro`. Do **not**
+create a separate `deepseek*` provider.
+
+## Why this matters
+
+- The model id **must not contain `[1m]`**. Use the suffixless
+  `deepseek-v4-pro`. The upstream gateway maps this to the 1M context variant.
+- Adding a new provider usually requires a cold restart of the OpenClaw gateway.
+  Hot reload may show the model in `openclaw models list` but still reject
+  `/model` commands.
+
+## Model definition source
+
+`add-model` can copy `deepseek-v4-pro` from a source config via `--from`, or it
+can load the canonical definition from `references/deepseek_model.json`:
+
+```bash
+python3 scripts/cli.py add-model gateway-provider references/deepseek_model.json \
+  --config PATH --alias "DeepSeek V4 Pro"
+```
+
+## Typical workflow
+
+1. Run `audit` on the target config.
+2. Run `add-model gateway-provider deepseek-v4-pro --config PATH --from KNOWN_GOOD_PATH`
+   to copy the gateway provider if it is missing and ensure the DeepSeek model
+   and alias exist.
+3. Run `audit` again to confirm no structural errors.
+4. Run `switch gateway-provider/deepseek-v4-pro --config PATH --restart` to make
+   it the default model and restart the gateway.
+
+## What not to do
+
+- Do not add a `deepseek*` provider pointing directly at the DeepSeek API.
+- Do not write the API key into the target config unless it comes from a
+  known-good source config via `copy` or `add-model --from`.
+- Do not rely on hot reload after adding a brand-new provider.

--- a/openclaw/references/lobster_registry.example.json
+++ b/openclaw/references/lobster_registry.example.json
@@ -1,0 +1,4 @@
+{
+  "lobster-a": "/path/to/lobster-a/openclaw.json",
+  "lobster-b": "/path/to/lobster-b/openclaw.json"
+}

--- a/openclaw/references/openclaw_architecture.md
+++ b/openclaw/references/openclaw_architecture.md
@@ -1,0 +1,90 @@
+# OpenClaw (龙虾) Config Architecture
+
+OpenClaw stores its runtime configuration in a single JSON file, usually named
+`openclaw.json`. This reference describes the parts of that file that the
+`openclaw` skill touches.
+
+## File locations
+
+The skill looks for a config in this order when `--config` is not given:
+
+1. `~/workspace/.force/openclaw/openclaw.json`
+2. `~/.kimi_openclaw/openclaw.json`
+3. `~/.openclaw/openclaw.json`
+
+## Lobster nickname registry
+
+You can register human nicknames for configs in `lobsters.json` at one of the
+locations above. Example:
+
+```json
+{
+  "lobster-a": "/path/to/lobster-a/openclaw.json",
+  "lobster-b": "/path/to/lobster-b/openclaw.json"
+}
+```
+
+Once registered, the nicknames can be used anywhere a config path is expected:
+`--config`, `--from`, `--to`, and `diff` arguments.
+
+## Top-level structure
+
+```json
+{
+  "models": {
+    "providers": {
+      "provider-name": {
+        "baseUrl": "https://...",
+        "apiKey": "...",
+        "api": "anthropic-messages",
+        "models": [
+          { "id": "model-id", "name": "...", ... }
+        ]
+      }
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": "provider-name/model-id",
+      "models": {
+        "provider-name/model-id": { "alias": "Display Name" }
+      }
+    }
+  },
+  "plugins": {
+    "allow": ["plugin-a", "plugin-b"],
+    "entries": {
+      "plugin-a": { "enabled": true, ... }
+    },
+    "installs": {
+      "plugin-a": { ... }
+    }
+  }
+}
+```
+
+## Key concepts
+
+- **Provider** — a gateway or upstream API endpoint. Each provider has a
+  `baseUrl`, an `api` type, and a list of `models`.
+- **Model** — a concrete model id exposed through a provider. The id must match
+  what the gateway expects.
+- **Alias** — a user-facing entry under `agents.defaults.models`. Aliases let
+  users switch models with commands like `/model provider-name/model-id`.
+- **Default model** — the model reference stored in `agents.defaults.model`.
+  This is the model the lobster uses unless told otherwise.
+- **Plugins** — OpenClaw extensions. The skill checks that `allow`, `entries`,
+  and `installs` are consistent.
+
+## Model reference format
+
+Most commands use the form `provider-name/model-id`. Examples:
+
+- `gateway-provider/deepseek-v4-pro`
+- `gateway-provider/model-a`
+
+## Internal names
+
+In user conversations, "虾" or "龙虾" refers to an OpenClaw instance.
+Examples include "甲虾" and "乙虾". These are just human nicknames for
+separate config files or deployments.

--- a/openclaw/scripts/add_model.py
+++ b/openclaw/scripts/add_model.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Add a model definition (and alias) to a provider in an OpenClaw config."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+from pathlib import Path
+
+from audit import audit as run_audit
+from openclaw_config import (
+    ConfigError,
+    backup_config,
+    get_aliases,
+    get_providers,
+    load_config,
+    provider_model_ids,
+    resolve_config_path,
+    resolve_lobster_config_path,
+    restart_gateway,
+    save_config,
+)
+
+
+def load_model_json(path: Path) -> tuple[dict, str | None]:
+    """Load a model definition from a JSON file.
+
+    Supports both a plain model object and a wrapper object with
+    {'model': {...}, 'alias': {'alias': 'Display Name'}}.
+    """
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, dict):
+        raise ValueError(f"Model JSON must be an object, got {type(data).__name__}")
+    if "model" in data and isinstance(data["model"], dict):
+        model = data["model"]
+        alias = None
+        if isinstance(data.get("alias"), dict):
+            alias = data["alias"].get("alias")
+        return model, alias
+    return data, None
+
+
+def find_model_in_provider(provider: dict, model_id: str) -> dict | None:
+    """Return the model definition from a provider by id, or None."""
+    for m in provider.get("models", []):
+        if isinstance(m, dict) and m.get("id") == model_id:
+            return m
+    return None
+
+
+def print_audit_summary(issues: list[dict], label: str) -> None:
+    errors = sum(1 for i in issues if i["level"] == "error")
+    warnings = sum(1 for i in issues if i["level"] == "warning")
+    print(f"{label}: {errors} error(s), {warnings} warning(s).")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Add a model to an OpenClaw provider")
+    parser.add_argument("provider", help="Provider name to add the model to")
+    parser.add_argument("model", help="Model id to add, or path to a JSON model definition")
+    parser.add_argument("--config", type=Path, help="Target openclaw.json")
+    parser.add_argument("--from", dest="source", help="Source config or lobster nickname to copy provider/model from")
+    parser.add_argument("--from-lobster", help="Source lobster nickname (alternative to --from)")
+    parser.add_argument("--alias", help="Display name for the alias (default: model name or id)")
+    parser.add_argument("--restart", action="store_true", help="Restart gateway after saving")
+    parser.add_argument("--dry-run", action="store_true", help="Show what would change without writing")
+    parser.add_argument("--no-audit", action="store_true", help="Skip automatic audit preflight/postflight")
+    args = parser.parse_args(argv)
+
+    try:
+        config_path = resolve_config_path(args.config)
+    except ConfigError as e:
+        print(f"Config error: {e}", file=sys.stderr)
+        return 2
+
+    try:
+        config = load_config(config_path)
+    except ConfigError as e:
+        print(f"Failed to load target config: {e}", file=sys.stderr)
+        return 2
+
+    if not args.no_audit:
+        issues = run_audit(config, config_path)
+        print_audit_summary(issues, "Pre-change audit")
+        if any(i["level"] == "error" for i in issues):
+            print("Aborting due to audit errors. Use --no-audit to skip.", file=sys.stderr)
+            return 2
+
+    providers = get_providers(config)
+
+    # Resolve source config path if provided (path or nickname).
+    source_path: Path | None = None
+    if args.source:
+        source_path = resolve_lobster_config_path(args.source)
+        if source_path is None:
+            source_path = Path(args.source)
+    elif args.from_lobster:
+        source_path = resolve_lobster_config_path(args.from_lobster)
+        if source_path is None:
+            print(f"Unknown lobster nickname: {args.from_lobster}", file=sys.stderr)
+            return 2
+
+    source_config = None
+    if source_path:
+        try:
+            source_config = load_config(source_path)
+        except ConfigError as e:
+            print(f"Failed to load source config: {e}", file=sys.stderr)
+            return 2
+
+    # Ensure provider exists in target.
+    if args.provider not in providers:
+        if not source_config:
+            print(
+                f"Target config has no '{args.provider}' provider. "
+                "Provide --from SOURCE to copy it, or create the provider manually.",
+                file=sys.stderr,
+            )
+            return 2
+        source_providers = get_providers(source_config)
+        if args.provider not in source_providers:
+            print(f"Source config also has no '{args.provider}' provider.", file=sys.stderr)
+            return 2
+        providers[args.provider] = copy.deepcopy(source_providers[args.provider])
+        print(f"Copied '{args.provider}' provider from source config.")
+
+    # Resolve model definition.
+    model_path = Path(args.model)
+    file_alias: str | None = None
+    if model_path.exists() and model_path.is_file():
+        try:
+            model_def, file_alias = load_model_json(model_path)
+        except (OSError, ValueError, json.JSONDecodeError) as e:
+            print(f"Failed to load model JSON: {e}", file=sys.stderr)
+            return 2
+    else:
+        model_id = args.model
+        if source_config:
+            source_providers = get_providers(source_config)
+            if args.provider in source_providers:
+                model_def = find_model_in_provider(source_providers[args.provider], model_id)
+                if model_def is None:
+                    print(
+                        f"Model '{model_id}' not found in source provider '{args.provider}'. "
+                        "Provide a model JSON file path instead.",
+                        file=sys.stderr,
+                    )
+                    return 2
+                model_def = copy.deepcopy(model_def)
+            else:
+                print(f"Source config has no '{args.provider}' provider to copy model from.", file=sys.stderr)
+                return 2
+        else:
+            print(
+                f"Model '{model_id}' must be a JSON file path, or --from must point to a config containing it.",
+                file=sys.stderr,
+            )
+            return 2
+
+    if not isinstance(model_def, dict) or not model_def.get("id"):
+        print("Model definition must be an object with an 'id' field.", file=sys.stderr)
+        return 2
+
+    model_id = model_def["id"]
+
+    # Ensure model exists in target provider.
+    target_provider = providers[args.provider]
+    if model_id in provider_model_ids(target_provider):
+        print(f"Model '{model_id}' already exists in '{args.provider}' provider.")
+    else:
+        target_provider.setdefault("models", []).append(copy.deepcopy(model_def))
+        print(f"Added '{model_id}' model to '{args.provider}' provider.")
+
+    # Ensure alias exists.
+    alias_ref = f"{args.provider}/{model_id}"
+    aliases = config.setdefault("agents", {}).setdefault("defaults", {}).setdefault("models", {})
+    if alias_ref in aliases:
+        print(f"Alias '{alias_ref}' already exists.")
+    else:
+        alias_name = args.alias or file_alias or model_def.get("name") or model_id
+        aliases[alias_ref] = {"alias": alias_name}
+        print(f"Added alias '{alias_ref}' → '{alias_name}'.")
+
+    if args.dry_run:
+        print("Dry run: no changes written.")
+        print(f"To make this the default model, run: switch {alias_ref} --config {config_path}")
+        return 0
+
+    backup_path = backup_config(config_path)
+    print(f"Config backed up to: {backup_path}")
+
+    save_config(config_path, config)
+    print(f"Config saved to: {config_path}")
+
+    if not args.no_audit:
+        issues = run_audit(config, config_path)
+        print_audit_summary(issues, "Post-change audit")
+
+    if args.restart:
+        restart_gateway()
+    else:
+        print("NOTE: You must restart the OpenClaw gateway for the change to take effect.")
+        print(f"To switch default model, run: switch {alias_ref} --config {config_path} --restart")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/openclaw/scripts/audit.py
+++ b/openclaw/scripts/audit.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Audit an openclaw.json configuration for common structural issues."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from openclaw_config import (
+    ConfigError,
+    get_aliases,
+    get_default_model,
+    get_providers,
+    load_config,
+    provider_model_ids,
+    resolve_config_path,
+    split_model_ref,
+)
+
+
+def audit(config: dict, path: Path) -> list[dict]:
+    issues: list[dict] = []
+
+    providers = get_providers(config)
+    aliases = get_aliases(config)
+    default_ref = get_default_model(config)
+
+    if not providers:
+        issues.append({"level": "error", "scope": "models.providers", "message": "No model providers defined."})
+
+    # Provider-level checks
+    for pname, provider in providers.items():
+        if not provider.get("baseUrl"):
+            issues.append({"level": "error", "scope": f"models.providers.{pname}", "message": "Missing baseUrl."})
+        if not provider.get("api"):
+            issues.append({"level": "error", "scope": f"models.providers.{pname}", "message": "Missing api field."})
+
+        models = provider.get("models", [])
+        if not isinstance(models, list):
+            issues.append({"level": "error", "scope": f"models.providers.{pname}.models", "message": "models is not an array."})
+            continue
+
+        ids = [m.get("id") for m in models if m.get("id")]
+        seen = set()
+        for mid in ids:
+            if mid in seen:
+                issues.append({"level": "warning", "scope": f"models.providers.{pname}.models", "message": f"Duplicate model id: {mid}"})
+            seen.add(mid)
+
+        for i, model in enumerate(models):
+            if not isinstance(model, dict):
+                issues.append({"level": "error", "scope": f"models.providers.{pname}.models[{i}]", "message": "Model entry is not an object."})
+                continue
+            if not model.get("id"):
+                issues.append({"level": "error", "scope": f"models.providers.{pname}.models[{i}]", "message": "Model missing id."})
+
+    # Default model checks
+    if not default_ref:
+        issues.append({"level": "error", "scope": "agents.defaults.model", "message": "No default model set."})
+    else:
+        try:
+            provider_name, model_id = split_model_ref(default_ref)
+            if provider_name not in providers:
+                issues.append({"level": "error", "scope": "agents.defaults.model", "message": f"Default model provider '{provider_name}' not found in models.providers."})
+            elif model_id not in provider_model_ids(providers.get(provider_name, {})):
+                issues.append({"level": "error", "scope": "agents.defaults.model", "message": f"Default model '{model_id}' not found in provider '{provider_name}'."})
+        except ValueError as e:
+            issues.append({"level": "error", "scope": "agents.defaults.model", "message": str(e)})
+
+    # Alias checks
+    for alias_ref in aliases:
+        try:
+            provider_name, model_id = split_model_ref(alias_ref)
+            if provider_name not in providers:
+                issues.append({"level": "warning", "scope": "agents.defaults.models", "message": f"Alias '{alias_ref}' points to unknown provider '{provider_name}'."})
+            elif model_id not in provider_model_ids(providers.get(provider_name, {})):
+                issues.append({"level": "warning", "scope": "agents.defaults.models", "message": f"Alias '{alias_ref}' points to model '{model_id}' not listed in provider '{provider_name}'."})
+        except ValueError as e:
+            issues.append({"level": "warning", "scope": "agents.defaults.models", "message": f"Invalid alias reference '{alias_ref}': {e}"})
+
+    # Plugin consistency checks
+    plugins = config.get("plugins", {})
+    allowed = set(plugins.get("allow", []))
+    entries = set((plugins.get("entries") or {}).keys())
+    installs = set((plugins.get("installs") or {}).keys())
+
+    for name in allowed - entries:
+        issues.append({"level": "info", "scope": "plugins.allow", "message": f"'{name}' is allowed but has no plugins.entries config."})
+
+    enabled_entries = {name for name, cfg in (plugins.get("entries") or {}).items() if isinstance(cfg, dict) and cfg.get("enabled")}
+    for name in enabled_entries - installs:
+        issues.append({"level": "warning", "scope": "plugins.entries", "message": f"'{name}' is enabled but has no plugins.installs record (will fail to load)."})
+
+    for name in installs - allowed:
+        issues.append({"level": "info", "scope": "plugins.installs", "message": f"'{name}' is installed but not in plugins.allow."})
+
+    # DeepSeek-specific heuristic: catch the common mistake of a separate deepseek provider.
+    for pname in providers:
+        if pname.lower().startswith("deepseek"):
+            issues.append({
+                "level": "warning",
+                "scope": f"models.providers.{pname}",
+                "message": (
+                    f"Provider '{pname}' looks like a direct DeepSeek provider. "
+                    "For DeepSeek V4 Pro 1M, the supported path is the internal gateway provider (see references/deepseek_patch_sop.md)."
+                ),
+            })
+
+    return issues
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Audit an openclaw.json configuration.")
+    parser.add_argument("--config", type=Path, help="Path to openclaw.json")
+    parser.add_argument("--json", action="store_true", help="Output machine-readable JSON")
+    args = parser.parse_args(argv)
+
+    try:
+        config_path = resolve_config_path(args.config)
+    except ConfigError as e:
+        print(f"Config error: {e}", file=sys.stderr)
+        return 2
+
+    try:
+        config = load_config(config_path)
+    except ConfigError as e:
+        print(f"Failed to load config: {e}", file=sys.stderr)
+        return 2
+
+    issues = audit(config, config_path)
+
+    if args.json:
+        print(json.dumps({"config": str(config_path), "issues": issues}, indent=2, ensure_ascii=False))
+        return 0 if not any(i["level"] == "error" for i in issues) else 1
+
+    print(f"Auditing: {config_path}")
+    print(f"Found {len(issues)} issue(s).\n")
+    for issue in issues:
+        icon = {"error": "❌", "warning": "⚠️", "info": "ℹ️"}.get(issue["level"], "•")
+        print(f"{icon} [{issue['level'].upper()}] {issue['scope']}")
+        print(f"   {issue['message']}\n")
+
+    errors = sum(1 for i in issues if i["level"] == "error")
+    warnings = sum(1 for i in issues if i["level"] == "warning")
+    print(f"Summary: {errors} error(s), {warnings} warning(s).")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/openclaw/scripts/cli.py
+++ b/openclaw/scripts/cli.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Unified entry point for the openclaw skill."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+import add_model
+import audit
+import compare
+import copy_provider
+import list_models
+import switch_model
+
+SUBCOMMANDS = {
+    "audit": audit,
+    "compare": compare,
+    "diff": compare,
+    "copy": copy_provider,
+    "copy-provider": copy_provider,
+    "add-model": add_model,
+    "list": list_models,
+    "switch": switch_model,
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="openclaw",
+        description="Manage OpenClaw (龙虾) configs: audit, diff, copy, add-model, list, switch.",
+    )
+    parser.add_argument(
+        "command",
+        choices=list(SUBCOMMANDS.keys()),
+        help="Subcommand to run",
+    )
+    parser.add_argument(
+        "args",
+        nargs=argparse.REMAINDER,
+        help="Arguments passed to the subcommand",
+    )
+    parsed = parser.parse_args()
+
+    module = SUBCOMMANDS[parsed.command]
+    return module.main(parsed.args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/openclaw/scripts/compare.py
+++ b/openclaw/scripts/compare.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Compare two OpenClaw configurations and report semantic differences."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from openclaw_config import ConfigError, get_aliases, get_default_model, get_providers, load_config, provider_model_ids, resolve_config_path
+
+
+def model_map(provider: dict) -> dict[str, dict]:
+    return {m.get("id"): m for m in provider.get("models", []) if m.get("id")}
+
+
+def diff_models(left_provider: dict, right_provider: dict, include_cost: bool = False) -> list[dict]:
+    diffs = []
+    left_models = model_map(left_provider)
+    right_models = model_map(right_provider)
+    all_ids = sorted(set(left_models) | set(right_models))
+    for mid in all_ids:
+        if mid not in left_models:
+            diffs.append({"type": "added", "model_id": mid, "detail": right_models[mid]})
+        elif mid not in right_models:
+            diffs.append({"type": "removed", "model_id": mid, "detail": left_models[mid]})
+        else:
+            lm, rm = left_models[mid], right_models[mid]
+            field_diffs = {}
+            for key in sorted(set(lm) | set(rm)):
+                if key == "cost" and not include_cost:
+                    continue
+                if lm.get(key) != rm.get(key):
+                    field_diffs[key] = {"left": lm.get(key), "right": rm.get(key)}
+            if field_diffs:
+                diffs.append({"type": "changed", "model_id": mid, "fields": field_diffs})
+    return diffs
+
+
+def compare_configs(left: dict, right: dict, include_cost: bool = False) -> dict:
+    result: dict = {
+        "providers": {"added": [], "removed": [], "changed": []},
+        "default_model": {},
+        "aliases": {"added": [], "removed": [], "changed": []},
+        "plugins": {"allow": {}, "enabled_entries": {}, "installs": {}},
+    }
+
+    left_providers = get_providers(left)
+    right_providers = get_providers(right)
+
+    for name in sorted(set(left_providers) - set(right_providers)):
+        result["providers"]["removed"].append({"name": name, "detail": left_providers[name]})
+    for name in sorted(set(right_providers) - set(left_providers)):
+        result["providers"]["added"].append({"name": name, "detail": right_providers[name]})
+    for name in sorted(set(left_providers) & set(right_providers)):
+        diffs = diff_models(left_providers[name], right_providers[name], include_cost=include_cost)
+        if diffs:
+            result["providers"]["changed"].append({"name": name, "model_diffs": diffs})
+
+    left_default = get_default_model(left)
+    right_default = get_default_model(right)
+    if left_default != right_default:
+        result["default_model"] = {"left": left_default, "right": right_default}
+
+    left_aliases = get_aliases(left)
+    right_aliases = get_aliases(right)
+    all_aliases = sorted(set(left_aliases) | set(right_aliases))
+    for ref in all_aliases:
+        if ref in left_aliases and ref not in right_aliases:
+            result["aliases"]["removed"].append({"ref": ref, "detail": left_aliases[ref]})
+        elif ref in right_aliases and ref not in left_aliases:
+            result["aliases"]["added"].append({"ref": ref, "detail": right_aliases[ref]})
+        elif left_aliases[ref] != right_aliases[ref]:
+            result["aliases"]["changed"].append({"ref": ref, "left": left_aliases[ref], "right": right_aliases[ref]})
+
+    def set_diff(left_list, right_list):
+        return {
+            "only_left": sorted(set(left_list) - set(right_list)),
+            "only_right": sorted(set(right_list) - set(left_list)),
+        }
+
+    left_plugins = left.get("plugins", {})
+    right_plugins = right.get("plugins", {})
+    result["plugins"]["allow"] = set_diff(left_plugins.get("allow", []), right_plugins.get("allow", []))
+
+    left_entries = set(k for k, v in (left_plugins.get("entries") or {}).items() if isinstance(v, dict) and v.get("enabled"))
+    right_entries = set(k for k, v in (right_plugins.get("entries") or {}).items() if isinstance(v, dict) and v.get("enabled"))
+    result["plugins"]["enabled_entries"] = set_diff(left_entries, right_entries)
+
+    left_installs = set((left_plugins.get("installs") or {}).keys())
+    right_installs = set((right_plugins.get("installs") or {}).keys())
+    result["plugins"]["installs"] = set_diff(left_installs, right_installs)
+
+    return result
+
+
+def print_report(report: dict, left_path: Path, right_path: Path) -> None:
+    print(f"# OpenClaw Config Diff\n")
+    print(f"- Left:  `{left_path}`")
+    print(f"- Right: `{right_path}`\n")
+
+    # Providers
+    p = report["providers"]
+    if p["added"] or p["removed"] or p["changed"]:
+        print("## Providers\n")
+        for item in p["removed"]:
+            print(f"- ❌ Removed provider `{item['name']}`")
+        for item in p["added"]:
+            print(f"- ✅ Added provider `{item['name']}`")
+        for item in p["changed"]:
+            print(f"- 📝 Changed provider `{item['name']}`:")
+            for d in item["model_diffs"]:
+                if d["type"] == "added":
+                    print(f"  - Added model `{d['model_id']}`")
+                elif d["type"] == "removed":
+                    print(f"  - Removed model `{d['model_id']}`")
+                elif d["type"] == "changed":
+                    print(f"  - Changed model `{d['model_id']}`:")
+                    for field, vals in d["fields"].items():
+                        print(f"    - `{field}`: {vals['left']} → {vals['right']}")
+        print()
+    else:
+        print("## Providers\nNo changes.\n")
+
+    # Default model
+    dm = report["default_model"]
+    if dm:
+        print(f"## Default Model\n`{dm['left']}` → `{dm['right']}`\n")
+
+    # Aliases
+    a = report["aliases"]
+    if a["added"] or a["removed"] or a["changed"]:
+        print("## Aliases\n")
+        for item in a["removed"]:
+            print(f"- ❌ Removed `{item['ref']}`")
+        for item in a["added"]:
+            print(f"- ✅ Added `{item['ref']}` → `{item['detail']}`")
+        for item in a["changed"]:
+            print(f"- 📝 Changed `{item['ref']}`: `{item['left']}` → `{item['right']}`")
+        print()
+
+    # Plugins
+    pl = report["plugins"]
+    has_plugin_diff = any(pl[k]["only_left"] or pl[k]["only_right"] for k in pl)
+    if has_plugin_diff:
+        print("## Plugins\n")
+        print("### plugins.allow")
+        for name in pl["allow"]["only_left"]:
+            print(f"- ❌ only in left: `{name}`")
+        for name in pl["allow"]["only_right"]:
+            print(f"- ✅ only in right: `{name}`")
+        print("\n### enabled plugin entries")
+        for name in pl["enabled_entries"]["only_left"]:
+            print(f"- ❌ only enabled in left: `{name}`")
+        for name in pl["enabled_entries"]["only_right"]:
+            print(f"- ✅ only enabled in right: `{name}`")
+        print("\n### plugins.installs")
+        for name in pl["installs"]["only_left"]:
+            print(f"- ❌ only installed in left: `{name}`")
+        for name in pl["installs"]["only_right"]:
+            print(f"- ✅ only installed in right: `{name}`")
+        print()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Compare two OpenClaw configs.")
+    parser.add_argument("left", help="Left openclaw.json or lobster nickname")
+    parser.add_argument("right", help="Right openclaw.json or lobster nickname")
+    parser.add_argument("--json", action="store_true", help="Output JSON report")
+    parser.add_argument("--include-cost", action="store_true", help="Include cost field diffs for models")
+    args = parser.parse_args(argv)
+
+    try:
+        left_path = resolve_config_path(args.left)
+        right_path = resolve_config_path(args.right)
+        left_cfg = load_config(left_path)
+        right_cfg = load_config(right_path)
+    except ConfigError as e:
+        print(f"Failed to load config: {e}", file=sys.stderr)
+        return 2
+
+    report = compare_configs(left_cfg, right_cfg, include_cost=args.include_cost)
+
+    if args.json:
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+        return 0
+
+    print_report(report, left_path, right_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/openclaw/scripts/copy_provider.py
+++ b/openclaw/scripts/copy_provider.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Copy a provider (or just specific models/aliases) from one OpenClaw config to another."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import sys
+from pathlib import Path
+
+from audit import audit as run_audit
+from openclaw_config import (
+    ConfigError,
+    backup_config,
+    get_aliases,
+    get_providers,
+    load_config,
+    provider_model_ids,
+    resolve_config_path,
+    resolve_lobster_config_path,
+    restart_gateway,
+    save_config,
+)
+
+
+def parse_model_filter(models: list[str] | None) -> set[str] | None:
+    return set(models) if models else None
+
+
+def merge_provider(target_provider: dict, source_provider: dict, model_filter: set[str] | None) -> tuple[bool, list[str]]:
+    """
+    Merge source provider settings into target provider.
+
+    - Updates baseUrl/api if source has values.
+    - Adds or updates models by id (does not remove target-only models).
+    - Returns (changed, list of affected model ids).
+    """
+    changed = False
+    affected: list[str] = []
+
+    for key in ("baseUrl", "api"):
+        if source_provider.get(key) and source_provider.get(key) != target_provider.get(key):
+            target_provider[key] = source_provider[key]
+            changed = True
+
+    source_models = {m.get("id"): m for m in source_provider.get("models", []) if m.get("id")}
+    if model_filter:
+        source_models = {k: v for k, v in source_models.items() if k in model_filter}
+
+    target_models = {m.get("id"): m for m in target_provider.get("models", []) if m.get("id")}
+
+    for mid, model_def in source_models.items():
+        if mid not in target_models:
+            target_provider.setdefault("models", []).append(copy.deepcopy(model_def))
+            affected.append(mid)
+            changed = True
+        elif target_models[mid] != model_def:
+            # Replace in-place to sync definition with source.
+            for i, m in enumerate(target_provider.get("models", [])):
+                if m.get("id") == mid:
+                    target_provider["models"][i] = copy.deepcopy(model_def)
+                    break
+            affected.append(mid)
+            changed = True
+
+    return changed, affected
+
+
+def print_audit_summary(issues: list[dict], label: str) -> None:
+    errors = sum(1 for i in issues if i["level"] == "error")
+    warnings = sum(1 for i in issues if i["level"] == "warning")
+    print(f"{label}: {errors} error(s), {warnings} warning(s).")
+
+
+def resolve_path_arg(value: str | None, lobster_value: str | None, label: str) -> Path:
+    """Resolve a --from/--to argument that may be a path or a lobster nickname."""
+    if value is None and lobster_value is None:
+        raise ConfigError(f"{label} not specified")
+
+    raw = lobster_value if value is None else value
+    resolved = resolve_lobster_config_path(raw)
+    if resolved is not None:
+        return resolved
+    return Path(raw)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Copy provider configuration between OpenClaw configs")
+    parser.add_argument("--from", dest="source", help="Source config path or lobster nickname")
+    parser.add_argument("--from-lobster", help="Source lobster nickname")
+    parser.add_argument("--to", dest="target", help="Target config path or lobster nickname (defaults to discovered default config)")
+    parser.add_argument("--to-lobster", help="Target lobster nickname")
+    parser.add_argument("provider", help="Provider name to copy")
+    parser.add_argument("--model", action="append", dest="models", help="Only copy these model ids (can repeat)")
+    parser.add_argument("--alias", action="store_true", help="Also copy aliases pointing to this provider")
+    parser.add_argument("--restart", action="store_true", help="Restart gateway after saving")
+    parser.add_argument("--dry-run", action="store_true", help="Show what would change without writing")
+    parser.add_argument("--no-audit", action="store_true", help="Skip automatic audit preflight/postflight")
+    args = parser.parse_args(argv)
+
+    try:
+        source_path = resolve_path_arg(args.source, args.from_lobster, "Source")
+    except ConfigError as e:
+        print(f"Config error: {e}", file=sys.stderr)
+        return 2
+
+    try:
+        target_path = resolve_config_path(args.target)
+        if args.target is None and args.to_lobster:
+            target_path = resolve_path_arg(args.target, args.to_lobster, "Target")
+    except ConfigError as e:
+        print(f"Config error: {e}", file=sys.stderr)
+        return 2
+
+    try:
+        source = load_config(source_path)
+    except ConfigError as e:
+        print(f"Failed to load source config: {e}", file=sys.stderr)
+        return 2
+    try:
+        target = load_config(target_path)
+    except ConfigError as e:
+        print(f"Failed to load target config: {e}", file=sys.stderr)
+        return 2
+
+    if not args.no_audit:
+        issues = run_audit(target, target_path)
+        print_audit_summary(issues, "Pre-change audit")
+        if any(i["level"] == "error" for i in issues):
+            print("Aborting due to audit errors. Use --no-audit to skip.", file=sys.stderr)
+            return 2
+
+    source_providers = get_providers(source)
+    if args.provider not in source_providers:
+        available = ", ".join(source_providers.keys())
+        print(f"Provider '{args.provider}' not found in source. Available: {available}", file=sys.stderr)
+        return 2
+
+    target_providers = get_providers(target)
+    source_provider = source_providers[args.provider]
+    model_filter = parse_model_filter(args.models)
+
+    if args.models:
+        allowed_ids = parse_model_filter(args.models)
+        missing = allowed_ids - set(provider_model_ids(source_provider))
+        if missing:
+            print(f"Model id(s) not found in source provider '{args.provider}': {', '.join(sorted(missing))}", file=sys.stderr)
+            return 2
+
+    if args.provider not in target_providers:
+        target_providers[args.provider] = copy.deepcopy(source_provider)
+        if model_filter:
+            target_providers[args.provider]["models"] = [
+                m for m in target_providers[args.provider].get("models", [])
+                if m.get("id") in model_filter
+            ]
+        print(f"Added provider '{args.provider}' from source config.")
+        affected_ids = provider_model_ids(target_providers[args.provider])
+    else:
+        changed, affected_ids = merge_provider(target_providers[args.provider], source_provider, model_filter)
+        if changed:
+            print(f"Merged provider '{args.provider}': updated/added models {affected_ids}.")
+        else:
+            print(f"Provider '{args.provider}' already in sync; no changes made.")
+
+    if args.alias:
+        source_aliases = get_aliases(source)
+        target_aliases = get_aliases(target)
+        copied_any = False
+        for ref, detail in source_aliases.items():
+            if ref.startswith(f"{args.provider}/"):
+                if model_filter and ref.split("/", 1)[1] not in model_filter:
+                    continue
+                target_aliases[ref] = copy.deepcopy(detail)
+                copied_any = True
+                alias_name = detail.get("alias") if isinstance(detail, dict) else str(detail)
+                print(f"Copied alias '{ref}' → {alias_name}")
+        if not copied_any:
+            print("No matching aliases for this provider found in source config.")
+
+    if args.dry_run:
+        print("Dry run: no changes written.")
+        return 0
+
+    backup_path = backup_config(target_path)
+    print(f"Target config backed up to: {backup_path}")
+    save_config(target_path, target)
+    print(f"Target config saved to: {target_path}")
+
+    if not args.no_audit:
+        issues = run_audit(target, target_path)
+        print_audit_summary(issues, "Post-change audit")
+
+    if args.restart:
+        restart_gateway()
+    else:
+        print("NOTE: You must restart the OpenClaw gateway for provider changes to take effect.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/openclaw/scripts/list_models.py
+++ b/openclaw/scripts/list_models.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""List providers, models, aliases, and default model for an OpenClaw config."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from openclaw_config import (
+    ConfigError,
+    get_aliases,
+    get_default_model,
+    get_providers,
+    load_config,
+    provider_model_ids,
+    resolve_config_path,
+    split_model_ref,
+)
+
+
+def validate(config: dict) -> list[str]:
+    """Return lightweight validation messages (default + aliases resolve)."""
+    messages = []
+    providers = get_providers(config)
+    aliases = get_aliases(config)
+    default_ref = get_default_model(config)
+
+    if default_ref:
+        try:
+            pname, mid = split_model_ref(default_ref)
+            if pname not in providers:
+                messages.append(f"Default model provider '{pname}' does not exist.")
+            elif mid not in provider_model_ids(providers[pname]):
+                messages.append(f"Default model '{mid}' not found in provider '{pname}'.")
+        except ValueError as e:
+            messages.append(f"Default model reference invalid: {e}")
+
+    for ref in aliases:
+        try:
+            pname, mid = split_model_ref(ref)
+            if pname not in providers:
+                messages.append(f"Alias '{ref}' points to missing provider '{pname}'.")
+            elif mid not in provider_model_ids(providers[pname]):
+                messages.append(f"Alias '{ref}' points to missing model '{mid}'.")
+        except ValueError as e:
+            messages.append(f"Alias '{ref}' invalid: {e}")
+
+    return messages
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="List OpenClaw models and aliases")
+    parser.add_argument("--config", type=Path, help="Path to openclaw.json")
+    parser.add_argument("--json", action="store_true", help="Output machine-readable JSON")
+    parser.add_argument("--validate", action="store_true", help="Also check that default model and aliases resolve")
+    args = parser.parse_args(argv)
+
+    try:
+        config_path = resolve_config_path(args.config)
+    except ConfigError as e:
+        print(f"Config error: {e}", file=sys.stderr)
+        return 2
+
+    try:
+        config = load_config(config_path)
+    except ConfigError as e:
+        print(f"Failed to load config: {e}", file=sys.stderr)
+        return 2
+
+    providers = get_providers(config)
+    aliases = get_aliases(config)
+    default_ref = get_default_model(config)
+
+    if args.json:
+        output = {
+            "config": str(config_path),
+            "default_model": default_ref,
+            "providers": {},
+            "aliases": aliases,
+        }
+        for name, provider in providers.items():
+            output["providers"][name] = {
+                "baseUrl": provider.get("baseUrl"),
+                "api": provider.get("api"),
+                "models": [
+                    {
+                        "id": m.get("id"),
+                        "name": m.get("name"),
+                        "contextWindow": m.get("contextWindow"),
+                        "maxTokens": m.get("maxTokens"),
+                        "reasoning": m.get("reasoning"),
+                    }
+                    for m in provider.get("models", [])
+                ],
+            }
+        if args.validate:
+            output["validation"] = validate(config)
+        print(json.dumps(output, indent=2, ensure_ascii=False))
+        return 0
+
+    print(f"Config: {config_path}\n")
+    print(f"Default model: {default_ref or '(not set)'}\n")
+    print("## Providers\n")
+    for name, provider in providers.items():
+        print(f"- `{name}` → {provider.get('baseUrl', 'no baseUrl')}")
+        for mid in provider_model_ids(provider):
+            print(f"  - `{mid}`")
+    print("\n## Aliases\n")
+    if aliases:
+        for ref, detail in aliases.items():
+            alias_name = detail.get("alias") if isinstance(detail, dict) else "(unnamed)"
+            marker = " ← default" if ref == default_ref else ""
+            print(f"- `{ref}` → {alias_name}{marker}")
+    else:
+        print("No aliases defined.")
+
+    if args.validate:
+        messages = validate(config)
+        print("\n## Validation\n")
+        if messages:
+            for m in messages:
+                print(f"- ⚠️ {m}")
+        else:
+            print("Default model and all aliases resolve correctly.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/openclaw/scripts/openclaw_config.py
+++ b/openclaw/scripts/openclaw_config.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Shared helpers for the openclaw skill.
+
+Single source of truth for OpenClaw config I/O, discovery, backup, and
+common transforms. Imported by all subcommand scripts in this skill.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# Default search locations for OpenClaw configs, in order of preference.
+DEFAULT_CONFIG_PATHS = [
+    Path.home() / "workspace" / ".force" / "openclaw" / "openclaw.json",
+    Path.home() / ".kimi_openclaw" / "openclaw.json",
+    Path.home() / ".openclaw" / "openclaw.json",
+]
+
+# Locations for the lobster nickname → config path registry.
+LOBSTER_REGISTRY_PATHS = [
+    Path.home() / "workspace" / ".force" / "openclaw" / "lobsters.json",
+    Path.home() / ".kimi_openclaw" / "lobsters.json",
+    Path.home() / ".openclaw" / "lobsters.json",
+]
+
+
+class ConfigError(Exception):
+    """Raised when a config file cannot be loaded or is structurally invalid."""
+
+
+def find_default_config() -> Path | None:
+    """Return the first existing default config path, or None."""
+    for p in DEFAULT_CONFIG_PATHS:
+        if p.exists():
+            return p
+    return None
+
+
+def load_lobster_registry() -> dict[str, str]:
+    """Load the lobster nickname → config path registry if it exists."""
+    for p in LOBSTER_REGISTRY_PATHS:
+        if p.exists():
+            try:
+                with p.open("r", encoding="utf-8") as f:
+                    data = json.load(f)
+                if isinstance(data, dict):
+                    return {str(k): str(v) for k, v in data.items()}
+            except (OSError, json.JSONDecodeError):
+                continue
+    return {}
+
+
+def resolve_lobster_config_path(name_or_path: str | Path | None) -> Path | None:
+    """Resolve a string that may be a path or a lobster nickname.
+
+    - If None, return None.
+    - If it points to an existing file, return that path.
+    - Otherwise look it up in the lobster registry.
+    """
+    if name_or_path is None:
+        return None
+    p = Path(name_or_path)
+    if p.exists() and p.is_file():
+        return p
+    registry = load_lobster_registry()
+    if str(name_or_path) in registry:
+        return Path(registry[str(name_or_path)])
+    return None
+
+
+def resolve_config_path(path: Path | str | None) -> Path:
+    """Resolve an explicit config path, lobster nickname, or default locations."""
+    if path is not None:
+        resolved = resolve_lobster_config_path(path)
+        if resolved is not None:
+            return resolved
+        return Path(path)
+    default = find_default_config()
+    if default is None:
+        raise ConfigError(
+            "No openclaw.json found in default locations:\n"
+            + "\n".join(f"  - {p}" for p in DEFAULT_CONFIG_PATHS)
+        )
+    return default
+
+
+def load_config(path: Path | str) -> dict[str, Any]:
+    """Load openclaw.json and return it as a dict."""
+    p = Path(path)
+    if not p.exists():
+        raise ConfigError(f"Config file not found: {p}")
+    try:
+        with p.open("r", encoding="utf-8") as f:
+            return json.load(f)
+    except json.JSONDecodeError as e:
+        raise ConfigError(f"Invalid JSON in {p}: {e}") from e
+
+
+def save_config(path: Path | str, config: dict[str, Any]) -> None:
+    """Save config back to disk as formatted JSON."""
+    p = Path(path)
+    with p.open("w", encoding="utf-8") as f:
+        json.dump(config, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+
+
+def backup_config(path: Path | str, max_backups: int = 20) -> Path:
+    """Copy config to a timestamped backup beside the original.
+
+    Keeps at most ``max_backups`` most recent backups to prevent unbounded
+    growth of the config-backups directory.
+    """
+    p = Path(path)
+    backup_dir = p.parent / "config-backups"
+    backup_dir.mkdir(exist_ok=True)
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    backup_path = backup_dir / f"{p.stem}-{ts}{p.suffix}"
+    shutil.copy2(p, backup_path)
+
+    # Prune oldest backups beyond the retention limit.
+    existing = sorted(backup_dir.glob(f"{p.stem}-*{p.suffix}"), key=os.path.getmtime)
+    for old in existing[:-max_backups]:
+        old.unlink()
+
+    return backup_path
+
+
+def get_providers(config: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Return the models.providers dict, or {} if missing."""
+    return config.get("models", {}).get("providers", {}) or {}
+
+
+def get_aliases(config: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Return agents.defaults.models alias map, or {} if missing."""
+    return config.get("agents", {}).get("defaults", {}).get("models", {}) or {}
+
+
+def get_default_model(config: dict[str, Any]) -> str | None:
+    """Return the current default model reference string, or None."""
+    default = config.get("agents", {}).get("defaults", {}).get("model")
+    if isinstance(default, str):
+        return default
+    if isinstance(default, dict):
+        return default.get("primary") or default.get("default")
+    return None
+
+
+def set_default_model(config: dict[str, Any], ref: str) -> None:
+    """
+    Set the default model reference.
+
+    Preserves the existing structure: if the current default is an object with
+    a 'primary' key, update that key; otherwise store as a plain string.
+    """
+    defaults = config.setdefault("agents", {}).setdefault("defaults", {})
+    current = defaults.get("model")
+    if isinstance(current, dict):
+        defaults["model"] = {**current, "primary": ref}
+    else:
+        defaults["model"] = ref
+
+
+def provider_model_ids(provider: dict[str, Any]) -> list[str]:
+    """Return the list of model ids for a provider."""
+    return [m.get("id") for m in provider.get("models", []) if m.get("id")]
+
+
+def split_model_ref(ref: str) -> tuple[str, str]:
+    """Split 'provider/model-id' into (provider, model-id)."""
+    if "/" in ref:
+        provider, model_id = ref.split("/", 1)
+        return provider, model_id
+    raise ValueError(f"Model reference must be 'provider/model-id', got: {ref}")
+
+
+def restart_gateway() -> bool:
+    """
+    Attempt to restart the OpenClaw gateway.
+
+    Tries, in order:
+      1. openclaw gateway restart
+      2. systemctl --user restart openclaw-gateway
+      3. systemctl restart openclaw-gateway
+    """
+    commands = [
+        ["openclaw", "gateway", "restart"],
+        ["systemctl", "--user", "restart", "openclaw-gateway"],
+        ["systemctl", "restart", "openclaw-gateway"],
+    ]
+    for cmd in commands:
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=60, check=False
+            )
+            if result.returncode == 0:
+                print(f"Gateway restarted with: {' '.join(cmd)}")
+                return True
+        except FileNotFoundError:
+            continue
+        except Exception:
+            continue
+    print(
+        "Warning: Could not restart gateway automatically. "
+        "Please run 'openclaw gateway restart' or restart the OpenClaw service manually.",
+        file=sys.stderr,
+    )
+    return False
+
+
+def pretty_json(value: Any) -> str:
+    return json.dumps(value, indent=2, ensure_ascii=False)

--- a/openclaw/scripts/switch_model.py
+++ b/openclaw/scripts/switch_model.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Safely switch the default model of an OpenClaw instance."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from audit import audit as run_audit
+from openclaw_config import (
+    ConfigError,
+    backup_config,
+    get_default_model,
+    get_providers,
+    load_config,
+    provider_model_ids,
+    resolve_config_path,
+    restart_gateway,
+    save_config,
+    set_default_model,
+    split_model_ref,
+)
+
+
+def print_audit_summary(issues: list[dict], label: str) -> None:
+    errors = sum(1 for i in issues if i["level"] == "error")
+    warnings = sum(1 for i in issues if i["level"] == "warning")
+    print(f"{label}: {errors} error(s), {warnings} warning(s).")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Switch OpenClaw default model")
+    parser.add_argument("model_ref", help="Target model reference, e.g. gateway-provider/deepseek-v4-pro")
+    parser.add_argument("--config", type=Path, help="Path to openclaw.json or lobster nickname")
+    parser.add_argument("--restart", action="store_true", help="Restart gateway after switching")
+    parser.add_argument("--dry-run", action="store_true", help="Show what would change without writing")
+    parser.add_argument("--no-audit", action="store_true", help="Skip automatic audit preflight/postflight")
+    args = parser.parse_args(argv)
+
+    try:
+        config_path = resolve_config_path(args.config)
+    except ConfigError as e:
+        print(f"Config error: {e}", file=sys.stderr)
+        return 2
+
+    try:
+        config = load_config(config_path)
+    except ConfigError as e:
+        print(f"Failed to load config: {e}", file=sys.stderr)
+        return 2
+
+    if not args.no_audit:
+        issues = run_audit(config, config_path)
+        print_audit_summary(issues, "Pre-change audit")
+        if any(i["level"] == "error" for i in issues):
+            print("Aborting due to audit errors. Use --no-audit to skip.", file=sys.stderr)
+            return 2
+
+    try:
+        provider_name, model_id = split_model_ref(args.model_ref)
+    except ValueError as e:
+        print(f"Invalid model reference: {e}", file=sys.stderr)
+        print("Expected format: provider/model-id", file=sys.stderr)
+        return 2
+
+    providers = get_providers(config)
+    if provider_name not in providers:
+        print(f"Provider '{provider_name}' not found.", file=sys.stderr)
+        print(f"Available providers: {', '.join(providers)}", file=sys.stderr)
+        return 2
+
+    if model_id not in provider_model_ids(providers[provider_name]):
+        print(f"Model '{model_id}' not found in provider '{provider_name}'.", file=sys.stderr)
+        print(f"Available models: {', '.join(provider_model_ids(providers[provider_name]))}", file=sys.stderr)
+        return 2
+
+    current_default = get_default_model(config)
+    if current_default == args.model_ref:
+        print(f"'{args.model_ref}' is already the default model. No change needed.")
+        if args.restart:
+            restart_gateway()
+        return 0
+
+    if args.dry_run:
+        print(f"Dry run: would set default model to '{args.model_ref}'.")
+        return 0
+
+    backup_path = backup_config(config_path)
+    print(f"Config backed up to: {backup_path}")
+
+    set_default_model(config, args.model_ref)
+    save_config(config_path, config)
+    print(f"Default model switched to: {args.model_ref}")
+
+    if not args.no_audit:
+        issues = run_audit(config, config_path)
+        print_audit_summary(issues, "Post-change audit")
+
+    if args.restart:
+        restart_gateway()
+    else:
+        print("NOTE: You must restart the OpenClaw gateway for the change to take effect.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What
New skill **openclaw**: unified CLI to manage OpenClaw (龙虾/lobster) instance configurations — audit / diff / copy / add-model / list / switch models across `openclaw.json` files, plus DeepSeek model patches, default-model/alias management, and config validation.

## Sanitization (public-repo PII gate)
- Real private instance nicknames were used as examples throughout SKILL.md and architecture docs → replaced with generic placeholders (甲虾/乙虾) before publishing.
- `security_scan` passed; full re-read confirms no remaining private names, keys, or absolute paths (config-discovery paths use `~`-relative form).

## Changes
- marketplace: register openclaw (51→52 plugins), metadata 1.70→1.71
- docs: README / README.zh-CN / CLAUDE skill lists synced 72→73, badges 1.71.0

doc-skill-list consistency check green (73 skills across all docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)