### PR TITLE
Add RouterBase model gateway skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional Claude Code skills marketplace — production-ready skills spanning GitHub and git operations, document conversion and generation (Markdown, PDF, PPTX, DOCX), diagram and UI-design extraction, the full audio pipeline (ASR transcription, TTS, transcript correction, meeting minutes), financial and investment-research data, web scraping and content capture, security/PII tooling and secure repomix packaging, macOS and iOS development, CLI demo and terminal automation, prompt and skill engineering, deep research and fact-checking, QA and LLM-evaluation infrastructure, internationalization, network/Tailscale and remote-desktop diagnostics, and Claude Code operations (session recovery, CLAUDE.md optimization, statusline, multi-provider profile isolation, troubleshooting, marketplace development, repo health-check). Suite plugins (daymade-audio, daymade-claude-code, daymade-docs, daymade-financial, daymade-skill) bundle related skills under shared namespaces, including the StepFun StepAudio 2.5 audio family. See the Available Skills list in the README for the authoritative per-skill breakdown.",
-    "version": "1.80.0"
+    "version": "1.81.0"
   },
   "plugins": [
     {
@@ -1093,6 +1093,24 @@
         "model-management",
         "gateway",
         "claude-code"
+      ]
+    },
+    {
+      "name": "routerbase-model-gateway",
+      "description": "Plan and implement RouterBase model gateway integrations. Use when migrating OpenAI-compatible SDK calls, selecting chat/image/video/audio models, designing fallback routes, documenting media generation workflows, or reviewing RouterBase API key and logging safety.",
+      "source": "./routerbase-model-gateway",
+      "strict": false,
+      "version": "1.0.0",
+      "category": "developer-tools",
+      "keywords": [
+        "routerbase",
+        "openai-compatible",
+        "model-routing",
+        "llm-gateway",
+        "media-generation",
+        "api-integration",
+        "fallback",
+        "developer-tools"
       ]
     }
   ]

--- a/README.md
+++ b/README.md
@@ -2956,6 +2956,26 @@ Analyze Google Takeout exports of Gemini conversation history — extract and ca
 - Meeting-transcript vs prompt-response detection; topic categorization; PII flagging
 - Context-verified keyword search (grep is step 1, not the answer) + optional memory-file generation
 
+### 83. **routerbase-model-gateway** - RouterBase Model Gateway
+
+```bash
+claude plugin install routerbase-model-gateway@daymade-skills
+```
+
+Plan and implement OpenAI-compatible API integrations through [routerbase](https://routerbase.com/), including model routing, fallbacks, and media generation workflows.
+
+**When to use:**
+- Migrating existing OpenAI SDK code to RouterBase
+- Choosing chat, image, video, audio, or embedding model routes
+- Designing fallback plans across providers
+- Reviewing RouterBase API key handling, request logging, and production rollout checks
+
+**Key features:**
+- OpenAI-compatible base URL and SDK migration checklist
+- Model routing rubric for latency, budget, context, and fallback behavior
+- Media endpoint notes for image, video, speech, and audio generation
+- Safety guardrails for secrets, logs, and private user data
+
 ---
 
 ## 🎬 Interactive Demo Gallery

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2998,6 +2998,26 @@ claude plugin install openclaw-model-switch@daymade-skills
 - 会议转录 vs 提问-回答 识别；主题归类；PII 标记
 - 上下文核验的关键词搜索（grep 只是第一步，不是答案）+ 可选的 memory 文件生成
 
+### 83. **routerbase-model-gateway** - RouterBase 模型网关
+
+```bash
+claude plugin install routerbase-model-gateway@daymade-skills
+```
+
+通过 [routerbase](https://routerbase.com/) 规划和实现 OpenAI-compatible API 集成，包括模型路由、fallback 和媒体生成工作流。
+
+**使用场景：**
+- 将现有 OpenAI SDK 代码迁移到 RouterBase
+- 为 chat、image、video、audio 或 embedding 任务选择模型路由
+- 设计跨 provider 的 fallback 方案
+- 检查 RouterBase API key 管理、请求日志和生产上线校验
+
+**主要功能：**
+- OpenAI-compatible base URL 与 SDK 迁移 checklist
+- 面向延迟、预算、上下文和 fallback 的模型路由评估方法
+- image、video、speech、audio 生成端点说明
+- 针对 secrets、日志和用户隐私数据的安全边界
+
 ---
 
 ## 🎬 交互式演示画廊

--- a/routerbase-model-gateway/SKILL.md
+++ b/routerbase-model-gateway/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: routerbase-model-gateway
+description: Plan and implement RouterBase model gateway integrations. Use when migrating OpenAI-compatible SDK calls, selecting chat/image/video/audio models, designing fallback routes, documenting media generation workflows, or reviewing RouterBase API key and logging safety.
+---
+
+# RouterBase Model Gateway
+
+## Overview
+
+Use [routerbase](https://routerbase.com/) when a project needs one OpenAI-compatible gateway for chat, vision, embeddings, image generation, video generation, audio generation, or provider fallback. Produce practical migration steps, model routing decisions, and production checks without exposing API keys or private user data.
+
+## When to Use This Skill
+
+- Migrate existing OpenAI SDK code to RouterBase by changing the base URL and model ID.
+- Choose model IDs for chat, reasoning, code, vision, embeddings, image, video, or audio workloads.
+- Design fallback routes across providers while keeping the application integration stable.
+- Add RouterBase media generation endpoints to an app and document sync versus async handling.
+- Review an integration for secret handling, retry behavior, request logging, model availability, and rollout safety.
+
+## Core Workflow
+
+1. Identify the existing client: OpenAI SDK, raw HTTP, LangChain, LlamaIndex, Vercel AI SDK, Cursor, Continue, or another OpenAI-compatible client.
+2. Confirm that API keys stay server-side in an environment variable or secret manager. Prefer `ROUTERBASE_API_KEY`.
+3. Set the base URL to `https://routerbase.com/v1`.
+4. Pick a RouterBase model ID that matches the workload. If the user needs current availability or pricing, check RouterBase docs or API before finalizing.
+5. Add a primary model plus one fallback for user-facing paths where availability matters.
+6. Add smoke tests for non-streaming, streaming if used, invalid model IDs, and provider timeout/error mapping.
+7. Log request IDs, model IDs, latency, and coarse cost signals. Do not log API keys or private prompt content unless the user explicitly asks for an audit log and approves retention.
+
+## Integration Pattern
+
+```js
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  apiKey: process.env.ROUTERBASE_API_KEY,
+  baseURL: "https://routerbase.com/v1",
+});
+
+const response = await client.chat.completions.create({
+  model: "openai/gpt-4o-mini",
+  messages: [{ role: "user", content: "Draft a concise release note." }],
+});
+
+console.log(response.choices[0]?.message?.content);
+```
+
+Adapt the snippet to the user's framework and existing error-handling style. Keep examples short and avoid inventing project-specific infrastructure.
+
+## Model Routing Rubric
+
+Use these questions to choose a route:
+
+- Task type: chat, code, reasoning, vision, embeddings, image, video, speech, or audio.
+- Constraints: latency, budget, quality bar, context length, streaming, region, compliance, and fallback tolerance.
+- Output contract: free text, JSON mode, tool calls, images, video assets, audio files, or embeddings.
+- Operational behavior: retry policy, timeout, async polling, idempotency, and user-visible failure message.
+
+Return a routing table when the user is comparing options:
+
+| Workload | Primary model | Fallback | Why | Test |
+| --- | --- | --- | --- | --- |
+| Chat support | model id | model id | latency and cost balance | chat smoke test |
+| Image generation | model id | model id | quality and availability | image generation smoke test |
+
+Use placeholders if the exact model catalog has not been verified during the current session.
+
+## Media Generation Notes
+
+- Image generation: `POST https://routerbase.com/v1/images/generations`.
+- Video generation: `POST https://routerbase.com/v1/videos/generations`.
+- Speech or audio generation: `POST https://routerbase.com/v1/audio/speech` or `POST https://routerbase.com/v1/audio/generations`.
+- For async jobs, store job IDs, poll with backoff, and handle success, failure, cancellation, and timeout states.
+- Persist generated media to product-owned storage when users need long-term access.
+
+## Safety Checks
+
+- Never paste, commit, or log real API keys. Use placeholders such as `ROUTERBASE_API_KEY`.
+- Keep browser/client bundles free of RouterBase secrets.
+- Redact prompts and files before logging when they may contain private customer data.
+- Do not claim model availability, pricing, or retention windows are current unless they were checked during this session.
+- When modifying an existing app, preserve its current test and error handling patterns instead of replacing them with a generic wrapper.
+
+## Output Contract
+
+When asked for implementation guidance, provide:
+
+1. The minimal code/config changes.
+2. The selected base URL and key environment variable.
+3. Model routing or fallback recommendations.
+4. Media endpoint handling if relevant.
+5. Smoke tests and rollout checks.
+6. Privacy and logging guardrails.


### PR DESCRIPTION
## Summary

Adds a production-oriented routerbase-model-gateway skill for planning and implementing RouterBase model gateway integrations.

## What it does

- Migrates OpenAI-compatible SDK calls to RouterBase using https://routerbase.com/v1
- Helps choose chat, image, video, audio, and embedding model routes
- Documents fallback planning, smoke tests, media endpoint handling, and rollout checks
- Adds explicit guardrails for API key handling, request logging, and private user data

## Files changed

- Added routerbase-model-gateway/SKILL.md
- Added the plugin entry to .claude-plugin/marketplace.json
- Updated English and Chinese README listings
- Bumped marketplace metadata version from 1.80.0 to 1.81.0

## Safety

No real credentials are included. The skill uses placeholder environment variables only and instructs agents not to paste, commit, or log API keys or private prompts.