### PR TITLE
feat(transcript-fixer): --apply-domain — trust explicitly-passed domain's rules in safe mode

### DIFF
--- a/daymade-audio/transcript-fixer/SKILL.md
+++ b/daymade-audio/transcript-fixer/SKILL.md
@@ -25,8 +25,15 @@ uv run scripts/fix_transcription.py --init
 # *_needs_review.md for you / the AI pass to judge, not applied silently.
 uv run scripts/fix_transcription.py --input meeting.md --stage 1
 
-# Apply EVERY risk level (the pre-safe-mode behavior). Higher false-positive
-# risk — only when the dictionary's domain matches this transcript.
+# Trust ONE project domain's rules (recommended for batches): rules of the
+# domain you explicitly pass via --domain apply at every risk level — they were
+# hand-confirmed for this project's vocabulary, so domain match = trust. The
+# roster and everything else keep safe-mode deferral. One pass instead of three
+# (safe run -> review sidecar -> --apply-all rerun).
+uv run scripts/fix_transcription.py --input meeting.md --stage 1 --domain myproject --apply-domain
+
+# Apply EVERY risk level regardless of origin (the pre-safe-mode behavior).
+# Higher false-positive risk — only when you've reviewed ALL loaded rules.
 uv run scripts/fix_transcription.py --input meeting.md --stage 1 --apply-all
 
 # Dry run: preview all Stage 1 changes (with risk levels) without writing *_stage1.md

--- a/daymade-audio/transcript-fixer/scripts/cli/argument_parser.py
+++ b/daymade-audio/transcript-fixer/scripts/cli/argument_parser.py
@@ -109,6 +109,17 @@ def create_argument_parser() -> argparse.ArgumentParser:
              "domain matches the transcript and you've reviewed the rules."
     )
     parser.add_argument(
+        "--apply-domain",
+        action="store_true",
+        dest="apply_domain",
+        help="Trust the rules of the domain you explicitly passed via --domain: apply them at "
+             "every risk level, while keeping safe-mode deferral for everything else (people "
+             "roster, context rules). Rationale: rules added under a project domain were "
+             "hand-confirmed for exactly this kind of transcript, so domain match = trust. "
+             "Narrower than --apply-all; no-op without --domain. Batch workflows go from three "
+             "passes (safe -> review sidecar -> --apply-all rerun) to one."
+    )
+    parser.add_argument(
         "--changes-file",
         action="store_true",
         dest="changes_file",

--- a/daymade-audio/transcript-fixer/scripts/cli/commands.py
+++ b/daymade-audio/transcript-fixer/scripts/cli/commands.py
@@ -434,6 +434,16 @@ def cmd_run_correction(args: argparse.Namespace) -> None:
     context_rules = service.load_context_rules()
     domain_stats = service.get_domain_stats()
 
+    # --apply-domain: the user explicitly asserted this transcript belongs to
+    # args.domain, and every rule loaded above came from exactly that domain —
+    # each was hand-added for this project's vocabulary, so domain match =
+    # trust. Mark them so _assess_risk grades them low (auto-applied even in
+    # safe mode). MUST run before the roster merge below: roster entries are
+    # global (cross-project) and keep normal risk grading.
+    if getattr(args, "apply_domain", False) and args.domain:
+        for _m in correction_meta.values():
+            _m["trusted_domain"] = True
+
     # Merge person-name ASR variants from the people roster (if configured).
     # Source: args.people_roster > env TRANSCRIPT_FIXER_PEOPLE_ROSTER > config.json paths.people_roster_path.
     # The roster is the curated SSOT for important recurring people; DB entries (catch-all,
@@ -505,6 +515,8 @@ def cmd_run_correction(args: argparse.Namespace) -> None:
         print("🔧 Stage 1: Dictionary Corrections")
         if dry_run:
             print("   (DRY RUN — no files will be written)")
+        elif review_mode and getattr(args, "apply_domain", False) and args.domain:
+            print(f"   (SAFE MODE + trusted domain '{args.domain}' — its rules apply at every risk level; roster/other rules still defer to *_needs_review.md.)")
         elif review_mode:
             print("   (SAFE MODE [default] — only low-risk auto-applied; medium/high → *_needs_review.md. Pass --apply-all to apply every level.)")
         else:

--- a/daymade-audio/transcript-fixer/scripts/core/dictionary_processor.py
+++ b/daymade-audio/transcript-fixer/scripts/core/dictionary_processor.py
@@ -357,6 +357,12 @@ class DictionaryProcessor:
         meta = self.correction_meta.get(wrong, {})
         confidence = meta.get("confidence", 1.0)
 
+        # --apply-domain marked this rule as belonging to the domain the user
+        # explicitly asserted for this transcript; domain match = trust, so it
+        # auto-applies even in safe mode (see cmd Stage 1 setup).
+        if meta.get("trusted_domain"):
+            return "low"
+
         if wrong in ALL_COMMON_WORDS:
             return "high"
 


### PR DESCRIPTION
## What

New `--apply-domain` flag for Stage 1: when the user explicitly passes `--domain X`, the rules of domain X apply at **every** risk level, while the people roster and all other rules keep the default safe-mode deferral.

## Why

Rules added under a project domain (`--add ... --domain X`) were each hand-confirmed for that project's vocabulary. When the user then asserts a transcript belongs to that domain, re-deferring those same rules to `*_needs_review.md` adds no safety — it just forces a three-pass batch workflow (safe run → review sidecar → `--apply-all` rerun). With `--apply-domain` it's one pass, and the roster/global rules stay conservatively graded.

## Scope & compatibility

- Backward compatible: no-op unless BOTH `--domain` and `--apply-domain` are passed
- Narrower than `--apply-all` (which trusts everything loaded)
- Tests: 251 passed; the 7 failures are pre-existing env issues, identical on a stash-verified baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K1pquZM7kFYxhAtsM6CETt