### PR TITLE
feat(git-safety-net): local-Git disaster prevention & recovery skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional Claude Code skills marketplace — production-ready skills spanning GitHub and git operations (including current-base contributor PR review), document conversion and generation (Markdown, PDF, PPTX, DOCX), diagram and UI-design extraction, the full audio pipeline (ASR transcription, TTS, transcript correction, meeting minutes), financial and investment-research data, web scraping and content capture, security/PII tooling and secure repomix packaging, macOS and iOS development, CLI demo and terminal automation, prompt and skill engineering, deep research and fact-checking, QA and LLM-evaluation infrastructure, internationalization, network/Tailscale and remote-desktop diagnostics, and Claude Code operations (fast local conversation discovery across Claude Code and Codex, session recovery, CLAUDE.md optimization, statusline, multi-provider profile isolation, troubleshooting, marketplace development, repo health-check). Suite plugins (daymade-audio, daymade-claude-code, daymade-docs, daymade-financial, daymade-skill) bundle related skills under shared namespaces, including the StepFun StepAudio 2.5 audio family. See the Available Skills list in the README for the authoritative per-skill breakdown.",
-    "version": "1.84.0"
+    "version": "1.85.0"
   },
   "plugins": [
     {
@@ -395,6 +395,26 @@
         "contributor",
         "open-pr-sweep",
         "curation"
+      ]
+    },
+    {
+      "name": "git-safety-net",
+      "description": "Prevent and recover from local-Git disasters: commits stranded on the wrong or unpushed branch, orphaned or dropped stashes, dangling commits about to be garbage-collected, work that looks lost after heavy branch/stash/rebase juggling or parallel-agent sessions, and \"is everything actually merged?\" uncertainty. Recovers deleted commits/branches/stashes via reflog and fsck, audits what is at risk with `git log --branches --not --remotes`, pins dangling commits gc-proof before cleanup, and verifies a branch is merged by CONTENT (defeating the squash-merge \"100 commits ahead\" illusion) rather than by commit count — optionally with adversarial multi-agent verification. Use when the user fears they lost code, asks to recover a deleted commit/branch/stash, wonders what is still unmerged, needs to prove nothing was dropped after rebasing or deleting branches, resolves a version/lockfile collision between two branches, or wants habits so a branch mess never loses work again. Triggers on \"did I lose work\", \"recover lost commit\", \"restore deleted branch\", \"stash disappeared\", \"is everything merged\", \"what's not merged\", \"git reflog\", \"dangling commits\", \"分支灾难\", \"误删分支/commit\", \"stash 丢了\", \"确认全部合并了\". This is LOCAL-Git safety and forensics — distinct from GitHub PR/API operations (github-ops) and routine repo setup/sync (auto-repo-setup).",
+      "source": "./git-safety-net",
+      "strict": false,
+      "version": "1.0.0",
+      "category": "developer-tools",
+      "keywords": [
+        "git",
+        "reflog",
+        "dangling-commits",
+        "lost-commits",
+        "branch-recovery",
+        "merge-verification",
+        "squash-merge",
+        "disaster-recovery",
+        "worktree",
+        "claude-code"
       ]
     },
     {

--- a/README.md
+++ b/README.md
@@ -3093,6 +3093,40 @@ for source selection, path normalization, privacy boundaries, and diagnostics.
 
 ---
 
+### 87. **git-safety-net** - Prevent & Recover From Local-Git Disasters
+
+> **Install**: `claude plugin install git-safety-net@daymade-skills`
+
+Prevent and recover from the branch/stash/rebase tangles that strand or lose local
+commits, and answer "is everything actually merged?" with content-level proof instead
+of misleading commit counts. Every command is read-only or additive until a step is
+explicitly labeled destructive — recovery never makes the loss worse.
+
+**Key features:**
+- Recovers deleted commits/branches/stashes via `git reflog` and `git fsck` (the ~90-day window)
+- Audits what is truly at risk with `git log --branches --not --remotes` (local-only = the loss set)
+- Pins dangling commits gc-proof under `refs/dangling-backup/` before any cleanup
+- Verifies a branch is merged by CONTENT — defeating the squash-merge "100 commits ahead" illusion
+- Optional adversarial multi-agent verification for a high-stakes "is everything merged?" call
+- Prevention habits: worktrees over stash-juggling, push WIP early, pre-rebase/pre-delete audit
+
+**Example usage:**
+```text
+/git-safety-net
+did I lose any commits after all that branch switching?
+is everything merged into main, or is something still stranded?
+recover the commit I lost after a bad rebase
+```
+
+📚 **Documentation**: See
+[recovery_playbook.md](./git-safety-net/references/recovery_playbook.md),
+[merge_verification.md](./git-safety-net/references/merge_verification.md), and
+[prevention_practices.md](./git-safety-net/references/prevention_practices.md).
+
+**Requirements**: Git and a standard bash shell. No third-party packages or network access.
+
+---
+
 ## 🎬 Interactive Demo Gallery
 
 Want to see all demos in one place with click-to-enlarge functionality? Check out our [interactive demo gallery](./demos/index.html) or browse the [demos directory](./demos/).

--- a/git-safety-net/.security-scan-passed
+++ b/git-safety-net/.security-scan-passed
@@ -1,0 +1,4 @@
+Security scan passed
+Scanned at: 2026-07-13T14:12:47.567249+00:00
+Tool: gitleaks + pattern-based validation
+Content hash: f97870e94617cac5dfaf381c015b2b5fac5406c1655fcbcbcf13cf9a6919bdd4

--- a/git-safety-net/.security-scan-passed
+++ b/git-safety-net/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-07-13T14:12:47.567249+00:00
+Scanned at: 2026-07-13T19:21:30.025573+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: f97870e94617cac5dfaf381c015b2b5fac5406c1655fcbcbcf13cf9a6919bdd4
+Content hash: d07c9582d2f99909aef16c2c87da1fc6dd86fd30c2105e998a58a55cc05d8159

--- a/git-safety-net/SKILL.md
+++ b/git-safety-net/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: git-safety-net
+description: >-
+  Prevent and recover from local-Git disasters — commits stranded on the wrong or
+  unpushed branch, orphaned/dropped stashes, dangling commits about to be
+  garbage-collected, work that seems lost after heavy branch/stash/rebase juggling
+  or parallel-agent work, and "is everything actually merged?" uncertainty. Use
+  whenever the user fears they lost code, asks to recover a deleted commit / branch
+  / stash, wonders what is still unmerged, needs to prove nothing was dropped after
+  rebasing or deleting branches, resolves a version/lockfile collision between two
+  branches, or wants habits so a branch mess never loses work again. Triggers on
+  "did I lose work", "recover lost commit", "restore deleted branch", "stash
+  disappeared", "is everything merged", "what's not merged", "git reflog", "dangling
+  commits", "分支灾难", "误删分支/commit", "stash 丢了", "确认全部合并了". This is
+  LOCAL-Git safety and forensics — distinct from GitHub PR/API operations (github-ops)
+  and routine repo setup/sync (auto-repo-setup).
+---
+
+# Git Safety Net
+
+Prevent losing work in a tangle of branches/stashes/rebases, and recover it forensically
+when something already went sideways. The commands here are all **read-only or additive**
+until a step is explicitly labeled destructive — recovery must never make the loss worse.
+
+## Entry router — pick the mode from what the user is worried about
+
+| The user says / needs… | Go to |
+|---|---|
+| "I think I lost a commit / branch / stash", "recover the deleted X", "git reflog" | **Mode A — Recover** |
+| "did I lose anything?", after a messy rebase / branch-delete / parallel-agent session | **Mode B — Audit & preserve** |
+| "is everything merged?", "what's still not on main?", before deleting old branches | **Mode C — Verify merged** |
+| "so this never happens again", starting parallel/multi-branch work | **Mode D — Prevent** |
+
+When in doubt, **run Mode B first** (`git_loss_audit.sh`) — it is cheap, read-only, and tells
+you whether anything is actually at risk before you decide what to do.
+
+## The five load-bearing rules (internalize these; the modes apply them)
+
+1. **`git log --branches --not --remotes` is the ONLY authoritative "what would be lost" check.**
+   It lists commits reachable from a local branch but on *no* remote — the true at-risk set.
+   Empty = zero loss. Ahead/behind counts and `git status` do **not** answer this.
+2. **`git reflog` is the first move for "I lost a commit," not `fsck`.** Reflog records every
+   HEAD position (commits, checkouts, resets, rebases) for ~90 days and the lost commit is
+   usually in its top few lines. `git fsck` is the deeper net for commits reflog can't reach.
+3. **Preserve before you clean up.** Pin at-risk/dangling commits somewhere garbage collection
+   can't reach them *before* deleting a branch, running `gc`, or force-pushing. Cleanup is
+   reversible only while a ref (or the reflog window) still points at the work.
+4. **Verify "merged" by CONTENT, never by commit count.** After a squash-merge, `main..branch`
+   shows the branch's original commits as "unmerged" even though their content is on main —
+   often 100+ phantom commits. Judge with file/blob comparison, not counts (Mode C).
+5. **For a high-stakes "is everything merged?" call, verify adversarially — ideally with a
+   fan-out of independent agents each trying to *disprove* it.** One reviewer (human or model)
+   scanning many branches reliably misses a real gap; independent cross-checks catch it.
+
+## Mode A — Recover lost work
+
+A commit/branch/stash that "disappeared" is almost always still in the object store for ~90 days.
+Full ladder (reflog → fsck → dangling) with exact commands and the canonical Git facts:
+**[references/recovery_playbook.md](references/recovery_playbook.md)**. The 30-second version:
+
+```bash
+git reflog --date=iso | head -40          # find the lost HEAD position (most recoveries are here)
+git show <sha>                            # CONFIRM it's the right commit before acting
+git switch -c rescue/<name> <sha>         # recover onto a NEW branch — never reset onto live work
+```
+
+If reflog doesn't show it (e.g. a dropped stash, an orphan from a rebase), fall through to
+`git fsck --dangling` — see the playbook.
+
+## Mode B — Audit what's at risk, then preserve it
+
+**Step 1 — audit (read-only).** What, if anything, is at risk of loss right now:
+
+```bash
+scripts/git_loss_audit.sh          # defaults to remote "origin"; pass a remote name to override
+```
+
+Expected output: a count of **local-only commits** (on a local branch, no remote — the real
+loss risk) and **dangling commits** (orphaned, reflog-reachable now, gc-eligible later), plus a
+one-line verdict. `local-only: 0  dangling: 0` means nothing is at risk.
+
+**Step 2 — preserve (additive, gc-proof).** If anything showed up, make it un-loseable *before*
+touching branches or running gc:
+
+```bash
+scripts/git_preserve_danglers.sh --patch-dir ~/git-danglers   # pin + export patches
+```
+
+This pins every dangling commit under `refs/dangling-backup/<sha>` (garbage collection can never
+reach a referenced commit) without cluttering `git branch`, and optionally writes a `.patch` per
+non-stash commit. For a *specific* important commit, also give it the full treatment — local
+branch **and** a pushed remote branch **and** a `git format-patch` file — so a single disk or a
+single `git gc` can't take it. Details + why triple-backup: **[references/recovery_playbook.md](references/recovery_playbook.md)**.
+
+## Mode C — Verify everything is merged (without being fooled by counts)
+
+The trap: a stale branch shows "173 commits ahead of main" yet every line is already on main
+(squash-merge artifact). Never conclude "unmerged" from counts. Per-branch content check:
+
+```bash
+scripts/git_verify_branch_merged.sh <branch> [<base>]   # base defaults to origin/main
+```
+
+It reports **MERGED** (content on base — safe to delete) / **UNMERGED** (with the specific files
+whose content is absent from base) using added-file detection, blob comparison, and
+ancestor/`--find-object` checks — the same method that distinguishes "superseded old version"
+from "genuinely missing work." Full technique, plus the **adversarial multi-agent verification**
+pattern for a whole repo of branches (read-only agents, one per batch, each told to *falsify*
+"everything is merged," every finding independently re-checked):
+**[references/merge_verification.md](references/merge_verification.md)**.
+
+## Mode D — Prevent the disaster
+
+The habits that keep a branch tangle from ever stranding work:
+**[references/prevention_practices.md](references/prevention_practices.md)**. The load-bearing few:
+
+- **Use `git worktree` for parallel work, not stash+switch.** Repeated `git stash` → switch →
+  rebase is what orphans stashes; a worktree gives each line of work its own checkout with
+  nothing to drop.
+- **Push a work-in-progress branch to a remote early.** The one commit only on a local branch is
+  the only commit that a dead laptop actually loses.
+- **Confirm the current branch before committing** (`git branch --show-current`) — a fix committed
+  onto the wrong feature branch is invisible to its real PR and easy to lose on cleanup.
+- **Before any rebase or branch-delete, run the Mode B audit.** Ten seconds; it's the difference
+  between "nothing to lose" and finding out after gc.
+- **Before bumping a shared version/lockfile, check the base's current value** so two parallel
+  branches don't both claim the same bump (a silent collision that blocks the later change from
+  shipping).
+
+## Scripts (execute these; they are read-only unless noted)
+
+| Script | Does | Mutates? |
+|---|---|---|
+| `scripts/git_loss_audit.sh [remote]` | Report local-only + dangling commits; verdict | No (read-only) |
+| `scripts/git_preserve_danglers.sh [--patch-dir DIR]` | Pin danglers to `refs/dangling-backup/`, optional patches | Adds refs only (never deletes/gc) |
+| `scripts/git_verify_branch_merged.sh <branch> [base]` | Content-level MERGED/UNMERGED verdict for one branch | No (read-only) |
+
+All three run from the repository root. They only ever `fetch`, `log`, `diff`, `show`,
+`cat-file`, `rev-list`, `fsck`, `for-each-ref`, and (preserve only) `update-ref` — never
+`checkout`, `reset`, `push`, or `gc`, so they are safe to run in a dirty tree or alongside
+other agents.
+
+## Troubleshooting
+
+- **`git_loss_audit.sh` reports dangling commits that look like old stashes** — expected after
+  stash-heavy work. They're reflog-reachable now; pin them with `git_preserve_danglers.sh` if you
+  want them past the gc window, then inspect with `git show <sha>` at leisure.
+- **A branch shows huge "commits ahead" but you suspect it's merged** — trust
+  `git_verify_branch_merged.sh` (content), not the count. See Mode C.
+- **`git fetch` in a script hangs behind a proxy / offline** — the audit still works on cached
+  remote refs; pass an already-fetched state or skip the fetch. Loss detection uses local refs.
+- **You're on a detached HEAD after checking out a commit** — that commit is safe as long as you
+  `git switch -c <branch> HEAD` (or the reflog remembers it for ~90 days). Don't leave important
+  new work on a detached HEAD across a `gc`.
+- **`refs/dangling-backup/*` refs are cluttering things later** — once you've confirmed (Mode C)
+  their content is on a remote, delete them with `git for-each-ref --format='%(refname)'
+  refs/dangling-backup/ | xargs -n1 git update-ref -d`. Only after you've verified.
+
+## Next step
+
+After recovery/audit, if the repo also needs routine setup, safe commit/push, conflict handling,
+or handoff hygiene, that's the `auto-repo-setup` skill's job (invoke `/auto-repo-setup`) — this
+skill is the forensic/recovery layer, that one is the routine-workflow layer.

--- a/git-safety-net/SKILL.md
+++ b/git-safety-net/SKILL.md
@@ -36,9 +36,11 @@ you whether anything is actually at risk before you decide what to do.
 
 ## The five load-bearing rules (internalize these; the modes apply them)
 
-1. **`git log --branches --not --remotes` is the ONLY authoritative "what would be lost" check.**
-   It lists commits reachable from a local branch but on *no* remote — the true at-risk set.
-   Empty = zero loss. Ahead/behind counts and `git status` do **not** answer this.
+1. **`git log HEAD --branches --tags --not --remotes` is the authoritative "what would be lost"
+   check** (plus `git stash list`). It lists commits reachable locally — from HEAD (catches
+   detached-HEAD work), a branch, or a tag — but on *no* remote, the true at-risk set. Plain
+   `--branches` misses detached-HEAD and tag-only commits. Empty = zero loss. Ahead/behind counts
+   and `git status` do **not** answer this.
 2. **`git reflog` is the first move for "I lost a commit," not `fsck`.** Reflog records every
    HEAD position (commits, checkouts, resets, rebases) for ~90 days and the lost commit is
    usually in its top few lines. `git fsck` is the deeper net for commits reflog can't reach.
@@ -75,9 +77,12 @@ If reflog doesn't show it (e.g. a dropped stash, an orphan from a rebase), fall 
 scripts/git_loss_audit.sh          # defaults to remote "origin"; pass a remote name to override
 ```
 
-Expected output: a count of **local-only commits** (on a local branch, no remote — the real
-loss risk) and **dangling commits** (orphaned, reflog-reachable now, gc-eligible later), plus a
-one-line verdict. `local-only: 0  dangling: 0` means nothing is at risk.
+Expected output: counts of **local-only commits** (reachable from HEAD/a branch/a tag but on no
+remote — the real loss risk, and it catches detached-HEAD and tag-only work), **stashes**
+(local-only by nature), and **dangling commits** (orphaned, reflog-reachable now, gc-eligible
+later), plus a one-line verdict. `local-only: 0  stashes: 0  dangling: 0` means nothing is at risk.
+Exit is 1 only when local-only commits exist (the surprising, actionable case); stashes and
+danglers are reported but stay exit 0 so a routine stash doesn't cry wolf.
 
 **Step 2 — preserve (additive, gc-proof).** If anything showed up, make it un-loseable *before*
 touching branches or running gc:
@@ -101,13 +106,17 @@ The trap: a stale branch shows "173 commits ahead of main" yet every line is alr
 scripts/git_verify_branch_merged.sh <branch> [<base>]   # base defaults to origin/main
 ```
 
-It reports **MERGED** (content on base — safe to delete) / **UNMERGED** (with the specific files
-whose content is absent from base) using added-file detection, blob comparison, and
-ancestor/`--find-object` checks — the same method that distinguishes "superseded old version"
-from "genuinely missing work." Full technique, plus the **adversarial multi-agent verification**
-pattern for a whole repo of branches (read-only agents, one per batch, each told to *falsify*
-"everything is merged," every finding independently re-checked):
-**[references/merge_verification.md](references/merge_verification.md)**.
+It reports **MERGED (ancestor)** or **MERGED (content contained)** — safe to delete — versus
+**UNMERGED / NEEDS REVIEW**, listing the files the branch would still change. The verdict is sound,
+not heuristic: it does a trial 3-way merge of the branch *into* the base with `git merge-tree`
+(in memory, no checkout) and only says "safe to delete" when that merge changes nothing — so a
+squash-merged branch reads MERGED despite a nonzero commit count, while a revert/edit/new-file the
+base lacks reads UNMERGED. It is **safety-biased**: anything it can't prove contained is reported
+for review, because a false "merged" loses work while a false "unmerged" only costs a look. Full
+technique (and why `--find-object`/blob heuristics are unsound for auto-decisions), plus the
+**adversarial multi-agent verification** pattern for a whole repo of branches (read-only agents,
+one per batch, each told to *falsify* "everything is merged," every finding independently
+re-checked): **[references/merge_verification.md](references/merge_verification.md)**.
 
 ## Mode D — Prevent the disaster
 

--- a/git-safety-net/references/merge_verification.md
+++ b/git-safety-net/references/merge_verification.md
@@ -1,0 +1,124 @@
+# Merge Verification — prove content is merged without being fooled by counts
+
+## Contents
+- Why commit counts lie (the squash-merge illusion)
+- The content-level toolkit (five checks)
+- Per-branch verdict procedure
+- "Superseded old version" vs "genuinely missing" — don't confuse them
+- Adversarial multi-agent verification (for a whole repo of branches)
+- Rules for the verification agents
+
+## Why commit counts lie (the squash-merge illusion)
+
+When a PR is **squash-merged**, main gets one new commit whose *content* equals the branch, but
+whose *sha* is new — the branch's original commits are not ancestors of main. So:
+
+```bash
+git rev-list --count origin/main..stale-branch   # → 173  ("173 commits ahead!")
+```
+
+…is a lie about merge status. Those 173 commits are the branch's own history; their content is
+already on main. **Never conclude "unmerged" (or "safe to keep this branch") from a count.**
+The same applies to rebased branches: rebasing rewrites shas, so the pre-rebase commits look
+"unmerged" while their content landed long ago.
+
+The only trustworthy question is: **is the branch's file content present on the base?**
+
+## The content-level toolkit (five checks)
+
+Run these with explicit refs (`origin/main`, `origin/<branch>`) — no checkout needed.
+
+1. **Whole files the branch adds that the base lacks** (an unmerged *new* skill/module shows here):
+   ```bash
+   git diff origin/main origin/<branch> --diff-filter=A --name-only
+   ```
+   Empty = the branch introduces no file absent from main. Non-empty → inspect each: is it truly
+   absent (`git cat-file -e origin/main:<path>` fails) or just moved/renamed on main?
+
+2. **Per-file blob identity** (is this file byte-identical on both sides?):
+   ```bash
+   git diff --quiet origin/<branch>:<file> origin/main:<file> && echo IDENTICAL || echo DIFFERS
+   ```
+
+3. **Is this exact file version anywhere in the base's history** (proves main passed through it and
+   moved on — i.e. superseded, not missing):
+   ```bash
+   blob=$(git rev-parse origin/<branch>:<file>)
+   git log origin/main --oneline --find-object="$blob" | head
+   ```
+   A hit means main once held this exact content, then rewrote it → superseded, safe.
+
+4. **True ancestor** (the branch is literally in main's history — fully merged, deletable):
+   ```bash
+   git merge-base --is-ancestor origin/<branch> origin/main && echo MERGED-ANCESTOR
+   ```
+
+5. **Patch-equivalence for a single commit** (did this commit's change land under a different sha?):
+   ```bash
+   git cherry origin/main <sha>       # '-' prefix = already in main; '+' = not
+   ```
+
+## Per-branch verdict procedure
+
+For each branch, decide among three outcomes:
+
+- **MERGED (ancestor)** — check 4 passes → in main's history, delete freely.
+- **STALE-SQUASH (merged by content)** — check 1 empty (no unmerged new files) and every modified
+  file resolves via check 2 (identical) or check 3 (superseded old version on main). Content is on
+  main; the commit count is an artifact. Deletable.
+- **UNMERGED** — check 1 lists a file genuinely absent from main, **or** a modified file has branch
+  content that is *not* identical and *not* found in main's history (check 3 empty) and represents
+  real behavior main lacks. Report the specific `file` (and ideally the specific hunk/function).
+
+`scripts/git_verify_branch_merged.sh <branch> [base]` automates checks 1–4 and prints the verdict.
+
+## "Superseded old version" vs "genuinely missing" — don't confuse them
+
+The subtle error is seeing a modified file "differs from main" and calling the branch UNMERGED,
+when in fact **main evolved *past* the branch** (has everything the branch had, plus more). Two
+tells that main is ahead, not behind:
+
+- The base file is **larger / a superset**: `git show origin/main:<file> | wc -l` ≫
+  `git show origin/<branch>:<file> | wc -l`, and the branch's distinctive symbols all appear in
+  main (`git show origin/main:<file> | grep -F '<branch-only-symbol>'`).
+- The branch's exact blob appears in main's history (check 3 above) — main held it, then rewrote it.
+
+Only when the branch has a symbol/function/behavior that is **nowhere in main's current file and
+nowhere in main's history** is it genuinely unmerged. When unsure, quote the specific missing line
+and let the human confirm — a false "unmerged" wastes a re-merge; a false "merged" loses the work.
+
+## Adversarial multi-agent verification (for a whole repo of branches)
+
+A single reviewer scanning a dozen branches reliably misses one real gap (it happened in the
+session this skill was distilled from: a solo pass mis-judged a genuine 2-line fix as "already
+merged" by matching the wrong call site; a fan-out of independent agents caught it). For a
+high-stakes "is *everything* merged?" verdict, fan out:
+
+1. **Partition** the branches across N agents (e.g. large feature-adding branches, small fix
+   branches, local-only-history branches, plus one agent that independently re-runs the loss
+   check and re-derives the "should this old branch be merged?" verdict from content).
+2. **Frame each agent adversarially**: "Default to the assumption that these branches still have
+   unmerged unique content, and try to *prove* it. Judge by content (checks above), never by
+   commit count. Report per branch: MERGED / STALE-SQUASH / **UNMERGED (with file:line evidence)**."
+3. **Lock them read-only** (see rules below) so concurrent agents don't corrupt each other's tree.
+4. **Counter-review every finding yourself.** An agent's "UNMERGED" is a *hypothesis*: re-run the
+   specific blob/line check before believing it (agents produce false positives too). An agent's
+   "all merged" is only as good as its method — spot-check that it judged by content, not counts.
+5. **Converge**: everything merged across all agents = strong confirmation; any single content-backed
+   UNMERGED finding = a real gap to land.
+
+This is inline orchestration (the skill spawns the agents), so `git-safety-net` must run inline —
+a subagent cannot spawn subagents.
+
+## Rules for the verification agents
+
+Put these in every agent's prompt — they are what make parallel verification safe and correct:
+
+- **Read-only, always.** Only `fetch --quiet`, `diff`, `log`, `show`, `cat-file`, `rev-list`,
+  `merge-base`, `ls-tree`, `for-each-ref`, `branch -r --contains`. **Never** `checkout`, `switch`,
+  `reset`, `rebase`, `commit`, `push`, `update-ref`, or `gc`. Multiple agents share one working
+  tree; a single `checkout` corrupts everyone else's run.
+- **Explicit refs only** (`origin/main`, `origin/<branch>`) so nothing depends on the current
+  checkout.
+- **Judge by content, not counts** — restate checks 1–5 in the prompt.
+- **Return structured per-branch verdicts with file:line evidence for any UNMERGED**, not prose.

--- a/git-safety-net/references/merge_verification.md
+++ b/git-safety-net/references/merge_verification.md
@@ -2,9 +2,10 @@
 
 ## Contents
 - Why commit counts lie (the squash-merge illusion)
-- The content-level toolkit (five checks)
+- The sound content check (a trial merge, not a heuristic)
 - Per-branch verdict procedure
-- "Superseded old version" vs "genuinely missing" — don't confuse them
+- Why safety-biased: a false "merged" loses work, a false "unmerged" only costs a look
+- Manual-only investigation hints (do NOT auto-decide on these)
 - Adversarial multi-agent verification (for a whole repo of branches)
 - Rules for the verification agents
 
@@ -22,70 +23,80 @@ already on main. **Never conclude "unmerged" (or "safe to keep this branch") fro
 The same applies to rebased branches: rebasing rewrites shas, so the pre-rebase commits look
 "unmerged" while their content landed long ago.
 
-The only trustworthy question is: **is the branch's file content present on the base?**
+The only trustworthy question is: **is the branch's content already contained in the base?**
 
-## The content-level toolkit (five checks)
+## The sound content check (a trial merge, not a heuristic)
 
-Run these with explicit refs (`origin/main`, `origin/<branch>`) — no checkout needed.
+`scripts/git_verify_branch_merged.sh <branch> [base]` answers that question with Git's own merge
+machinery instead of per-file guesses. Two checks, in order:
 
-1. **Whole files the branch adds that the base lacks** (an unmerged *new* skill/module shows here):
+1. **Ancestor** — the branch is literally in the base's history:
    ```bash
-   git diff origin/main origin/<branch> --diff-filter=A --name-only
-   ```
-   Empty = the branch introduces no file absent from main. Non-empty → inspect each: is it truly
-   absent (`git cat-file -e origin/main:<path>` fails) or just moved/renamed on main?
-
-2. **Per-file blob identity** (is this file byte-identical on both sides?):
-   ```bash
-   git diff --quiet origin/<branch>:<file> origin/main:<file> && echo IDENTICAL || echo DIFFERS
+   git merge-base --is-ancestor origin/<branch> origin/main && echo "MERGED (ancestor)"
    ```
 
-3. **Is this exact file version anywhere in the base's history** (proves main passed through it and
-   moved on — i.e. superseded, not missing):
+2. **Content-contained** — do a trial 3-way merge of the branch *into* the base, in memory, and
+   ask whether it changes anything. If merging the branch produces the base's exact tree, the
+   branch adds nothing the base lacks — which is precisely the squash/rebase case where the count
+   says "ahead" but the content is already upstream:
    ```bash
-   blob=$(git rev-parse origin/<branch>:<file>)
-   git log origin/main --oneline --find-object="$blob" | head
-   ```
-   A hit means main once held this exact content, then rewrote it → superseded, safe.
-
-4. **True ancestor** (the branch is literally in main's history — fully merged, deletable):
-   ```bash
-   git merge-base --is-ancestor origin/<branch> origin/main && echo MERGED-ANCESTOR
+   base_tree=$(git rev-parse "origin/main^{tree}")
+   merged_tree=$(git merge-tree --write-tree origin/main origin/<branch> 2>/dev/null | head -1)
+   [ $? -eq 0 ] && [ "$merged_tree" = "$base_tree" ] && echo "MERGED (content contained)"
    ```
 
-5. **Patch-equivalence for a single commit** (did this commit's change land under a different sha?):
-   ```bash
-   git cherry origin/main <sha>       # '-' prefix = already in main; '+' = not
-   ```
+This is **sound**, not a heuristic, because it *is* Git's merge: a revert, an edit, or a new file
+the base lacks would change the merged tree and fail the equality — so it can never be silently
+mistaken for "merged." (`git merge-tree --write-tree` needs git ≥ 2.38; on older git the script
+cannot prove containment and falls back to reporting NEEDS REVIEW rather than guessing.)
+
+Everything else is **UNMERGED / NEEDS REVIEW**. To show what to review, list the branch's own
+contribution (three-dot = what it changed since diverging), display-safe for Unicode/space paths:
+
+```bash
+git -c core.quotePath=false diff --no-renames --name-status origin/main...origin/<branch> --
+```
+
+`--no-renames` decomposes a rename into add+delete (so a renamed-and-edited file can't hide); the
+`--` guarantees a branch named like a path (e.g. `docs`) is never parsed as a pathspec.
 
 ## Per-branch verdict procedure
 
-For each branch, decide among three outcomes:
+For each branch, the script decides among three outcomes:
 
-- **MERGED (ancestor)** — check 4 passes → in main's history, delete freely.
-- **STALE-SQUASH (merged by content)** — check 1 empty (no unmerged new files) and every modified
-  file resolves via check 2 (identical) or check 3 (superseded old version on main). Content is on
-  main; the commit count is an artifact. Deletable.
-- **UNMERGED** — check 1 lists a file genuinely absent from main, **or** a modified file has branch
-  content that is *not* identical and *not* found in main's history (check 3 empty) and represents
-  real behavior main lacks. Report the specific `file` (and ideally the specific hunk/function).
+- **MERGED (ancestor)** — in the base's history. Delete freely.
+- **MERGED (content contained)** — a trial merge into the base changes nothing; the "commits
+  ahead" count is a squash/rebase artifact. Delete freely.
+- **UNMERGED / NEEDS REVIEW** — a trial merge *would* change the base, so the branch carries
+  content the base does not already have (a genuinely new/edited/reverted/deleted file). Review
+  the listed contribution before deleting.
 
-`scripts/git_verify_branch_merged.sh <branch> [base]` automates checks 1–4 and prints the verdict.
+## Why safety-biased: a false "merged" loses work, a false "unmerged" only costs a look
 
-## "Superseded old version" vs "genuinely missing" — don't confuse them
+The two error directions are not symmetric. A false **UNMERGED** wastes a second look; a false
+**MERGED** tells you to delete a branch whose work then vanishes. So the check is deliberately
+biased: it only says "safe to delete" when it can *prove* containment, and it reports everything
+it cannot prove as NEEDS REVIEW. One real consequence: if a branch was squash-merged **and** the
+base later edited the same lines, the trial merge no longer reproduces the base tree exactly, so
+the script says NEEDS REVIEW rather than MERGED. That over-reporting is the correct trade — you
+look, confirm the lines are redundant, and delete; you never lose work to a confident wrong "yes."
 
-The subtle error is seeing a modified file "differs from main" and calling the branch UNMERGED,
-when in fact **main evolved *past* the branch** (has everything the branch had, plus more). Two
-tells that main is ahead, not behind:
+## Manual-only investigation hints (do NOT auto-decide on these)
 
-- The base file is **larger / a superset**: `git show origin/main:<file> | wc -l` ≫
-  `git show origin/<branch>:<file> | wc -l`, and the branch's distinctive symbols all appear in
-  main (`git show origin/main:<file> | grep -F '<branch-only-symbol>'`).
-- The branch's exact blob appears in main's history (check 3 above) — main held it, then rewrote it.
+These help a **human** investigate a NEEDS-REVIEW branch, but must never drive an automated
+"safe to delete" verdict — each has a false-positive mode that can hide real unmerged work:
 
-Only when the branch has a symbol/function/behavior that is **nowhere in main's current file and
-nowhere in main's history** is it genuinely unmerged. When unsure, quote the specific missing line
-and let the human confirm — a false "unmerged" wastes a re-merge; a false "merged" loses the work.
+- `git log origin/main --oneline --find-object="$blob" -- <path>` — did this exact blob ever
+  appear at this path in the base's history? A hit *suggests* the base passed through this content.
+  **Unsound for auto-decisions:** it also matches a revert (the base *used* to have it but doesn't
+  now — the revert is still unmerged work), so a match does not prove "currently contained."
+- `git cherry origin/main origin/<branch>` — marks each branch commit `-` (patch already upstream)
+  or `+` (not). Useful for cherry-picked/rebased commits, but a squash-merge combines commits into
+  one new patch-id, so cherry shows the originals as `+` even though their content is merged.
+- Superset tells (base file is larger and contains the branch's distinctive symbols) — a hint the
+  base evolved past the branch, to be **confirmed by eye**, not trusted blindly.
+
+When a hint and the trial merge disagree, trust the trial merge; it is the sound one.
 
 ## Adversarial multi-agent verification (for a whole repo of branches)
 
@@ -98,14 +109,16 @@ high-stakes "is *everything* merged?" verdict, fan out:
    branches, local-only-history branches, plus one agent that independently re-runs the loss
    check and re-derives the "should this old branch be merged?" verdict from content).
 2. **Frame each agent adversarially**: "Default to the assumption that these branches still have
-   unmerged unique content, and try to *prove* it. Judge by content (checks above), never by
-   commit count. Report per branch: MERGED / STALE-SQUASH / **UNMERGED (with file:line evidence)**."
+   unmerged unique content, and try to *prove* it. Judge by content (the trial-merge check above),
+   never by commit count. Report per branch: MERGED / **UNMERGED / NEEDS REVIEW (with the file(s)
+   the trial merge would change)**."
 3. **Lock them read-only** (see rules below) so concurrent agents don't corrupt each other's tree.
 4. **Counter-review every finding yourself.** An agent's "UNMERGED" is a *hypothesis*: re-run the
-   specific blob/line check before believing it (agents produce false positives too). An agent's
-   "all merged" is only as good as its method — spot-check that it judged by content, not counts.
-5. **Converge**: everything merged across all agents = strong confirmation; any single content-backed
-   UNMERGED finding = a real gap to land.
+   trial-merge / inspect the specific files before believing it (agents produce false positives
+   too). An agent's "all merged" is only as good as its method — spot-check that it judged by
+   content, not counts.
+5. **Converge**: everything merged across all agents = strong confirmation; any single
+   content-backed UNMERGED finding = a real gap to land.
 
 This is inline orchestration (the skill spawns the agents), so `git-safety-net` must run inline —
 a subagent cannot spawn subagents.
@@ -114,11 +127,12 @@ a subagent cannot spawn subagents.
 
 Put these in every agent's prompt — they are what make parallel verification safe and correct:
 
-- **Read-only, always.** Only `fetch --quiet`, `diff`, `log`, `show`, `cat-file`, `rev-list`,
-  `merge-base`, `ls-tree`, `for-each-ref`, `branch -r --contains`. **Never** `checkout`, `switch`,
-  `reset`, `rebase`, `commit`, `push`, `update-ref`, or `gc`. Multiple agents share one working
-  tree; a single `checkout` corrupts everyone else's run.
+- **Read-only, always.** Only `fetch --quiet`, `merge-base`, `merge-tree`, `diff`, `log`, `show`,
+  `cat-file`, `rev-list`, `rev-parse`, `ls-tree`, `for-each-ref`, `branch -r --contains`. **Never**
+  `checkout`, `switch`, `reset`, `rebase`, `commit`, `push`, `update-ref`, or `gc`. Multiple agents
+  share one working tree; a single `checkout` corrupts everyone else's run.
 - **Explicit refs only** (`origin/main`, `origin/<branch>`) so nothing depends on the current
   checkout.
-- **Judge by content, not counts** — restate checks 1–5 in the prompt.
-- **Return structured per-branch verdicts with file:line evidence for any UNMERGED**, not prose.
+- **Judge by content via the trial merge, not by counts** — restate the check in the prompt.
+- **Return structured per-branch verdicts with the file(s) the trial merge would change for any
+  UNMERGED**, not prose.

--- a/git-safety-net/references/prevention_practices.md
+++ b/git-safety-net/references/prevention_practices.md
@@ -1,0 +1,127 @@
+# Prevention Practices — keep a branch tangle from ever stranding work
+
+Each practice below maps to a specific way work actually gets lost. They are cheap habits, not
+ceremony; adopt the ones whose failure mode you're exposed to.
+
+## Contents
+- Parallel work: worktrees, not stash-juggling
+- Push work-in-progress branches early
+- Confirm the branch before every commit
+- Audit before rebase / branch-delete
+- Snapshot before any history rewrite
+- Version / lockfile collisions between parallel branches
+- Commit-scope hygiene (don't sweep unrelated staged work)
+- Set a wider reflog safety window once
+
+## Parallel work: worktrees, not stash-juggling
+
+**Failure mode:** the classic disaster is `git stash` → switch branch → work → `git stash` again →
+rebase → switch back. Each `stash` that gets superseded or dropped orphans a commit; after a busy
+session you can have dozens of dangling stash states that `git stash list` no longer shows, one
+`gc` from gone.
+
+**Prevention:** give each parallel line of work its own checkout with `git worktree`:
+
+```bash
+git worktree add ../repo-featureB featureB     # a second working dir on branch featureB
+# work in ../repo-featureB with zero stashing; the main checkout stays on your primary branch
+git worktree remove ../repo-featureB           # when done
+```
+
+Nothing to stash means nothing to drop. This also stops the "another agent switched my branch
+underneath me" problem — each agent/task gets its own worktree.
+
+## Push work-in-progress branches early
+
+**Failure mode:** a commit that exists only on a local branch is the *only* thing a dead disk
+actually loses. Everything on a remote is safe.
+
+**Prevention:** the moment a WIP branch has a commit worth keeping, push it:
+
+```bash
+git push -u origin <wip-branch>
+```
+
+It doesn't need to be a PR — just a remote copy. Re-push as you go. Then
+`git log --branches --not --remotes` (the at-risk check) stays empty, which is the state you want.
+
+## Confirm the branch before every commit
+
+**Failure mode:** committing a fix onto the wrong feature branch (easy when juggling several, or
+when an agent left you somewhere unexpected). The commit is then invisible to the PR it belongs
+to, and gets deleted along with the wrong branch during cleanup.
+
+**Prevention:** glance at the branch before committing:
+
+```bash
+git branch --show-current      # is this where this change belongs?
+```
+
+If you commit to the wrong branch anyway, it's recoverable: `git log` the sha, `git branch
+correct-branch <sha>`, then remove it from the wrong branch — but confirming up front is free.
+
+## Audit before rebase / branch-delete
+
+**Failure mode:** deleting a branch or rebasing can orphan commits; if any were local-only, they
+head toward gc.
+
+**Prevention:** run the ten-second at-risk check first (see recovery_playbook.md):
+
+```bash
+git fetch --all --quiet
+git log --branches --not --remotes --oneline    # empty = nothing to lose; act freely
+```
+
+Non-empty → preserve those commits (branch/push/patch) before the destructive step.
+
+## Snapshot before any history rewrite
+
+**Failure mode:** `rebase`, `reset --hard`, `filter-repo`, and interactive-rebase mistakes abandon
+the pre-rewrite commits.
+
+**Prevention:** a throwaway backup branch makes the whole operation reversible:
+
+```bash
+git branch backup/pre-rewrite      # points at the current tip; delete once you're happy
+```
+
+If the rewrite goes wrong, `git reset --hard backup/pre-rewrite` restores it exactly.
+
+## Version / lockfile collisions between parallel branches
+
+**Failure mode:** two branches developed in parallel both bump the *same* shared file to the *same*
+new value (a package version, a manifest version, a lockfile hash). They merge without a Git
+conflict (both wrote the same line), but the second feature now ships under a version number the
+first already used — so consumers that pin/refresh by version never see the second change.
+
+**Prevention:** before bumping a shared version, check the base's current value, and bump *above*
+whatever is already there:
+
+```bash
+git fetch origin --quiet
+git show origin/main:<manifest>     # what version is main ALREADY at? bump to strictly higher
+```
+
+If a collision already merged, fix it by bumping again above the collided value and re-releasing.
+
+## Commit-scope hygiene (don't sweep unrelated staged work)
+
+**Failure mode:** `git add .` or `git commit -a` sweeps unrelated changes (another task's edits,
+generated files) into a commit; later that commit gets reverted/reset and takes the unrelated work
+with it.
+
+**Prevention:** stage explicit paths, and verify the staged set before committing:
+
+```bash
+git add <the specific paths for THIS change>
+git diff --cached --name-only        # confirm ONLY the intended files are staged
+```
+
+## Set a wider reflog safety window once
+
+The reflog is your recovery window; widen it once, globally, so a busy repo doesn't age work out:
+
+```bash
+git config --global gc.reflogExpire "180 days"
+git config --global gc.reflogExpireUnreachable "90 days"
+```

--- a/git-safety-net/references/prevention_practices.md
+++ b/git-safety-net/references/prevention_practices.md
@@ -43,7 +43,8 @@ git push -u origin <wip-branch>
 ```
 
 It doesn't need to be a PR — just a remote copy. Re-push as you go. Then
-`git log --branches --not --remotes` (the at-risk check) stays empty, which is the state you want.
+`git log HEAD --branches --tags --not --remotes` (the at-risk check) stays empty, which is the
+state you want.
 
 ## Confirm the branch before every commit
 
@@ -69,7 +70,7 @@ head toward gc.
 
 ```bash
 git fetch --all --quiet
-git log --branches --not --remotes --oneline    # empty = nothing to lose; act freely
+git log HEAD --branches --tags --not --remotes --oneline   # empty = nothing to lose; act freely
 ```
 
 Non-empty → preserve those commits (branch/push/patch) before the destructive step.

--- a/git-safety-net/references/recovery_playbook.md
+++ b/git-safety-net/references/recovery_playbook.md
@@ -26,16 +26,23 @@ one thing that permanently loses work is `gc` running while nothing references i
 ## The authoritative "is anything at risk" check
 
 Before anything else, answer the only question that matters — *is any commit reachable only
-locally, on no remote?* That is the exact at-risk set:
+locally, on no remote?* That is the exact at-risk set. Check **every** place local work hides,
+not just branches:
 
 ```bash
 git fetch --all --quiet
-git log --branches --not --remotes --oneline --decorate
+git log HEAD --branches --tags --not --remotes --oneline --decorate   # HEAD→detached-HEAD work, --tags→tag-only commits
+git stash list                                                         # stashes are local-only too
 ```
 
-- **Empty output = zero loss.** Every local commit is also on a remote; a dead disk loses nothing.
+- **All empty = zero loss.** Every local commit is also on a remote; a dead disk loses nothing.
 - **Non-empty = those exact commits exist only on this machine.** Back them up (below) before any
   branch cleanup.
+
+Why `HEAD --branches --tags`, not just `--branches`: a plain `git log --branches --not --remotes`
+misses a **detached-HEAD** commit (on no branch) and a **tag-only** commit — both classic loss
+vectors. `scripts/git_loss_audit.sh` runs exactly this expanded set plus the stash and dangling
+checks.
 
 Do **not** substitute `git status` or ahead/behind counts for this — they answer different
 questions. To confirm a single commit is safe on a remote:

--- a/git-safety-net/references/recovery_playbook.md
+++ b/git-safety-net/references/recovery_playbook.md
@@ -1,0 +1,164 @@
+# Recovery Playbook — get lost work back, then make it un-loseable
+
+## Contents
+- Mental model: nothing is gone until gc runs
+- The authoritative "is anything at risk" check
+- Ladder step 1 — `git reflog` (first move, ~90% of recoveries)
+- Ladder step 2 — dropped stashes
+- Ladder step 3 — detached-HEAD work
+- Ladder step 4 — `git fsck` for true orphans
+- Preserve: pin danglers so gc can never take them
+- Triple-backup a critical commit
+- Widen the safety window (config)
+- Destructive-operation safety (reset/force-push/rewrite)
+- Sources
+
+## Mental model: nothing is gone until gc runs
+
+A commit is an immutable object in `.git/objects`. Deleting a branch, `reset --hard`, a bad
+rebase, or `stash drop` only removes a *reference* to the commit — the object itself survives
+until `git gc` prunes unreachable objects. The reflog keeps a ref alive for **~90 days**
+(reachable) / **~30 days** (already unreachable), which is why same-day recovery almost always
+works. So the recovery mindset is: **find the dangling object, point a ref at it, done.** The
+one thing that permanently loses work is `gc` running while nothing references it — which is why
+"preserve before cleanup" (below) matters.
+
+## The authoritative "is anything at risk" check
+
+Before anything else, answer the only question that matters — *is any commit reachable only
+locally, on no remote?* That is the exact at-risk set:
+
+```bash
+git fetch --all --quiet
+git log --branches --not --remotes --oneline --decorate
+```
+
+- **Empty output = zero loss.** Every local commit is also on a remote; a dead disk loses nothing.
+- **Non-empty = those exact commits exist only on this machine.** Back them up (below) before any
+  branch cleanup.
+
+Do **not** substitute `git status` or ahead/behind counts for this — they answer different
+questions. To confirm a single commit is safe on a remote:
+
+```bash
+git branch -r --contains <sha>       # lists remote branches that contain it (empty = local-only)
+```
+
+## Ladder step 1 — `git reflog` (first move)
+
+Any "I lost a commit / reset too far / bad rebase" starts here:
+
+```bash
+git reflog --date=iso | head -40
+```
+
+Each line is a past HEAD position with its sha and what moved it (`commit`, `checkout`, `reset`,
+`rebase -i (finish)`, …). Find the sha of the state you want back, **confirm it**, then recover
+onto a *new* branch (never reset your live branch onto it):
+
+```bash
+git show <sha>                       # CONFIRM: is this the content you want?
+git switch -c rescue/<name> <sha>    # or: git branch rescue/<name> <sha>
+```
+
+Branch-specific reflogs exist too: `git reflog show <branch>` recovers where a specific branch
+tip used to point (e.g. before a force-push clobbered it).
+
+## Ladder step 2 — dropped stashes
+
+`git stash drop` / `git stash pop` (which drops on success) removes the stash ref but leaves the
+underlying commit dangling. `git stash list` won't show it; find it via fsck:
+
+```bash
+git fsck --no-reflogs --unreachable | grep commit    # or: git fsck --dangling
+git show <stash-sha>                                 # verify it's the stash you lost
+git stash apply <stash-sha>                           # re-apply it, or:
+git branch rescue/stash <stash-sha>                   # park it on a branch
+```
+
+Stash commits have a distinctive message (`WIP on <branch>: …`), which helps identify them among
+fsck output.
+
+## Ladder step 3 — detached-HEAD work
+
+Committing while on a detached HEAD (after `git checkout <sha>`), then switching away, orphans
+those commits — they belong to no branch. Reflog remembers them:
+
+```bash
+git reflog | grep -i 'HEAD@'         # find the detached commits you made
+git switch -c saved-work <sha>        # give them a home
+```
+
+**Prevent the loss entirely:** the moment you make a commit you care about on a detached HEAD,
+`git switch -c <branch> HEAD` before doing anything else.
+
+## Ladder step 4 — `git fsck` for true orphans
+
+When reflog doesn't reach it (reflog expired, or the commit was never HEAD on this clone), fsck
+walks the object store directly:
+
+```bash
+git fsck --dangling                  # dangling commits/blobs/trees not reachable from any ref
+```
+
+Inspect candidates with `git show <sha>`. Dangling *blobs* can be a single lost file:
+`git show <blob-sha> > recovered_file`.
+
+## Preserve: pin danglers so gc can never take them
+
+Dangling commits are recoverable **only until gc runs**. To make them permanently safe without
+cluttering `git branch`, pin each under a hidden ref namespace — a referenced object is never
+collected:
+
+```bash
+git fsck --dangling 2>/dev/null | awk '/dangling commit/ {print $3}' | while read sha; do
+  git update-ref "refs/dangling-backup/$sha" "$sha"
+done
+git for-each-ref refs/dangling-backup/   # confirm what's pinned
+```
+
+`scripts/git_preserve_danglers.sh` does exactly this (and optional patch export). Why a hidden
+`refs/dangling-backup/*` and not `git stash store`? These refs don't appear in `git branch` or
+`git stash list`, so they protect the objects without turning your branch/stash lists into noise,
+and you can bulk-delete them once you've verified the content is safe elsewhere.
+
+## Triple-backup a critical commit
+
+For a specific commit you must not lose (e.g. real unpushed work found by the at-risk check), one
+copy isn't enough — a single disk failure or a single `gc` shouldn't be able to take it. Give it
+three independent homes:
+
+```bash
+git branch backup/<name> <sha>                                   # 1) local branch
+git push origin backup/<name>                                    # 2) remote branch (survives disk loss)
+git format-patch -1 <sha> --stdout > <name>.patch                # 3) patch file (survives repo loss)
+```
+
+Now the commit survives losing any one of: the working tree, the remote, or the whole repo.
+
+## Widen the safety window (config)
+
+The default reflog window is generous but finite. For repos where recovery matters, extend it:
+
+```bash
+git config --global gc.reflogExpire "180 days"
+git config --global gc.reflogExpireUnreachable "90 days"
+```
+
+## Destructive-operation safety (reset / force-push / rewrite)
+
+Recovery is easiest when the operation that "lost" the work was itself reversible. Prefer:
+
+- **On already-pushed history, `git revert`, not `git reset`.** Revert adds an inverse commit;
+  reset abandons commits that teammates may have based work on.
+- **If you must force-push, use `git push --force-with-lease`, not `--force`.** `--force-with-lease`
+  refuses the push if the remote moved since you last fetched — it won't silently clobber a
+  teammate's (or another agent's) commits.
+- **Before any history rewrite (`rebase`, `filter-repo`, `reset --hard`), snapshot first:**
+  `git branch backup/pre-rewrite` (and run the at-risk check). Ten seconds; fully reversible.
+
+## Sources
+
+- Pro Git — Data Recovery (reflog / fsck / dangling objects): <https://git-scm.com/book/en/v2/Git-Internals-Maintenance-and-Data-Recovery>
+- `git reflog` recovery guides (2026): <https://devtoolbox.dedyn.io/blog/git-reflog-recover-lost-commits-guide>, <https://oneuptime.com/blog/post/2026-01-24-git-reflog-recovery/view>
+- Detached HEAD recovery: <https://circleci.com/blog/git-detached-head-state/>

--- a/git-safety-net/scripts/git_loss_audit.sh
+++ b/git-safety-net/scripts/git_loss_audit.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# git_loss_audit.sh — report what local Git work is at risk of loss. READ-ONLY.
+#
+# Answers the two authoritative "would I actually lose anything?" questions:
+#   1. LOCAL-ONLY commits — reachable from a local branch but on NO remote. This is
+#      the true loss set: a dead disk loses exactly these. (git log --branches --not --remotes)
+#   2. DANGLING commits — orphaned objects (dropped stashes, rebase leftovers, abandoned
+#      resets). Reflog-reachable now, but eligible for `git gc` later. (git fsck --dangling)
+#
+# It never mutates anything (only fetch/log/fsck/rev-parse), so it is safe in a dirty
+# tree or alongside other agents.
+#
+# Usage (run from anywhere inside the repo):
+#   git_loss_audit.sh [remote]        # remote defaults to "origin"
+#
+# Exit code: 0 if nothing is at risk, 1 if local-only commits exist (the actionable case),
+# 2 if not run inside a Git repository. Dangling-only is exit 0 (recoverable, not urgent).
+set -euo pipefail
+
+REMOTE="${1:-origin}"
+
+# Must be inside a work tree; fail clearly rather than emitting confusing git errors.
+if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
+  echo "ERROR: not inside a Git repository." >&2
+  exit 2
+fi
+cd "$(git rev-parse --show-toplevel)"
+
+# Refresh remote-tracking refs so the local-only check is accurate. Best-effort: if the
+# remote is unreachable (offline / proxy), keep going with cached refs rather than aborting —
+# loss detection still works against whatever remote state we last saw.
+if git remote get-url "$REMOTE" >/dev/null 2>&1; then
+  if ! git fetch "$REMOTE" --prune --quiet 2>/dev/null; then
+    echo "note: could not fetch '$REMOTE' (offline?); auditing against cached remote refs." >&2
+  fi
+else
+  echo "note: no remote named '$REMOTE'; every local commit will count as local-only." >&2
+fi
+
+echo "=== Local-only commits (reachable from a local branch, on NO remote) ==="
+LOCAL_ONLY="$(git log --branches --not --remotes --oneline --decorate 2>/dev/null || true)"
+if [ -n "$LOCAL_ONLY" ]; then
+  echo "$LOCAL_ONLY" | sed 's/^/  /'
+else
+  echo "  (none)"
+fi
+LOCAL_ONLY_COUNT="$(printf '%s' "$LOCAL_ONLY" | grep -c . || true)"
+
+echo ""
+echo "=== Dangling commits (orphaned; reflog-reachable now, gc-eligible later) ==="
+DANGLING="$(git fsck --dangling 2>/dev/null | awk '/dangling commit/ {print $3}' || true)"
+DANGLING_COUNT="$(printf '%s' "$DANGLING" | grep -c . || true)"
+if [ "$DANGLING_COUNT" -gt 0 ]; then
+  # Show a short, human-readable sample so the user can eyeball what's orphaned.
+  printf '%s\n' "$DANGLING" | head -20 | while read -r sha; do
+    [ -n "$sha" ] && printf '  %s %s\n' "$(git log -1 --format='%h' "$sha" 2>/dev/null)" \
+      "$(git log -1 --format='%s' "$sha" 2>/dev/null | cut -c1-64)"
+  done
+  [ "$DANGLING_COUNT" -gt 20 ] && echo "  ... and $((DANGLING_COUNT - 20)) more"
+else
+  echo "  (none)"
+fi
+
+echo ""
+echo "=== Verdict ==="
+echo "  local-only: ${LOCAL_ONLY_COUNT}   dangling: ${DANGLING_COUNT}"
+if [ "$LOCAL_ONLY_COUNT" -gt 0 ]; then
+  echo "  ⚠ ${LOCAL_ONLY_COUNT} commit(s) exist ONLY locally. Back them up before any branch cleanup:"
+  echo "    git_preserve_danglers.sh   (or branch+push+patch a specific commit — see recovery_playbook.md)"
+  exit 1
+elif [ "$DANGLING_COUNT" -gt 0 ]; then
+  echo "  ${DANGLING_COUNT} dangling commit(s) are recoverable now but gc-eligible later."
+  echo "    Pin them past the gc window with: git_preserve_danglers.sh"
+  exit 0
+else
+  echo "  ✓ Zero loss risk — every local commit is on a remote, no orphaned objects."
+  exit 0
+fi

--- a/git-safety-net/scripts/git_loss_audit.sh
+++ b/git-safety-net/scripts/git_loss_audit.sh
@@ -1,20 +1,25 @@
 #!/usr/bin/env bash
 # git_loss_audit.sh — report what local Git work is at risk of loss. READ-ONLY.
 #
-# Answers the two authoritative "would I actually lose anything?" questions:
-#   1. LOCAL-ONLY commits — reachable from a local branch but on NO remote. This is
-#      the true loss set: a dead disk loses exactly these. (git log --branches --not --remotes)
-#   2. DANGLING commits — orphaned objects (dropped stashes, rebase leftovers, abandoned
-#      resets). Reflog-reachable now, but eligible for `git gc` later. (git fsck --dangling)
+# Answers the authoritative "would I actually lose anything?" questions across EVERY local place
+# work hides — not just branches:
+#   1. LOCAL-ONLY commits — reachable from HEAD, a local branch, or a tag, but on NO remote. This
+#      is the true loss set: a dead disk loses exactly these. Using HEAD (not just --branches)
+#      catches DETACHED-HEAD commits; --tags catches tag-only commits — both invisible to a plain
+#      `git log --branches --not --remotes`. (git log HEAD --branches --tags --not --remotes)
+#   2. STASHES — `git stash` entries are local-only by nature and a classic loss vector.
+#   3. DANGLING commits — orphaned objects (dropped stashes, rebase leftovers, abandoned resets).
+#      Reflog-reachable now, but eligible for `git gc` later. (git fsck --dangling)
 #
-# It never mutates anything (only fetch/log/fsck/rev-parse), so it is safe in a dirty
+# It never mutates anything (only fetch/log/stash-list/fsck/rev-parse), so it is safe in a dirty
 # tree or alongside other agents.
 #
 # Usage (run from anywhere inside the repo):
 #   git_loss_audit.sh [remote]        # remote defaults to "origin"
 #
-# Exit code: 0 if nothing is at risk, 1 if local-only commits exist (the actionable case),
-# 2 if not run inside a Git repository. Dangling-only is exit 0 (recoverable, not urgent).
+# Exit code: 0 if nothing is at surprising risk, 1 if LOCAL-ONLY commits exist (the actionable
+# case), 2 if not run inside a Git repository. Stashes and dangling commits are reported but stay
+# exit 0 (known/recoverable, not a surprise) so exit 1 keeps meaning "unexpected work off-remote."
 set -euo pipefail
 
 REMOTE="${1:-origin}"
@@ -26,9 +31,8 @@ if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
 fi
 cd "$(git rev-parse --show-toplevel)"
 
-# Refresh remote-tracking refs so the local-only check is accurate. Best-effort: if the
-# remote is unreachable (offline / proxy), keep going with cached refs rather than aborting —
-# loss detection still works against whatever remote state we last saw.
+# Refresh remote-tracking refs so the local-only check is accurate. Best-effort: if the remote is
+# unreachable (offline / proxy), keep going with cached refs rather than aborting.
 if git remote get-url "$REMOTE" >/dev/null 2>&1; then
   if ! git fetch "$REMOTE" --prune --quiet 2>/dev/null; then
     echo "note: could not fetch '$REMOTE' (offline?); auditing against cached remote refs." >&2
@@ -36,9 +40,17 @@ if git remote get-url "$REMOTE" >/dev/null 2>&1; then
 else
   echo "note: no remote named '$REMOTE'; every local commit will count as local-only." >&2
 fi
+# If more than one remote exists, remote-tracking refs of the OTHER remotes also suppress the
+# local-only check; a stale tracking ref there could mask real loss. Flag it rather than hide it.
+REMOTE_COUNT="$(git remote | grep -c . || true)"
+if [ "$REMOTE_COUNT" -gt 1 ]; then
+  echo "note: $REMOTE_COUNT remotes configured; only '$REMOTE' was refreshed. Stale tracking refs" >&2
+  echo "      on the others could hide local-only work — 'git fetch --all --prune' to be sure." >&2
+fi
 
-echo "=== Local-only commits (reachable from a local branch, on NO remote) ==="
-LOCAL_ONLY="$(git log --branches --not --remotes --oneline --decorate 2>/dev/null || true)"
+echo "=== Local-only commits (reachable from HEAD / a local branch / a tag, on NO remote) ==="
+# HEAD covers detached-HEAD work; --tags covers tag-only commits; both are missed by --branches.
+LOCAL_ONLY="$(git log HEAD --branches --tags --not --remotes --oneline --decorate 2>/dev/null || true)"
 if [ -n "$LOCAL_ONLY" ]; then
   echo "$LOCAL_ONLY" | sed 's/^/  /'
 else
@@ -47,11 +59,20 @@ fi
 LOCAL_ONLY_COUNT="$(printf '%s' "$LOCAL_ONLY" | grep -c . || true)"
 
 echo ""
+echo "=== Stashes (local-only by nature — a dead disk loses these too) ==="
+STASHES="$(git stash list 2>/dev/null || true)"
+STASH_COUNT="$(printf '%s' "$STASHES" | grep -c . || true)"
+if [ "$STASH_COUNT" -gt 0 ]; then
+  printf '%s\n' "$STASHES" | sed 's/^/  /'
+else
+  echo "  (none)"
+fi
+
+echo ""
 echo "=== Dangling commits (orphaned; reflog-reachable now, gc-eligible later) ==="
 DANGLING="$(git fsck --dangling 2>/dev/null | awk '/dangling commit/ {print $3}' || true)"
 DANGLING_COUNT="$(printf '%s' "$DANGLING" | grep -c . || true)"
 if [ "$DANGLING_COUNT" -gt 0 ]; then
-  # Show a short, human-readable sample so the user can eyeball what's orphaned.
   printf '%s\n' "$DANGLING" | head -20 | while read -r sha; do
     [ -n "$sha" ] && printf '  %s %s\n' "$(git log -1 --format='%h' "$sha" 2>/dev/null)" \
       "$(git log -1 --format='%s' "$sha" 2>/dev/null | cut -c1-64)"
@@ -63,16 +84,25 @@ fi
 
 echo ""
 echo "=== Verdict ==="
-echo "  local-only: ${LOCAL_ONLY_COUNT}   dangling: ${DANGLING_COUNT}"
+echo "  local-only: ${LOCAL_ONLY_COUNT}   stashes: ${STASH_COUNT}   dangling: ${DANGLING_COUNT}"
 if [ "$LOCAL_ONLY_COUNT" -gt 0 ]; then
-  echo "  ⚠ ${LOCAL_ONLY_COUNT} commit(s) exist ONLY locally. Back them up before any branch cleanup:"
-  echo "    git_preserve_danglers.sh   (or branch+push+patch a specific commit — see recovery_playbook.md)"
-  exit 1
-elif [ "$DANGLING_COUNT" -gt 0 ]; then
-  echo "  ${DANGLING_COUNT} dangling commit(s) are recoverable now but gc-eligible later."
-  echo "    Pin them past the gc window with: git_preserve_danglers.sh"
-  exit 0
-else
-  echo "  ✓ Zero loss risk — every local commit is on a remote, no orphaned objects."
-  exit 0
+  echo "  ⚠ ${LOCAL_ONLY_COUNT} commit(s) exist ONLY locally (no remote has them). Back each up with the"
+  echo "    triple-backup — a local branch is not enough, since gc/disk loss can still take it:"
+  echo "      git branch backup/<name> <sha> && git push origin backup/<name> && git format-patch -1 <sha> --stdout > <name>.patch"
+  echo "    (git_preserve_danglers.sh only covers DANGLING commits, not these branch-reachable ones.)"
 fi
+if [ "$STASH_COUNT" -gt 0 ]; then
+  echo "  • ${STASH_COUNT} stash(es) are local-only; if any is precious, turn it into a commit + push it."
+fi
+if [ "$DANGLING_COUNT" -gt 0 ]; then
+  echo "  • ${DANGLING_COUNT} dangling commit(s) are recoverable now but gc-eligible later — pin past the"
+  echo "    gc window with: git_preserve_danglers.sh"
+fi
+if [ "$LOCAL_ONLY_COUNT" -eq 0 ] && [ "$STASH_COUNT" -eq 0 ] && [ "$DANGLING_COUNT" -eq 0 ]; then
+  echo "  ✓ Zero loss risk — every local commit is on a remote, no stashes, no orphaned objects."
+fi
+
+# Exit 1 only for the surprising, actionable case (commits off every remote); stashes/dangling are
+# known/recoverable and stay exit 0 so a routine stash doesn't cry wolf.
+[ "$LOCAL_ONLY_COUNT" -gt 0 ] && exit 1
+exit 0

--- a/git-safety-net/scripts/git_preserve_danglers.sh
+++ b/git-safety-net/scripts/git_preserve_danglers.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# git_preserve_danglers.sh — make orphaned commits un-loseable BEFORE any cleanup. Additive-only.
+#
+# Dangling commits (dropped stashes, rebase leftovers, abandoned resets, detached-HEAD work) are
+# recoverable ONLY until `git gc` runs. This pins each one under a hidden ref namespace
+# refs/dangling-backup/<sha> — a referenced object is never garbage-collected — so they survive
+# gc without cluttering `git branch` or `git stash list`. Optionally exports a .patch per commit.
+#
+# It only ever runs read-only git plus `git update-ref` to ADD refs. It never deletes a ref,
+# never checks out, never resets, never runs gc — so it cannot make a loss worse.
+#
+# Usage (run from anywhere inside the repo):
+#   git_preserve_danglers.sh                       # pin all dangling commits
+#   git_preserve_danglers.sh --patch-dir DIR       # pin AND write DIR/<shortsha>-<slug>.patch each
+#
+# After running, `git for-each-ref refs/dangling-backup/` lists what was pinned. To unpin later
+# (only once you've confirmed the content is safe on a remote), see the SKILL.md troubleshooting.
+set -euo pipefail
+
+PATCH_DIR=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --patch-dir)
+      PATCH_DIR="${2:-}"
+      if [ -z "$PATCH_DIR" ]; then echo "ERROR: --patch-dir needs a directory argument." >&2; exit 2; fi
+      shift 2 ;;
+    -h|--help)
+      grep '^# ' "$0" | sed 's/^# //'; exit 0 ;;
+    *)
+      echo "ERROR: unknown argument '$1' (expected --patch-dir DIR)." >&2; exit 2 ;;
+  esac
+done
+
+if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
+  echo "ERROR: not inside a Git repository." >&2
+  exit 2
+fi
+cd "$(git rev-parse --show-toplevel)"
+
+if [ -n "$PATCH_DIR" ]; then
+  mkdir -p "$PATCH_DIR"
+fi
+
+# Collect dangling commit shas. `git fsck --dangling` also reports dangling blobs/trees; we only
+# pin commits (a whole recoverable state). Blobs/trees are reachable from a pinned commit anyway.
+DANGLING="$(git fsck --dangling 2>/dev/null | awk '/dangling commit/ {print $3}' || true)"
+
+if [ -z "$DANGLING" ]; then
+  echo "No dangling commits — nothing to preserve. (If you expected some, they may already be"
+  echo "pinned, or reachable from a branch. Run git_loss_audit.sh for the full picture.)"
+  exit 0
+fi
+
+PINNED=0
+PATCHED=0
+while read -r sha; do
+  [ -z "$sha" ] && continue
+  # Pin it. refs/dangling-backup/<full-sha> is unique per commit and invisible to `git branch`.
+  git update-ref "refs/dangling-backup/$sha" "$sha"
+  PINNED=$((PINNED + 1))
+
+  SUBJECT="$(git log -1 --format='%s' "$sha" 2>/dev/null | cut -c1-64)"
+  printf '  pinned %s  %s\n' "$(git rev-parse --short "$sha")" "$SUBJECT"
+
+  if [ -n "$PATCH_DIR" ]; then
+    # Stash commits (subject "WIP on …") are diffs against their parent and don't format-patch
+    # cleanly as a standalone commit; skip patch export for them but keep them pinned (the pin is
+    # the real safety). For normal commits, a single-commit patch is a repo-independent backup.
+    if git log -1 --format='%s' "$sha" 2>/dev/null | grep -q '^WIP on '; then
+      printf '    (stash-like commit — pinned only, no patch)\n'
+    else
+      SHORT="$(git rev-parse --short "$sha")"
+      SLUG="$(git log -1 --format='%f' "$sha" 2>/dev/null | cut -c1-40)"
+      OUT="$PATCH_DIR/${SHORT}-${SLUG}.patch"
+      if git format-patch -1 "$sha" --stdout > "$OUT" 2>/dev/null; then
+        PATCHED=$((PATCHED + 1))
+      else
+        rm -f "$OUT"
+        printf '    (could not format-patch %s — pinned only)\n' "$SHORT"
+      fi
+    fi
+  fi
+done <<< "$DANGLING"
+
+echo ""
+echo "=== Preserved ==="
+echo "  pinned:  $PINNED commit(s) under refs/dangling-backup/"
+[ -n "$PATCH_DIR" ] && echo "  patched: $PATCHED patch file(s) in $PATCH_DIR"
+echo ""
+echo "  Verify:  git for-each-ref refs/dangling-backup/"
+echo "  Inspect: git show <sha>       (each pinned commit is now gc-proof)"
+echo "  These pins protect the objects; they do NOT put the work on a remote. For a commit you"
+echo "  truly can't lose, also push a branch + keep a patch (triple-backup — see recovery_playbook.md)."

--- a/git-safety-net/scripts/git_preserve_danglers.sh
+++ b/git-safety-net/scripts/git_preserve_danglers.sh
@@ -35,10 +35,25 @@ if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
   echo "ERROR: not inside a Git repository." >&2
   exit 2
 fi
+
+# Resolve --patch-dir to an ABSOLUTE path against the caller's CWD BEFORE we cd to the repo root,
+# so a relative --patch-dir means what the user expects (their current directory, not the repo top).
+if [ -n "$PATCH_DIR" ]; then
+  case "$PATCH_DIR" in
+    /*) : ;;                            # already absolute
+    *)  PATCH_DIR="$PWD/$PATCH_DIR" ;;  # relative → anchor to the caller's CWD
+  esac
+fi
+
 cd "$(git rev-parse --show-toplevel)"
 
+# Create the patch dir, but never let a patch-export problem abort the PRIMARY job (pinning). If
+# the directory can't be made, warn and disable patch export; the pinning below still runs.
 if [ -n "$PATCH_DIR" ]; then
-  mkdir -p "$PATCH_DIR"
+  if ! mkdir -p "$PATCH_DIR" 2>/dev/null; then
+    echo "warning: cannot create --patch-dir '$PATCH_DIR'; pinning only, skipping patch export." >&2
+    PATCH_DIR=""
+  fi
 fi
 
 # Collect dangling commit shas. `git fsck --dangling` also reports dangling blobs/trees; we only
@@ -63,11 +78,16 @@ while read -r sha; do
   printf '  pinned %s  %s\n' "$(git rev-parse --short "$sha")" "$SUBJECT"
 
   if [ -n "$PATCH_DIR" ]; then
-    # Stash commits (subject "WIP on …") are diffs against their parent and don't format-patch
-    # cleanly as a standalone commit; skip patch export for them but keep them pinned (the pin is
-    # the real safety). For normal commits, a single-commit patch is a repo-independent backup.
-    if git log -1 --format='%s' "$sha" 2>/dev/null | grep -q '^WIP on '; then
-      printf '    (stash-like commit — pinned only, no patch)\n'
+    # A stash commit (and any merge) has >=2 parents; `git format-patch -1` cannot represent a
+    # merge and will SILENTLY emit a different commit's patch (exit 0), so we would write a wrong
+    # backup and report it as success. Detect by PARENT COUNT, not by the "WIP on " subject —
+    # a `git stash push -m msg` stash reads "On <branch>: msg" (would slip through the old check),
+    # and a real commit titled "WIP on …" would have been wrongly skipped. rev-list --parents
+    # prints "<sha> <parent1> <parent2>…", so >2 tokens means >=2 parents. The pin already made
+    # the object gc-proof; we only skip the (impossible) patch for merges.
+    PARENTS="$(git rev-list --parents -n1 "$sha" 2>/dev/null | wc -w | tr -d ' ')"
+    if [ "${PARENTS:-1}" -gt 2 ]; then
+      printf '    (merge/stash commit — pinned only, no patch)\n'
     else
       SHORT="$(git rev-parse --short "$sha")"
       SLUG="$(git log -1 --format='%f' "$sha" 2>/dev/null | cut -c1-40)"

--- a/git-safety-net/scripts/git_verify_branch_merged.sh
+++ b/git-safety-net/scripts/git_verify_branch_merged.sh
@@ -2,18 +2,29 @@
 # git_verify_branch_merged.sh — is a branch's CONTENT already on the base? READ-ONLY.
 #
 # Commit counts lie: after a squash-merge, `main..branch` shows all the branch's original commits
-# as "unmerged" even though every line is on main. This judges by CONTENT instead, so you can
-# safely decide whether a branch is deletable or still holds unmerged work.
+# as "unmerged" even though every line is on main. This judges by CONTENT using Git's own merge
+# machinery, so you can safely decide whether a branch is deletable or still holds unmerged work.
 #
-# It runs only fetch/diff/log/cat-file/merge-base/rev-parse against explicit refs — no checkout,
-# no mutation — so it's safe in a dirty tree and alongside other agents.
+# It is SAFETY-BIASED: it only says "safe to delete" when it can PROVE the branch is contained in
+# the base. Anything it cannot prove contained is reported UNMERGED / NEEDS REVIEW — because a
+# false "merged" loses work, while a false "unmerged" only costs a second look.
+#
+# Method (sound, not heuristic):
+#   1. If the branch is an ancestor of base  -> MERGED (already in history).
+#   2. Else do a trial 3-way merge of the branch INTO the base (git merge-tree, in memory, no
+#      checkout). If merging changes nothing (result tree == base tree), the branch adds nothing
+#      the base lacks -> MERGED (content contained) — this is what defeats the squash-merge count.
+#   3. Otherwise -> UNMERGED / NEEDS REVIEW, listing the branch's contribution to inspect.
+#
+# It runs only fetch/merge-base/merge-tree/rev-parse/diff against explicit refs — no checkout, no
+# mutation — so it is safe in a dirty tree and alongside other agents.
 #
 # Usage (run from anywhere inside the repo):
 #   git_verify_branch_merged.sh <branch> [base]     # base defaults to origin/main
 #
-# <branch> may be a local name (resolved to origin/<branch> if that exists) or an explicit ref.
-# Exit code: 0 = MERGED (content on base, deletable), 1 = UNMERGED (has content base lacks),
-# 2 = usage/repo error.
+# <branch> resolves to your LOCAL branch of that name if it exists (that is what you would delete,
+# and it is the superset of any unpushed work), else a bare ref, else origin/<branch>.
+# Exit code: 0 = MERGED (safe to delete), 1 = UNMERGED / needs review, 2 = usage/repo error.
 set -euo pipefail
 
 if [ $# -lt 1 ]; then
@@ -32,12 +43,14 @@ cd "$(git rev-parse --show-toplevel)"
 # Best-effort refresh so we compare against current remote state (offline → cached refs).
 git fetch --all --prune --quiet 2>/dev/null || echo "note: fetch failed; comparing against cached refs." >&2
 
-# Resolve the branch to a concrete ref. Prefer the remote-tracking copy (origin/<branch>) because
-# that's the shared truth; fall back to whatever the user passed if it resolves.
+# Resolve the branch. Prefer the LOCAL branch of that name: it is what `git branch -D` would
+# delete, and it is the superset of any commits not yet pushed to origin/<branch>. Only fall back
+# to the remote-tracking copy when no local branch exists.
 resolve_ref() {
   local arg="$1"
-  if git rev-parse --verify --quiet "origin/$arg" >/dev/null; then echo "origin/$arg"; return; fi
-  if git rev-parse --verify --quiet "$arg" >/dev/null; then echo "$arg"; return; fi
+  if git rev-parse --verify --quiet "refs/heads/$arg" >/dev/null; then echo "refs/heads/$arg"; return; fi
+  if git rev-parse --verify --quiet "$arg" >/dev/null;            then echo "$arg";            return; fi
+  if git rev-parse --verify --quiet "origin/$arg" >/dev/null;     then echo "origin/$arg";     return; fi
   return 1
 }
 BRANCH_REF="$(resolve_ref "$BRANCH_ARG")" || { echo "ERROR: cannot resolve branch ref '$BRANCH_ARG'." >&2; exit 2; }
@@ -46,73 +59,57 @@ if ! git rev-parse --verify --quiet "$BASE" >/dev/null; then
 fi
 
 echo "Verifying '$BRANCH_REF'  vs base '$BASE'  (by content, not commit count)"
+# If a local branch and its remote-tracking copy disagree, say which one we judged (the local one,
+# which may hold unpushed commits) so the verdict is not silently about the wrong ref.
+if [ "$BRANCH_REF" = "refs/heads/$BRANCH_ARG" ] && git rev-parse --verify --quiet "origin/$BRANCH_ARG" >/dev/null; then
+  if [ "$(git rev-parse "refs/heads/$BRANCH_ARG")" != "$(git rev-parse "origin/$BRANCH_ARG")" ]; then
+    echo "  (local 'refs/heads/$BRANCH_ARG' differs from 'origin/$BRANCH_ARG' — judging the LOCAL branch, the superset)"
+  fi
+fi
 echo ""
 
-# --- Check 4 first: is the branch literally an ancestor of base? (fully merged, no rewrite) ---
+# --- Step 1: ancestor? (fully merged into base's history, no rewrite) ---
 if git merge-base --is-ancestor "$BRANCH_REF" "$BASE"; then
   echo "  ✓ MERGED (ancestor) — '$BRANCH_REF' is in '$BASE' history. Safe to delete."
   exit 0
 fi
 
-# Not an ancestor → could be squash/rebase-merged (content on base, new shas) OR genuinely unmerged.
-# --- Check 1: whole files the branch ADDS that the base lacks. A truly-unmerged new module/skill
-#     surfaces here. ---
-ADDED_ABSENT=""
-while read -r f; do
-  [ -z "$f" ] && continue
-  # Is this path genuinely absent from base? (Not just moved — we check the exact path.)
-  if ! git cat-file -e "$BASE:$f" 2>/dev/null; then
-    ADDED_ABSENT+="$f"$'\n'
-  fi
-done < <(git diff "$BASE" "$BRANCH_REF" --diff-filter=A --name-only 2>/dev/null || true)
-
-# --- Checks 2+3: for files the branch MODIFIES, is the branch's version identical to base, or at
-#     least present somewhere in base's history (superseded)? If neither, it's real unmerged content. ---
-MODIFIED_UNMERGED=""
-while read -r f; do
-  [ -z "$f" ] && continue
-  # Skip files absent from base (handled above as adds/renames).
-  git cat-file -e "$BASE:$f" 2>/dev/null || continue
-  # Check 2: byte-identical on both sides → nothing to merge for this file.
-  if git diff --quiet "$BRANCH_REF:$f" "$BASE:$f" 2>/dev/null; then
-    continue
-  fi
-  # Check 3: does the branch's exact blob appear anywhere in base's history? If so, base passed
-  # through this content and moved on (superseded old version) — not missing.
-  blob="$(git rev-parse "$BRANCH_REF:$f" 2>/dev/null || true)"
-  if [ -n "$blob" ] && [ -n "$(git log "$BASE" --oneline --find-object="$blob" 2>/dev/null | head -1)" ]; then
-    continue
-  fi
-  MODIFIED_UNMERGED+="$f"$'\n'
-done < <(git diff "$BASE" "$BRANCH_REF" --diff-filter=M --name-only 2>/dev/null || true)
-
-ADDED_COUNT="$(printf '%s' "$ADDED_ABSENT" | grep -c . || true)"
-MOD_COUNT="$(printf '%s' "$MODIFIED_UNMERGED" | grep -c . || true)"
-
-if [ "$ADDED_COUNT" -eq 0 ] && [ "$MOD_COUNT" -eq 0 ]; then
-  echo "  ✓ STALE-SQUASH (merged by content) — no file the branch adds is missing from base, and"
-  echo "    every file it modifies is either identical to base or a superseded older version whose"
-  echo "    exact content is in base's history. The 'commits ahead' count is a squash/rebase artifact."
-  echo "    Safe to delete."
+# --- Step 2: content-contained? Trial 3-way merge of branch INTO base, in memory. If merging the
+#     branch changes nothing, the branch adds nothing base lacks (the classic squash/rebase case
+#     where the count says "ahead" but the content is already upstream). This is sound: it is
+#     exactly Git's merge, so a revert/edit the base lacks WOULD change the tree and fail this. ---
+BASE_TREE="$(git rev-parse "$BASE^{tree}")"
+MERGED_TREE="$(git merge-tree --write-tree "$BASE" "$BRANCH_REF" 2>/dev/null | head -1)"
+MT_RC="${PIPESTATUS[0]}"
+if [ "$MT_RC" -ge 128 ]; then
+  # `git merge-tree --write-tree` needs git >= 2.38. Older git can't prove containment, so stay
+  # safe: fall through to UNMERGED / NEEDS REVIEW rather than guess "merged".
+  echo "  note: 'git merge-tree --write-tree' unavailable (git < 2.38); cannot prove content" >&2
+  echo "        containment — reporting NEEDS REVIEW conservatively. Upgrade git for a MERGED verdict." >&2
+elif [ "$MT_RC" -eq 0 ] && [ "$MERGED_TREE" = "$BASE_TREE" ]; then
+  echo "  ✓ MERGED (content contained) — a trial merge of '$BRANCH_REF' into '$BASE' changes"
+  echo "    nothing: every change the branch carries is already on base. The 'commits ahead'"
+  echo "    count is a squash/rebase artifact. Safe to delete."
   exit 0
 fi
 
-echo "  ✗ UNMERGED — '$BRANCH_REF' has content that is NOT on '$BASE':"
-if [ "$ADDED_COUNT" -gt 0 ]; then
-  echo ""
-  echo "    New files present on branch, absent from base:"
-  printf '%s' "$ADDED_ABSENT" | sed 's/^/      + /'
-fi
-if [ "$MOD_COUNT" -gt 0 ]; then
-  echo ""
-  echo "    Modified files whose branch content is neither on base nor in base's history:"
-  printf '%s' "$MODIFIED_UNMERGED" | sed 's/^/      ~ /'
-  echo ""
-  echo "    Inspect a specific one with:"
-  FIRST="$(printf '%s' "$MODIFIED_UNMERGED" | head -1)"
-  echo "      git diff $BASE:$FIRST $BRANCH_REF:$FIRST"
+# --- Step 3: cannot prove contained → report for review, listing the branch's own contribution
+#     (three-dot: what the branch changed since it diverged from base). core.quotePath=false so
+#     CJK/Unicode paths display correctly; --no-renames so a rename shows as add+delete; `--`
+#     so a branch named like a path (e.g. `docs`) can never be mistaken for a pathspec. ---
+echo "  ✗ UNMERGED / NEEDS REVIEW — a trial merge of '$BRANCH_REF' into '$BASE' would change base,"
+echo "    so the branch carries content base does not already have. Its contribution to review:"
+echo ""
+CONTRIB="$(git -c core.quotePath=false diff --no-renames --name-status "$BASE...$BRANCH_REF" -- 2>/dev/null || true)"
+if [ -n "$CONTRIB" ]; then
+  printf '%s\n' "$CONTRIB" | sed 's/^/      /'
+else
+  echo "      (no path-level diff on the branch side; the divergence may be a merge/history"
+  echo "       difference — inspect with: git log $BASE..$BRANCH_REF)"
 fi
 echo ""
-echo "    NOTE (per merge_verification.md): a false UNMERGED wastes a re-merge; verify the specific"
-echo "    hunk is behavior base truly lacks before landing it — main may have evolved past the branch."
+echo "    Inspect the full contribution with:  git diff $BASE...$BRANCH_REF"
+echo "    NOTE (per merge_verification.md): this is the SAFE direction — a false UNMERGED costs"
+echo "    only a second look, whereas a false MERGED loses work. If base merely evolved past the"
+echo "    branch, confirm the specific lines are truly redundant before deleting."
 exit 1

--- a/git-safety-net/scripts/git_verify_branch_merged.sh
+++ b/git-safety-net/scripts/git_verify_branch_merged.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# git_verify_branch_merged.sh — is a branch's CONTENT already on the base? READ-ONLY.
+#
+# Commit counts lie: after a squash-merge, `main..branch` shows all the branch's original commits
+# as "unmerged" even though every line is on main. This judges by CONTENT instead, so you can
+# safely decide whether a branch is deletable or still holds unmerged work.
+#
+# It runs only fetch/diff/log/cat-file/merge-base/rev-parse against explicit refs — no checkout,
+# no mutation — so it's safe in a dirty tree and alongside other agents.
+#
+# Usage (run from anywhere inside the repo):
+#   git_verify_branch_merged.sh <branch> [base]     # base defaults to origin/main
+#
+# <branch> may be a local name (resolved to origin/<branch> if that exists) or an explicit ref.
+# Exit code: 0 = MERGED (content on base, deletable), 1 = UNMERGED (has content base lacks),
+# 2 = usage/repo error.
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  echo "usage: git_verify_branch_merged.sh <branch> [base]   (base defaults to origin/main)" >&2
+  exit 2
+fi
+BRANCH_ARG="$1"
+BASE="${2:-origin/main}"
+
+if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
+  echo "ERROR: not inside a Git repository." >&2
+  exit 2
+fi
+cd "$(git rev-parse --show-toplevel)"
+
+# Best-effort refresh so we compare against current remote state (offline → cached refs).
+git fetch --all --prune --quiet 2>/dev/null || echo "note: fetch failed; comparing against cached refs." >&2
+
+# Resolve the branch to a concrete ref. Prefer the remote-tracking copy (origin/<branch>) because
+# that's the shared truth; fall back to whatever the user passed if it resolves.
+resolve_ref() {
+  local arg="$1"
+  if git rev-parse --verify --quiet "origin/$arg" >/dev/null; then echo "origin/$arg"; return; fi
+  if git rev-parse --verify --quiet "$arg" >/dev/null; then echo "$arg"; return; fi
+  return 1
+}
+BRANCH_REF="$(resolve_ref "$BRANCH_ARG")" || { echo "ERROR: cannot resolve branch ref '$BRANCH_ARG'." >&2; exit 2; }
+if ! git rev-parse --verify --quiet "$BASE" >/dev/null; then
+  echo "ERROR: cannot resolve base ref '$BASE'." >&2; exit 2
+fi
+
+echo "Verifying '$BRANCH_REF'  vs base '$BASE'  (by content, not commit count)"
+echo ""
+
+# --- Check 4 first: is the branch literally an ancestor of base? (fully merged, no rewrite) ---
+if git merge-base --is-ancestor "$BRANCH_REF" "$BASE"; then
+  echo "  ✓ MERGED (ancestor) — '$BRANCH_REF' is in '$BASE' history. Safe to delete."
+  exit 0
+fi
+
+# Not an ancestor → could be squash/rebase-merged (content on base, new shas) OR genuinely unmerged.
+# --- Check 1: whole files the branch ADDS that the base lacks. A truly-unmerged new module/skill
+#     surfaces here. ---
+ADDED_ABSENT=""
+while read -r f; do
+  [ -z "$f" ] && continue
+  # Is this path genuinely absent from base? (Not just moved — we check the exact path.)
+  if ! git cat-file -e "$BASE:$f" 2>/dev/null; then
+    ADDED_ABSENT+="$f"$'\n'
+  fi
+done < <(git diff "$BASE" "$BRANCH_REF" --diff-filter=A --name-only 2>/dev/null || true)
+
+# --- Checks 2+3: for files the branch MODIFIES, is the branch's version identical to base, or at
+#     least present somewhere in base's history (superseded)? If neither, it's real unmerged content. ---
+MODIFIED_UNMERGED=""
+while read -r f; do
+  [ -z "$f" ] && continue
+  # Skip files absent from base (handled above as adds/renames).
+  git cat-file -e "$BASE:$f" 2>/dev/null || continue
+  # Check 2: byte-identical on both sides → nothing to merge for this file.
+  if git diff --quiet "$BRANCH_REF:$f" "$BASE:$f" 2>/dev/null; then
+    continue
+  fi
+  # Check 3: does the branch's exact blob appear anywhere in base's history? If so, base passed
+  # through this content and moved on (superseded old version) — not missing.
+  blob="$(git rev-parse "$BRANCH_REF:$f" 2>/dev/null || true)"
+  if [ -n "$blob" ] && [ -n "$(git log "$BASE" --oneline --find-object="$blob" 2>/dev/null | head -1)" ]; then
+    continue
+  fi
+  MODIFIED_UNMERGED+="$f"$'\n'
+done < <(git diff "$BASE" "$BRANCH_REF" --diff-filter=M --name-only 2>/dev/null || true)
+
+ADDED_COUNT="$(printf '%s' "$ADDED_ABSENT" | grep -c . || true)"
+MOD_COUNT="$(printf '%s' "$MODIFIED_UNMERGED" | grep -c . || true)"
+
+if [ "$ADDED_COUNT" -eq 0 ] && [ "$MOD_COUNT" -eq 0 ]; then
+  echo "  ✓ STALE-SQUASH (merged by content) — no file the branch adds is missing from base, and"
+  echo "    every file it modifies is either identical to base or a superseded older version whose"
+  echo "    exact content is in base's history. The 'commits ahead' count is a squash/rebase artifact."
+  echo "    Safe to delete."
+  exit 0
+fi
+
+echo "  ✗ UNMERGED — '$BRANCH_REF' has content that is NOT on '$BASE':"
+if [ "$ADDED_COUNT" -gt 0 ]; then
+  echo ""
+  echo "    New files present on branch, absent from base:"
+  printf '%s' "$ADDED_ABSENT" | sed 's/^/      + /'
+fi
+if [ "$MOD_COUNT" -gt 0 ]; then
+  echo ""
+  echo "    Modified files whose branch content is neither on base nor in base's history:"
+  printf '%s' "$MODIFIED_UNMERGED" | sed 's/^/      ~ /'
+  echo ""
+  echo "    Inspect a specific one with:"
+  FIRST="$(printf '%s' "$MODIFIED_UNMERGED" | head -1)"
+  echo "      git diff $BASE:$FIRST $BRANCH_REF:$FIRST"
+fi
+echo ""
+echo "    NOTE (per merge_verification.md): a false UNMERGED wastes a re-merge; verify the specific"
+echo "    hunk is behavior base truly lacks before landing it — main may have evolved past the branch."
+exit 1


### PR DESCRIPTION
## What

A new standalone skill, **git-safety-net**, that both **prevents** and **recovers from** the branch/stash/rebase tangles that strand or lose local commits — and answers *"is everything actually merged?"* by **content**, not by misleading commit counts.

Distilled from a real session where heavy branch-switching left work looking lost and a squash-merged branch showed "N commits ahead" of main while every line was already merged.

## Four modes (entry router in SKILL.md)

- **Mode A — Recover**: reflog → fsck ladder for a deleted commit / branch / dropped stash / detached-HEAD orphan (the ~90-day window).
- **Mode B — Audit & preserve**: `git log --branches --not --remotes` as the authoritative "what would actually be lost" check; pin dangling commits gc-proof under `refs/dangling-backup/` *before* any cleanup.
- **Mode C — Verify merged**: content-level MERGED / STALE-SQUASH / UNMERGED verdict that defeats the squash-merge *"100 commits ahead"* illusion (added-file detection + blob identity + `--find-object` + ancestor check), plus an optional **adversarial multi-agent** pattern for a whole repo of branches.
- **Mode D — Prevent**: worktrees over stash-juggling, push WIP early, confirm-branch-before-commit, pre-rebase/pre-delete audit, version/lockfile collision check.

## Scripts (all read-only or additive — never `checkout`/`reset`/`push`/`gc`)

| Script | Does | Mutates? |
|---|---|---|
| `git_loss_audit.sh [remote]` | Report local-only + dangling commits; verdict | No |
| `git_preserve_danglers.sh [--patch-dir DIR]` | Pin danglers to `refs/dangling-backup/`, optional patches | Adds refs only |
| `git_verify_branch_merged.sh <branch> [base]` | Content-level MERGED/UNMERGED for one branch | No |

All three end-to-end tested (clean repo, no-remote, dangling-commit fixture, squash-merged branch → correctly STALE-SQUASH, UNMERGED exit codes).

## Positioning

Orthogonal to existing skills: **LOCAL-Git safety & forensics**, distinct from GitHub PR/API ops (`github-ops`) and routine repo setup/sync (`auto-repo-setup`). Inline skill (Mode C orchestrates verification agents).

## Registration

- `marketplace.json` 1.84.0 → 1.85.0 + new plugin entry
- README entry 87
- `quick_validate` + `security_scan` pass; leak grep + semantic read-through clean (public-repo safe: placeholders only, no real SHAs / project names / PII)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jbcqpjz6xsVMTMpdV3VTTn