### PR TITLE
fix(transcript-fixer): honest --output file paths + query-first upsert on re-add

### DIFF
--- a/daymade-audio/transcript-fixer/scripts/cli/commands.py
+++ b/daymade-audio/transcript-fixer/scripts/cli/commands.py
@@ -402,8 +402,23 @@ def cmd_run_correction(args: argparse.Namespace) -> None:
         print(f"❌ Error: File not found: {input_path}")
         sys.exit(1)
 
-    # Setup output directory
-    output_dir = Path(args.output) if args.output else input_path.parent
+    # Setup output location. --output may be a DIRECTORY (the tool writes the
+    # <stem>_stage1.md / _changes.md / _needs_review.md sidecars into it) or a
+    # FILE path (the corrected Stage 1 output is written directly to that file).
+    # A file path used to be silently mkdir'd into a directory of that name
+    # (e.g. `result.md/`), hiding the real output inside it and printing only a
+    # basename — a footgun that reads as a false success. Detect the file-path
+    # intent (recognized text suffix, not an existing directory) and honor it.
+    stage1_output_override = None
+    if args.output:
+        out_arg = Path(args.output)
+        if not out_arg.is_dir() and out_arg.suffix.lower() in ('.md', '.markdown', '.txt'):
+            stage1_output_override = out_arg
+            output_dir = out_arg.parent
+        else:
+            output_dir = out_arg
+    else:
+        output_dir = input_path.parent
     output_dir.mkdir(parents=True, exist_ok=True)
 
     # Auto-finalize: if a previous Stage 1 run left *_stage1.md behind and it is
@@ -531,7 +546,9 @@ def cmd_run_correction(args: argparse.Namespace) -> None:
             print(f"  - Skipped for review: {skipped_count}")
 
         if not dry_run:
-            stage1_file = output_dir / f"{input_path.stem}_stage1.md"
+            # Honor an explicit --output FILE path; otherwise use the
+            # <stem>_stage1.md sidecar inside the output directory.
+            stage1_file = stage1_output_override or (output_dir / f"{input_path.stem}_stage1.md")
             # On a no-op run (0 corrections applied), stage1_text is byte-identical
             # to the input, so _stage1.md would just duplicate the input and
             # _changes.md would say "No corrections applied." Both are pure noise:
@@ -540,10 +557,13 @@ def cmd_run_correction(args: argparse.Namespace) -> None:
             # the input directly) and force a manual `rm`. Skip writing them on a
             # no-op. _needs_review.md below still writes when safe mode deferred
             # anything (skipped_count > 0), so human review is never lost.
-            if applied_count > 0:
+            # Write when corrections were applied, OR when the user gave an
+            # explicit --output FILE path (they asked for a file there — produce
+            # it even if unchanged, so the destination is never silently absent).
+            if applied_count > 0 or stage1_output_override is not None:
                 with open(stage1_file, 'w', encoding='utf-8') as f:
                     f.write(stage1_text)
-                print(f"💾 Saved: {stage1_file.name}")
+                print(f"💾 Saved: {stage1_file}")
                 stage1_report_source = stage1_file
             else:
                 print(f"✓ No corrections applied — skipping {stage1_file.name} (input is already the final output)")
@@ -561,7 +581,7 @@ def cmd_run_correction(args: argparse.Namespace) -> None:
                 changes_file_path = output_dir / f"{input_path.stem}_changes.md"
                 with open(changes_file_path, 'w', encoding='utf-8') as f:
                     f.write(changes_report)
-                print(f"📋 Changes report: {changes_file_path.name}")
+                print(f"📋 Changes report: {changes_file_path}")
 
             # Write needs-review file
             if review_mode and skipped_count > 0:
@@ -570,7 +590,7 @@ def cmd_run_correction(args: argparse.Namespace) -> None:
                 review_file_path = output_dir / f"{input_path.stem}_needs_review.md"
                 with open(review_file_path, 'w', encoding='utf-8') as f:
                     f.write(review_report)
-                print(f"🟡 Needs review: {review_file_path.name}")
+                print(f"🟡 Needs review: {review_file_path}")
 
         else:
             # Dry run: write a changes report so the user can preview. Mark which
@@ -583,7 +603,7 @@ def cmd_run_correction(args: argparse.Namespace) -> None:
             preview_path = output_dir / f"{input_path.stem}_dryrun.md"
             with open(preview_path, 'w', encoding='utf-8') as f:
                 f.write(preview_report)
-            print(f"🔍 Dry-run preview: {preview_path.name}")
+            print(f"🔍 Dry-run preview: {preview_path}")
 
         # Hint when 0 corrections and other domains have rules
         if summary['total_changes'] == 0 and args.domain and domain_stats:
@@ -625,7 +645,7 @@ def cmd_run_correction(args: argparse.Namespace) -> None:
         stage2_file = output_dir / f"{input_path.stem}_stage2.md"
         with open(stage2_file, 'w', encoding='utf-8') as f:
             f.write(stage2_text)
-        print(f"💾 Saved: {stage2_file.name}\n")
+        print(f"💾 Saved: {stage2_file}\n")
 
         # Save history for learning — only the Stage 1 changes that were
         # ACTUALLY applied. In safe mode (review_mode=True) medium/high-risk
@@ -1105,7 +1125,7 @@ def cmd_extract_uncertain(args: argparse.Namespace) -> None:
         f.write(report)
 
     print(f"   Found {len(items)} uncertain item(s)")
-    print(f"💾 Saved: {output_path.name}")
+    print(f"💾 Saved: {output_path}")
 
 
 def cmd_report_false_positive(args: argparse.Namespace) -> None:

--- a/daymade-audio/transcript-fixer/scripts/core/correction_repository.py
+++ b/daymade-audio/transcript-fixer/scripts/core/correction_repository.py
@@ -210,7 +210,8 @@ class CorrectionRepository:
         source: str = "manual",
         confidence: float = 1.0,
         added_by: Optional[str] = None,
-        notes: Optional[str] = None
+        notes: Optional[str] = None,
+        force: bool = False
     ) -> int:
         """
         Add a new correction with full validation.
@@ -267,37 +268,63 @@ class CorrectionRepository:
 
             except sqlite3.IntegrityError as e:
                 if "UNIQUE constraint failed" in str(e):
-                    # Update existing correction instead (within same transaction)
-                    logger.warning(f"Correction already exists, updating: {from_text}")
-                    cursor = conn.execute("""
-                        UPDATE corrections
-                        SET to_text = ?, source = ?, confidence = ?,
-                            added_by = ?, notes = ?, added_at = CURRENT_TIMESTAMP
-                        WHERE from_text = ? AND domain = ? AND is_active = 1
-                    """, (to_text, source, confidence, added_by, notes, from_text, domain))
+                    # A row for (from_text, domain) already exists. Query it
+                    # WITHOUT filtering on is_active so a soft-deleted (e.g.
+                    # false-positive-disabled) row is handled deliberately rather
+                    # than crashing: the old code updated only is_active=1 rows and
+                    # then raised a misleading "Correction not found" when the
+                    # existing row was disabled.
+                    row = conn.execute("""
+                        SELECT id, to_text, is_active, notes, added_at
+                        FROM corrections
+                        WHERE from_text = ? AND domain = ?
+                    """, (from_text, domain)).fetchone()
 
-                    if cursor.rowcount > 0:
-                        # Get the ID of the updated row
-                        cursor = conn.execute("""
-                            SELECT id FROM corrections
-                            WHERE from_text = ? AND domain = ? AND is_active = 1
-                        """, (from_text, domain))
-                        correction_id = cursor.fetchone()[0]
+                    if row is None:
+                        # UNIQUE fired but no matching row — a genuine integrity error.
+                        raise ValidationError(f"Integrity constraint violated: {e}") from e
 
-                        # Audit log
-                        self._audit_log(
-                            conn,
-                            action="update_correction",
-                            entity_type="correction",
-                            entity_id=correction_id,
-                            user=added_by,
-                            details=f"Updated: '{from_text}' → '{to_text}' (domain: {domain})"
+                    existing_id, old_to_text, is_active, old_notes, old_added_at = row
+
+                    # A disabled row is a deliberate signal (typically a reported
+                    # false positive). Do not silently resurrect it — require force.
+                    if not is_active and not force:
+                        detail = (
+                            f"Correction '{from_text}' -> '{old_to_text}' exists in "
+                            f"domain '{domain}' but is DISABLED"
+                        )
+                        if old_notes:
+                            detail += f" ({old_notes})"
+                        if old_added_at:
+                            detail += f", added {old_added_at}"
+                        raise ValidationError(
+                            detail
+                            + f".\nTo reactivate it with target '{to_text}', re-run with --force."
                         )
 
-                        logger.info(f"Updated correction ID {correction_id}: {from_text} → {to_text}")
-                        return correction_id
-                    else:
-                        raise ValidationError(f"Correction not found: {from_text} in domain {domain}")
+                    reactivated = not is_active
+                    conn.execute("""
+                        UPDATE corrections
+                        SET to_text = ?, source = ?, confidence = ?,
+                            added_by = ?, notes = ?, added_at = CURRENT_TIMESTAMP,
+                            is_active = 1
+                        WHERE id = ?
+                    """, (to_text, source, confidence, added_by, notes, existing_id))
+
+                    verb = "Reactivated" if reactivated else "Updated"
+                    self._audit_log(
+                        conn,
+                        action="reactivate_correction" if reactivated else "update_correction",
+                        entity_type="correction",
+                        entity_id=existing_id,
+                        user=added_by,
+                        details=(
+                            f"{verb}: '{from_text}' → '{to_text}' (domain: {domain})"
+                            + (f" [was disabled: → '{old_to_text}']" if reactivated else "")
+                        )
+                    )
+                    logger.info(f"{verb} correction ID {existing_id}: {from_text} → {to_text}")
+                    return existing_id
                 raise ValidationError(f"Integrity constraint violated: {e}") from e
 
     def get_correction(self, from_text: str, domain: str = "general") -> Optional[Correction]:

--- a/daymade-audio/transcript-fixer/scripts/core/correction_service.py
+++ b/daymade-audio/transcript-fixer/scripts/core/correction_service.py
@@ -260,7 +260,8 @@ class CorrectionService:
                 source=source,
                 confidence=confidence,
                 added_by=added_by,
-                notes=notes
+                notes=notes,
+                force=force
             )
 
             logger.info(


### PR DESCRIPTION
## Summary

Two bugs in the transcript-fixer correction workflow, both surfaced while ingesting meeting transcripts.

### Bug 1 — `--output FILE.md` created a directory + false success
`--output` was always treated as a directory: passing a file path like `result.md` silently ran `mkdir result.md/` and wrote `<stem>_stage1.md` inside it, while the console printed only a basename (`Saved: <stem>_stage1.md`). It looked like success, but the file wasn't where you asked for it.

**Fix:** a file-suffixed `--output` (`.md`/`.markdown`/`.txt`, not an existing dir) is now written directly to that path. Every `Saved` / changes-report / needs-review / dry-run / stage2 line prints the full resolved path — no more "where did it go". Directory `--output` is unchanged (backward-compatible).

### Bug 2 — `add_correction` crashed on re-adding a soft-deleted rule
When `(from_text, domain)` already existed but was soft-deleted (`is_active=0`, e.g. previously reported as a false positive), the UNIQUE-conflict handler only `UPDATE`d `is_active=1` rows, matched nothing, and raised a misleading `Correction not found` — a crash, not a message.

**Fix:** on UNIQUE conflict, query the existing row **regardless of `is_active`** and upsert deliberately:
- active row → update in place (as before)
- disabled row, no `--force` → clear error naming the disable reason/date + old target, instructing to re-run with `--force`
- disabled row + `--force` → reactivate + update target, with an audit-log entry

A false-positive-disabled rule is never silently resurrected. `force` is threaded CLI → service → repository.

## Tests
All 266 tests pass (`pytest tests/` with `pytest-asyncio`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)