### PR TITLE
feat(skill-creator): package_skill excludes more artifacts + dist/ output (daymade-skill 1.3.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -210,7 +210,7 @@
       "description": "Daymade skills core suite. Bundles skill creation, quality review, search, and marketplace development tooling under one shared namespace.",
       "source": "./daymade-skill",
       "strict": false,
-      "version": "1.2.0",
+      "version": "1.3.0",
       "category": "suite",
       "keywords": [
         "suite",

--- a/daymade-skill/skill-creator/scripts/package_skill.py
+++ b/daymade-skill/skill-creator/scripts/package_skill.py
@@ -8,6 +8,12 @@ Usage:
 Example:
     uv run --with PyYAML python -m scripts.package_skill skills/public/my-skill
     uv run --with PyYAML python -m scripts.package_skill skills/public/my-skill ./dist
+
+Notes:
+    - The skill SOURCE OF TRUTH is the skill folder itself (e.g. skills/public/my-skill).
+    - The .skill file produced by this script is a DISTRIBUTION ARTIFACT (zip bundle).
+    - By default the artifact is written to <skill-folder>/dist/ so it stays next to
+      its source and is easy to find and clean up. It is NOT the canonical skill location.
 """
 
 import fnmatch
@@ -26,11 +32,11 @@ from scripts.quick_validate import validate_skill
 from scripts.security_scan import calculate_skill_hash
 
 # Patterns to exclude when packaging skills.
-EXCLUDE_DIRS = {"__pycache__", "node_modules"}
+EXCLUDE_DIRS = {"__pycache__", "node_modules", ".pytest_cache", ".venv"}
 EXCLUDE_GLOBS = {"*.pyc"}
-EXCLUDE_FILES = {".DS_Store"}
+EXCLUDE_FILES = {".DS_Store", ".security-scan-passed"}
 # Directories excluded only at the skill root (not when nested deeper).
-ROOT_EXCLUDE_DIRS = {"evals"}
+ROOT_EXCLUDE_DIRS = {"evals", "dist"}
 
 
 def should_exclude(rel_path: Path) -> bool:
@@ -91,8 +97,9 @@ def package_skill(skill_path, output_dir=None):
     Package a skill folder into a .skill file.
 
     Args:
-        skill_path: Path to the skill folder
-        output_dir: Optional output directory for the .skill file (defaults to current directory)
+        skill_path: Path to the skill folder (source of truth)
+        output_dir: Optional output directory for the .skill artifact.
+                    Defaults to <skill-folder>/dist/.
 
     Returns:
         Path to the created .skill file, or None if error
@@ -141,9 +148,10 @@ def package_skill(skill_path, output_dir=None):
     skill_name = skill_path.name
     if output_dir:
         output_path = Path(output_dir).resolve()
-        output_path.mkdir(parents=True, exist_ok=True)
     else:
-        output_path = Path.cwd()
+        # Default: place artifact next to source in a dedicated dist/ folder
+        output_path = skill_path / "dist"
+    output_path.mkdir(parents=True, exist_ok=True)
 
     skill_filename = output_path / f"{skill_name}.skill"
 
@@ -161,7 +169,9 @@ def package_skill(skill_path, output_dir=None):
                 zipf.write(file_path, arcname)
                 print(f"  Added: {arcname}")
 
-        print(f"\nSuccessfully packaged skill to: {skill_filename}")
+        print(f"\nDistribution artifact created: {skill_filename}")
+        print(f"  Source of truth (kept in git): {skill_path}")
+        print(f"  The .skill file is a disposable zip bundle; delete it after distribution if desired.")
         return skill_filename
 
     except Exception as e:
@@ -175,14 +185,18 @@ def main():
         print("\nExample:")
         print("  uv run --with PyYAML python -m scripts.package_skill skills/public/my-skill")
         print("  uv run --with PyYAML python -m scripts.package_skill skills/public/my-skill ./dist")
+        print("\nDefault output: <skill-folder>/dist/<skill-name>.skill")
+        print("The skill folder itself is the source of truth; the .skill file is a distribution artifact.")
         sys.exit(1)
 
     skill_path = sys.argv[1]
     output_dir = sys.argv[2] if len(sys.argv) > 2 else None
 
-    print(f"Packaging skill: {skill_path}")
+    print(f"Packaging skill source: {skill_path}")
     if output_dir:
-        print(f"   Output directory: {output_dir}")
+        print(f"   Artifact output directory: {output_dir}")
+    else:
+        print(f"   Artifact output directory: {Path(skill_path).resolve() / 'dist'}")
     print()
 
     result = package_skill(skill_path, output_dir)

--- a/daymade-skill/skill-creator/tests/test_package_skill.py
+++ b/daymade-skill/skill-creator/tests/test_package_skill.py
@@ -1,0 +1,128 @@
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from scripts.package_skill import package_skill, should_exclude
+from scripts.security_scan import calculate_skill_hash
+
+
+@pytest.mark.parametrize(
+    "rel_path,expected",
+    [
+        (Path("my-skill/__pycache__/foo.cpython-313.pyc"), True),
+        (Path("my-skill/scripts/__pycache__/bar.py"), True),
+        (Path("my-skill/node_modules/lodash/index.js"), True),
+        (Path("my-skill/.pytest_cache/v/cache/nodeids"), True),
+        (Path("my-skill/.DS_Store"), True),
+        (Path("my-skill/evals/evals.json"), True),
+        (Path("my-skill/dist/my-skill.skill"), True),
+        (Path("my-skill/scripts/nested/evals/helper.py"), False),
+        (Path("my-skill/references/guide.md"), False),
+        (Path("my-skill/SKILL.md"), False),
+    ],
+)
+def test_should_exclude(rel_path, expected):
+    assert should_exclude(rel_path) is expected
+
+
+def _make_minimal_skill(tmp_path: Path, name: str = "minimal-skill") -> Path:
+    """Create a minimal valid skill folder and its security marker."""
+    skill_dir = tmp_path / name
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: A minimal skill for testing\n---\n\n# Minimal\n",
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+def _add_security_marker(skill_dir: Path) -> None:
+    """Write a .security-scan-passed marker matching the current content hash."""
+    content_hash = calculate_skill_hash(skill_dir)
+    (skill_dir / ".security-scan-passed").write_text(
+        f"Security scan passed\nContent hash: {content_hash}\n", encoding="utf-8"
+    )
+
+
+def test_package_skill_default_output_path(tmp_path):
+    skill_dir = _make_minimal_skill(tmp_path, "test-skill")
+    _add_security_marker(skill_dir)
+
+    artifact = package_skill(skill_dir)
+
+    assert artifact is not None
+    expected = skill_dir / "dist" / "test-skill.skill"
+    assert artifact == expected
+    assert artifact.exists()
+    assert artifact.parent == skill_dir / "dist"
+
+
+def test_package_skill_custom_output_dir(tmp_path):
+    skill_dir = _make_minimal_skill(tmp_path, "test-skill")
+    _add_security_marker(skill_dir)
+    custom_dir = tmp_path / "custom-artifacts"
+
+    artifact = package_skill(skill_dir, output_dir=str(custom_dir))
+
+    assert artifact is not None
+    assert artifact == custom_dir / "test-skill.skill"
+    assert artifact.exists()
+    # Default dist/ should NOT be created when a custom dir is provided.
+    assert not (skill_dir / "dist").exists()
+
+
+def test_package_skill_artifact_contains_skill_files(tmp_path):
+    skill_dir = _make_minimal_skill(tmp_path, "test-skill")
+    (skill_dir / "references").mkdir()
+    (skill_dir / "references" / "guide.md").write_text("# Guide\n", encoding="utf-8")
+    _add_security_marker(skill_dir)
+
+    artifact = package_skill(skill_dir)
+
+    with zipfile.ZipFile(artifact, "r") as zf:
+        names = zf.namelist()
+    assert any("SKILL.md" in n for n in names)
+    assert any("references/guide.md" in n for n in names)
+    # Excluded files should not be packaged.
+    assert not any("__pycache__" in n for n in names)
+    assert not any(".security-scan-passed" in n for n in names)
+
+
+def test_package_skill_artifact_excludes_dist_directory(tmp_path):
+    skill_dir = _make_minimal_skill(tmp_path, "test-skill")
+    (skill_dir / "dist").mkdir()
+    (skill_dir / "dist" / "old-artifact.skill").write_text("fake", encoding="utf-8")
+    _add_security_marker(skill_dir)
+
+    artifact = package_skill(skill_dir)
+
+    with zipfile.ZipFile(artifact, "r") as zf:
+        names = zf.namelist()
+    assert not any("dist/" in n for n in names)
+    assert any("SKILL.md" in n for n in names)
+
+
+def test_package_skill_missing_security_marker(tmp_path, capsys):
+    skill_dir = tmp_path / "unsafe-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: unsafe-skill\ndescription: no security scan\n---\n", encoding="utf-8"
+    )
+
+    artifact = package_skill(skill_dir)
+
+    assert artifact is None
+    captured = capsys.readouterr()
+    assert "Security scan not completed" in captured.out
+
+
+def test_package_skill_missing_skill_md(tmp_path, capsys):
+    skill_dir = tmp_path / "bad-skill"
+    skill_dir.mkdir()
+
+    artifact = package_skill(skill_dir)
+
+    assert artifact is None
+    captured = capsys.readouterr()
+    assert "SKILL.md not found" in captured.out


### PR DESCRIPTION
## What
Improve `package_skill.py`:
- Exclude more build/test artifacts from `.skill` bundles: `.pytest_cache`, `.venv` (dirs), `.security-scan-passed` (file), `dist` (root dir)
- Default artifact output now `<skill>/dist/` (next to source, easy to find and clean) instead of cwd
- Clearer messaging: skill folder is source-of-truth, `.skill` is a disposable distribution artifact
- Add `test_package_skill.py` — 16 tests, all passing

## Changes
- `daymade-skill/skill-creator/scripts/package_skill.py` + new `tests/test_package_skill.py`
- bump daymade-skill suite 1.2.0 → 1.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)