### PR TITLE
refactor(_conversation_core): extract shared data model into _core.model (P2)

### DIFF
--- a/daymade-claude-code/_conversation_core/model.py
+++ b/daymade-claude-code/_conversation_core/model.py
@@ -1,0 +1,64 @@
+"""Shared conversation data model for the local-history skills.
+
+`Conversation` / `ProviderResult` / `CodexDatabase` are used by both the Claude
+and Codex providers and by the renderers, so they live in the shared core (SSOT:
+`daymade-claude-code/_conversation_core/`, bundled into each skill's
+`scripts/_core/` by `sync_core.py`). Extracting them here lets a skill like
+`continue-codex-work` reuse the same model without re-declaring it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+from .parse import iso_timestamp
+
+
+@dataclass
+class Conversation:
+    provider: str
+    session_id: str
+    title: str
+    cwd: str
+    updated_at: Optional[float]
+    created_at: Optional[float]
+    archived: bool
+    kind: str
+    path: str
+    metadata_source: str
+    timestamp_source: str
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["updated_at"] = (
+            iso_timestamp(self.updated_at) if self.updated_at is not None else None
+        )
+        data["created_at"] = (
+            iso_timestamp(self.created_at) if self.created_at is not None else None
+        )
+        return data
+
+
+@dataclass
+class ProviderResult:
+    provider: str
+    backend: str
+    home: str
+    conversations: list[Conversation] = field(default_factory=list)
+    excluded_subagents: int = 0
+    excluded_archived: int = 0
+    excluded_automated: int = 0
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def total(self) -> int:
+        return len(self.conversations)
+
+
+@dataclass
+class CodexDatabase:
+    path: Path
+    columns: set[str]
+    max_updated_ms: int

--- a/daymade-claude-code/claude-code-history-files-finder/scripts/_core/model.py
+++ b/daymade-claude-code/claude-code-history-files-finder/scripts/_core/model.py
@@ -1,0 +1,64 @@
+"""Shared conversation data model for the local-history skills.
+
+`Conversation` / `ProviderResult` / `CodexDatabase` are used by both the Claude
+and Codex providers and by the renderers, so they live in the shared core (SSOT:
+`daymade-claude-code/_conversation_core/`, bundled into each skill's
+`scripts/_core/` by `sync_core.py`). Extracting them here lets a skill like
+`continue-codex-work` reuse the same model without re-declaring it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+from .parse import iso_timestamp
+
+
+@dataclass
+class Conversation:
+    provider: str
+    session_id: str
+    title: str
+    cwd: str
+    updated_at: Optional[float]
+    created_at: Optional[float]
+    archived: bool
+    kind: str
+    path: str
+    metadata_source: str
+    timestamp_source: str
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["updated_at"] = (
+            iso_timestamp(self.updated_at) if self.updated_at is not None else None
+        )
+        data["created_at"] = (
+            iso_timestamp(self.created_at) if self.created_at is not None else None
+        )
+        return data
+
+
+@dataclass
+class ProviderResult:
+    provider: str
+    backend: str
+    home: str
+    conversations: list[Conversation] = field(default_factory=list)
+    excluded_subagents: int = 0
+    excluded_archived: int = 0
+    excluded_automated: int = 0
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def total(self) -> int:
+        return len(self.conversations)
+
+
+@dataclass
+class CodexDatabase:
+    path: Path
+    columns: set[str]
+    max_updated_ms: int

--- a/daymade-claude-code/continue-claude-work/scripts/_core/model.py
+++ b/daymade-claude-code/continue-claude-work/scripts/_core/model.py
@@ -1,0 +1,64 @@
+"""Shared conversation data model for the local-history skills.
+
+`Conversation` / `ProviderResult` / `CodexDatabase` are used by both the Claude
+and Codex providers and by the renderers, so they live in the shared core (SSOT:
+`daymade-claude-code/_conversation_core/`, bundled into each skill's
+`scripts/_core/` by `sync_core.py`). Extracting them here lets a skill like
+`continue-codex-work` reuse the same model without re-declaring it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+from .parse import iso_timestamp
+
+
+@dataclass
+class Conversation:
+    provider: str
+    session_id: str
+    title: str
+    cwd: str
+    updated_at: Optional[float]
+    created_at: Optional[float]
+    archived: bool
+    kind: str
+    path: str
+    metadata_source: str
+    timestamp_source: str
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["updated_at"] = (
+            iso_timestamp(self.updated_at) if self.updated_at is not None else None
+        )
+        data["created_at"] = (
+            iso_timestamp(self.created_at) if self.created_at is not None else None
+        )
+        return data
+
+
+@dataclass
+class ProviderResult:
+    provider: str
+    backend: str
+    home: str
+    conversations: list[Conversation] = field(default_factory=list)
+    excluded_subagents: int = 0
+    excluded_archived: int = 0
+    excluded_automated: int = 0
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def total(self) -> int:
+        return len(self.conversations)
+
+
+@dataclass
+class CodexDatabase:
+    path: Path
+    columns: set[str]
+    max_updated_ms: int

--- a/daymade-claude-code/local-conversation-history/scripts/_core/model.py
+++ b/daymade-claude-code/local-conversation-history/scripts/_core/model.py
@@ -1,0 +1,64 @@
+"""Shared conversation data model for the local-history skills.
+
+`Conversation` / `ProviderResult` / `CodexDatabase` are used by both the Claude
+and Codex providers and by the renderers, so they live in the shared core (SSOT:
+`daymade-claude-code/_conversation_core/`, bundled into each skill's
+`scripts/_core/` by `sync_core.py`). Extracting them here lets a skill like
+`continue-codex-work` reuse the same model without re-declaring it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+from .parse import iso_timestamp
+
+
+@dataclass
+class Conversation:
+    provider: str
+    session_id: str
+    title: str
+    cwd: str
+    updated_at: Optional[float]
+    created_at: Optional[float]
+    archived: bool
+    kind: str
+    path: str
+    metadata_source: str
+    timestamp_source: str
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["updated_at"] = (
+            iso_timestamp(self.updated_at) if self.updated_at is not None else None
+        )
+        data["created_at"] = (
+            iso_timestamp(self.created_at) if self.created_at is not None else None
+        )
+        return data
+
+
+@dataclass
+class ProviderResult:
+    provider: str
+    backend: str
+    home: str
+    conversations: list[Conversation] = field(default_factory=list)
+    excluded_subagents: int = 0
+    excluded_archived: int = 0
+    excluded_automated: int = 0
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def total(self) -> int:
+        return len(self.conversations)
+
+
+@dataclass
+class CodexDatabase:
+    path: Path
+    columns: set[str]
+    max_updated_ms: int

--- a/daymade-claude-code/local-conversation-history/scripts/list_local_history.py
+++ b/daymade-claude-code/local-conversation-history/scripts/list_local_history.py
@@ -30,6 +30,7 @@ from _core.parse import (  # noqa: E402
     timezone_offset_colon,
     workspace_matches,
 )
+from _core.model import Conversation, ProviderResult, CodexDatabase  # noqa: E402
 
 
 MAX_PREFIX_BYTES = 2 * 1024 * 1024
@@ -71,52 +72,8 @@ def configure_utf8_streams() -> None:
             reconfigure(encoding="utf-8", errors="replace")
 
 
-@dataclass
-class Conversation:
-    provider: str
-    session_id: str
-    title: str
-    cwd: str
-    updated_at: Optional[float]
-    created_at: Optional[float]
-    archived: bool
-    kind: str
-    path: str
-    metadata_source: str
-    timestamp_source: str
-
-    def to_dict(self) -> dict[str, Any]:
-        data = asdict(self)
-        data["updated_at"] = (
-            iso_timestamp(self.updated_at) if self.updated_at is not None else None
-        )
-        data["created_at"] = (
-            iso_timestamp(self.created_at) if self.created_at is not None else None
-        )
-        return data
-
-
-@dataclass
-class ProviderResult:
-    provider: str
-    backend: str
-    home: str
-    conversations: list[Conversation] = field(default_factory=list)
-    excluded_subagents: int = 0
-    excluded_archived: int = 0
-    excluded_automated: int = 0
-    warnings: list[str] = field(default_factory=list)
-
-    @property
-    def total(self) -> int:
-        return len(self.conversations)
-
-
-@dataclass
-class CodexDatabase:
-    path: Path
-    columns: set[str]
-    max_updated_ms: int
+# Conversation / ProviderResult / CodexDatabase now live in the shared
+# _core.model module (imported near the top of this file).
 
 
 def looks_like_attachment_prefix(value: str) -> bool:


### PR DESCRIPTION
Continues the conversation-history skills consolidation (after #147 homes / #149 parse).

Moves the `Conversation` / `ProviderResult` / `CodexDatabase` dataclasses out of `list_local_history.py` into `_conversation_core/model.py`, bundled into each skill's `scripts/_core/` by `sync_core.py`. This shared model is the foundation the Codex provider extraction and a future `continue-codex-work` skill build on.

**Verified:** `list_local_history`'s 8 tests green; `sync_core.py check` passes; list runs and multi-home discovery still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)