### PR TITLE
docs(transcript-fixer): harden name-source reading + fix legacy-reference debt

### DIFF
--- a/daymade-audio/transcript-fixer/SKILL.md
+++ b/daymade-audio/transcript-fixer/SKILL.md
@@ -217,17 +217,17 @@ When running inside Claude Code, use Claude's own language understanding for Pha
    - **Needs verification** — a proper noun you can't confirm from context: a person / company / ticker / product / place name (a misheard drug name in a medical interview, a researcher's surname in a podcast, a ticker on an earnings call), or any term you can't point to a specific source for — even one you think you recognize ("I'm pretty sure" is exactly how wrong names slip in). **Resolve it through a local-first search ladder before asking the user.** For project / personal entities the authoritative spelling almost always already lives on this machine, and WebSearch is near-useless on internal names — it returns wrong same-name people, or nothing — and worse, a fluent wrong guess becomes a confident fix that's hard to catch later. Search in this order:
 
 
-	      0. **People roster** — `people.md` (or wherever `people_roster_path` in
-	         `~/.transcript-fixer/config.json` points). This is your curated SSOT
-	         of long-term recurring people with their ASR variants annotated under
-	         `- **ASR 变体**:`. A garbled name that already maps to a canonical
-	         person here — e.g. `Hollie`→`Holly Yang`, `丛老师`→`聪聪` — is a
-	         Confident fix: apply immediately. **This one step replaces asking the
-	         user for every name they've already documented.** Skip only for
-	         transcripts whose speakers are confirmed NOT in the roster.
+      0. **People roster** — `people.md` (or wherever `people_roster_path` in
+         `~/.transcript-fixer/config.json` points). This is your curated SSOT
+         of long-term recurring people with their ASR variants annotated under
+         `- **ASR 变体**:`. A garbled name that already maps to a canonical
+         person here — e.g. `Hollie`→`Holly Yang`, `丛老师`→`聪聪` — is a
+         Confident fix: apply immediately. **This one step replaces asking the
+         user for every name they've already documented.** Skip only for
+         transcripts whose speakers are confirmed NOT in the roster.
       1. **All domains of `corrections.db`, not just the current `--domain`.** The same entity shatters into different ASR variants across projects, and every prior fix already collapsed them to the canonical name — so the answer is often sitting in another domain you didn't pass to `--stage 1`. Checking only the current domain and giving up is the recurring failure mode.
          `sqlite3 ~/.transcript-fixer/corrections.db "SELECT from_text, to_text, domain FROM active_corrections WHERE to_text LIKE '%<fragment>%' OR from_text LIKE '%<fragment>%';"`
-      2. **Project delivery docs** — cost reports, review sheets, deliverables, PKM notes for that project. These are human-written correct spellings, the strongest possible source. `grep -rl "<fragment>" <project-dir>` then read the hits. (The domain context file from step 3 usually names the project's alias ledger explicitly — start there.)
+      2. **Project delivery docs & the alias ledger** — cost reports, review sheets, deliverables, PKM notes for that project. These are human-written correct spellings, the strongest possible source. `grep -rl "<fragment>" <project-dir>` then read the hits. (The domain context file from step 3 usually names the project's alias ledger explicitly — start there.) **Read every name table the ledger holds, not just the one that looks like "the speaker list."** A project's people are almost always split across role-based tables — internal speakers, external collaborators, client-side, vendor/dealer-side, attendees — and the person you're chasing often lives in a sibling table you didn't open. If a name you end up confirming wasn't reachable from the context file's name-source manifest, that manifest is incomplete: add the missing table to it so the next run can't miss it. (See `domain_context_guide.md` Rule 6 for the failure case this prevents.)
       3. **Memory** (`~/.claude/.../memory/`) — project relationship maps and person profiles often record canonical names explicitly.
       4. **WebSearch** — only for genuinely public entities (a public-company ticker, a known researcher, a drug name). Skip for anything project-internal.
 

--- a/daymade-audio/transcript-fixer/references/architecture.md
+++ b/daymade-audio/transcript-fixer/references/architecture.md
@@ -148,11 +148,6 @@ All business-logic modules are kept small and single-purpose. The authoritative 
 │   Data Access Layer (SQLite-based)      │
 │                                         │
 │  ┌──────────────────────────────────┐  │
-│  │ CorrectionManager (Facade)       │  │
-│  │ - Backward-compatible API        │  │
-│  └──────────────┬───────────────────┘  │
-│                 │                       │
-│  ┌──────────────▼───────────────────┐  │
 │  │ CorrectionService                │  │
 │  │ - Business logic                 │  │
 │  │ - Validation                     │  │
@@ -477,7 +472,7 @@ class ValidationRules:
     max_text_length: int = 1000
     min_text_length: int = 1
     max_domain_length: int = 50
-    allowed_domain_pattern: str = r'^[a-zA-Z0-9_-]+$'
+    allowed_domain_pattern: str = r'^[\w一-鿿぀-ゟ゠-ヿ가-힯-]+$'  # Unicode letters incl. CJK/kana/hangul
 ```
 
 ### CLI Integration (commands.py)
@@ -596,8 +591,8 @@ confidence = (
 **Key Methods**:
 ```python
 analyze_and_suggest()     # Main analysis pipeline
-approve_suggestion()      # Move to corrections.json
-reject_suggestion()       # Move to rejected.json
+approve_suggestion()      # Insert into the corrections table (SQLite)
+reject_suggestion()       # Mark rejected (pending list lives in learned/pending_review.json)
 list_pending()           # Get all suggestions
 ```
 
@@ -780,7 +775,7 @@ class SpellCheckProcessor:
 
 ### Adding New Export Formats
 
-1. Add method to `CorrectionManager`
+1. Add method to `CorrectionService`
 2. Support new file format
 3. Add CLI command
 

--- a/daymade-audio/transcript-fixer/references/best_practices.md
+++ b/daymade-audio/transcript-fixer/references/best_practices.md
@@ -68,17 +68,16 @@ uv run scripts/fix_transcription.py --review-learned
 
 ### Use Domain Separation
 
-**Prevent conflicts**: Same phonetic error might have different corrections in different domains.
+**Prevent conflicts**: a fix that's right for *your* project can be wrong in someone else's transcript, so isolate it under a project domain instead of the global `general`. A rule added with `--domain <project>` only fires when you pass that domain.
 
-**Example**:
-- Finance domain: "股价" (stock price) is correct
-- General domain: "股价" → "框架" (framework) ASR error
+**Example** (person name): the ASR keeps garbling a teammate's name as `<garbled-name>` → `<Name>`. That's right in your project — but `<garbled-name>` might be a real, differently-spelled person elsewhere, so it must NOT go in `general`:
 
 ```bash
-# Domain-specific corrections
-uv run scripts/fix_transcription.py --add "股价" "框架" --domain general
-# No correction needed in finance domain - "股价" is correct there
+# Isolated — only fires when you pass --domain <project>
+uv run scripts/fix_transcription.py --add "<garbled-name>" "<Name>" --domain <project>
 ```
+
+Never put a common real word into `general` — that silently corrupts every future transcript where the word is correct. Common-word / context-dependent homophones belong in the domain **context file** (with a disambiguating cue), not the dictionary — see `false_positive_guide.md` + `domain_context_guide.md`.
 
 **Available domains**:
 - `general` (default) - General-purpose corrections
@@ -86,7 +85,7 @@ uv run scripts/fix_transcription.py --add "股价" "框架" --domain general
 - `finance` - Financial terminology
 - `medical` - Medical terminology
 
-**Custom domains**: Any string matching `^[a-z0-9_]+$` (lowercase, numbers, underscore).
+**Custom domains**: Any string matching `^[\w一-鿿぀-ゟ゠-ヿ가-힯-]+$` — Unicode letters (including CJK / kana / hangul), digits, underscore, hyphen. So a Chinese/Japanese/Korean project slug is a valid domain name (e.g. `--domain 火星加速器`).
 
 ### Domain Selection Strategy
 

--- a/daymade-audio/transcript-fixer/references/database_schema.md
+++ b/daymade-audio/transcript-fixer/references/database_schema.md
@@ -106,12 +106,7 @@ Key-value configuration store.
 | description | TEXT | What this config does |
 | updated_at | TIMESTAMP | Last update |
 
-**Default configs**:
-- `schema_version`: '2.0'
-- `api_model`: 'GLM-5.2'
-- `learning_frequency_threshold`: 3
-- `learning_confidence_threshold`: 0.8
-- `history_retention_days`: 90
+**Default configs**: the authoritative default set (12 keys) lives in `scripts/core/defaults.py` (`SYSTEM_CONFIG_DEFAULTS`) — don't hand-copy it here, it drifts. Common keys include `schema_version` ('2.0'), `api_model`, `learning_frequency_threshold`, `learning_confidence_threshold`, `history_retention_days`. To see the live values: `SELECT key, value FROM system_config;`
 
 ### audit_log
 
@@ -128,6 +123,19 @@ Comprehensive operations trail.
 | details | TEXT | JSON details |
 | success | BOOLEAN | Success flag |
 | error_message | TEXT | Error if failed |
+
+### suggestion_examples
+
+Per-occurrence context for a learned suggestion (one suggestion → many examples). FK to `learned_suggestions(id)` ON DELETE CASCADE.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | INTEGER | Primary key |
+| suggestion_id | INTEGER | FK → learned_suggestions.id |
+| filename | TEXT | Source transcript filename |
+| line_number | INTEGER | Where it occurred |
+| context | TEXT | Surrounding text |
+| occurred_at | TIMESTAMP | When observed |
 
 ## Views
 

--- a/daymade-audio/transcript-fixer/references/domain_context_guide.md
+++ b/daymade-audio/transcript-fixer/references/domain_context_guide.md
@@ -52,7 +52,13 @@ For each trap:
 - Order by frequency; prune entries that stop recurring.
 
 ## Authoritative name sources (pointers, not copies)
-- Where the project's alias ledger lives (path + section)
+This is a **manifest to be read in full**, not a single hint. A project's people
+are almost always split across several tables by role — internal speakers,
+external collaborators, client-side, vendor/dealer-side, workshop attendees — so
+**enumerate every name-bearing table and read each one completely**. Pointing at
+only the table that looks like "the speaker list" is exactly how a real,
+documented person gets missed (Rule 6).
+- The project's alias ledger — **list every person table it holds** (path + each section), not just the main one
 - Which people-roster sections apply
 - Existing dictionary domains to query first
 ```
@@ -79,8 +85,10 @@ word, so it's a deterministic fix and went to the dictionary via
 `--add "云条" "语音条" --domain clip-production` instead. Only entries whose
 "from" side is real text in some other reading stay in this file.)
 
-## Authoritative name sources
-- Alias ledger: <project-repo>/context.md §speaker-alias-table
+## Authoritative name sources  (read ALL of these — names split by role)
+- Alias ledger: <project-repo>/context.md — 3 person tables, read every one:
+  ① top team directory (internal staff) ② §speaker-alias-table (internal speakers + ASR variants)
+  ③ §client-and-vendor-side (client + dealer-side staff — e.g. the editor whose name ASR keeps garbling)
 - People roster: ~/.transcript-fixer/people.md (team section)
 - Dictionary: corrections.db domain `clip-production` (query before adding)
 ```
@@ -104,3 +112,14 @@ word, so it's a deterministic fix and went to the dictionary via
 5. **Private stays private.** These files may name real people and projects.
    They live in user space precisely so they never ship with the skill; don't
    paste their contents into public repos or shared docs.
+6. **The name-source list is a complete manifest, and it self-corrects.** Names
+   scatter across role-based tables (internal / external / client / vendor /
+   attendees), so the pointer must enumerate *every* table and the reader must
+   read *all* of them — stopping at the first "speaker list"–looking table is the
+   recurring miss. Make the enforcement structural, not willpower: if you ever
+   confirm a project person whose name is NOT reachable from any manifest entry,
+   the manifest is incomplete — add the missing table to it before finishing, so
+   the next run cannot repeat the miss. (2026-07-15: a context file pointed only
+   at one `§speaker-alias-table`; the agent faithfully read that single table and
+   flagged a real editor — documented all along in the sibling dealer-side table
+   — as "unverifiable".)

--- a/daymade-audio/transcript-fixer/references/file_formats.md
+++ b/daymade-audio/transcript-fixer/references/file_formats.md
@@ -32,6 +32,8 @@ This document describes the SQLite database format used by transcript-fixer v2.0
 
 ## Database Schema
 
+> **The full, authoritative table schema is `database_schema.md`** (8 tables + views) — read that before writing queries. This section summarizes the same tables for storage-format context; if the two ever disagree, `database_schema.md` and `scripts/core/schema.sql` win. Default config values live in `scripts/core/defaults.py`, not copied here.
+
 ### Core Tables
 
 #### corrections

--- a/daymade-audio/transcript-fixer/references/iteration_workflow.md
+++ b/daymade-audio/transcript-fixer/references/iteration_workflow.md
@@ -75,21 +75,22 @@ Choose the right domain for corrections:
 
 ```bash
 # Domain-specific correction
-uv run scripts/fix_transcription.py --add "股价系统" "框架系统" --domain embodied_ai
+uv run scripts/fix_transcription.py --add "巨升智能" "具身智能" --domain embodied_ai
 uv run scripts/fix_transcription.py --add "片片总" "翩翩总" --domain 火星加速器
 ```
 
 ## Common ASR Error Patterns
 
-Build your dictionary with these common patterns:
+Safe dictionary candidates are **non-words and garbled fragments** — a rule fires the same way every time with zero false-positive risk. Common-word homophones are NOT safe dictionary rules:
 
-| Type | Examples |
-|------|----------|
-| **Homophones** | 赢→营, 减→剪, 被看→被砍, 营业→营的 |
-| **Names** | 片片→翩翩, 亮亮→亮哥 |
-| **Technical** | 巨升智能→具身智能, 股价→框架 |
-| **English** | log→vlog |
-| **Broken words** | 姐弟→结业, 单反→单访 |
+| Type | Examples | Home |
+|------|----------|------|
+| **Broken / non-words** | 姐弟→结业, 单反→单访, 巨升智能→具身智能 | Dictionary (`--add`) — safe |
+| **English garbles** | log→vlog, cloucode→Claude Code | Dictionary — safe |
+| **Person / project names** | 片片→翩翩, 亮亮→亮哥 | Project `--domain` (isolated), not `general` |
+| **Common-word homophones** | 减→剪, 赢→营, 营业→营的 | ❌ NOT the dictionary — the "from" side is a real word (减少/输赢/营业), so a blanket rule corrupts other sentences. Route to the domain **context file** with its disambiguating cue (`domain_context_guide.md`). |
+
+Rule of thumb: if the "from" side is real text in some other reading, it does not belong in the dictionary. (Mirrors SKILL.md's decision matrix + `false_positive_guide.md`.)
 
 ## When GLM API Fails
 

--- a/daymade-audio/transcript-fixer/references/quick_reference.md
+++ b/daymade-audio/transcript-fixer/references/quick_reference.md
@@ -73,13 +73,14 @@ service = CorrectionService(repository)
 
 # Add corrections
 corrections = [
-    ("巨升智能", "具身智能", "embodied_ai"),
+    ("巨升智能", "具身智能", "embodied_ai"),   # non-word → term: safe
     ("巨升", "具身", "embodied_ai"),
-    ("奇迹创坛", "奇绩创坛", "general"),
-    ("火星营", "火星营", "general"),
-    ("矩阵公司", "初创公司", "general"),
-    ("股价", "框架", "general"),
-    ("三观", "三关", "general"),
+    ("奇迹创坛", "奇绩创坛", "general"),        # garbled proper noun → correct name: safe
+    # NOTE: a common real word that's only wrong in one context (an everyday
+    # homophone, a word that clashes with a ticker/name) does NOT belong here —
+    # a "general" rule on it corrupts every transcript where the word is correct.
+    # Route those to the domain context file (domain_context_guide.md), and
+    # person/project names to a project --domain, never "general".
 ]
 
 for from_text, to_text, domain in corrections:

--- a/daymade-audio/transcript-fixer/references/script_parameters.md
+++ b/daymade-audio/transcript-fixer/references/script_parameters.md
@@ -83,9 +83,8 @@ uv run scripts/fix_transcription.py --input meeting.md --stage 1 --output ./meet
 ### Exit Codes
 
 - `0` - Success
-- `1` - Missing required parameters or file not found
-- `2` - API key not configured (Stage 2 or 3 only)
-- `3` - API request failed
+- `1` - Missing required parameters, file not found, or API key not configured (Stage 2/3)
+- API request failures do **not** get a dedicated exit code — the pipeline keeps the original text and prints a warning (see "API Fallback" in SKILL.md)
 
 ## fix_transcript_timestamps.py
 
@@ -226,7 +225,8 @@ Generates four files in the output directory:
 Test dictionary updates before running expensive AI corrections:
 
 ```bash
-# 1. Update CORRECTIONS_DICT in scripts/fix_transcription.py
+# 1. Add the rule (dictionary lives in SQLite, not a source variable):
+#    uv run scripts/fix_transcription.py --add "错误词" "正确词" --domain <domain>
 # 2. Run Stage 1 only
 uv run scripts/fix_transcription.py --input meeting.md --stage 1
 
@@ -255,12 +255,12 @@ Generate and open word-level diff immediately after correction:
 # Run corrections
 uv run scripts/fix_transcription.py --input meeting.md --stage 3
 
-# Generate and open diff
-uv run scripts/generate_word_diff.py meeting.md meeting_stage2.html
+# Generate and open diff (args: original, corrected, output.html)
+uv run scripts/generate_word_diff.py meeting.md meeting_stage2.md meeting_diff.html
 
-open meeting_stage2.diff.html  # macOS
-# xdg-open meeting_stage2.diff.html  # Linux
-# start meeting_stage2.diff.html  # Windows
+open meeting_diff.html  # macOS
+# xdg-open meeting_diff.html  # Linux
+# start meeting_diff.html  # Windows
 ```
 
 ## Environment Variables

--- a/daymade-audio/transcript-fixer/references/team_collaboration.md
+++ b/daymade-audio/transcript-fixer/references/team_collaboration.md
@@ -45,10 +45,10 @@ Share your corrections with team members:
 
 ```bash
 # Export specific domain
-python scripts/fix_transcription.py --export team_corrections.json --domain embodied_ai
+uv run scripts/fix_transcription.py --export team_corrections.json --domain embodied_ai
 
 # Export general corrections
-python scripts/fix_transcription.py --export team_corrections.json
+uv run scripts/fix_transcription.py --export team_corrections.json
 ```
 
 **Output**: Creates a standalone JSON file with your corrections.
@@ -59,10 +59,10 @@ Two modes: **merge** (combine) or **replace** (overwrite):
 
 ```bash
 # Merge (recommended) - combines with existing corrections
-python scripts/fix_transcription.py --import team_corrections.json --merge
+uv run scripts/fix_transcription.py --import team_corrections.json --merge
 
 # Replace - overwrites existing corrections (dangerous!)
-python scripts/fix_transcription.py --import team_corrections.json
+uv run scripts/fix_transcription.py --import team_corrections.json
 ```
 
 **Merge behavior**:
@@ -75,12 +75,12 @@ python scripts/fix_transcription.py --import team_corrections.json
 **Person A (Domain Expert)**:
 ```bash
 # Build correction dictionary
-python fix_transcription.py --add "巨升" "具身" --domain embodied_ai
-python fix_transcription.py --add "奇迹创坛" "奇绩创坛" --domain embodied_ai
+uv run scripts/fix_transcription.py --add "巨升" "具身" --domain embodied_ai
+uv run scripts/fix_transcription.py --add "奇迹创坛" "奇绩创坛" --domain embodied_ai
 # ... add 50 more corrections ...
 
 # Export for team
-python fix_transcription.py --export ai_corrections.json --domain embodied_ai
+uv run scripts/fix_transcription.py --export ai_corrections.json --domain embodied_ai
 # Send ai_corrections.json to team via Slack/email
 ```
 
@@ -88,89 +88,57 @@ python fix_transcription.py --export ai_corrections.json --domain embodied_ai
 ```bash
 # Receive ai_corrections.json
 # Import and merge with existing corrections
-python fix_transcription.py --import ai_corrections.json --merge
+uv run scripts/fix_transcription.py --import ai_corrections.json --merge
 
 # Now Person B has all 50+ corrections!
 ```
 
 ## Git-Based Collaboration
 
-For teams using Git, version control the entire correction database.
+The local store is a SQLite database (`~/.transcript-fixer/corrections.db`) — **never commit the `.db`** (it is gitignored for a reason; see `best_practices.md` / `file_formats.md`). To version-control corrections in git, commit the **JSON exports**, not the database.
 
 ### Initial Setup
 
-**Person A (First User)**:
+**Person A (first user)** — export the dictionary and commit the JSON to a shared repo (a normal repo, **not** `~/.transcript-fixer`):
 ```bash
-cd ~/.transcript-fixer
-git init
-git add corrections.json context_rules.json config.json
-git add domains/
-git commit -m "Initial correction database"
+uv run scripts/fix_transcription.py --export team_corrections.json
 
-# Push to shared repo
+mkdir ~/transcript-corrections && cd ~/transcript-corrections
+mv ~/path/to/team_corrections.json .
+git init && git add team_corrections.json
+git commit -m "Initial correction export"
 git remote add origin git@github.com:org/transcript-corrections.git
 git push -u origin main
 ```
 
-### Team Members Clone
+### Team Members Clone + Import
 
-**Person B, C, D (Team Members)**:
 ```bash
-# Clone shared corrections
-git clone git@github.com:org/transcript-corrections.git ~/.transcript-fixer
-
-# Now everyone has the same corrections!
+git clone git@github.com:org/transcript-corrections.git ~/transcript-corrections
+uv run scripts/fix_transcription.py --import ~/transcript-corrections/team_corrections.json --merge
+# --merge combines with each person's existing local corrections;
+# --import without --merge overwrites (dangerous).
 ```
 
 ### Ongoing Sync
 
-**Daily workflow**:
 ```bash
-# Morning: Pull team updates
-cd ~/.transcript-fixer
-git pull origin main
+# Morning: pull the shared export, import into your local DB
+cd ~/transcript-corrections && git pull origin main
+uv run scripts/fix_transcription.py --import team_corrections.json --merge
 
-# During day: Add corrections
-python fix_transcription.py --add "错误" "正确"
+# During the day: add corrections to your local DB
+uv run scripts/fix_transcription.py --add "错误" "正确" --domain <domain>
 
-# Evening: Push your additions
-cd ~/.transcript-fixer
-git add corrections.json
-git commit -m "Added 5 new embodied AI corrections"
-git push origin main
+# Evening: re-export and push the updated JSON
+uv run scripts/fix_transcription.py --export ~/transcript-corrections/team_corrections.json
+cd ~/transcript-corrections && git add team_corrections.json
+git commit -m "Add embodied-AI corrections" && git push origin main
 ```
 
 ### Handling Conflicts
 
-When two people add different corrections to same file:
-
-```bash
-cd ~/.transcript-fixer
-git pull origin main
-
-# If conflict occurs:
-# CONFLICT in corrections.json
-
-# Option 1: Manual merge (recommended)
-nano corrections.json  # Edit to combine both changes
-git add corrections.json
-git commit -m "Merged corrections from teammate"
-git push
-
-# Option 2: Keep yours
-git checkout --ours corrections.json
-git add corrections.json
-git commit -m "Kept local corrections"
-git push
-
-# Option 3: Keep theirs
-git checkout --theirs corrections.json
-git add corrections.json
-git commit -m "Used teammate's corrections"
-git push
-```
-
-**Best Practice**: JSON merge conflicts are usually easy - just combine the correction entries from both versions.
+Conflicts live in the **exported JSON**, never in a database. The export is a flat list of correction entries, so a merge conflict just means combining both sides' entries — resolve by hand (`git checkout --ours/--theirs team_corrections.json`, then re-add), or simpler: take either version, then have each person re-run `--import … --merge` so both sets of local additions re-converge into the shared export on the next push.
 
 ## Selective Domain Sharing
 
@@ -179,7 +147,7 @@ Share only specific domains with different teams:
 ### Finance Team
 ```bash
 # Finance team exports their domain
-python fix_transcription.py --export finance_corrections.json --domain finance
+uv run scripts/fix_transcription.py --export finance_corrections.json --domain finance
 
 # Share finance_corrections.json with finance team only
 ```
@@ -187,7 +155,7 @@ python fix_transcription.py --export finance_corrections.json --domain finance
 ### AI Team
 ```bash
 # AI team exports their domain
-python fix_transcription.py --export ai_corrections.json --domain embodied_ai
+uv run scripts/fix_transcription.py --export ai_corrections.json --domain embodied_ai
 
 # Share ai_corrections.json with AI team only
 ```
@@ -195,8 +163,8 @@ python fix_transcription.py --export ai_corrections.json --domain embodied_ai
 ### Individual imports specific domains
 ```bash
 # Alice works on both finance and AI
-python fix_transcription.py --import finance_corrections.json --merge
-python fix_transcription.py --import ai_corrections.json --merge
+uv run scripts/fix_transcription.py --import finance_corrections.json --merge
+uv run scripts/fix_transcription.py --import ai_corrections.json --merge
 ```
 
 ## Git Branching Strategy
@@ -205,12 +173,15 @@ For larger teams, use branches for different domains or workflows:
 
 ### Feature Branches
 ```bash
-# Create branch for major dictionary additions
-git checkout -b add-medical-terms
-python fix_transcription.py --add "医疗术语" "正确术语" --domain medical
+# In the exports repo, branch for a big batch:
+cd ~/transcript-corrections && git checkout -b add-medical-terms
+# Add the corrections to your local DB:
+uv run scripts/fix_transcription.py --add "医疗术语" "正确术语" --domain medical
 # ... add 100 medical corrections ...
-git add domains/medical.json
-git commit -m "Added 100 medical terminology corrections"
+# Re-export and commit the updated JSON:
+uv run scripts/fix_transcription.py --export team_corrections.json
+git add team_corrections.json
+git commit -m "Add 100 medical terminology corrections"
 git push origin add-medical-terms
 
 # Create PR for review
@@ -231,52 +202,47 @@ git push origin domain/finance
 
 ## Automated Sync (Advanced)
 
-Set up automatic Git sync using cron/Task Scheduler:
+Automate the pull cycle on the **exports repo** (never `~/.transcript-fixer`). A `git pull` alone does not touch the local DB — you still `--import` the pulled JSON afterward.
 
 ### macOS/Linux Cron
 ```bash
-# Edit crontab
 crontab -e
-
-# Add daily sync at 9 AM and 6 PM
-0 9,18 * * * cd ~/.transcript-fixer && git pull origin main && git push origin main
+# Pull the shared export twice daily (then import on your own cadence)
+0 9,18 * * * cd ~/transcript-corrections && git pull -q origin main
 ```
 
 ### Windows Task Scheduler
 ```powershell
-# Create scheduled task
-$action = New-ScheduledTaskAction -Execute "git" -Argument "pull origin main" -WorkingDirectory "$env:USERPROFILE\.transcript-fixer"
+$action = New-ScheduledTaskAction -Execute "git" -Argument "pull origin main" -WorkingDirectory "$env:USERPROFILE\transcript-corrections"
 $trigger = New-ScheduledTaskTrigger -Daily -At 9am
 Register-ScheduledTask -Action $action -Trigger $trigger -TaskName "SyncTranscriptCorrections"
 ```
 
 ## Backup and Recovery
 
+The whole store is one SQLite file (`corrections.db`) plus your JSON exports.
+
 ### Backup Strategy
 ```bash
-# Weekly backup to cloud
-cd ~/.transcript-fixer
-tar -czf transcript-corrections-$(date +%Y%m%d).tar.gz corrections.json context_rules.json domains/
+# Weekly backup of the local store + any exports
+tar -czf transcript-corrections-$(date +%Y%m%d).tar.gz \
+  ~/.transcript-fixer/corrections.db ~/transcript-corrections/*.json
 # Upload to Dropbox/Google Drive/S3
 ```
 
 ### Recovery from Backup
 ```bash
-# Extract backup
-tar -xzf transcript-corrections-20250127.tar.gz -C ~/.transcript-fixer/
+# Restore corrections.db back to ~/.transcript-fixer/
+tar -xzf transcript-corrections-20250127.tar.gz
+cp .transcript-fixer/corrections.db ~/.transcript-fixer/corrections.db
 ```
 
-### Recovery from Git
+### Recovery from Git (the exports)
 ```bash
-# View history
-cd ~/.transcript-fixer
-git log corrections.json
-
-# Restore from 3 commits ago
-git checkout HEAD~3 corrections.json
-
-# Or restore specific version
-git checkout abc123def corrections.json
+cd ~/transcript-corrections
+git log team_corrections.json                 # view history
+git checkout HEAD~3 team_corrections.json      # restore an older export
+uv run scripts/fix_transcription.py --import team_corrections.json   # no --merge = replace local with this export
 ```
 
 ## Team Best Practices
@@ -291,36 +257,27 @@ git checkout abc123def corrections.json
 
 ## Integration with CI/CD
 
-For enterprise teams, integrate validation into CI:
+For enterprise teams, validate the **exported JSON** in the shared-exports repo on every PR:
 
 ### GitHub Actions Example
 ```yaml
 # .github/workflows/validate-corrections.yml
 name: Validate Corrections
-
 on:
   pull_request:
-    paths:
-      - 'corrections.json'
-      - 'domains/*.json'
+    paths: ['*.json']
 
 jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Validate JSON
+      - uses: actions/checkout@v4
+      - name: Validate JSON is well-formed
         run: |
-          python -m json.tool corrections.json > /dev/null
-          for file in domains/*.json; do
-            python -m json.tool "$file" > /dev/null
-          done
-
-      - name: Check for duplicates
-        run: |
-          python scripts/check_duplicates.py corrections.json
+          for f in *.json; do python -m json.tool "$f" > /dev/null; done
 ```
+
+Duplicate detection is handled by the tool itself: `--import … --merge` de-duplicates against existing corrections, so there is no separate `check_duplicates.py`.
 
 ## Troubleshooting
 
@@ -348,12 +305,12 @@ ssh -T git@github.com
 ### Merge Conflicts Too Complex
 ```bash
 # Nuclear option: Keep one version
-git checkout --ours corrections.json  # Keep yours
+git checkout --ours team_corrections.json  # Keep yours
 # OR
-git checkout --theirs corrections.json  # Keep theirs
+git checkout --theirs team_corrections.json  # Keep theirs
 
 # Then re-import the other version
-python fix_transcription.py --import other_version.json --merge
+uv run scripts/fix_transcription.py --import other_version.json --merge
 ```
 
 ## Security Considerations

--- a/daymade-audio/transcript-fixer/references/workflow_guide.md
+++ b/daymade-audio/transcript-fixer/references/workflow_guide.md
@@ -2,6 +2,8 @@
 
 Detailed step-by-step workflows for transcript correction and management.
 
+> **Read this first — the primary path is native, not the API stages below.** Inside Claude Code the workflow is: `--stage 1` (dictionary, instant, free) → then Claude reads the output and corrects the rest **natively** (no API key). Stage 1 runs in **safe mode** by default (only low-risk non-word rules auto-apply; risky ones defer to `*_needs_review.md`) and auto-loads your people roster + the domain context file. The API "Stage 2/3" flow documented later is the **backup channel for automation without Claude Code**, not the default. The current authoritative workflow is SKILL.md's "Native AI Correction"; this guide's stage mechanics are still accurate, just no longer the recommended entry point.
+
 ## Table of Contents
 
 - [Pre-Flight Checklist](#pre-flight-checklist)
@@ -307,7 +309,7 @@ uv run scripts/fix_transcription.py --input file.md --stage 3 --domain general
 
 **Output**: Both `file_stage1.md` and `file_stage2.md`.
 
-**Recommended**: Use Stage 3 for most workflows.
+**When to prefer this**: automation / batch runs **without** Claude Code, or reproducible API-based processing. Inside Claude Code, the native path (Stage 1 + Claude's own correction) is the default — see SKILL.md and the note at the top of this guide.
 
 ### 6. Context-Aware Rules
 

--- a/daymade-audio/transcript-fixer/scripts/cli/commands.py
+++ b/daymade-audio/transcript-fixer/scripts/cli/commands.py
@@ -472,15 +472,14 @@ def cmd_run_correction(args: argparse.Namespace) -> dict | None:
             _m["trusted_domain"] = True
 
     # Merge person-name ASR variants from the people roster (if configured).
-    # Source: args.people_roster > env TRANSCRIPT_FIXER_PEOPLE_ROSTER > config.json paths.people_roster_path.
+    # Source: env TRANSCRIPT_FIXER_PEOPLE_ROSTER > config.json paths.people_roster_path (there is no --people-roster CLI flag).
     # The roster is the curated SSOT for important recurring people; DB entries (catch-all,
     # including minor/one-off names and generic terms) win on conflict so the roster never
     # silently overrides a hand-tuned DB entry. Roster corrections are in-memory only —
     # never written to the DB, per the "one SSOT + DB stays" design.
     from pathlib import Path as _Path
     from utils.config import get_config
-    roster_path = (getattr(args, 'people_roster', None)
-                   or os.getenv("TRANSCRIPT_FIXER_PEOPLE_ROSTER")
+    roster_path = (os.getenv("TRANSCRIPT_FIXER_PEOPLE_ROSTER")
                    or get_config().paths.people_roster_path)
     if roster_path:
         roster_path = _Path(roster_path).expanduser()


### PR DESCRIPTION
## What

Two things, both in `daymade-audio/transcript-fixer` (docs + one behavior-neutral code tidy):

**1. Structural hardening — name-source reading.** The domain-context "authoritative name sources" section is now a **complete, self-correcting manifest**: read every role-based name table (internal / external / client / vendor / attendees), not just the one that looks like "the speaker list"; if a confirmed name isn't reachable from the manifest, the manifest is incomplete and the missing table gets added. Same read-all-tables step added to the native verification ladder. Prevents a real miss where an agent read one of several name tables and flagged a documented person as "unverifiable".

**2. Quality audit of the older references.** A fresh-eyes audit found the load-bearing surface (SKILL.md, false-positive guide, domain-context, safe-mode) clean, but older references had drifted to a pre-SQLite / pre-native world:

- `team_collaboration`: git-collab + CI told you to commit a **nonexistent JSON file store** (`corrections.json` / `domains/`) into `~/.transcript-fixer` and called a phantom `check_duplicates.py`. Rewritten onto **committed JSON exports** (the store is SQLite `corrections.db`, gitignored).
- `script_parameters`: `CORRECTIONS_DICT` (a removed variable) → `--add`; corrected exit codes + the word-diff example.
- `best_practices` / `quick_reference` / `iteration_workflow`: stopped teaching common-word homophones (a ticker word, `减→剪`) as **global dictionary rules** — routed to the domain context file, per the skill's own false-positive rule.
- `database_schema`: added the missing `suggestion_examples` table (8th); config defaults now point at `core/defaults.py` instead of a hand-copied (drifted) list.
- `workflow_guide`: fronts the native + safe-mode path; API Stage 3 reframed as the automation backup, not the default.
- `architecture`: dropped the nonexistent `CorrectionManager` facade; fixed the domain regex (CJK allowed) + learning-engine storage refs.
- Normalized bare `python` → `uv run`; removed a dead `--people-roster` getattr; fixed verification-ladder markdown indentation.

## Verification
- `quick_validate`: valid — the prior `check_duplicates.py` missing-file warning is gone.
- `commands.py` compiles; the removed getattr was always `None` (behavior-neutral).
- No capability removed — corrections/consolidations of stale docs only.
- PII Guard (gitleaks) clean on both commit and push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
