### PR TITLE
feat(download-gemini-images): add Gemini conversation image downloader (v1.72.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional Claude Code skills marketplace — production-ready skills spanning GitHub and git operations, document conversion and generation (Markdown, PDF, PPTX, DOCX), diagram and UI-design extraction, the full audio pipeline (ASR transcription, TTS, transcript correction, meeting minutes), financial and investment-research data, web scraping and content capture, security/PII tooling and secure repomix packaging, macOS and iOS development, CLI demo and terminal automation, prompt and skill engineering, deep research and fact-checking, QA and LLM-evaluation infrastructure, internationalization, network/Tailscale and remote-desktop diagnostics, and Claude Code operations (session recovery, CLAUDE.md optimization, statusline, multi-provider profile isolation, troubleshooting, marketplace development, repo health-check). Suite plugins (daymade-audio, daymade-claude-code, daymade-docs, daymade-skill) bundle related skills under shared namespaces, including the StepFun StepAudio 2.5 audio family. See the Available Skills list in the README for the authoritative per-skill breakdown.",
-    "version": "1.71.0"
+    "version": "1.72.0"
   },
   "plugins": [
     {
@@ -1033,6 +1033,23 @@
         "deepseek",
         "claude-code",
         "config-validation"
+      ]
+    },
+    {
+      "name": "download-gemini-images",
+      "description": "Download, export, save, or package images from a Google Gemini conversation page — uploaded images or generated image previews. Use when the task needs logged-in Chrome/Gemini state, opening Gemini image lightboxes, downloading the larger displayed files, renaming them in order, and producing a ZIP archive.",
+      "source": "./download-gemini-images",
+      "strict": false,
+      "version": "1.0.0",
+      "category": "media",
+      "keywords": [
+        "gemini",
+        "images",
+        "download",
+        "chrome",
+        "lightbox",
+        "zip",
+        "export"
       ]
     }
   ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository Overview
 
-This is a Claude Code skills marketplace containing 73 production-ready skills organized in a plugin marketplace structure. Most plugins expose one skill for narrow installs; suite plugins expose related skills under shared namespaces for combined installation workflows.
+This is a Claude Code skills marketplace containing 74 production-ready skills organized in a plugin marketplace structure. Most plugins expose one skill for narrow installs; suite plugins expose related skills under shared namespaces for combined installation workflows.
 
 **Essential Skill**: `skill-creator` is the most important skill in this marketplace - it's a meta-skill that enables users to create their own skills. Always recommend it first for users interested in extending Claude Code.
 
@@ -153,7 +153,7 @@ If it fires, fix the issue — do NOT use `--no-verify` to bypass.
 ## Marketplace Configuration
 
 The marketplace is configured in `.claude-plugin/marketplace.json`:
-- Contains 52 plugin entries: single-skill plugins point `source` directly at the skill directory (no `skills` field); suite plugins (`daymade-audio`, `daymade-claude-code`, `daymade-docs`, `daymade-skill`) use explicit `skills` arrays for multi-skill routing
+- Contains 53 plugin entries: single-skill plugins point `source` directly at the skill directory (no `skills` field); suite plugins (`daymade-audio`, `daymade-claude-code`, `daymade-docs`, `daymade-skill`) use explicit `skills` arrays for multi-skill routing
 - Each plugin has: name, description, source, version, category, keywords
 - Marketplace metadata: name, owner, version
 - Single-skill plugins follow the official pattern (167/168 plugins in `anthropics/claude-plugins-official`): `source` points to skill directory, `skills` omitted
@@ -272,6 +272,7 @@ This applies when you change ANY file under a skill directory:
 71. **codex-image-gallery** - Start a self-contained local web gallery for browsing Codex-generated images from `~/.codex/generated_images` or a custom `GALLERY_ROOT`
 72. **frontend-visual-qa** - Reviews rendered frontends, dashboards, HTML slides, and generated UIs for visual quality defects that lint/build miss (awkward line breaks, wrapped controls, horizontal overflow, double scrollbars, AI slop, Chrome DevTools viewport mistakes); use after frontend-design/ui-designer and alongside qa-expert
 73. **openclaw** - Manage OpenClaw (龙虾/lobster) instance configs: audit, diff, copy, add-model, list, switch models across openclaw.json files; DeepSeek model patches, default-model/alias management, config validation
+74. **download-gemini-images** - Download images (uploaded files or generated previews) from a Google Gemini conversation page via logged-in Chrome; lightbox-first with pageAssets fallback, ordered ZIP packaging with integrity verification
 
 **Recommendation**: Always suggest `skill-creator` first for users interested in creating skills or extending Claude Code.
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@
 [![简体中文](https://img.shields.io/badge/语言-简体中文-red)](./README.zh-CN.md)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Skills](https://img.shields.io/badge/skills-73-blue.svg)](https://github.com/daymade/claude-code-skills)
-[![Version](https://img.shields.io/badge/version-1.71.0-green.svg)](https://github.com/daymade/claude-code-skills)
+[![Skills](https://img.shields.io/badge/skills-74-blue.svg)](https://github.com/daymade/claude-code-skills)
+[![Version](https://img.shields.io/badge/version-1.72.0-green.svg)](https://github.com/daymade/claude-code-skills)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-2.0.13+-purple.svg)](https://claude.com/code)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./CONTRIBUTING.md)
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/daymade/claude-code-skills/graphs/commit-activity)
 
 </div>
 
-Professional Claude Code skills marketplace featuring 73 production-ready skills for enhanced development workflows.
+Professional Claude Code skills marketplace featuring 74 production-ready skills for enhanced development workflows.
 
 ## 📑 Table of Contents
 
@@ -2813,6 +2813,24 @@ Manage OpenClaw (龙虾/lobster) instance configurations — audit, diff, copy, 
 - Unified CLI: audit / diff / copy / add-model / list / switch
 - Auto-audit on mutating commands with a `--no-audit` escape hatch
 - Nickname registry for cross-config operations
+
+### 76. **download-gemini-images** - Download Images from Gemini Conversations
+
+```bash
+claude plugin install download-gemini-images@daymade-skills
+```
+
+Download images (uploaded files or generated previews) from a Google Gemini conversation page using your logged-in Chrome session, then package them into an ordered ZIP.
+
+**When to use:**
+- Saving images from a Gemini chat/app page (uploaded or generated previews)
+- Need the larger lightbox image, not the thumbnail
+- Renaming downloaded images in order and producing a ZIP archive
+
+**Key features:**
+- Lightbox-first download via the Chrome plugin (uses your existing Google session)
+- `pageAssets` fallback when lightbox automation fails
+- Ordered ZIP packaging with integrity verification
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,15 +6,15 @@
 [![简体中文](https://img.shields.io/badge/语言-简体中文-red)](./README.zh-CN.md)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Skills](https://img.shields.io/badge/skills-73-blue.svg)](https://github.com/daymade/claude-code-skills)
-[![Version](https://img.shields.io/badge/version-1.71.0-green.svg)](https://github.com/daymade/claude-code-skills)
+[![Skills](https://img.shields.io/badge/skills-74-blue.svg)](https://github.com/daymade/claude-code-skills)
+[![Version](https://img.shields.io/badge/version-1.72.0-green.svg)](https://github.com/daymade/claude-code-skills)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-2.0.13+-purple.svg)](https://claude.com/code)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./CONTRIBUTING.md)
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/daymade/claude-code-skills/graphs/commit-activity)
 
 </div>
 
-专业的 Claude Code 技能市场，提供 73 个生产就绪的技能，用于增强开发工作流。
+专业的 Claude Code 技能市场，提供 74 个生产就绪的技能，用于增强开发工作流。
 
 ## 📑 目录
 
@@ -2855,6 +2855,24 @@ claude plugin install openclaw@daymade-skills
 - 统一 CLI：audit / diff / copy / add-model / list / switch
 - 变更命令自动审计，带 `--no-audit` 逃生口
 - 昵称注册表支持跨配置操作
+
+### 76. **download-gemini-images** - 从 Gemini 对话下载图片
+
+```bash
+claude plugin install download-gemini-images@daymade-skills
+```
+
+用你已登录的 Chrome session 从 Google Gemini 对话页下载图片（上传的或生成的预览），按顺序重命名后打包成 ZIP。
+
+**使用场景：**
+- 保存 Gemini 对话页里的图片（上传的或生成的预览）
+- 需要更大的 lightbox 大图，而非缩略图
+- 把下载的图片按顺序重命名并打包成 ZIP
+
+**主要功能：**
+- 通过 Chrome 插件优先下载 lightbox 大图（用你现有的 Google session）
+- lightbox 自动化失败时回退到 `pageAssets`
+- 有序 ZIP 打包 + 完整性校验
 
 ---
 

--- a/download-gemini-images/.security-scan-passed
+++ b/download-gemini-images/.security-scan-passed
@@ -1,0 +1,4 @@
+Security scan passed
+Scanned at: 2026-06-28T15:00:46.577315
+Tool: gitleaks + pattern-based validation
+Content hash: e032b713d761630d2edc21fa39c84a67061811ca4bd3b1e18a976a89ae0e95cb

--- a/download-gemini-images/SKILL.md
+++ b/download-gemini-images/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: download-gemini-images
+description: Download, export, save, or package images from a Google Gemini conversation/chat/app page, especially uploaded images or generated image previews visible in a Gemini thread. Use when the task needs logged-in Chrome/Gemini state, opening Gemini image lightboxes, downloading the larger displayed image files, renaming them in order, and producing a ZIP archive.
+---
+
+# Download Gemini Images
+
+## Overview
+
+Download Gemini conversation images from the user's logged-in Chrome session. Prefer the lightbox image over thumbnail/page-preview assets because Gemini often exposes a larger `blob:` image only after the user opens a preview.
+
+## Workflow
+
+1. Use the Chrome plugin, not a fresh unauthenticated browser, because Gemini conversations usually require the user's existing Google session.
+2. Bootstrap Chrome per the Chrome skill, claim the already-open Gemini tab if it exists, or open the user-provided Gemini URL in Chrome.
+3. Import and run `scripts/download_gemini_images.mjs` from a `node_repl` JS call after `browser` is available.
+4. Package the output directory with `scripts/package_images.sh`.
+5. Report the ZIP path, image count, and any lower-resolution fallback.
+6. Finalize Chrome control after downloads are complete, keeping the user's original Gemini tab open when appropriate.
+
+## Main Script
+
+Resolve the script path relative to this skill directory, then import it in the same Node REPL session used for Chrome automation:
+
+```js
+var { downloadGeminiImagesFromChrome } = await import("/absolute/path/to/download-gemini-images/scripts/download_gemini_images.mjs");
+var result = await downloadGeminiImagesFromChrome({
+  browser,
+  tabUrlIncludes: "gemini.google.com/app",
+  expectedCount: 20,
+  outputDir: `${nodeRepl.homeDir}/Downloads/gemini_conversation_images_${new Date().toISOString().slice(0, 10).replaceAll("-", "")}`
+});
+nodeRepl.write(JSON.stringify(result, null, 2));
+```
+
+Set `expectedCount` only when the user gave a specific count. Omit it to download every visible `Show the uploaded image in a lightbox` button.
+
+## Packaging
+
+After the main script returns `outputDir`, run:
+
+```bash
+/absolute/path/to/download-gemini-images/scripts/package_images.sh "$outputDir" "$HOME/Downloads/gemini_conversation_images.zip"
+```
+
+The packaging script creates the ZIP, runs `zip -T`, and verifies that the archive contains the same ordered image files as the directory.
+
+## Fallback
+
+If lightbox automation fails but the page is visibly loaded, use the tab `pageAssets` capability:
+
+```js
+var pageAssets = await tab.capabilities.get("pageAssets");
+var inventory = await pageAssets.list();
+var uploaded = inventory.assets.filter(a => a.kind === "image" && a.url.includes("lh3.googleusercontent.com/gg/"));
+var bundle = await pageAssets.bundle({ inventoryId: inventory.id, assetIds: uploaded.map(a => a.id) });
+nodeRepl.write(JSON.stringify(bundle, null, 2));
+```
+
+This usually captures 512px preview JPEGs, not the larger lightbox files. Tell the user when this fallback is used.
+
+## Notes
+
+- Do not inspect browser cookies, local storage, passwords, or session stores.
+- Downloading files is an inbound transfer and does not require confirmation by itself.
+- If Gemini asks the user to log in, pause and ask the user to complete login in Chrome.
+- If the user wants the images in the same order as the thread, use the script's ordered names: `image_01.jpg`, `image_02.jpg`, etc.

--- a/download-gemini-images/agents/openai.yaml
+++ b/download-gemini-images/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Download Gemini Images"
+  short_description: "Download Gemini chat images as a ZIP"
+  default_prompt: "Use $download-gemini-images to download all images from this Gemini conversation and package them as a ZIP."

--- a/download-gemini-images/scripts/download_gemini_images.mjs
+++ b/download-gemini-images/scripts/download_gemini_images.mjs
@@ -1,0 +1,234 @@
+import { copyFile, mkdir, readdir, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const DEFAULT_BUTTON_SELECTOR = 'button[aria-label="Show the uploaded image in a lightbox"]';
+const DEFAULT_SELECTED_SELECTOR = 'img[alt="Selected image presented in a lightbox."]';
+
+function pad2(value) {
+  return String(value).padStart(2, "0");
+}
+
+function defaultDateStamp() {
+  return new Date().toISOString().slice(0, 10).replaceAll("-", "");
+}
+
+function normalizeExtension(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  if (ext === ".jpeg") return ".jpg";
+  if ([".jpg", ".png", ".webp", ".gif"].includes(ext)) return ext;
+  return ".jpg";
+}
+
+async function pathExists(filePath) {
+  try {
+    await stat(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function newestMatchingFile(directory, predicate) {
+  const names = await readdir(directory);
+  const candidates = [];
+
+  for (const name of names) {
+    if (!predicate(name)) continue;
+    const filePath = path.join(directory, name);
+    const info = await stat(filePath);
+    if (info.isFile()) {
+      candidates.push({ filePath, mtimeMs: info.mtimeMs, size: info.size });
+    }
+  }
+
+  candidates.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  return candidates[0] || null;
+}
+
+async function waitForDownloadedMedia(downloadsDir, uuid, startedAtMs, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  const extensions = [".jpeg", ".jpg", ".png", ".webp"];
+
+  while (Date.now() < deadline) {
+    if (uuid) {
+      for (const ext of extensions) {
+        const exactPath = path.join(downloadsDir, `${uuid}${ext}`);
+        if (await pathExists(exactPath)) return exactPath;
+      }
+    }
+
+    const newest = await newestMatchingFile(downloadsDir, (name) => {
+      if (!extensions.some((ext) => name.toLowerCase().endsWith(ext))) return false;
+      if (uuid && !name.includes(uuid)) return false;
+      return true;
+    });
+
+    if (newest && newest.mtimeMs >= startedAtMs - 2000 && newest.size > 0) {
+      return newest.filePath;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+
+  throw new Error(`Timed out waiting for downloaded Gemini media ${uuid || ""}`.trim());
+}
+
+async function selectedImageInfo(tab, selector) {
+  return await tab.playwright.evaluate((selectedSelector) => {
+    const img = document.querySelector(selectedSelector);
+    if (!img) return null;
+    const src = img.currentSrc || img.src || "";
+    return {
+      src,
+      naturalWidth: img.naturalWidth || 0,
+      naturalHeight: img.naturalHeight || 0,
+      renderedWidth: img.width || 0,
+      renderedHeight: img.height || 0
+    };
+  }, selector);
+}
+
+async function waitForSelectedImage(tab, selector, previousSrc, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const info = await selectedImageInfo(tab, selector);
+    if (
+      info &&
+      info.src.startsWith("blob:") &&
+      info.naturalWidth > 0 &&
+      info.naturalHeight > 0 &&
+      (!previousSrc || info.src !== previousSrc)
+    ) {
+      return info;
+    }
+
+    await tab.playwright.waitForTimeout(150);
+  }
+
+  throw new Error("Timed out waiting for Gemini lightbox image");
+}
+
+async function claimGeminiTab(browser, tabUrlIncludes) {
+  const openTabs = await browser.user.openTabs();
+  const matches = openTabs.filter((tabInfo) => {
+    const url = tabInfo.url || "";
+    const title = tabInfo.title || "";
+    return url.includes(tabUrlIncludes) || (url.includes("gemini.google.com") && title.includes("Gemini"));
+  });
+
+  if (matches.length === 0) {
+    throw new Error(`No open Gemini tab matched ${tabUrlIncludes}`);
+  }
+
+  return await browser.user.claimTab(matches[0]);
+}
+
+export async function downloadGeminiImagesFromChrome(options = {}) {
+  const browser = options.browser || globalThis.browser;
+  if (!browser) throw new Error("Chrome browser runtime is not initialized");
+
+  const homeDir = globalThis.nodeRepl?.homeDir || ".";
+  const downloadsDir = options.downloadsDir || path.join(homeDir, "Downloads");
+  const outputDir =
+    options.outputDir ||
+    path.join(downloadsDir, `gemini_conversation_images_${defaultDateStamp()}`);
+  const tabUrlIncludes = options.tabUrlIncludes || "gemini.google.com/app";
+  const imageButtonSelector = options.imageButtonSelector || DEFAULT_BUTTON_SELECTOR;
+  const selectedImageSelector = options.selectedImageSelector || DEFAULT_SELECTED_SELECTOR;
+  const expectedCount = options.expectedCount;
+  const lightboxTimeoutMs = options.lightboxTimeoutMs || 15000;
+  const downloadTimeoutMs = options.downloadTimeoutMs || 20000;
+
+  const tab = options.tab || (await claimGeminiTab(browser, tabUrlIncludes));
+  const pageUrl = await tab.url();
+  const pageTitle = await tab.title();
+
+  await mkdir(outputDir, { recursive: true });
+
+  let buttons = tab.playwright.locator(imageButtonSelector);
+  const initialCount = await buttons.count();
+  if (initialCount === 0) {
+    throw new Error(`No Gemini image lightbox buttons found with selector ${imageButtonSelector}`);
+  }
+  if (expectedCount != null && initialCount !== expectedCount) {
+    throw new Error(`Expected ${expectedCount} Gemini images, found ${initialCount}`);
+  }
+
+  const selected = tab.playwright.locator(selectedImageSelector);
+  const files = [];
+  let previousBlobSrc = "";
+
+  for (let index = 0; index < initialCount; index += 1) {
+    try {
+      await tab.cua.keypress({ keys: ["ESC"] });
+    } catch {
+      // The lightbox may already be closed.
+    }
+    await tab.playwright.waitForTimeout(150);
+
+    buttons = tab.playwright.locator(imageButtonSelector);
+    const currentCount = await buttons.count();
+    if (currentCount !== initialCount) {
+      throw new Error(`Gemini image button count changed from ${initialCount} to ${currentCount}`);
+    }
+
+    await buttons.nth(index).click({ timeoutMs: 10000 });
+    const imageInfo = await waitForSelectedImage(
+      tab,
+      selectedImageSelector,
+      previousBlobSrc,
+      lightboxTimeoutMs
+    );
+    previousBlobSrc = imageInfo.src;
+
+    const selectedCount = await selected.count();
+    if (selectedCount !== 1) {
+      throw new Error(`Expected exactly one selected lightbox image, found ${selectedCount}`);
+    }
+
+    const uuid = imageInfo.src.match(/\/([0-9a-f-]{36})$/i)?.[1] || null;
+    const downloadStartedAt = Date.now();
+    await selected.downloadMedia({ timeoutMs: downloadTimeoutMs });
+    const downloadedPath = await waitForDownloadedMedia(
+      downloadsDir,
+      uuid,
+      downloadStartedAt,
+      downloadTimeoutMs
+    );
+
+    const outputName = `image_${pad2(index + 1)}${normalizeExtension(downloadedPath)}`;
+    const outputPath = path.join(outputDir, outputName);
+    await copyFile(downloadedPath, outputPath);
+
+    files.push({
+      index: index + 1,
+      outputName,
+      outputPath,
+      downloadedPath,
+      uuid,
+      naturalWidth: imageInfo.naturalWidth,
+      naturalHeight: imageInfo.naturalHeight
+    });
+  }
+
+  const manifest = {
+    generatedAt: new Date().toISOString(),
+    pageTitle,
+    pageUrl,
+    outputDir,
+    imageCount: files.length,
+    files
+  };
+  const manifestPath = path.join(outputDir, "manifest.json");
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+
+  return {
+    pageTitle,
+    pageUrl,
+    outputDir,
+    manifestPath,
+    imageCount: files.length,
+    files
+  };
+}

--- a/download-gemini-images/scripts/package_images.sh
+++ b/download-gemini-images/scripts/package_images.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "usage: package_images.sh <image-directory> [zip-path]" >&2
+  exit 2
+fi
+
+image_dir=$1
+if [[ ! -d "$image_dir" ]]; then
+  echo "image directory does not exist: $image_dir" >&2
+  exit 1
+fi
+
+if [[ $# -eq 2 ]]; then
+  zip_path=$2
+else
+  zip_path="${image_dir%/}.zip"
+fi
+
+parent_dir=$(cd "$(dirname "$image_dir")" && pwd)
+base_name=$(basename "$image_dir")
+
+image_count=$(
+  find "$image_dir" -maxdepth 1 -type f \
+    \( -iname 'image_*.jpg' -o -iname 'image_*.jpeg' -o -iname 'image_*.png' -o -iname 'image_*.webp' \) |
+    wc -l | tr -d ' '
+)
+
+if [[ "$image_count" == "0" ]]; then
+  echo "no ordered image files found in $image_dir" >&2
+  exit 1
+fi
+
+rm -f "$zip_path"
+(
+  cd "$parent_dir"
+  zip -qr "$zip_path" "$base_name"
+)
+
+zip -T "$zip_path" >/dev/null
+
+zip_count=$(
+  zipinfo -1 "$zip_path" |
+    grep -E '/image_[0-9][0-9]\.(jpg|jpeg|png|webp)$' |
+    wc -l | tr -d ' '
+)
+
+if [[ "$zip_count" != "$image_count" ]]; then
+  echo "zip image count mismatch: directory=$image_count zip=$zip_count" >&2
+  exit 1
+fi
+
+printf 'zip_path=%s\nimage_count=%s\n' "$zip_path" "$image_count"


### PR DESCRIPTION
## What
New skill **download-gemini-images**: download images (uploaded files or generated previews) from a Google Gemini conversation page using your logged-in Chrome session, rename them in order, and package into a verified ZIP. Lightbox-first with a `pageAssets` fallback.

## Changes
- marketplace: register (52→53 plugins), metadata 1.71→1.72
- docs: README / README.zh-CN / CLAUDE skill lists synced 73→74, badges 1.72.0

## Safety
- Generic tool (anyone's Gemini); full read-through clean — no PII, absolute paths are `/absolute/path/to/...` placeholders. `security_scan` green; doc-skill-list check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)