### PR TITLE
feat(wps-doc-scraper): add public WPS/KDocs/ProcessOn archiver (v1.73.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional Claude Code skills marketplace — production-ready skills spanning GitHub and git operations, document conversion and generation (Markdown, PDF, PPTX, DOCX), diagram and UI-design extraction, the full audio pipeline (ASR transcription, TTS, transcript correction, meeting minutes), financial and investment-research data, web scraping and content capture, security/PII tooling and secure repomix packaging, macOS and iOS development, CLI demo and terminal automation, prompt and skill engineering, deep research and fact-checking, QA and LLM-evaluation infrastructure, internationalization, network/Tailscale and remote-desktop diagnostics, and Claude Code operations (session recovery, CLAUDE.md optimization, statusline, multi-provider profile isolation, troubleshooting, marketplace development, repo health-check). Suite plugins (daymade-audio, daymade-claude-code, daymade-docs, daymade-skill) bundle related skills under shared namespaces, including the StepFun StepAudio 2.5 audio family. See the Available Skills list in the README for the authoritative per-skill breakdown.",
-    "version": "1.72.0"
+    "version": "1.73.0"
   },
   "plugins": [
     {
@@ -1050,6 +1050,23 @@
         "lightbox",
         "zip",
         "export"
+      ]
+    },
+    {
+      "name": "wps-doc-scraper",
+      "description": "Faithfully archive public WPS / KDocs / 金山文档 links — especially embedded ProcessOn .pof mind maps and canvases — as raw source data, original SVG/PNG, and Markdown. Use when a user gives a kdocs.cn or wps.processon.com link and asks to scrape, save, download, 扒下来, 归档, or 转 Markdown without logging in.",
+      "source": "./wps-doc-scraper",
+      "strict": false,
+      "version": "1.0.0",
+      "category": "productivity",
+      "keywords": [
+        "wps",
+        "kdocs",
+        "processon",
+        "mindmap",
+        "scraper",
+        "markdown",
+        "archive"
       ]
     }
   ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository Overview
 
-This is a Claude Code skills marketplace containing 74 production-ready skills organized in a plugin marketplace structure. Most plugins expose one skill for narrow installs; suite plugins expose related skills under shared namespaces for combined installation workflows.
+This is a Claude Code skills marketplace containing 75 production-ready skills organized in a plugin marketplace structure. Most plugins expose one skill for narrow installs; suite plugins expose related skills under shared namespaces for combined installation workflows.
 
 **Essential Skill**: `skill-creator` is the most important skill in this marketplace - it's a meta-skill that enables users to create their own skills. Always recommend it first for users interested in extending Claude Code.
 
@@ -153,7 +153,7 @@ If it fires, fix the issue — do NOT use `--no-verify` to bypass.
 ## Marketplace Configuration
 
 The marketplace is configured in `.claude-plugin/marketplace.json`:
-- Contains 53 plugin entries: single-skill plugins point `source` directly at the skill directory (no `skills` field); suite plugins (`daymade-audio`, `daymade-claude-code`, `daymade-docs`, `daymade-skill`) use explicit `skills` arrays for multi-skill routing
+- Contains 54 plugin entries: single-skill plugins point `source` directly at the skill directory (no `skills` field); suite plugins (`daymade-audio`, `daymade-claude-code`, `daymade-docs`, `daymade-skill`) use explicit `skills` arrays for multi-skill routing
 - Each plugin has: name, description, source, version, category, keywords
 - Marketplace metadata: name, owner, version
 - Single-skill plugins follow the official pattern (167/168 plugins in `anthropics/claude-plugins-official`): `source` points to skill directory, `skills` omitted
@@ -273,6 +273,7 @@ This applies when you change ANY file under a skill directory:
 72. **frontend-visual-qa** - Reviews rendered frontends, dashboards, HTML slides, and generated UIs for visual quality defects that lint/build miss (awkward line breaks, wrapped controls, horizontal overflow, double scrollbars, AI slop, Chrome DevTools viewport mistakes); use after frontend-design/ui-designer and alongside qa-expert
 73. **openclaw** - Manage OpenClaw (龙虾/lobster) instance configs: audit, diff, copy, add-model, list, switch models across openclaw.json files; DeepSeek model patches, default-model/alias management, config validation
 74. **download-gemini-images** - Download images (uploaded files or generated previews) from a Google Gemini conversation page via logged-in Chrome; lightbox-first with pageAssets fallback, ordered ZIP packaging with integrity verification
+75. **wps-doc-scraper** - Faithfully archive public WPS/KDocs/金山文档 links (incl. embedded ProcessOn mind maps and canvases) as raw source data, original SVG/PNG, and Markdown without login; unauthenticated data-API-first with browser-DOM fallback
 
 **Recommendation**: Always suggest `skill-creator` first for users interested in creating skills or extending Claude Code.
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@
 [![简体中文](https://img.shields.io/badge/语言-简体中文-red)](./README.zh-CN.md)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Skills](https://img.shields.io/badge/skills-74-blue.svg)](https://github.com/daymade/claude-code-skills)
-[![Version](https://img.shields.io/badge/version-1.72.0-green.svg)](https://github.com/daymade/claude-code-skills)
+[![Skills](https://img.shields.io/badge/skills-75-blue.svg)](https://github.com/daymade/claude-code-skills)
+[![Version](https://img.shields.io/badge/version-1.73.0-green.svg)](https://github.com/daymade/claude-code-skills)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-2.0.13+-purple.svg)](https://claude.com/code)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./CONTRIBUTING.md)
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/daymade/claude-code-skills/graphs/commit-activity)
 
 </div>
 
-Professional Claude Code skills marketplace featuring 74 production-ready skills for enhanced development workflows.
+Professional Claude Code skills marketplace featuring 75 production-ready skills for enhanced development workflows.
 
 ## 📑 Table of Contents
 
@@ -2831,6 +2831,24 @@ Download images (uploaded files or generated previews) from a Google Gemini conv
 - Lightbox-first download via the Chrome plugin (uses your existing Google session)
 - `pageAssets` fallback when lightbox automation fails
 - Ordered ZIP packaging with integrity verification
+
+### 77. **wps-doc-scraper** - Archive Public WPS/KDocs Documents
+
+```bash
+claude plugin install wps-doc-scraper@daymade-skills
+```
+
+Faithfully archive public WPS / KDocs / 金山文档 links — especially embedded ProcessOn mind maps and canvases — as raw source data, original SVG/PNG, and Markdown, without logging in.
+
+**When to use:**
+- Given a `kdocs.cn` or `wps.processon.com` link to scrape, save, download, or convert to Markdown
+- Archiving an embedded ProcessOn mind map or canvas with source fidelity
+- Need the raw payloads + original visual artifact, not just rendered text
+
+**Key features:**
+- Unauthenticated data-API-first extraction (no login, no account save)
+- Original SVG/PNG capture for canvases and mind maps
+- Markdown as a structured representation of the source
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,15 +6,15 @@
 [![简体中文](https://img.shields.io/badge/语言-简体中文-red)](./README.zh-CN.md)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Skills](https://img.shields.io/badge/skills-74-blue.svg)](https://github.com/daymade/claude-code-skills)
-[![Version](https://img.shields.io/badge/version-1.72.0-green.svg)](https://github.com/daymade/claude-code-skills)
+[![Skills](https://img.shields.io/badge/skills-75-blue.svg)](https://github.com/daymade/claude-code-skills)
+[![Version](https://img.shields.io/badge/version-1.73.0-green.svg)](https://github.com/daymade/claude-code-skills)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-2.0.13+-purple.svg)](https://claude.com/code)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./CONTRIBUTING.md)
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/daymade/claude-code-skills/graphs/commit-activity)
 
 </div>
 
-专业的 Claude Code 技能市场，提供 74 个生产就绪的技能，用于增强开发工作流。
+专业的 Claude Code 技能市场，提供 75 个生产就绪的技能，用于增强开发工作流。
 
 ## 📑 目录
 
@@ -2873,6 +2873,24 @@ claude plugin install download-gemini-images@daymade-skills
 - 通过 Chrome 插件优先下载 lightbox 大图（用你现有的 Google session）
 - lightbox 自动化失败时回退到 `pageAssets`
 - 有序 ZIP 打包 + 完整性校验
+
+### 77. **wps-doc-scraper** - 归档公开 WPS/KDocs 文档
+
+```bash
+claude plugin install wps-doc-scraper@daymade-skills
+```
+
+忠实归档公开的 WPS / KDocs / 金山文档链接 —— 尤其是内嵌的 ProcessOn 思维导图和画布 —— 保存为原始源数据、原版 SVG/PNG 和 Markdown，无需登录。
+
+**使用场景：**
+- 给一个 `kdocs.cn` 或 `wps.processon.com` 链接，要抓取、保存、下载或转 Markdown
+- 归档内嵌的 ProcessOn 思维导图或画布，保持源保真度
+- 需要原始 payload + 原版视觉产物，而不只是渲染后的文本
+
+**主要功能：**
+- 优先用免登录数据 API 提取（不登录、不存到账号）
+- 画布和思维导图的原版 SVG/PNG 捕获
+- Markdown 作为源的结构化表示
 
 ---
 

--- a/wps-doc-scraper/.security-scan-passed
+++ b/wps-doc-scraper/.security-scan-passed
@@ -1,0 +1,4 @@
+Security scan passed
+Scanned at: 2026-06-28T15:06:29.942311
+Tool: gitleaks + pattern-based validation
+Content hash: bb72327cbea2d332955048c14a208e28965647bd1bf8d05261495e792a8ab835

--- a/wps-doc-scraper/SKILL.md
+++ b/wps-doc-scraper/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: wps-doc-scraper
+description: Faithfully archive public WPS/KDocs/金山文档 links, especially embedded ProcessOn .pof mind maps and canvases, as raw source data, original SVG/PNG, and Markdown. Use when a user gives a kdocs.cn or wps.processon.com link and asks to scrape, save, download, 扒下来, 归档, or 转 Markdown without logging in or saving the document to an account.
+---
+
+# WPS Doc Scraper
+
+## Overview
+
+Archive WPS/KDocs public documents with source fidelity. Prefer unauthenticated data APIs, keep the raw payloads, capture the original visual artifact when the document is a canvas or mind map, and generate Markdown only as a structured representation of the source.
+
+This is an extraction skill, not a writing skill. Do not use an LLM to rewrite, summarize, smooth, or infer missing document content unless the user explicitly asks for a separate analysis after the archive is complete.
+
+## Workflow Decision Tree
+
+1. Identify the URL type.
+   - `kdocs.cn/view/l/<share_id>` or `kdocs.cn/l/<share_id>`: read public link metadata first.
+   - `wps.processon.com/diagrams/view?...`: extract `file_id` and `group_id`, then use the ProcessOn data API.
+   - `wps.processon.com/wpsapi/diagrams/view/api?...`: treat as the source API directly.
+   - Other WPS/KDocs pages: collect public metadata, try official public export/download only when available, then use browser DOM capture as a fallback.
+
+2. For ProcessOn `.pof` mind maps or canvases, run the API extractor:
+
+   ```bash
+   python3 /path/to/wps-doc-scraper/scripts/wps_processon_extract.py \
+     --url "https://www.kdocs.cn/view/l/..." \
+     --output-dir "/path/to/archive-dir"
+   ```
+
+   Expected outputs: `processon-api.json`, `processon-definition.json`, `capture-manifest.json`, and `<title>.md`.
+
+3. Capture the original image.
+   - If the page exposes a rendered SVG, save the serialized full SVG as `<title>-全画布.svg`.
+   - If the SVG uses `foreignObject`, do not trust ImageMagick alone for text rendering. Use `scripts/render_svg_tiles.py` to make the PNG through macOS Quick Look square tiles.
+
+   ```bash
+   python3 /path/to/wps-doc-scraper/scripts/render_svg_tiles.py \
+     --svg "/path/to/<title>-全画布.svg" \
+     --output "/path/to/<title>-全画布.png"
+   ```
+
+4. Validate the archive.
+   - Markdown is a structural conversion, not an editorial rewrite.
+   - The original image exists for visual documents.
+   - Raw JSON and manifest exist.
+   - No output text contains the Unicode replacement character `�`.
+   - Any failed or permission-limited path is recorded in the manifest or final response.
+
+## Hard Rules
+
+- Never log in, save to an account, copy into the user's cloud drive, or mutate the remote document unless the user explicitly requests it.
+- Never bypass CAPTCHAs, paywalls, tenant restrictions, or permission walls. A public link that requires login is a hard boundary unless the user provides authorized access.
+- Do not infer hidden nodes or missing text. Preserve what the API or rendered DOM actually exposes.
+- HTTP 200 is not enough. Detect login-wall payloads such as `用户未登录`, empty definitions, and placeholder shells.
+- Keep raw source artifacts before transformation: API JSON, parsed definition JSON, serialized SVG, screenshots or PNGs, and a capture manifest.
+- For browser fallback, capture DOM/source data before screenshots when possible; screenshots alone are not a faithful text archive.
+- Report extraction gaps plainly. Do not silently produce a polished Markdown file from partial data.
+
+## Bundled Resources
+
+### scripts/
+
+- `wps_processon_extract.py`: deterministic extractor for public WPS/KDocs ProcessOn `.pof` mind maps. It resolves KDocs share metadata, downloads the ProcessOn data API JSON, parses the embedded definition, and writes Markdown plus a manifest.
+- `render_svg_tiles.py`: macOS Quick Look based SVG-to-PNG renderer for full-canvas SVGs with `foreignObject` text. It renders square vertical tiles and stitches them into one PNG.
+
+### references/
+
+- `processon-mindmap-api.md`: endpoint pattern and payload shape for WPS-hosted ProcessOn files.
+- `rendered-svg-capture.md`: browser-side process for extracting the rendered full-canvas SVG and producing a PNG.
+- `capture-manifest.md`: minimum manifest fields and acceptance checks.
+- `permission-and-failure-boundaries.md`: login walls, forbidden escalation, and failure reporting rules.

--- a/wps-doc-scraper/agents/openai.yaml
+++ b/wps-doc-scraper/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "WPS Doc Scraper"
+  short_description: "Archive WPS/KDocs documents faithfully"
+  default_prompt: "Use $wps-doc-scraper to save this WPS/KDocs link as local source data, original image, and Markdown."

--- a/wps-doc-scraper/references/capture-manifest.md
+++ b/wps-doc-scraper/references/capture-manifest.md
@@ -1,0 +1,39 @@
+# Capture Manifest
+
+Every archive should include `capture-manifest.json`. Minimum fields:
+
+```json
+{
+  "captured_at": "2026-06-26T00:00:00+00:00",
+  "source_url": "https://www.kdocs.cn/view/l/...",
+  "source_type": "kdocs_processon",
+  "kdocs_share_id": "...",
+  "kdocs_link_api_url": "https://drive.kdocs.cn/api/v5/links/...?review=true",
+  "processon_api_url": "https://wps.processon.com/wpsapi/diagrams/view/api?...",
+  "file_id": "...",
+  "group_id": "...",
+  "title": "...",
+  "creator": "...",
+  "counts": {
+    "nodes": 0,
+    "comments": 0
+  },
+  "outputs": {
+    "processon_api_json": "processon-api.json",
+    "processon_definition_json": "processon-definition.json",
+    "markdown": "title.md",
+    "rendered_svg": "title-全画布.svg",
+    "rendered_png": "title-全画布.png"
+  },
+  "notes": []
+}
+```
+
+## Acceptance Checks
+
+- Raw API JSON exists.
+- Parsed definition JSON exists when a ProcessOn API payload is available.
+- Markdown exists and is generated from source structure.
+- Original image exists for visual/canvas documents, unless a permission or rendering boundary is documented.
+- No text output contains `�`.
+- Partial extraction is marked partial in `notes`; do not present it as complete.

--- a/wps-doc-scraper/references/permission-and-failure-boundaries.md
+++ b/wps-doc-scraper/references/permission-and-failure-boundaries.md
@@ -1,0 +1,28 @@
+# Permission And Failure Boundaries
+
+## Allowed
+
+- Access public KDocs/WPS/ProcessOn endpoints that load without authentication.
+- Use the user's already-open browser session only to view content the user can legitimately access.
+- Save local copies of source JSON, rendered DOM/SVG, screenshots, PNGs, and Markdown.
+- Use official public download/export buttons when they are visible and do not require saving the file into an account.
+
+## Not Allowed
+
+- Logging into WPS/KDocs without explicit user instruction.
+- Clicking "save to my cloud", "copy to my drive", or similar account-mutating actions unless explicitly requested.
+- Bypassing CAPTCHAs, tenant restrictions, paywalls, password prompts, disabled download controls, or private-share limits.
+- Reconstructing hidden or permission-denied content from guesses.
+- Treating a login-wall JSON response as usable source data.
+
+## Failure Reporting
+
+If extraction fails, report the exact boundary:
+
+- public link metadata unavailable
+- ProcessOn API did not include `definition`
+- browser rendered only a login shell
+- original image could not be captured
+- PNG renderer missing Quick Look or ImageMagick
+
+Keep any partial raw artifacts that were legitimately fetched and mark the archive partial.

--- a/wps-doc-scraper/references/processon-mindmap-api.md
+++ b/wps-doc-scraper/references/processon-mindmap-api.md
@@ -1,0 +1,62 @@
+# ProcessOn Mind Map API
+
+Use this reference when the WPS/KDocs public link embeds a ProcessOn `.pof` mind map or canvas.
+
+## Public KDocs Link Metadata
+
+For a share link like:
+
+```text
+https://www.kdocs.cn/view/l/<share_id>
+```
+
+the unauthenticated metadata endpoint is:
+
+```text
+https://drive.kdocs.cn/api/v5/links/<share_id>?review=true
+```
+
+For public ProcessOn mind maps, useful fields commonly include:
+
+- `fileinfo.id`: ProcessOn/WPS file id.
+- `fileinfo.groupid`: ProcessOn group id.
+- `fileinfo.fname`: original filename, often ending with `.pof`.
+- `user_acl.download` and `user_permission`: helpful for permission reporting only.
+
+If the endpoint returns `用户未登录`, a placeholder shell, or omits file ids, do not force the path. Report the permission boundary.
+
+## ProcessOn View And Data API
+
+KDocs usually embeds:
+
+```text
+https://wps.processon.com/diagrams/view?file_id=<file_id>&group_id=<group_id>&is_recycle=false&user_id=0&product=kdocs_web&platform=&lang=en-US
+```
+
+The data API is:
+
+```text
+https://wps.processon.com/wpsapi/diagrams/view/api?file_id=<file_id>&group_id=<group_id>&is_recycle=false&user_id=0&product=kdocs_web&platform=&lang=en-US
+```
+
+The API returns JSON with a `definition` field. `definition` is usually a JSON-encoded string containing:
+
+- `title`: document title.
+- `children`: top-level mind-map nodes.
+- `children[].children`: nested nodes.
+- `children[].summaries`: summary/brace text attached to a node range.
+- `comments`: comments with `selectionId`; the node id is usually the prefix before `_`.
+- style/theme fields that are useful for rendering but not for Markdown text extraction.
+
+Always save both the raw API payload and the parsed `definition` JSON.
+
+## Markdown Conversion
+
+Markdown should mirror the tree structure:
+
+- node title -> bullet text
+- nested children -> nested bullets
+- summaries -> child bullets labeled `摘要`
+- comments -> child bullets labeled `评论`
+
+Do not reorder, smooth, summarize, or infer text. Convert HTML line breaks inside node titles to real newlines and strip markup that only exists for display.

--- a/wps-doc-scraper/references/rendered-svg-capture.md
+++ b/wps-doc-scraper/references/rendered-svg-capture.md
@@ -1,0 +1,50 @@
+# Rendered SVG Capture
+
+Use this reference when the original visual artifact is required for a WPS-hosted ProcessOn mind map or canvas.
+
+## Browser Discovery
+
+1. Open the KDocs public link without logging in.
+2. Find the embedded ProcessOn frame:
+
+```js
+[...document.querySelectorAll("iframe")].map((iframe) => iframe.src).filter(Boolean)
+```
+
+3. Open the `wps.processon.com/diagrams/view?...` frame URL.
+4. Wait until the canvas has rendered, then locate the main SVG:
+
+```js
+[...document.querySelectorAll("svg")].map((svg, i) => ({
+  i,
+  text: svg.textContent.slice(0, 80),
+  box: svg.getBoundingClientRect().toJSON?.() || svg.getBoundingClientRect()
+}))
+```
+
+Choose the SVG that contains the mind-map text, not toolbar icons.
+
+## Full-Canvas Serialization
+
+The visible SVG may have a viewport-sized root while its internal content extends beyond the viewport. Compute the content bounds from the meaningful SVG child/group nodes, clone the SVG, adjust `width`, `height`, and `viewBox`, and serialize it.
+
+Keep the serialized SVG as `<title>-全画布.svg`. Normalize obvious HTML-in-SVG issues before rendering:
+
+- `<br>` -> `<br/>`
+- `&nbsp;` -> `&#160;`
+
+Do not rely on a viewport screenshot as the only original image if the map extends offscreen.
+
+## PNG Rendering
+
+ProcessOn mind maps often use SVG `foreignObject` for text. ImageMagick's direct SVG renderer can drop that text. Prefer:
+
+```bash
+python3 /path/to/wps-doc-scraper/scripts/render_svg_tiles.py \
+  --svg "/path/to/<title>-全画布.svg" \
+  --output "/path/to/<title>-全画布.png"
+```
+
+The renderer uses macOS Quick Look on square vertical tiles and stitches them with ImageMagick. This avoids the horizontal cropping that can happen with non-square Quick Look thumbnails.
+
+Validate the resulting PNG dimensions and visually inspect that Chinese text is present and not clipped.

--- a/wps-doc-scraper/scripts/render_svg_tiles.py
+++ b/wps-doc-scraper/scripts/render_svg_tiles.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Render a full-canvas SVG to PNG through macOS Quick Look square tiles."""
+
+from __future__ import annotations
+
+import argparse
+import math
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+class RenderError(RuntimeError):
+    pass
+
+
+def normalize_svg(text: str) -> str:
+    text = re.sub(r"<br(\s[^/>]*)?>", lambda m: m.group(0)[:-1] + "/>" if not m.group(0).endswith("/>") else m.group(0), text, flags=re.IGNORECASE)
+    return text.replace("&nbsp;", "&#160;")
+
+
+def attr(root_tag: str, name: str) -> str | None:
+    match = re.search(rf"\b{name}\s*=\s*(['\"])(.*?)\1", root_tag, flags=re.IGNORECASE | re.DOTALL)
+    return match.group(2) if match else None
+
+
+def parse_length(value: str | None) -> float | None:
+    if not value:
+        return None
+    match = re.match(r"\s*([0-9]+(?:\.[0-9]+)?)", value)
+    return float(match.group(1)) if match else None
+
+
+def detect_size(svg_text: str) -> tuple[int, int]:
+    root_match = re.search(r"<svg\b[^>]*>", svg_text, flags=re.IGNORECASE | re.DOTALL)
+    if not root_match:
+        raise RenderError("No <svg> root tag found")
+    root_tag = root_match.group(0)
+    width = parse_length(attr(root_tag, "width"))
+    height = parse_length(attr(root_tag, "height"))
+    view_box = attr(root_tag, "viewBox")
+    if (width is None or height is None) and view_box:
+        parts = re.split(r"[\s,]+", view_box.strip())
+        if len(parts) == 4:
+            width = width or parse_length(parts[2])
+            height = height or parse_length(parts[3])
+    if width is None or height is None:
+        raise RenderError("SVG width/height could not be detected; pass --width and --height")
+    return max(1, math.ceil(width)), max(1, math.ceil(height))
+
+
+def split_svg_body(svg_text: str) -> tuple[str, str]:
+    root_match = re.search(r"<svg\b[^>]*>", svg_text, flags=re.IGNORECASE | re.DOTALL)
+    close_index = svg_text.lower().rfind("</svg>")
+    if not root_match or close_index < 0:
+        raise RenderError("SVG root is incomplete")
+    root_tag = root_match.group(0)
+    body = svg_text[root_match.end() : close_index]
+    ns = ""
+    if "xmlns=" not in root_tag:
+        ns += ' xmlns="http://www.w3.org/2000/svg"'
+    if "xmlns:xlink=" not in root_tag and "xlink:" in svg_text:
+        ns += ' xmlns:xlink="http://www.w3.org/1999/xlink"'
+    return ns, body
+
+
+def find_imagemagick() -> list[str]:
+    magick = shutil.which("magick")
+    if magick:
+        return [magick]
+    convert = shutil.which("convert")
+    if convert:
+        return [convert]
+    raise RenderError("ImageMagick was not found (`magick` or `convert` is required for crop/append)")
+
+
+def run(cmd: list[str]) -> None:
+    proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    if proc.returncode != 0:
+        details = (proc.stderr or proc.stdout).strip()
+        raise RenderError(f"Command failed: {' '.join(cmd)}\n{details}")
+
+
+def quicklook_render(svg_path: Path, output_dir: Path, size: int) -> Path:
+    before = set(output_dir.iterdir()) if output_dir.exists() else set()
+    run(["qlmanage", "-t", "-s", str(size), "-o", str(output_dir), str(svg_path)])
+    after = set(output_dir.iterdir())
+    created = [path for path in after - before if path.suffix.lower() == ".png"]
+    expected = output_dir / f"{svg_path.name}.png"
+    if expected.exists():
+        return expected
+    if created:
+        return created[0]
+    candidates = sorted(output_dir.glob(f"{svg_path.name}*.png"))
+    if candidates:
+        return candidates[-1]
+    raise RenderError(f"Quick Look did not produce a PNG for {svg_path}")
+
+
+def make_tile_svg(body: str, ns: str, width: int, tile_size: int, y: int) -> str:
+    return (
+        f'<svg{ns} width="{tile_size}" height="{tile_size}" '
+        f'viewBox="0 {y} {tile_size} {tile_size}">\n'
+        f"{body}\n"
+        "</svg>\n"
+    )
+
+
+def render_tiles(svg_text: str, output: Path, width: int, height: int, tile_size: int, keep_temp: bool) -> None:
+    if shutil.which("qlmanage") is None:
+        raise RenderError("macOS qlmanage was not found")
+    image_tool = find_imagemagick()
+    ns, body = split_svg_body(svg_text)
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    tmp_ctx = tempfile.TemporaryDirectory(prefix="wps-svg-tiles-")
+    tmp = Path(tmp_ctx.name)
+    try:
+        rendered_dir = tmp / "rendered"
+        rendered_dir.mkdir()
+        cropped_paths: list[Path] = []
+        tile_count = math.ceil(height / tile_size)
+        for index in range(tile_count):
+            y = index * tile_size
+            crop_h = min(tile_size, height - y)
+            tile_svg = tmp / f"tile-{index:04d}.svg"
+            tile_svg.write_text(make_tile_svg(body, ns, width, tile_size, y), encoding="utf-8")
+            rendered_png = quicklook_render(tile_svg, rendered_dir, tile_size)
+            cropped = tmp / f"tile-{index:04d}-crop.png"
+            run(image_tool + [str(rendered_png), "-crop", f"{width}x{crop_h}+0+0", "+repage", str(cropped)])
+            cropped_paths.append(cropped)
+
+        run(image_tool + [*(str(path) for path in cropped_paths), "-append", str(output)])
+        if keep_temp:
+            keep_dir = output.with_suffix(output.suffix + ".tiles")
+            if keep_dir.exists():
+                shutil.rmtree(keep_dir)
+            shutil.copytree(tmp, keep_dir)
+    finally:
+        tmp_ctx.cleanup()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--svg", type=Path, required=True, help="Serialized full-canvas SVG")
+    parser.add_argument("--output", type=Path, required=True, help="PNG output path")
+    parser.add_argument("--width", type=int, help="Override SVG width")
+    parser.add_argument("--height", type=int, help="Override SVG height")
+    parser.add_argument("--tile-size", type=int, help="Square tile size; defaults to SVG width")
+    parser.add_argument("--keep-temp", action="store_true", help="Keep generated tile files next to the output")
+    args = parser.parse_args(argv)
+
+    svg_text = normalize_svg(args.svg.read_text(encoding="utf-8"))
+    if "\ufffd" in svg_text:
+        raise RenderError("SVG contains Unicode replacement characters")
+
+    detected_width, detected_height = detect_size(svg_text)
+    width = args.width or detected_width
+    height = args.height or detected_height
+    tile_size = args.tile_size or width
+    if tile_size < width:
+        raise RenderError("--tile-size must be at least the SVG width so every tile captures the full row")
+
+    render_tiles(svg_text, args.output, width, height, tile_size, args.keep_temp)
+    print(f"Wrote {args.output} ({width}x{height})")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except RenderError as exc:
+        print(f"render_svg_tiles.py: {exc}", file=sys.stderr)
+        raise SystemExit(2)

--- a/wps-doc-scraper/scripts/wps_processon_extract.py
+++ b/wps-doc-scraper/scripts/wps_processon_extract.py
@@ -1,0 +1,579 @@
+#!/usr/bin/env python3
+"""Extract public WPS/KDocs ProcessOn mind maps into source JSON and Markdown."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import html
+import json
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125 Safari/537.36"
+)
+PROCESSON_API_BASE = "https://wps.processon.com/wpsapi/diagrams/view/api"
+KDOCS_LINK_RE = re.compile(r"https?://(?:www\.)?kdocs\.cn/(?:view/)?l/([^/?#]+)")
+
+
+class ExtractionError(RuntimeError):
+    pass
+
+
+def fetch_json(url: str, timeout: int) -> dict[str, Any]:
+    req = urllib.request.Request(
+        url,
+        headers={
+            "User-Agent": USER_AGENT,
+            "Accept": "application/json,text/plain,*/*",
+            "Referer": "https://www.kdocs.cn/",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read()
+    except urllib.error.HTTPError as exc:
+        raise ExtractionError(f"HTTP {exc.code} while fetching {url}") from exc
+    except urllib.error.URLError as exc:
+        raise ExtractionError(f"Network error while fetching {url}: {exc.reason}") from exc
+
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ExtractionError(f"Non-UTF-8 response from {url}") from exc
+
+    if "用户未登录" in text or "login" in text.lower() and "definition" not in text:
+        raise ExtractionError(f"Response looks like a login wall: {url}")
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        snippet = text[:200].replace("\n", " ")
+        raise ExtractionError(f"Response is not JSON from {url}: {snippet}") from exc
+
+    if isinstance(data, dict):
+        return data
+    raise ExtractionError(f"JSON response is not an object: {url}")
+
+
+def first_payload(obj: dict[str, Any]) -> dict[str, Any]:
+    for key in ("data", "result"):
+        value = obj.get(key)
+        if isinstance(value, dict) and (
+            "definition" in value or "fileinfo" in value or "fileId" in value
+        ):
+            return value
+    return obj
+
+
+def find_dict_with_any_key(obj: Any, keys: set[str]) -> dict[str, Any] | None:
+    if isinstance(obj, dict):
+        if any(key in obj for key in keys):
+            return obj
+        for value in obj.values():
+            found = find_dict_with_any_key(value, keys)
+            if found is not None:
+                return found
+    elif isinstance(obj, list):
+        for value in obj:
+            found = find_dict_with_any_key(value, keys)
+            if found is not None:
+                return found
+    return None
+
+
+def one(query: dict[str, list[str]], key: str) -> str | None:
+    values = query.get(key)
+    return values[0] if values else None
+
+
+def strip_known_extension(name: str | None) -> str | None:
+    if not name:
+        return None
+    for suffix in (".pof", ".pos", ".processon"):
+        if name.lower().endswith(suffix):
+            return name[: -len(suffix)]
+    return name
+
+
+def person_name(value: Any) -> str | None:
+    if isinstance(value, dict):
+        for key in ("name", "userName", "username", "displayName", "id"):
+            if value.get(key) is not None:
+                return clean_text(value.get(key)) or None
+        return None
+    return clean_text(value) or None
+
+
+def safe_filename(value: str, fallback: str = "wps-processon") -> str:
+    value = clean_text(value).splitlines()[0] if value else ""
+    value = re.sub(r'[\\/:*?"<>|]+', "_", value).strip(" .")
+    value = re.sub(r"\s+", " ", value)
+    return (value or fallback)[:140]
+
+
+def build_processon_api_url(query: dict[str, list[str]]) -> str:
+    required = ["file_id", "group_id"]
+    missing = [key for key in required if not one(query, key)]
+    if missing:
+        raise ExtractionError(f"ProcessOn URL is missing required query keys: {', '.join(missing)}")
+    return PROCESSON_API_BASE + "?" + urllib.parse.urlencode(query, doseq=True)
+
+
+def resolve_source(url: str, timeout: int) -> dict[str, Any]:
+    parsed = urllib.parse.urlparse(url)
+    host = parsed.netloc.lower()
+    result: dict[str, Any] = {
+        "source_url": url,
+        "source_type": "unknown",
+        "kdocs_share_id": None,
+        "kdocs_link_api_url": None,
+        "kdocs_link_json": None,
+        "processon_api_url": None,
+        "file_id": None,
+        "group_id": None,
+        "link_title": None,
+        "creator": None,
+    }
+
+    if host.endswith("kdocs.cn"):
+        match = KDOCS_LINK_RE.search(url)
+        if not match:
+            raise ExtractionError("KDocs URL does not match /view/l/<share_id> or /l/<share_id>")
+        share_id = match.group(1)
+        link_api_url = f"https://drive.kdocs.cn/api/v5/links/{share_id}?review=true"
+        link_json = fetch_json(link_api_url, timeout)
+        link_payload = first_payload(link_json)
+        fileinfo = link_payload.get("fileinfo")
+        if not isinstance(fileinfo, dict):
+            fileinfo = find_dict_with_any_key(link_payload, {"groupid", "group_id", "fname", "id"})
+        if not isinstance(fileinfo, dict):
+            raise ExtractionError("KDocs link metadata did not include fileinfo")
+
+        file_id = str(fileinfo.get("id") or fileinfo.get("file_id") or "").strip()
+        group_id = str(fileinfo.get("groupid") or fileinfo.get("group_id") or "").strip()
+        if not file_id or not group_id:
+            raise ExtractionError("KDocs link metadata did not include file id and group id")
+
+        query = {
+            "file_id": [file_id],
+            "group_id": [group_id],
+            "is_recycle": ["false"],
+            "user_id": ["0"],
+            "product": ["kdocs_web"],
+            "platform": [""],
+            "lang": ["en-US"],
+        }
+        result.update(
+            {
+                "source_type": "kdocs_processon",
+                "kdocs_share_id": share_id,
+                "kdocs_link_api_url": link_api_url,
+                "kdocs_link_json": link_json,
+                "processon_api_url": build_processon_api_url(query),
+                "file_id": file_id,
+                "group_id": group_id,
+                "link_title": strip_known_extension(fileinfo.get("fname")),
+                "creator": person_name(
+                    link_payload.get("creator")
+                    or fileinfo.get("creator")
+                    or fileinfo.get("creator_name")
+                ),
+            }
+        )
+        return result
+
+    if "processon.com" in host:
+        query = urllib.parse.parse_qs(parsed.query, keep_blank_values=True)
+        if "/wpsapi/diagrams/view/api" in parsed.path:
+            result.update(
+                {
+                    "source_type": "processon_api",
+                    "processon_api_url": url,
+                    "file_id": one(query, "file_id"),
+                    "group_id": one(query, "group_id"),
+                }
+            )
+            return result
+
+        if "/diagrams/view" in parsed.path:
+            result.update(
+                {
+                    "source_type": "processon_view",
+                    "processon_api_url": build_processon_api_url(query),
+                    "file_id": one(query, "file_id"),
+                    "group_id": one(query, "group_id"),
+                }
+            )
+            return result
+
+    raise ExtractionError("Unsupported URL. Expected kdocs.cn public link or wps.processon.com view/API URL.")
+
+
+def clean_text(value: Any) -> str:
+    if value is None:
+        return ""
+    text = str(value)
+    text = re.sub(r"<br\s*/?>", "\n", text, flags=re.IGNORECASE)
+    text = re.sub(r"</p>\s*<p[^>]*>", "\n", text, flags=re.IGNORECASE)
+    text = re.sub(r"<[^>]+>", "", text)
+    text = html.unescape(text).replace("\xa0", " ")
+    lines = [re.sub(r"[ \t]+", " ", line).strip() for line in text.splitlines()]
+    return "\n".join(line for line in lines if line).strip()
+
+
+def collect_nodes(nodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for node in nodes:
+        out.append(node)
+        children = node.get("children")
+        if isinstance(children, list):
+            out.extend(collect_nodes([child for child in children if isinstance(child, dict)]))
+    return out
+
+
+def index_comments(comments: list[dict[str, Any]]) -> tuple[dict[str, list[dict[str, Any]]], list[dict[str, Any]]]:
+    by_node: dict[str, list[dict[str, Any]]] = {}
+    unmapped: list[dict[str, Any]] = []
+    for comment in comments:
+        selection = str(comment.get("selectionId") or "")
+        node_id = selection.split("_", 1)[0] if selection else ""
+        if node_id:
+            by_node.setdefault(node_id, []).append(comment)
+        else:
+            unmapped.append(comment)
+    return by_node, unmapped
+
+
+def format_comment(comment: dict[str, Any]) -> str:
+    user = clean_text(comment.get("userName")) or "unknown"
+    created = clean_text(comment.get("createTime"))
+    text = clean_text(comment.get("text")) or "(empty)"
+    meta = f"{user}"
+    if created:
+        meta += f", {created}"
+    return f"{meta}: {text}"
+
+
+def append_wrapped_lines(out: list[str], indent: str, prefix: str, text: str) -> None:
+    lines = text.splitlines() or [""]
+    out.append(f"{indent}{prefix}{lines[0]}")
+    for line in lines[1:]:
+        out.append(f"{indent}{' ' * len(prefix)}{line}")
+
+
+def render_node(
+    node: dict[str, Any],
+    out: list[str],
+    comments_by_node: dict[str, list[dict[str, Any]]],
+    depth: int = 0,
+) -> None:
+    indent = "  " * depth
+    title = clean_text(node.get("title")) or "(untitled)"
+    append_wrapped_lines(out, indent, "- ", title)
+
+    summaries = node.get("summaries")
+    if isinstance(summaries, list):
+        for summary in summaries:
+            if not isinstance(summary, dict):
+                continue
+            summary_text = clean_text(summary.get("title"))
+            if summary_text:
+                label = "摘要"
+                if summary.get("range"):
+                    label += f"（range {summary.get('range')}）"
+                append_wrapped_lines(out, indent + "  ", f"- {label}: ", summary_text)
+
+    for comment in comments_by_node.get(str(node.get("id")), []):
+        append_wrapped_lines(out, indent + "  ", "- 评论: ", format_comment(comment))
+
+    children = node.get("children")
+    if isinstance(children, list):
+        for child in children:
+            if isinstance(child, dict):
+                render_node(child, out, comments_by_node, depth + 1)
+
+
+def yaml_scalar(value: Any) -> str:
+    if value is None:
+        return "null"
+    return json.dumps(str(value), ensure_ascii=False)
+
+
+def payload_file_id(source: dict[str, Any], api_payload: dict[str, Any]) -> Any:
+    request_params = api_payload.get("requestParamKS")
+    if not isinstance(request_params, dict):
+        request_params = {}
+    return (
+        source.get("file_id")
+        or api_payload.get("fileId")
+        or api_payload.get("file_id")
+        or api_payload.get("wpsFileId")
+        or request_params.get("fileId")
+        or request_params.get("file_id")
+    )
+
+
+def payload_group_id(source: dict[str, Any], api_payload: dict[str, Any]) -> Any:
+    request_params = api_payload.get("requestParamKS")
+    if not isinstance(request_params, dict):
+        request_params = {}
+    return (
+        source.get("group_id")
+        or api_payload.get("groupId")
+        or api_payload.get("group_id")
+        or request_params.get("groupId")
+        or request_params.get("group_id")
+    )
+
+
+def build_markdown(
+    definition: dict[str, Any],
+    source: dict[str, Any],
+    api_payload: dict[str, Any],
+    manifest_name: str,
+    title_override: str | None = None,
+) -> str:
+    title = (
+        clean_text(title_override)
+        or clean_text(definition.get("title"))
+        or clean_text(source.get("link_title"))
+        or "WPS ProcessOn"
+    )
+    creator = person_name(source.get("creator") or api_payload.get("creatorName"))
+    children = definition.get("children") if isinstance(definition.get("children"), list) else []
+    comments = definition.get("comments") if isinstance(definition.get("comments"), list) else []
+    comments_by_node, unmapped = index_comments([c for c in comments if isinstance(c, dict)])
+    nodes = collect_nodes([node for node in children if isinstance(node, dict)])
+
+    lines: list[str] = [
+        "---",
+        f"title: {yaml_scalar(title)}",
+        f"source_url: {yaml_scalar(source.get('source_url'))}",
+        f"source_type: {yaml_scalar(source.get('source_type'))}",
+        f"file_id: {yaml_scalar(payload_file_id(source, api_payload))}",
+        f"group_id: {yaml_scalar(payload_group_id(source, api_payload))}",
+        f"creator: {yaml_scalar(creator)}",
+        f"captured_at: {yaml_scalar(dt.datetime.now(dt.timezone.utc).isoformat())}",
+        f"capture_manifest: {yaml_scalar(manifest_name)}",
+        "---",
+        "",
+        f"# {title}",
+        "",
+        "## Source",
+        "",
+        f"- Source URL: {source.get('source_url')}",
+        f"- ProcessOn API: {source.get('processon_api_url')}",
+        f"- File ID: {payload_file_id(source, api_payload) or ''}",
+        f"- Group ID: {payload_group_id(source, api_payload) or ''}",
+    ]
+    if source.get("kdocs_link_api_url"):
+        lines.append(f"- KDocs link API: {source.get('kdocs_link_api_url')}")
+    if creator:
+        lines.append(f"- Creator: {creator}")
+    lines.extend(
+        [
+            "",
+            "## Mind Map",
+            "",
+        ]
+    )
+
+    if children:
+        for child in children:
+            if isinstance(child, dict):
+                render_node(child, lines, comments_by_node, 0)
+    else:
+        lines.append("_No mind-map children were present in the ProcessOn definition._")
+
+    if unmapped:
+        lines.extend(["", "## Unmapped Comments", ""])
+        for comment in unmapped:
+            lines.append(f"- {format_comment(comment)}")
+
+    mapped_count = sum(len(items) for items in comments_by_node.values())
+    lines.extend(
+        [
+            "",
+            "## Extraction Notes",
+            "",
+            "- Markdown was generated from the ProcessOn `definition` JSON without LLM rewriting.",
+            f"- Parsed node count: {len(nodes)}",
+            f"- Parsed comment count: {len(comments)} ({mapped_count} mapped to node ids, {len(unmapped)} unmapped).",
+            "- Capture the rendered SVG/PNG separately when the original visual layout is required.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_json(path: Path, value: Any) -> None:
+    path.write_text(json.dumps(value, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ExtractionError(f"Invalid JSON file: {path}") from exc
+    if not isinstance(value, dict):
+        raise ExtractionError(f"JSON file is not an object: {path}")
+    return value
+
+
+def extract_definition(api_json: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+    payload = first_payload(api_json)
+    definition_value = payload.get("definition")
+    if isinstance(definition_value, str):
+        try:
+            definition = json.loads(definition_value)
+        except json.JSONDecodeError as exc:
+            raise ExtractionError("ProcessOn `definition` is not valid JSON") from exc
+    elif isinstance(definition_value, dict):
+        definition = definition_value
+    else:
+        raise ExtractionError("ProcessOn API payload did not include a `definition` object/string")
+    if not isinstance(definition, dict):
+        raise ExtractionError("ProcessOn definition is not a JSON object")
+    return payload, definition
+
+
+def validate_text_outputs(paths: list[Path]) -> None:
+    bad = []
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        if "\ufffd" in text:
+            bad.append(str(path))
+    if bad:
+        raise ExtractionError("Unicode replacement character found in output: " + ", ".join(bad))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--url", help="KDocs public link, ProcessOn view URL, or ProcessOn API URL")
+    parser.add_argument("--api-json", type=Path, help="Use an existing ProcessOn API JSON file")
+    parser.add_argument("--link-json", type=Path, help="Optional existing KDocs link metadata JSON file")
+    parser.add_argument("--output-dir", type=Path, required=True, help="Archive output directory")
+    parser.add_argument("--title", help="Override output Markdown base name")
+    parser.add_argument("--rendered-svg", help="Path or filename for a separately captured SVG")
+    parser.add_argument("--rendered-png", help="Path or filename for a separately rendered PNG")
+    parser.add_argument("--timeout", type=int, default=30)
+    args = parser.parse_args(argv)
+
+    if not args.url and not args.api_json:
+        parser.error("Provide --url or --api-json")
+
+    source: dict[str, Any]
+    if args.url:
+        source = resolve_source(args.url, args.timeout)
+    else:
+        source = {
+            "source_url": None,
+            "source_type": "local_processon_api_json",
+            "kdocs_share_id": None,
+            "kdocs_link_api_url": None,
+            "kdocs_link_json": None,
+            "processon_api_url": None,
+            "file_id": None,
+            "group_id": None,
+            "link_title": None,
+            "creator": None,
+        }
+
+    if args.link_json:
+        source["kdocs_link_json"] = load_json(args.link_json)
+
+    if args.api_json:
+        api_json = load_json(args.api_json)
+    else:
+        api_url = source.get("processon_api_url")
+        if not api_url:
+            raise ExtractionError("Could not resolve ProcessOn API URL")
+        api_json = fetch_json(str(api_url), args.timeout)
+
+    api_payload, definition = extract_definition(api_json)
+    title = args.title or clean_text(definition.get("title")) or clean_text(source.get("link_title")) or "WPS ProcessOn"
+    base = safe_filename(title)
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    api_path = args.output_dir / "processon-api.json"
+    definition_path = args.output_dir / "processon-definition.json"
+    manifest_path = args.output_dir / "capture-manifest.json"
+    markdown_path = args.output_dir / f"{base}.md"
+
+    write_json(api_path, api_json)
+    write_json(definition_path, definition)
+    if source.get("kdocs_link_json") is not None:
+        write_json(args.output_dir / "kdocs-link-api.json", source["kdocs_link_json"])
+
+    children = definition.get("children") if isinstance(definition.get("children"), list) else []
+    comments = definition.get("comments") if isinstance(definition.get("comments"), list) else []
+    node_count = len(collect_nodes([node for node in children if isinstance(node, dict)]))
+    manifest = {
+        "captured_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "source_url": source.get("source_url"),
+        "source_type": source.get("source_type"),
+        "kdocs_share_id": source.get("kdocs_share_id"),
+        "kdocs_link_api_url": source.get("kdocs_link_api_url"),
+        "processon_api_url": source.get("processon_api_url"),
+        "file_id": payload_file_id(source, api_payload),
+        "group_id": payload_group_id(source, api_payload),
+        "title": title,
+        "creator": person_name(source.get("creator") or api_payload.get("creatorName")),
+        "counts": {
+            "nodes": node_count,
+            "comments": len(comments),
+        },
+        "outputs": {
+            "processon_api_json": api_path.name,
+            "processon_definition_json": definition_path.name,
+            "markdown": markdown_path.name,
+            "rendered_svg": args.rendered_svg,
+            "rendered_png": args.rendered_png,
+        },
+        "notes": [
+            "Markdown is a structural conversion of ProcessOn definition JSON, not an LLM rewrite.",
+            "Capture the rendered SVG/PNG separately for the original visual layout.",
+        ],
+    }
+    write_json(manifest_path, manifest)
+
+    markdown = build_markdown(definition, source, api_payload, manifest_path.name, title)
+    markdown_path.write_text(markdown, encoding="utf-8")
+    validate_text_outputs([api_path, definition_path, manifest_path, markdown_path])
+
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "title": title,
+                "node_count": node_count,
+                "comment_count": len(comments),
+                "outputs": {
+                    "api_json": str(api_path),
+                    "definition_json": str(definition_path),
+                    "manifest": str(manifest_path),
+                    "markdown": str(markdown_path),
+                },
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ExtractionError as exc:
+        print(f"wps_processon_extract.py: {exc}", file=sys.stderr)
+        raise SystemExit(2)


### PR DESCRIPTION
## What
New skill **wps-doc-scraper**: faithfully archive public WPS / KDocs / 金山文档 links — especially embedded ProcessOn mind maps and canvases — as raw source data, original SVG/PNG, and Markdown, without logging in. Unauthenticated data-API-first with a browser-DOM fallback.

## Changes
- marketplace: register (53→54 plugins), metadata 1.72→1.73
- docs: README / README.zh-CN / CLAUDE skill lists synced 74→75, badges 1.73.0

## Safety
- Generic tool (public docs only). Read-through clean — example links are `<file_id>`/`<share_id>` placeholders, no real documents. `security_scan` green; doc-skill-list check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)