### PR TITLE
refactor(daymade-claude-code): shared _conversation_core + fix multi-profile blind spot in all 3 history skills (P0)

### DIFF
--- a/daymade-claude-code/_conversation_core/__init__.py
+++ b/daymade-claude-code/_conversation_core/__init__.py
@@ -1,0 +1,16 @@
+"""Shared core for the local conversation-history skills.
+
+Single source of truth for logic that would otherwise be re-implemented (and
+drift) across `claude-code-history-files-finder`, `local-conversation-history`,
+`continue-claude-work`, and `continue-codex-work`. This package is authored here
+and BUNDLED (copied) into each skill's `scripts/_core/` by `sync_core.py`, so
+every skill stays self-contained and installable on its own while sharing one
+implementation.
+
+Modules:
+    homes  — discover every Claude config home (main + per-model profiles).
+"""
+
+from .homes import discover_claude_homes, home_label
+
+__all__ = ["discover_claude_homes", "home_label"]

--- a/daymade-claude-code/_conversation_core/homes.py
+++ b/daymade-claude-code/_conversation_core/homes.py
@@ -1,0 +1,106 @@
+"""Discover every Claude config home that holds conversation history.
+
+Claude Code stores session history under ``<home>/projects/``. The default home
+is ``~/.claude``, but a user who runs third-party models through per-model
+*profiles* — each profile is its own ``CLAUDE_CONFIG_DIR`` — keeps a parallel
+history under ``~/.claude-profiles/<name>/`` and sometimes a sibling
+``~/.claude-<name>/``. A tool that only looks at ``~/.claude`` silently misses
+every conversation held under a profile, which is the #1 reason a real session
+is wrongly reported as "not found".
+
+This module is the single source of truth for that discovery. It is bundled
+(copied) into each conversation-history skill's ``scripts/_core/`` so every skill
+stays self-contained yet shares one implementation — fix the blind spot once,
+not once per skill.
+"""
+
+import os
+from pathlib import Path
+from typing import List, Optional, Union
+
+
+def discover_claude_homes(
+    explicit: Optional[Union[str, Path, List[Union[str, Path]]]] = None,
+) -> List[Path]:
+    """Return every Claude config home that has a ``projects/`` history dir.
+
+    Discovery is dynamic (glob), never a hardcoded profile list, so it adapts to
+    whatever profiles happen to exist on the machine.
+
+    Args:
+        explicit: ``None`` (default) auto-discovers all homes. A single path or a
+            list of paths restricts the search to exactly those homes (each must
+            contain a ``projects/`` subdir). An explicit request that matches no
+            home-with-history returns ``[]`` — callers MUST treat that as "your
+            selection matched nothing", never as a cue to auto-discover, or a
+            scope-narrowing flag would silently widen to the widest scope.
+
+    Returns:
+        De-duplicated, existence-checked list of home ``Path`` objects, each with
+        a ``projects/`` subdirectory. Order: ``CLAUDE_CONFIG_DIR`` (if set),
+        ``~/.claude``, then ``~/.claude-profiles/*`` and sibling ``~/.claude-*``
+        sorted by name.
+    """
+    homes: List[Path] = []
+    seen = set()
+
+    def add(candidate: Union[str, Path]) -> None:
+        try:
+            home = Path(candidate).expanduser()
+        except Exception:
+            return
+        if not (home / "projects").is_dir():
+            return
+        try:
+            key = str(home.resolve())
+        except Exception:
+            key = str(home)
+        if key in seen:
+            return
+        seen.add(key)
+        homes.append(home)
+
+    # An explicit override (single path or list) short-circuits discovery.
+    if explicit is not None:
+        candidates = explicit if isinstance(explicit, (list, tuple)) else [explicit]
+        for candidate in candidates:
+            add(candidate)
+        return homes
+
+    # CLAUDE_CONFIG_DIR wins first when set, then the default home.
+    env_home = os.environ.get("CLAUDE_CONFIG_DIR")
+    if env_home:
+        add(env_home)
+    add(Path.home() / ".claude")
+
+    # Per-model profile homes: ~/.claude-profiles/*/
+    profiles_root = Path.home() / ".claude-profiles"
+    if profiles_root.is_dir():
+        for child in sorted(profiles_root.iterdir()):
+            add(child)
+
+    # Sibling homes: ~/.claude-<name>/ that carry their own projects/
+    for child in sorted(Path.home().glob(".claude-*")):
+        if child.name != ".claude-profiles":
+            add(child)
+
+    return homes
+
+
+def home_label(home: Union[str, Path]) -> str:
+    """Short, human-readable provenance label for a home path.
+
+    ``~/.claude`` -> ``main``; ``~/.claude-profiles/kimi`` -> ``kimi``;
+    ``~/.claude-deepseek`` -> ``claude-deepseek``. A sibling ``~/.claude-<name>``
+    home keeps its ``claude-`` prefix so it never collides with a same-named
+    ``~/.claude-profiles/<name>`` profile. Used so output shows which profile a
+    session came from instead of an opaque absolute path.
+    """
+    home = Path(home)
+    if home.name == ".claude":
+        return "main"
+    if home.parent.name == ".claude-profiles":
+        return home.name
+    if home.name.startswith(".claude-"):
+        return home.name[len("."):]
+    return home.name

--- a/daymade-claude-code/claude-code-history-files-finder/scripts/_core/__init__.py
+++ b/daymade-claude-code/claude-code-history-files-finder/scripts/_core/__init__.py
@@ -1,0 +1,16 @@
+"""Shared core for the local conversation-history skills.
+
+Single source of truth for logic that would otherwise be re-implemented (and
+drift) across `claude-code-history-files-finder`, `local-conversation-history`,
+`continue-claude-work`, and `continue-codex-work`. This package is authored here
+and BUNDLED (copied) into each skill's `scripts/_core/` by `sync_core.py`, so
+every skill stays self-contained and installable on its own while sharing one
+implementation.
+
+Modules:
+    homes  — discover every Claude config home (main + per-model profiles).
+"""
+
+from .homes import discover_claude_homes, home_label
+
+__all__ = ["discover_claude_homes", "home_label"]

--- a/daymade-claude-code/claude-code-history-files-finder/scripts/_core/homes.py
+++ b/daymade-claude-code/claude-code-history-files-finder/scripts/_core/homes.py
@@ -1,0 +1,106 @@
+"""Discover every Claude config home that holds conversation history.
+
+Claude Code stores session history under ``<home>/projects/``. The default home
+is ``~/.claude``, but a user who runs third-party models through per-model
+*profiles* — each profile is its own ``CLAUDE_CONFIG_DIR`` — keeps a parallel
+history under ``~/.claude-profiles/<name>/`` and sometimes a sibling
+``~/.claude-<name>/``. A tool that only looks at ``~/.claude`` silently misses
+every conversation held under a profile, which is the #1 reason a real session
+is wrongly reported as "not found".
+
+This module is the single source of truth for that discovery. It is bundled
+(copied) into each conversation-history skill's ``scripts/_core/`` so every skill
+stays self-contained yet shares one implementation — fix the blind spot once,
+not once per skill.
+"""
+
+import os
+from pathlib import Path
+from typing import List, Optional, Union
+
+
+def discover_claude_homes(
+    explicit: Optional[Union[str, Path, List[Union[str, Path]]]] = None,
+) -> List[Path]:
+    """Return every Claude config home that has a ``projects/`` history dir.
+
+    Discovery is dynamic (glob), never a hardcoded profile list, so it adapts to
+    whatever profiles happen to exist on the machine.
+
+    Args:
+        explicit: ``None`` (default) auto-discovers all homes. A single path or a
+            list of paths restricts the search to exactly those homes (each must
+            contain a ``projects/`` subdir). An explicit request that matches no
+            home-with-history returns ``[]`` — callers MUST treat that as "your
+            selection matched nothing", never as a cue to auto-discover, or a
+            scope-narrowing flag would silently widen to the widest scope.
+
+    Returns:
+        De-duplicated, existence-checked list of home ``Path`` objects, each with
+        a ``projects/`` subdirectory. Order: ``CLAUDE_CONFIG_DIR`` (if set),
+        ``~/.claude``, then ``~/.claude-profiles/*`` and sibling ``~/.claude-*``
+        sorted by name.
+    """
+    homes: List[Path] = []
+    seen = set()
+
+    def add(candidate: Union[str, Path]) -> None:
+        try:
+            home = Path(candidate).expanduser()
+        except Exception:
+            return
+        if not (home / "projects").is_dir():
+            return
+        try:
+            key = str(home.resolve())
+        except Exception:
+            key = str(home)
+        if key in seen:
+            return
+        seen.add(key)
+        homes.append(home)
+
+    # An explicit override (single path or list) short-circuits discovery.
+    if explicit is not None:
+        candidates = explicit if isinstance(explicit, (list, tuple)) else [explicit]
+        for candidate in candidates:
+            add(candidate)
+        return homes
+
+    # CLAUDE_CONFIG_DIR wins first when set, then the default home.
+    env_home = os.environ.get("CLAUDE_CONFIG_DIR")
+    if env_home:
+        add(env_home)
+    add(Path.home() / ".claude")
+
+    # Per-model profile homes: ~/.claude-profiles/*/
+    profiles_root = Path.home() / ".claude-profiles"
+    if profiles_root.is_dir():
+        for child in sorted(profiles_root.iterdir()):
+            add(child)
+
+    # Sibling homes: ~/.claude-<name>/ that carry their own projects/
+    for child in sorted(Path.home().glob(".claude-*")):
+        if child.name != ".claude-profiles":
+            add(child)
+
+    return homes
+
+
+def home_label(home: Union[str, Path]) -> str:
+    """Short, human-readable provenance label for a home path.
+
+    ``~/.claude`` -> ``main``; ``~/.claude-profiles/kimi`` -> ``kimi``;
+    ``~/.claude-deepseek`` -> ``claude-deepseek``. A sibling ``~/.claude-<name>``
+    home keeps its ``claude-`` prefix so it never collides with a same-named
+    ``~/.claude-profiles/<name>`` profile. Used so output shows which profile a
+    session came from instead of an opaque absolute path.
+    """
+    home = Path(home)
+    if home.name == ".claude":
+        return "main"
+    if home.parent.name == ".claude-profiles":
+        return home.name
+    if home.name.startswith(".claude-"):
+        return home.name[len("."):]
+    return home.name

--- a/daymade-claude-code/claude-code-history-files-finder/scripts/analyze_sessions.py
+++ b/daymade-claude-code/claude-code-history-files-finder/scripts/analyze_sessions.py
@@ -13,7 +13,6 @@ the #1 way a real conversation is wrongly judged "not found".
 """
 
 import json
-import os
 import sys
 from pathlib import Path
 from typing import Dict, List, Any, Optional
@@ -21,92 +20,12 @@ from datetime import datetime
 from collections import defaultdict
 
 
-def discover_claude_homes(explicit=None) -> List[Path]:
-    """Discover every Claude config home that holds a ``projects/`` history dir.
-
-    Claude Code stores session history under ``<home>/projects/``. The default
-    home is ``~/.claude``, but a user who runs third-party models through
-    per-model *profiles* — each profile is its own ``CLAUDE_CONFIG_DIR`` — keeps
-    a parallel history under ``~/.claude-profiles/<name>/`` and sometimes a
-    sibling ``~/.claude-<name>/``. A tool that only looks at ``~/.claude``
-    silently misses every conversation held under a profile, which is the #1
-    reason a real session is wrongly reported as "not found".
-
-    Discovery is dynamic (glob), never a hardcoded profile list, so it adapts to
-    whatever profiles happen to exist on the machine.
-
-    Args:
-        explicit: Optional single path or list of paths. When given, ONLY those
-            homes are used (each must contain a ``projects/`` subdir) and
-            auto-discovery is skipped — this backs the ``--home`` / ``--main-only``
-            flags.
-
-    Returns:
-        De-duplicated, existence-checked list of home ``Path`` objects, each
-        with a ``projects/`` subdirectory.
-    """
-    homes: List[Path] = []
-    seen = set()
-
-    def add(candidate) -> None:
-        try:
-            home = Path(candidate).expanduser()
-        except Exception:
-            return
-        if not (home / "projects").is_dir():
-            return
-        try:
-            key = str(home.resolve())
-        except Exception:
-            key = str(home)
-        if key in seen:
-            return
-        seen.add(key)
-        homes.append(home)
-
-    # An explicit override (single path or list) short-circuits discovery.
-    if explicit:
-        for candidate in (explicit if isinstance(explicit, (list, tuple)) else [explicit]):
-            add(candidate)
-        return homes
-
-    # CLAUDE_CONFIG_DIR wins first when set, then the default home.
-    env_home = os.environ.get("CLAUDE_CONFIG_DIR")
-    if env_home:
-        add(env_home)
-    add(Path.home() / ".claude")
-
-    # Per-model profile homes: ~/.claude-profiles/*/
-    profiles_root = Path.home() / ".claude-profiles"
-    if profiles_root.is_dir():
-        for child in sorted(profiles_root.iterdir()):
-            add(child)
-
-    # Sibling homes: ~/.claude-<name>/ that carry their own projects/
-    for child in sorted(Path.home().glob(".claude-*")):
-        if child.name != ".claude-profiles":
-            add(child)
-
-    return homes
-
-
-def home_label(home) -> str:
-    """Short, human-readable provenance label for a home path.
-
-    ``~/.claude`` -> ``main``; ``~/.claude-profiles/kimi`` -> ``kimi``;
-    ``~/.claude-deepseek`` -> ``claude-deepseek``. Used so search/list output
-    shows which profile a session came from instead of an opaque absolute path.
-    A sibling ``~/.claude-<name>`` home keeps its ``claude-`` prefix so it never
-    collides with a same-named ``~/.claude-profiles/<name>`` profile.
-    """
-    home = Path(home)
-    if home.name == ".claude":
-        return "main"
-    if home.parent.name == ".claude-profiles":
-        return home.name
-    if home.name.startswith(".claude-"):
-        return home.name[len("."):]
-    return home.name
+# Multi-home discovery lives in the bundled `_core` package — the single source
+# of truth is daymade-claude-code/_conversation_core/, copied here into
+# scripts/_core/ by sync_core.py so this skill stays self-contained. Make this
+# script's own dir importable regardless of how it is invoked, then import.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _core.homes import discover_claude_homes, home_label  # noqa: E402
 
 
 class SessionAnalyzer:

--- a/daymade-claude-code/continue-claude-work/scripts/_core/__init__.py
+++ b/daymade-claude-code/continue-claude-work/scripts/_core/__init__.py
@@ -1,0 +1,16 @@
+"""Shared core for the local conversation-history skills.
+
+Single source of truth for logic that would otherwise be re-implemented (and
+drift) across `claude-code-history-files-finder`, `local-conversation-history`,
+`continue-claude-work`, and `continue-codex-work`. This package is authored here
+and BUNDLED (copied) into each skill's `scripts/_core/` by `sync_core.py`, so
+every skill stays self-contained and installable on its own while sharing one
+implementation.
+
+Modules:
+    homes  — discover every Claude config home (main + per-model profiles).
+"""
+
+from .homes import discover_claude_homes, home_label
+
+__all__ = ["discover_claude_homes", "home_label"]

--- a/daymade-claude-code/continue-claude-work/scripts/_core/homes.py
+++ b/daymade-claude-code/continue-claude-work/scripts/_core/homes.py
@@ -1,0 +1,106 @@
+"""Discover every Claude config home that holds conversation history.
+
+Claude Code stores session history under ``<home>/projects/``. The default home
+is ``~/.claude``, but a user who runs third-party models through per-model
+*profiles* — each profile is its own ``CLAUDE_CONFIG_DIR`` — keeps a parallel
+history under ``~/.claude-profiles/<name>/`` and sometimes a sibling
+``~/.claude-<name>/``. A tool that only looks at ``~/.claude`` silently misses
+every conversation held under a profile, which is the #1 reason a real session
+is wrongly reported as "not found".
+
+This module is the single source of truth for that discovery. It is bundled
+(copied) into each conversation-history skill's ``scripts/_core/`` so every skill
+stays self-contained yet shares one implementation — fix the blind spot once,
+not once per skill.
+"""
+
+import os
+from pathlib import Path
+from typing import List, Optional, Union
+
+
+def discover_claude_homes(
+    explicit: Optional[Union[str, Path, List[Union[str, Path]]]] = None,
+) -> List[Path]:
+    """Return every Claude config home that has a ``projects/`` history dir.
+
+    Discovery is dynamic (glob), never a hardcoded profile list, so it adapts to
+    whatever profiles happen to exist on the machine.
+
+    Args:
+        explicit: ``None`` (default) auto-discovers all homes. A single path or a
+            list of paths restricts the search to exactly those homes (each must
+            contain a ``projects/`` subdir). An explicit request that matches no
+            home-with-history returns ``[]`` — callers MUST treat that as "your
+            selection matched nothing", never as a cue to auto-discover, or a
+            scope-narrowing flag would silently widen to the widest scope.
+
+    Returns:
+        De-duplicated, existence-checked list of home ``Path`` objects, each with
+        a ``projects/`` subdirectory. Order: ``CLAUDE_CONFIG_DIR`` (if set),
+        ``~/.claude``, then ``~/.claude-profiles/*`` and sibling ``~/.claude-*``
+        sorted by name.
+    """
+    homes: List[Path] = []
+    seen = set()
+
+    def add(candidate: Union[str, Path]) -> None:
+        try:
+            home = Path(candidate).expanduser()
+        except Exception:
+            return
+        if not (home / "projects").is_dir():
+            return
+        try:
+            key = str(home.resolve())
+        except Exception:
+            key = str(home)
+        if key in seen:
+            return
+        seen.add(key)
+        homes.append(home)
+
+    # An explicit override (single path or list) short-circuits discovery.
+    if explicit is not None:
+        candidates = explicit if isinstance(explicit, (list, tuple)) else [explicit]
+        for candidate in candidates:
+            add(candidate)
+        return homes
+
+    # CLAUDE_CONFIG_DIR wins first when set, then the default home.
+    env_home = os.environ.get("CLAUDE_CONFIG_DIR")
+    if env_home:
+        add(env_home)
+    add(Path.home() / ".claude")
+
+    # Per-model profile homes: ~/.claude-profiles/*/
+    profiles_root = Path.home() / ".claude-profiles"
+    if profiles_root.is_dir():
+        for child in sorted(profiles_root.iterdir()):
+            add(child)
+
+    # Sibling homes: ~/.claude-<name>/ that carry their own projects/
+    for child in sorted(Path.home().glob(".claude-*")):
+        if child.name != ".claude-profiles":
+            add(child)
+
+    return homes
+
+
+def home_label(home: Union[str, Path]) -> str:
+    """Short, human-readable provenance label for a home path.
+
+    ``~/.claude`` -> ``main``; ``~/.claude-profiles/kimi`` -> ``kimi``;
+    ``~/.claude-deepseek`` -> ``claude-deepseek``. A sibling ``~/.claude-<name>``
+    home keeps its ``claude-`` prefix so it never collides with a same-named
+    ``~/.claude-profiles/<name>`` profile. Used so output shows which profile a
+    session came from instead of an opaque absolute path.
+    """
+    home = Path(home)
+    if home.name == ".claude":
+        return "main"
+    if home.parent.name == ".claude-profiles":
+        return home.name
+    if home.name.startswith(".claude-"):
+        return home.name[len("."):]
+    return home.name

--- a/daymade-claude-code/continue-claude-work/scripts/extract_resume_context.py
+++ b/daymade-claude-code/continue-claude-work/scripts/extract_resume_context.py
@@ -40,7 +40,13 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 CLAUDE_DIR = Path.home() / ".claude"
-PROJECTS_DIR = CLAUDE_DIR / "projects"
+PROJECTS_DIR = CLAUDE_DIR / "projects"  # default home only; discovery below spans all homes
+
+# Multi-home discovery lives in the bundled `_core` package (SSOT:
+# daymade-claude-code/_conversation_core/, copied here by sync_core.py) so a
+# project whose history lives under a per-model profile home is not missed.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _core.homes import discover_claude_homes  # noqa: E402
 
 # Message types that are noise — skip when extracting context
 NOISE_TYPES = {"progress", "queue-operation", "file-history-snapshot", "last-prompt"}
@@ -60,30 +66,67 @@ def normalize_path(project_path: str) -> str:
     return project_path.replace("/", "-")
 
 
+def _newest_session_mtime(project_dir: Path) -> float:
+    """Most-recent session-file mtime under a project dir (0.0 if none)."""
+    return max(
+        (f.stat().st_mtime for f in project_dir.glob("*.jsonl")),
+        default=0.0,
+    )
+
+
 def find_project_dir(project_path: str) -> Optional[Path]:
-    """Find the Claude projects directory for a given project path."""
+    """Find the Claude project dir for a path, searching ALL config homes.
+
+    The default home ~/.claude is only one place history can live; per-model
+    profiles keep theirs under ~/.claude-profiles/<name>/ etc. We look in every
+    home and decide exact-vs-fuzzy GLOBALLY (as the finder skill does): if the
+    exact encoded dir exists in any home, only exact matches count — so a
+    different project that merely shares the basename in another profile is
+    never picked; the substring fallback runs only when NO home has the exact
+    dir. When the same project exists under several homes, the one whose newest
+    session is most recent wins, so "resume my last session" lands on the
+    truly-latest one regardless of which profile it ran under.
+    """
     abs_path = os.path.abspath(project_path)
-
-    # If the path is already inside ~/.claude/projects/, use it directly
-    projects_str = str(PROJECTS_DIR) + "/"
-    if abs_path.startswith(projects_str):
-        candidate = Path(abs_path)
-        if candidate.is_dir():
-            return candidate
-        rel = abs_path[len(projects_str):]
-        top_dir = PROJECTS_DIR / rel.split("/")[0]
-        if top_dir.is_dir():
-            return top_dir
-
     normalized = normalize_path(abs_path)
-    candidate = PROJECTS_DIR / normalized
-    if candidate.is_dir():
-        return candidate
-    # Fallback: search for partial match
-    for d in PROJECTS_DIR.iterdir():
-        if d.is_dir() and normalized in d.name:
-            return d
-    return None
+
+    exact_hits: List[Path] = []
+    fuzzy_hits: List[Path] = []
+    for home in discover_claude_homes():
+        projects_dir = home / "projects"
+        if not projects_dir.is_dir():
+            continue
+
+        # Path already points inside this home's projects/.
+        projects_str = str(projects_dir) + "/"
+        if abs_path.startswith(projects_str):
+            candidate = Path(abs_path)
+            if candidate.is_dir():
+                exact_hits.append(candidate)
+                continue
+            top_dir = projects_dir / abs_path[len(projects_str):].split("/")[0]
+            if top_dir.is_dir():
+                exact_hits.append(top_dir)
+                continue
+
+        # Exact encoded-name match in this home.
+        candidate = projects_dir / normalized
+        if candidate.is_dir():
+            exact_hits.append(candidate)
+            continue
+
+        # Substring fallback — recorded separately and only used when no home
+        # has an exact match, to avoid cross-home basename conflation.
+        for d in projects_dir.iterdir():
+            if d.is_dir() and normalized in d.name:
+                fuzzy_hits.append(d)
+                break
+
+    hits = exact_hits or fuzzy_hits
+    if not hits:
+        return None
+    hits.sort(key=_newest_session_mtime, reverse=True)
+    return hits[0]
 
 
 def load_sessions_index(project_dir: Path) -> List[Dict]:
@@ -718,7 +761,8 @@ def main():
 
     if not project_dir:
         print(f"Error: no Claude session data found for {project_path}", file=sys.stderr)
-        print(f"Looked in: {PROJECTS_DIR / normalize_path(project_path)}", file=sys.stderr)
+        searched = ", ".join(str(h / "projects") for h in discover_claude_homes()) or str(PROJECTS_DIR)
+        print(f"Looked across all config homes: {searched}", file=sys.stderr)
         sys.exit(1)
 
     entries = load_sessions_index(project_dir)

--- a/daymade-claude-code/local-conversation-history/scripts/_core/__init__.py
+++ b/daymade-claude-code/local-conversation-history/scripts/_core/__init__.py
@@ -1,0 +1,16 @@
+"""Shared core for the local conversation-history skills.
+
+Single source of truth for logic that would otherwise be re-implemented (and
+drift) across `claude-code-history-files-finder`, `local-conversation-history`,
+`continue-claude-work`, and `continue-codex-work`. This package is authored here
+and BUNDLED (copied) into each skill's `scripts/_core/` by `sync_core.py`, so
+every skill stays self-contained and installable on its own while sharing one
+implementation.
+
+Modules:
+    homes  — discover every Claude config home (main + per-model profiles).
+"""
+
+from .homes import discover_claude_homes, home_label
+
+__all__ = ["discover_claude_homes", "home_label"]

--- a/daymade-claude-code/local-conversation-history/scripts/_core/homes.py
+++ b/daymade-claude-code/local-conversation-history/scripts/_core/homes.py
@@ -1,0 +1,106 @@
+"""Discover every Claude config home that holds conversation history.
+
+Claude Code stores session history under ``<home>/projects/``. The default home
+is ``~/.claude``, but a user who runs third-party models through per-model
+*profiles* — each profile is its own ``CLAUDE_CONFIG_DIR`` — keeps a parallel
+history under ``~/.claude-profiles/<name>/`` and sometimes a sibling
+``~/.claude-<name>/``. A tool that only looks at ``~/.claude`` silently misses
+every conversation held under a profile, which is the #1 reason a real session
+is wrongly reported as "not found".
+
+This module is the single source of truth for that discovery. It is bundled
+(copied) into each conversation-history skill's ``scripts/_core/`` so every skill
+stays self-contained yet shares one implementation — fix the blind spot once,
+not once per skill.
+"""
+
+import os
+from pathlib import Path
+from typing import List, Optional, Union
+
+
+def discover_claude_homes(
+    explicit: Optional[Union[str, Path, List[Union[str, Path]]]] = None,
+) -> List[Path]:
+    """Return every Claude config home that has a ``projects/`` history dir.
+
+    Discovery is dynamic (glob), never a hardcoded profile list, so it adapts to
+    whatever profiles happen to exist on the machine.
+
+    Args:
+        explicit: ``None`` (default) auto-discovers all homes. A single path or a
+            list of paths restricts the search to exactly those homes (each must
+            contain a ``projects/`` subdir). An explicit request that matches no
+            home-with-history returns ``[]`` — callers MUST treat that as "your
+            selection matched nothing", never as a cue to auto-discover, or a
+            scope-narrowing flag would silently widen to the widest scope.
+
+    Returns:
+        De-duplicated, existence-checked list of home ``Path`` objects, each with
+        a ``projects/`` subdirectory. Order: ``CLAUDE_CONFIG_DIR`` (if set),
+        ``~/.claude``, then ``~/.claude-profiles/*`` and sibling ``~/.claude-*``
+        sorted by name.
+    """
+    homes: List[Path] = []
+    seen = set()
+
+    def add(candidate: Union[str, Path]) -> None:
+        try:
+            home = Path(candidate).expanduser()
+        except Exception:
+            return
+        if not (home / "projects").is_dir():
+            return
+        try:
+            key = str(home.resolve())
+        except Exception:
+            key = str(home)
+        if key in seen:
+            return
+        seen.add(key)
+        homes.append(home)
+
+    # An explicit override (single path or list) short-circuits discovery.
+    if explicit is not None:
+        candidates = explicit if isinstance(explicit, (list, tuple)) else [explicit]
+        for candidate in candidates:
+            add(candidate)
+        return homes
+
+    # CLAUDE_CONFIG_DIR wins first when set, then the default home.
+    env_home = os.environ.get("CLAUDE_CONFIG_DIR")
+    if env_home:
+        add(env_home)
+    add(Path.home() / ".claude")
+
+    # Per-model profile homes: ~/.claude-profiles/*/
+    profiles_root = Path.home() / ".claude-profiles"
+    if profiles_root.is_dir():
+        for child in sorted(profiles_root.iterdir()):
+            add(child)
+
+    # Sibling homes: ~/.claude-<name>/ that carry their own projects/
+    for child in sorted(Path.home().glob(".claude-*")):
+        if child.name != ".claude-profiles":
+            add(child)
+
+    return homes
+
+
+def home_label(home: Union[str, Path]) -> str:
+    """Short, human-readable provenance label for a home path.
+
+    ``~/.claude`` -> ``main``; ``~/.claude-profiles/kimi`` -> ``kimi``;
+    ``~/.claude-deepseek`` -> ``claude-deepseek``. A sibling ``~/.claude-<name>``
+    home keeps its ``claude-`` prefix so it never collides with a same-named
+    ``~/.claude-profiles/<name>`` profile. Used so output shows which profile a
+    session came from instead of an opaque absolute path.
+    """
+    home = Path(home)
+    if home.name == ".claude":
+        return "main"
+    if home.parent.name == ".claude-profiles":
+        return home.name
+    if home.name.startswith(".claude-"):
+        return home.name[len("."):]
+    return home.name

--- a/daymade-claude-code/local-conversation-history/scripts/list_local_history.py
+++ b/daymade-claude-code/local-conversation-history/scripts/list_local_history.py
@@ -15,6 +15,13 @@ from pathlib import Path
 from typing import Any, Iterable, Iterator, Optional
 from urllib.parse import quote
 
+# Multi-home discovery lives in the bundled `_core` package — the single source
+# of truth is daymade-claude-code/_conversation_core/, copied here into
+# scripts/_core/ by sync_core.py. Make this script's own dir importable
+# regardless of how it is invoked, then import.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _core.homes import discover_claude_homes, home_label  # noqa: E402
+
 
 MAX_PREFIX_BYTES = 2 * 1024 * 1024
 MAX_PREFIX_LINES = 5000
@@ -973,6 +980,39 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def merge_claude_results(results: list[ProviderResult]) -> ProviderResult:
+    """Merge per-home Claude results into one, de-duplicating by session id.
+
+    A conversation shared across profile homes (the profile dirs link back to
+    one physical file) appears once; the copy with the newest ``updated_at``
+    wins. Exclusion counts and warnings are summed/combined, and ``home`` becomes
+    a comma-joined list of the profile labels the sessions came from.
+    """
+    real = [r for r in results if r is not None]
+    if not real:
+        return ProviderResult(provider="claude", backend="session-jsonl", home="")
+    if len(real) == 1:
+        return real[0]
+    by_id: dict[str, Conversation] = {}
+    for r in real:
+        for conv in r.conversations:
+            existing = by_id.get(conv.session_id)
+            if existing is None or (conv.updated_at or 0) > (existing.updated_at or 0):
+                by_id[conv.session_id] = conv
+    return ProviderResult(
+        provider=real[0].provider,
+        backend=real[0].backend,
+        home=", ".join(home_label(r.home) for r in real if r.home),
+        conversations=sorted(
+            by_id.values(), key=lambda c: (c.updated_at or 0), reverse=True
+        ),
+        excluded_subagents=sum(r.excluded_subagents for r in real),
+        excluded_archived=sum(r.excluded_archived for r in real),
+        excluded_automated=sum(r.excluded_automated for r in real),
+        warnings=[w for r in real for w in r.warnings],
+    )
+
+
 def main(argv: Optional[list[str]] = None) -> int:
     configure_utf8_streams()
     parser = build_parser()
@@ -996,7 +1036,17 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     results: list[ProviderResult] = []
     if args.source in {"all", "claude"}:
-        results.append(collect_claude(args, claude_home))
+        # An explicit --claude-home / CLAUDE_CONFIG_DIR pins a single home (the
+        # test fixtures rely on this). With neither set, search every config
+        # home so a conversation held under a per-model profile is not missed,
+        # then merge the per-home results into one de-duplicated list.
+        if args.claude_home or os.environ.get("CLAUDE_CONFIG_DIR"):
+            claude_homes = [claude_home]
+        else:
+            claude_homes = discover_claude_homes() or [claude_home]
+        results.append(
+            merge_claude_results([collect_claude(args, h) for h in claude_homes])
+        )
     if args.source in {"all", "codex"}:
         results.append(collect_codex(args, codex_home))
 

--- a/daymade-claude-code/sync_core.py
+++ b/daymade-claude-code/sync_core.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Bundle the shared `_conversation_core` package into each skill that uses it.
+
+Skills are distributed as self-contained bundles: `package_skill` archives only
+the skill's own directory, and installed skills live in isolated dirs. So a skill
+cannot import a sibling skill's code at runtime. Instead the shared core is
+authored ONCE in `daymade-claude-code/_conversation_core/` (the SSOT) and COPIED
+into each consuming skill's `scripts/_core/`. Each skill then does
+`from _core.homes import ...` against its own bundled copy and stays installable
+on its own.
+
+This is the "bundle, don't depend" rule applied to code. The cost is a sync
+discipline: after editing the SSOT you must re-run `sync`, and `check` (wired
+into validation/CI) fails the build if any bundled copy has drifted.
+
+Usage:
+    python sync_core.py sync     # copy SSOT -> every target skill's scripts/_core/
+    python sync_core.py check    # verify every bundled copy matches the SSOT (exit 1 on drift)
+"""
+
+import hashlib
+import shutil
+import sys
+from pathlib import Path
+from typing import Dict
+
+# Skills that bundle the shared core. Add a skill here when it starts importing
+# `_core` (e.g. continue-codex-work in a later phase).
+TARGET_SKILLS = [
+    "claude-code-history-files-finder",
+    "local-conversation-history",
+    "continue-claude-work",
+]
+
+HERE = Path(__file__).resolve().parent
+SSOT = HERE / "_conversation_core"
+BUNDLE_DIRNAME = "_core"  # skills import it as `_core` (scripts/ is on sys.path)
+
+
+def _core_files(root: Path) -> Dict[str, str]:
+    """Map relative path -> sha256 for every .py file under a core dir."""
+    out: Dict[str, str] = {}
+    if not root.is_dir():
+        return out
+    for path in sorted(root.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        rel = str(path.relative_to(root))
+        out[rel] = hashlib.sha256(path.read_bytes()).hexdigest()
+    return out
+
+
+def _bundle_dir(skill: str) -> Path:
+    return HERE / skill / "scripts" / BUNDLE_DIRNAME
+
+
+def sync() -> int:
+    ssot_files = _core_files(SSOT)
+    if not ssot_files:
+        print(f"error: no .py files found in SSOT {SSOT}", file=sys.stderr)
+        return 1
+    for skill in TARGET_SKILLS:
+        dest = _bundle_dir(skill)
+        if dest.exists():
+            shutil.rmtree(dest)
+        shutil.copytree(
+            SSOT, dest, ignore=shutil.ignore_patterns("__pycache__", "*.pyc")
+        )
+        print(f"synced {len(ssot_files)} file(s) -> {dest.relative_to(HERE)}")
+    return 0
+
+
+def check() -> int:
+    ssot_files = _core_files(SSOT)
+    if not ssot_files:
+        print(f"error: no .py files found in SSOT {SSOT}", file=sys.stderr)
+        return 1
+    drift = False
+    for skill in TARGET_SKILLS:
+        dest = _bundle_dir(skill)
+        bundled = _core_files(dest)
+        if bundled != ssot_files:
+            drift = True
+            missing = set(ssot_files) - set(bundled)
+            extra = set(bundled) - set(ssot_files)
+            changed = {
+                f for f in ssot_files.keys() & bundled.keys()
+                if ssot_files[f] != bundled[f]
+            }
+            print(f"DRIFT in {skill}/scripts/{BUNDLE_DIRNAME}:", file=sys.stderr)
+            for f in sorted(missing):
+                print(f"  missing: {f}", file=sys.stderr)
+            for f in sorted(extra):
+                print(f"  extra:   {f}", file=sys.stderr)
+            for f in sorted(changed):
+                print(f"  changed: {f}", file=sys.stderr)
+    if drift:
+        print("\nRun `python sync_core.py sync` to re-bundle.", file=sys.stderr)
+        return 1
+    print(f"OK: all {len(TARGET_SKILLS)} skill(s) in sync with SSOT.")
+    return 0
+
+
+def main() -> int:
+    if len(sys.argv) != 2 or sys.argv[1] not in ("sync", "check"):
+        print(__doc__)
+        return 2
+    return sync() if sys.argv[1] == "sync" else check()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What & why

The three local-history skills each re-implemented Claude config-home discovery, and all three looked at `~/.claude` only — silently missing any conversation held under a **per-model profile home** (`~/.claude-profiles/*`, sibling `~/.claude-*`). That is a false negative that made real sessions look "not found".

This is **P0** of consolidating the skills' shared logic behind one core (approved plan: shared `_conversation_core` + thin per-audience entry points). P0 establishes the architecture and, as a byproduct, fixes the multi-profile blind spot in **all three** skills at once — one implementation instead of three drifting copies.

## New shared core (single source of truth)

- **`_conversation_core/homes.py`** — `discover_claude_homes()` + `home_label()`: dynamic (glob) multi-home discovery. `None` vs `[]` distinguishes auto-discover from an explicit empty selection, so a scope-narrowing flag can never widen to all homes.
- **`sync_core.py`** — bundles `_core` into each skill's `scripts/_core/`. Skills are distributed self-contained (`package_skill` archives only the skill dir; installed skills are isolated), so a skill cannot import a sibling at runtime — this is "bundle, don't depend" applied to code. `sync` copies the SSOT into each skill; `check` fails the build on drift.

## Wired all three skills to the bundled `_core.homes`

Each imports from its own `scripts/_core/`, staying self-contained and installable on its own:

- **claude-code-history-files-finder** — drops its inline copy.
- **continue-claude-work** — `find_project_dir` now searches every home (exact-match-first *globally*, newest-session wins) instead of `~/.claude` only.
- **local-conversation-history** — the default (no `--claude-home`) now aggregates every home and de-duplicates by session id; an explicit `--claude-home` / `CLAUDE_CONFIG_DIR` still pins a single home, **preserving the existing test fixtures**.

## Verification

- Each skill now surfaces a session that lived **only** in a profile home and was previously invisible.
- `local-conversation-history`'s **8 tests stay green**.
- `sync_core.py check` passes (bundled copies == SSOT).
- Finder's exact-match-first regression tests (no cross-home basename conflation; scope flags fail loudly) still hold.
- `quick_validate` + `security_scan` pass on all three skills.

## Roadmap (later, separate PRs)

- **P1** extract the rest of the shared core (provider abstraction + parsing) from `list_local_history`.
- **P2** thin each skill's script over the fuller core; consolidate the four overlapping references.
- **P3** add `continue-codex-work` (reuses the core's Codex parsing).
- **P4** crisp per-skill trigger differentiation + list/search → continue handoffs.

## Notes for the reviewer

- No `daymade-claude-code` plugin version bump here (kept scoped); recommend bumping before/at merge so installed copies refresh.
- The repo does not yet gitignore `__pycache__`, so the bundled `_core` dirs will regenerate it locally — worth a `.gitignore` in a later pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A3GUWAWEdyVo1V9Bsvn9oB
