### PR TITLE
fix(transcript-fixer): 无 --domain 时把 domain 归一化为 "general"

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -197,7 +197,7 @@
       "description": "Audio processing suite covering the full speech pipeline: ASR transcription (Qwen3, StepFun) with batch-mode guards against music-only repetition-loop hallucinations, speaker diarization and CAM++ voiceprint identification for multi-speaker recordings, transcript error correction, structured meeting minutes generation, and TTS voice synthesis (StepFun). Install once for the complete audio workflow.",
       "source": "./daymade-audio",
       "strict": false,
-      "version": "1.6.0",
+      "version": "1.6.1",
       "category": "suite",
       "keywords": [
         "suite",

--- a/daymade-audio/transcript-fixer/scripts/cli/commands.py
+++ b/daymade-audio/transcript-fixer/scripts/cli/commands.py
@@ -688,9 +688,13 @@ def cmd_run_correction(args: argparse.Namespace) -> dict | None:
         # inflate the history count and persist edits that never reached the
         # output. This applied set mirrors the applied_count condition above.
         applied_stage1 = [c for c in stage1_changes if c.risk == "low" or not review_mode]
+        # --domain defaults to None (all domains). Normalize to "general" before it
+        # reaches the history/learning layers: a null domain routes Stage-2
+        # auto-approvable corrections into pending-review (validate_domain(None) raises)
+        # instead of learning them into the catch-all "general" domain.
         service.save_history(
             filename=str(input_path),
-            domain=args.domain,
+            domain=args.domain or "general",
             original_length=len(original_text),
             stage1_changes=len(applied_stage1),
             stage2_changes=len(stage2_changes),
@@ -706,7 +710,7 @@ def cmd_run_correction(args: argparse.Namespace) -> dict | None:
 
             learning = _get_learning_engine(service)
 
-            stats = learning.analyze_and_auto_approve(stage2_changes, args.domain)
+            stats = learning.analyze_and_auto_approve(stage2_changes, args.domain or "general")
 
             print(f"📊 Analysis Results:")
             print(f"   Total changes: {stats['total_changes']}")


### PR DESCRIPTION
## 背景
`--domain` 默认 `None`(全 domain)。transcript-fixer 的 Stage-2 有两个 call site 把 `args.domain` 裸传下去:
- `cli/commands.py` 的 `service.save_history(domain=args.domain, ...)`
- `learning.analyze_and_auto_approve(stage2_changes, args.domain)`

当前 main 上,下游 `validate_domain(None)` 会抛异常,导致**运行 Stage-2 而不带 `--domain` 时,本该自动通过的纠正被静默改道进待复核**,而不是学习进兜底的 `general` domain。(早期版本更严重,是直接 SQLite 报错。)

## 改动
两处都用 `args.domain or "general"` 兜住(2 行代码 + 一段说明注释)。`py_compile` 通过。

## 怎么发现的
这是分支 `skill-creator-domain-best-practices` 上 **#133 合并之后追加、从未单独 PR** 的一个 2 行修复(`09e7b82`)。在一次"确认所有分支是否都已合并进 main"的审计中,派了 **4 个独立 agent 对抗性核验**——其中一个逐 call-site 比对,发现 main 的 `commands.py:693/709` 仍是裸 `args.domain`,而无关的 294/363/823 才有 `or "general"`(单人排查容易在这里误判"已合")。经人工复核坐实,故此 PR 落地。

## 影响
除了这 2 行,其余十几个分支的内容都已确认在 main;合并此 PR 后即可确认"所有有价值的代码都在 main"。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jbcqpjz6xsVMTMpdV3VTTn