### PR TITLE
fix(asr-transcribe-to-text): 修复陌生人首次运行的两个 bug(输出目录 + voiceprint uv run)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -197,7 +197,7 @@
       "description": "Audio processing suite covering the full speech pipeline: ASR transcription (Qwen3, StepFun) with batch-mode guards against music-only repetition-loop hallucinations, speaker diarization and CAM++ voiceprint identification for multi-speaker recordings, transcript error correction, structured meeting minutes generation, and TTS voice synthesis (StepFun). Install once for the complete audio workflow.",
       "source": "./daymade-audio",
       "strict": false,
-      "version": "1.6.1",
+      "version": "1.6.2",
       "category": "suite",
       "keywords": [
         "suite",

--- a/daymade-audio/asr-transcribe-to-text/scripts/transcribe_local_mlx.py
+++ b/daymade-audio/asr-transcribe-to-text/scripts/transcribe_local_mlx.py
@@ -80,6 +80,7 @@ def main():
 
         name = os.path.splitext(os.path.basename(audio_path))[0]
         out_dir = args.output_dir or os.path.dirname(audio_path) or "."
+        os.makedirs(out_dir, exist_ok=True)
         output_path = os.path.join(out_dir, f"{name}.txt")
 
         print(f"\nTranscribing: {os.path.basename(audio_path)}", file=sys.stderr, flush=True)

--- a/daymade-audio/asr-transcribe-to-text/scripts/voiceprint_id.py
+++ b/daymade-audio/asr-transcribe-to-text/scripts/voiceprint_id.py
@@ -29,8 +29,14 @@ Usage:
       --diar rec.diarization.json [--csv rec.csv] [--threshold 0.45] [--margin 0.05]
 """
 # /// script
-# dependencies = ["funasr", "torch", "torchaudio", "soundfile", "numpy", "scipy"]
+# requires-python = ">=3.10,<3.12"
+# dependencies = ["funasr", "numba>=0.60", "torch", "torchaudio", "soundfile", "numpy", "scipy"]
 # ///
+# NOTE: requires-python is pinned <3.12 on purpose. funasr pulls
+# umap-learn -> pynndescent -> numba/llvmlite; on Python 3.13 uv backtracks to an
+# ancient llvmlite (0.36.0, source-build, fails), while 3.10/3.11 resolve modern
+# llvmlite (0.47) from wheels. `numba>=0.60` forces that modern, wheel-backed stack.
+# Verified: on 3.11 uv resolves llvmlite 0.47 / numba 0.65 from wheels (no source build).
 import argparse
 import csv as csvmod
 import json
@@ -143,6 +149,7 @@ def cmd_enroll(model, args):
     c = centroid(embs)
     refs = load_refs(args.refs)
     refs["centroids"][args.name] = c.tolist()
+    Path(args.refs).parent.mkdir(parents=True, exist_ok=True)
     Path(args.refs).write_text(json.dumps(refs, ensure_ascii=False, indent=2), encoding="utf-8")
     log(f"Enrolled '{args.name}' from {len(embs)} spans -> {args.refs} "
         f"(now: {list(refs['centroids'])})")


### PR DESCRIPTION
## 背景:doc-example smoke run 抓到的

照 SKILL.md「从零装、照着跑」实测这个 skill 时暴露的两个 bug。它们此前被掩盖,是因为写这些脚本的 PR #135 **从没真走过 `uv run` 路径**——当时的验证走的是一个内嵌 Python 3.11 runtime + 输出目录已预建,把两个坑全盖住了。这次是第一次有人照文档的 `uv run` 跑。

## Bug 1:`transcribe_local_mlx.py` 不建输出目录
`--output-dir` 指向一个不存在的目录 → 写 `.txt.tmp` 时 `FileNotFoundError`。
修:算出 `out_dir` 后加 `os.makedirs(out_dir, exist_ok=True)`。

## Bug 2(严重):`voiceprint_id.py` 的 `uv run` 路径整个跑不起来
PEP 723 依赖块**缺 `requires-python`**,于是 `uv` 用最新 Python 3.13:
- funasr → umap-learn → pynndescent → numba/llvmlite
- 3.13 上 uv 回溯到远古 `llvmlite 0.36.0`(只支持 <3.10、源码编译)→ **硬崩**
- 强制 3.11 又卡在从源码编译几分钟

修:锁 `requires-python = ">=3.10,<3.12"` + `numba>=0.60`,把解析空间收到「有现代 llvmlite 0.47 预编译 wheel」的 3.11。**已实测**:`uv run voiceprint_id.py enroll` 干净通过(exit 0,funasr 1.3.14 装好、CAM++ enroll 成功)。顺手补 `refs.json` 父目录的 `makedirs`。

## 验证
- Bug 1:修后基础转录 17s demo 音频 2.4s 跑通。
- Bug 2:后台 `uv run` 在 3.11 装依赖 + enroll,输出到一个**不存在的**目录,exit 0、refs.json 建成。
- 两个文件脱敏通读 + PII Guard 均过。

## 版本
bump daymade-audio 1.6.1→1.6.2,让已安装副本刷新到修复版。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GcriEuU82APx8WF5BCnwtn