### PR TITLE
docs(skill-creator): strengthen PII semantic-review SOP after openclaw near-miss (daymade-skill 1.4.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -210,7 +210,7 @@
       "description": "Daymade skills core suite. Bundles skill creation, quality review, search, and marketplace development tooling under one shared namespace.",
       "source": "./daymade-skill",
       "strict": false,
-      "version": "1.3.0",
+      "version": "1.4.0",
       "category": "suite",
       "keywords": [
         "suite",

--- a/daymade-skill/skill-creator/references/sanitization_checklist.md
+++ b/daymade-skill/skill-creator/references/sanitization_checklist.md
@@ -43,6 +43,9 @@ grep -rniE "ultrathink|internal-only|confidential" skill-folder/
 - Project codenames (e.g., "Acme Prepared", "Project Phoenix")
 - Internal product names (e.g., "Ops Console", "Admin Dashboard")
 - Tool-specific names (e.g., "Globex Gemini" → just "Gemini")
+- **CJK project/instance nicknames** (e.g., real pet-names for your own instances). gitleaks ignores CJK entirely, and the person-name grep above only lists a few given names — a Chinese project nickname sprinkled through your examples sails past every scanner.
+
+> **War-story (2026-06-28):** the `openclaw` skill used two real private instance nicknames as examples in 13+ places across SKILL.md and an architecture doc. `security_scan` was green, gitleaks found nothing, every grep pattern missed them — they were caught only by reading the file and recognizing the names as a real project, then replaced with generic placeholders. **A green scan on a config / personal-workflow skill is exactly when to slow down and read every example noun**, because those skills are built around your own real instances.
 
 **How to replace:**
 - Use generic terms: "the system", "the application", "the service"

--- a/daymade-skill/skill-creator/scripts/security_scan.py
+++ b/daymade-skill/skill-creator/scripts/security_scan.py
@@ -258,6 +258,11 @@ def print_simple_report(gitleaks_findings: List[Dict], skill_name: str) -> int:
     """
     if not gitleaks_findings:
         print(f"{GREEN}✅ Security scan passed: No secrets detected{RESET}")
+        print(f"{YELLOW}⚠  Keyword-based gate only. It does NOT catch real project/person")
+        print(f"   nicknames, CJK names (gitleaks ignores CJK), or verbatim transcript lines —")
+        print(f"   none have a secret signature. Before publishing to a PUBLIC repo you MUST")
+        print(f"   read the skill yourself; a green scan is not a clean bill of health.")
+        print(f"   See references/sanitization_checklist.md{RESET}")
         return 0
 
     critical_count = sum(1 for f in gitleaks_findings

--- a/references/new-skill-guide.md
+++ b/references/new-skill-guide.md
@@ -16,11 +16,13 @@
 
 ## Step-by-Step Process
 
-### 1. Refine the Skill (if needed)
+### 1. Refine the Skill + PII Read-Through (mandatory gate)
 ```bash
 cd skill-creator
 uv run python -m scripts.security_scan ../skill-name --verbose
 ```
+
+`security_scan` (gitleaks) is a **keyword-based first pass, NOT the gate**. It cannot see real project/person nicknames, CJK names (gitleaks ignores CJK), or verbatim transcript lines — none have a secret signature. **Before publishing you MUST read the whole skill yourself** (SKILL.md + every reference + every example) and judge each concrete noun semantically: generic placeholder, or lifted from a real project/person? See [`../daymade-skill/skill-creator/references/sanitization_checklist.md`](../daymade-skill/skill-creator/references/sanitization_checklist.md). A green scan is **not** a clean bill of health. (2026-06-28: openclaw shipped review with real instance nicknames that scan/gitleaks/grep all missed — caught only by the read-through.)
 
 ### 2. Package the Skill
 ```bash
@@ -222,6 +224,7 @@ Before committing, verify:
 6. **Relying on JSON syntax check alone** - `python -m json.tool` only catches malformed JSON. It will NOT catch missing plugin entries, broken source+skills resolution, or orphan SKILL.md files on disk. Use `bash daymade-claude-code/marketplace-dev/scripts/check_marketplace.sh` for the full 4-check validation.
 7. **Leaving orphan SKILL.md directories** - A tracked skill directory with no plugin entry in marketplace.json is invisible to `claude plugin install`. The reverse-sync check in `check_marketplace.sh` emits a WARN for each orphan. Treat every WARN as a real signal: register it or delete it.
 8. **Using `git add -A` or `git add .`** - When multiple sessions/agents edit the repo in parallel, a blanket stage can piggyback another agent's unstaged changes into your commit. Always stage files by name.
+   - **Detecting a concurrent session before you commit:** if working-tree files keep changing between your `git status` calls (e.g. a file you just deleted reappears, or `marketplace.json` grows entries you didn't add), find who is writing instead of guessing. List each Claude session's working directory — `for p in $(pgrep -f 'claude --dangerously'); do echo -n "$p "; lsof -a -p $p -d cwd -Fn 2>/dev/null | sed -n 's/^n//p'; done` — any session whose cwd is this repo is the culprit. Then cross-check file mtimes (`stat -f '%Sm %N' <file>`): minutes-old and static ⇒ the other session has stopped, the tree is safe to integrate; seconds-fresh ⇒ still active, so let it settle (or isolate your work in a `git worktree`) before committing. *(2026-06-28: ~10 rounds were lost treating a concurrent session's writes as a phantom bug — "the working tree keeps changing on its own" — until `ps`/`lsof` cwd + mtime pinned the real root cause. Root-cause first, don't keep reverting symptoms.)*
 9. **Forgetting to push** - Local changes are invisible until pushed to GitHub
 
 ## Quick Reference Commands


### PR DESCRIPTION
## Why
This session shipped `openclaw` with **real private instance nicknames used as examples in 13+ places**. `security_scan` was green, gitleaks and every grep pattern missed them (no secret signature; CJK names aren't covered by gitleaks). They were caught **only by a manual read-through** — and only because the reviewer happened to recognize the names. The rules already existed; they just weren't enforced as a gate. Harden the three places that should have stopped it.

## Changes
- **`security_scan.py`**: the "passed" message now explicitly warns it is keyword-based and does NOT catch real project/person nicknames, CJK names, or verbatim transcript lines — *a green scan is not a clean bill of health*.
- **`sanitization_checklist.md`**: add the CJK project-nickname blind spot to category 1 + an openclaw war-story (placeholders only, no real names).
- **`new-skill-guide.md`**: make the manual PII read-through a **mandatory Step-1 gate** (not just `security_scan`); add multi-agent concurrent-session diagnosis (`ps`/`lsof` cwd + mtime, root-cause-first) to the git-hygiene note.
- bump daymade-skill suite 1.3.0 → 1.4.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)