### PR TITLE
feat: add continue-codex-work skill (Codex-session resume)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -103,7 +103,7 @@
       "description": "Claude Code operations suite that bundles fast local conversation discovery across Claude Code and Codex, deep session history recovery, interrupted-work continuation, plugin/skill troubleshooting, CLAUDE.md progressive disclosure optimization, statusline configuration, exported .txt repair, full claude.ai conversation extraction with tool-call rendering and file download, plugin marketplace development, multi-provider profile isolation for running Kimi/GLM/DeepSeek/StepFun/Anthropic in separate windows, local source sync for Claude/Codex skill installs, and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
       "source": "./daymade-claude-code",
       "strict": false,
-      "version": "1.13.0",
+      "version": "1.14.0",
       "category": "suite",
       "keywords": [
         "suite",
@@ -126,6 +126,7 @@
         "./local-conversation-history",
         "./claude-code-history-files-finder",
         "./continue-claude-work",
+        "./continue-codex-work",
         "./claude-skills-troubleshooting",
         "./claude-md-progressive-disclosurer",
         "./statusline-generator",

--- a/daymade-claude-code/continue-codex-work/.security-scan-passed
+++ b/daymade-claude-code/continue-codex-work/.security-scan-passed
@@ -1,0 +1,4 @@
+Security scan passed
+Scanned at: 2026-07-15T15:55:55.600749+00:00
+Tool: gitleaks + pattern-based validation
+Content hash: b826e9ba6ab4701bac84b3049e8c760b2c5cc9a5fdd9083a9f62179ea1b67fc1

--- a/daymade-claude-code/continue-codex-work/SKILL.md
+++ b/daymade-claude-code/continue-codex-work/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: continue-codex-work
+description: >-
+  Recover actionable context from a prior Codex CLI session's local rollout files
+  and continue interrupted work without running `codex resume`. Use this whenever
+  the user wants to pick up Codex (OpenAI Codex CLI / GPT agent) work — they give a
+  Codex session id, ask to continue what Codex was doing, say a Codex run was cut
+  off mid-task, or want to inspect `~/.codex/sessions` rollout JSONL before
+  resuming. This is the Codex counterpart of continue-claude-work: reach for it for
+  Codex/`~/.codex` sessions, and for continue-claude-work when the prior session was
+  Claude Code (`~/.claude`).
+argument-hint: "[session-id]"
+---
+
+# Continue Codex Work
+
+## Overview
+
+Recover actionable context from a prior **Codex CLI** session and continue execution in the current conversation. Codex records each session as a rollout JSONL under `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` (with an optional `state_*.sqlite` index). Use those local files as the source of truth, then continue with concrete edits and checks — not just summarizing.
+
+**Why this exists instead of `codex resume`**: replaying a full rollout re-feeds every reasoning step, tool call, and tool output back into the context window. For long sessions that wastes the window on resolved turns and stale output. This skill **selectively reconstructs** only actionable context — the last compaction's surviving requests, recent user/assistant turns, the tool calls and files edited, and how the session ended — giving a fresh start with prior knowledge.
+
+This is the Codex sibling of `continue-claude-work`. The two are deliberately split because the on-disk formats differ: Claude Code writes `~/.claude/projects/<encoded>/<session>.jsonl`, Codex writes `~/.codex/sessions/.../rollout-*.jsonl` with a different record schema. Use **this** skill for Codex sessions; use `continue-claude-work` for Claude Code sessions.
+
+## File Structure Reference
+
+For the rollout directory layout, the record/payload schema, and the compaction format, see [references/file_structure.md](references/file_structure.md).
+
+## Workflow
+
+### Step 1: Extract Context (single script call)
+
+Run the bundled extractor. It handles session discovery (via the shared `_core`), rollout parsing, noise filtering, and workspace state in one call:
+
+```bash
+# Latest Codex session for the current project (cwd)
+python3 scripts/extract_codex_resume.py
+
+# A specific session by id (full or unambiguous prefix)
+python3 scripts/extract_codex_resume.py --session <SESSION_ID>
+
+# Search sessions by a keyword in the title
+python3 scripts/extract_codex_resume.py --query "skill migrator"
+
+# List recent sessions for the current project
+python3 scripts/extract_codex_resume.py --list
+
+# List across all projects (not just the current cwd)
+python3 scripts/extract_codex_resume.py --all-projects --list
+```
+
+**Expected output**: a structured Markdown **briefing**. What you should see:
+
+- A `# Codex Resume Context Briefing` header, then `## Session Info` (id, project cwd, last-active time, title, Codex version).
+- A one-line `**Session end reason**` — the single most important routing signal (see Step 2).
+- `## Compact Summary` — if the session was compacted, the surviving user/assistant thread (system preamble and re-injected `AGENTS.md` are stripped out).
+- `## Last User Requests` and `## Last Assistant Responses` — the most recent turns.
+- `## Recent Tool Calls`, `## Files Edited in Session` (from `apply_patch` results), `## Errors Encountered`.
+- `## Current Workspace State` — git branch, uncommitted changes, recent commits.
+
+If instead you see `No Codex sessions found for <path>`, the current directory has no Codex history — try `--all-projects --list` to find the right project, or pass `--session <id>` directly.
+
+### Step 2: Branch by Session End Reason
+
+The briefing's **Session end reason** tells you how the prior run stopped. Route on it:
+
+| End reason | What it means | Strategy |
+|-----------|---------------|----------|
+| **Clean exit** | The agent had the last word (a completed turn). | Read the last user request that was addressed; continue from any pending work. |
+| **In progress** | Tools ran but the agent left no closing message — cut off mid-task. | This is the common resume case. Read the recent tool calls + files edited, verify what landed, and finish the turn the agent was in. |
+| **Interrupted** | Tool calls were dispatched but never returned (hard stop / ctrl-c). | Re-check whether those actions took effect, then retry or move on. |
+| **Abandoned** | A user message got no response. | Treat the last user message as the current request. |
+| **Error cascade** | Repeated tool failures. | Do not retry blindly — diagnose the root cause first. |
+
+### Step 3: Reconcile and Continue
+
+Before making changes:
+1. Confirm the current directory matches the session's `cwd`.
+2. If the git branch differs from what the briefing shows, note it and decide whether to switch.
+3. Inspect the files listed under **Files Edited** — verify the prior run's changes actually landed (a rollout records that a patch was *attempted*; confirm the current file state).
+4. Do not assume old claims hold without checking — compaction and tool output are lossy.
+
+Then:
+- Implement the next concrete step aligned with the latest user request.
+- Run deterministic verification (tests, type-checks, build).
+- If blocked, state the exact blocker and propose one next action.
+
+### Step 4: Report
+
+Respond concisely:
+- **Context recovered**: which session, key findings from the briefing.
+- **Work executed**: files changed, commands run, test results.
+- **Remaining**: pending tasks, if any.
+
+## How the Script Works
+
+### Session discovery reuses the shared core
+
+Discovery goes through `_core.codex.collect_codex` (bundled into `scripts/_core/`), the same schema-tolerant reader the `local-conversation-history` skill uses: it prefers the `state_*.sqlite` index and falls back to scanning raw rollout JSONL when the DB is missing or its schema has drifted. So listing, `--query`, and latest-for-project all share one tested implementation.
+
+### Rollout parsing
+
+Codex's rollout schema is not Claude's. The parser reads:
+- **User / assistant turns** from the event stream (`event_msg/user_message`, `event_msg/agent_message`, `task_complete.last_agent_message`) — these store plain strings and mirror the `response_item/message` items, so we avoid double-counting and sidestep `output_text` content that isn't needed here.
+- **Files edited** from `event_msg/patch_apply_end` — the keys of its `changes` map are the files `apply_patch` touched.
+- **Tool calls** from `response_item/function_call` and `custom_tool_call`, paired with their `*_output` by `call_id` (an unpaired call means it never returned).
+- **Compaction** from `compacted` records — Codex replaces the compacted window with a `replacement_history` of messages (not a single summary), and re-injects the system preamble; the parser keeps only the user/assistant turns.
+
+### Session end reason detection
+
+Classified from the tail of the rollout: a trailing `task_complete`/`agent_message` is **completed**; unpaired tool calls are **interrupted**; tools that ran with no closing message are **in progress**; a trailing user message is **abandoned**; three or more tool failures are an **error cascade**.
+
+### Noise filtering
+
+Codex re-injects large system blocks after compaction and between turns — the permissions block, the agent-role message, and the project's `AGENTS.md`. The parser drops these using the shared `is_noise_text` (which recognizes `<permissions instructions`, `<system-reminder`, `# AGENTS.md instructions for`, and similar prefixes) so the briefing shows the real conversation, not the harness scaffolding.
+
+## Guardrails
+
+- Do not run `codex resume` or `codex --continue` — this skill provides context recovery within the current conversation.
+- Do not treat the compact summary or tool output as complete truth — they are lossy. Always verify claims against the current workspace.
+- Do not overwrite unrelated working-tree changes.
+- Do not load a whole rollout file into context — always use the script (rollouts are routinely multiple MB).
+
+## Limitations
+
+- Cannot recover sessions whose rollout files were deleted from `~/.codex/sessions/`.
+- Cannot access sessions from other machines (files are local only).
+- Tool-call previews are truncated — for the full command or patch, read the rollout line directly.
+- Compaction is lossy — early-conversation detail may be gone.
+- Codex has no per-session auto-memory equivalent to Claude Code's `MEMORY.md`; the project's `AGENTS.md` is deliberately filtered out as re-injected noise, so read it separately if you need the project's standing instructions.
+
+## Example Trigger Phrases
+
+- "continue the Codex session `019f66...`"
+- "codex got cut off mid-task, pick up where it left off"
+- "don't `codex resume`, just read the rollout and keep going"
+- "what was Codex doing in my last session in this repo?"
+- "find the Codex run where I built the skill migrator and continue it"
+
+## Related Skills
+
+- **`continue-claude-work`** — the same capability for Claude Code sessions (`~/.claude`). If the prior session was Claude, not Codex, use that skill instead.
+- **`local-conversation-history`** — lists both Claude and Codex conversations across every config home. Use it first when you are not sure which session (or which provider) you want, then bring the Codex session id here.

--- a/daymade-claude-code/continue-codex-work/references/file_structure.md
+++ b/daymade-claude-code/continue-codex-work/references/file_structure.md
@@ -1,0 +1,64 @@
+# Codex CLI Session File Structure
+
+Reference for the on-disk format the `extract_codex_resume.py` script parses.
+Verified against real rollouts from Codex CLI `0.144.4` (July 2026).
+
+## Directory layout
+
+```
+~/.codex/                                  # CODEX_HOME (override with $CODEX_HOME)
+├── sessions/
+│   └── YYYY/MM/DD/
+│       └── rollout-<ISO8601>-<uuid>.jsonl # one file per session; the uuid is the session id
+├── archived_sessions/                     # same shape, archived sessions
+├── sqlite/  or  ./                        # state_*.sqlite index (schema drifts between versions)
+├── session_index.jsonl                    # optional id -> thread_name title map
+└── AGENTS.md                              # project/global standing instructions (re-injected into rollouts)
+```
+
+The session id is a UUIDv7 embedded in the rollout filename and repeated inside the `session_meta` record. The optional `state_*.sqlite` `threads` table indexes sessions (id, cwd, title, timestamps, `rollout_path`); the shared `_core.codex` reader prefers it and falls back to scanning rollout files directly when it is missing or its schema has changed.
+
+## Rollout JSONL — record schema
+
+Every line is one JSON object with a top-level `timestamp`, `type`, and (usually) `payload`. The `payload.type` further discriminates `event_msg` and `response_item` records. Approximate frequency in a real 1100-line session is shown to indicate what dominates.
+
+| `type` | `payload.type` | Carries | Used for |
+|--------|----------------|---------|----------|
+| `session_meta` | — | `id`, `cwd`, `timestamp`, `cli_version`, `model_provider` | Session Info header |
+| `compacted` | — | `message` (often empty), `replacement_history` (list of messages), `window_number` | Compact Summary |
+| `event_msg` | `context_compacted` | just a marker | (the real content is in the `compacted` record) |
+| `event_msg` | `user_message` | `message` (plain string) | Last User Requests |
+| `event_msg` | `agent_message` | `message` (plain string) | Last Assistant Responses |
+| `event_msg` | `patch_apply_end` | `changes` (map: path -> {content\|unified_diff}), `success`, `stderr` | Files Edited; errors |
+| `event_msg` | `task_complete` | `last_agent_message`, `duration_ms` | Assistant text; turn boundary → end reason |
+| `event_msg` | `token_count` | usage counters | ignored (noise) |
+| `response_item` | `message` | `role` (developer/user/assistant), `content` (list) | see note below |
+| `response_item` | `reasoning` | model thinking | ignored (noise) |
+| `response_item` | `function_call` | `name`, `arguments` (JSON string), `call_id` | Recent Tool Calls |
+| `response_item` | `function_call_output` | `call_id`, `output` (list) | pairs a call; error detection |
+| `response_item` | `custom_tool_call` | `name` (e.g. `exec`), `input`, `call_id`, `status` | Recent Tool Calls |
+| `response_item` | `custom_tool_call_output` | `call_id`, `output` (list) | pairs a call; error detection |
+
+### Message content element types (important)
+
+`response_item/message` `content` is a list of `{type, text}` where `type` is **`input_text`** for user/developer content and **`output_text`** for assistant content. The shared `extract_text` decodes `text`/`input_text` but **not** `output_text`. That is why the parser reads user/assistant turns from the `event_msg` stream (`user_message` / `agent_message` / `task_complete.last_agent_message`, all plain strings) instead of from `response_item/message` — the event stream mirrors the same turns without the `output_text` gap, and avoids double-counting. Tool `output` and compaction `content` use `input_text`, which `extract_text` handles.
+
+## Compaction format
+
+When Codex compacts, it emits a `compacted` record whose `replacement_history` is the list of messages that **replace** the compacted window — not a single distilled summary like Claude Code. That history also re-injects the system preamble. In one real record the 13 items were:
+
+- items with `role: "user"` — the surviving user requests (high signal)
+- items with `role: "developer"` — the permissions block, the agent-role message, `<multi_agent_mode>` (system noise)
+- a `role: "user"` item whose content is `# AGENTS.md instructions for <cwd>` (~50 KB) — re-injected standing instructions, not a real turn (noise)
+
+So the parser keeps only `role` in `{user, assistant}` **and** drops anything `is_noise_text` recognizes (`<permissions instructions`, `<system-reminder`, `# AGENTS.md instructions for`, …), then truncates each surviving item. The result is the real request thread, without the harness scaffolding.
+
+## Session end reason
+
+Derived from the tail of the rollout and the set of unpaired tool calls:
+
+- **completed** — the last significant record is `task_complete` or `agent_message` (the agent had the last word).
+- **interrupted** — a `function_call`/`custom_tool_call` has no matching `*_output` (dispatched but never returned).
+- **in_progress** — tools ran and returned, but there is no closing `agent_message`/`task_complete` (cut off mid-task). This is the common resume case.
+- **abandoned** — the last significant record is a `user_message` with no response.
+- **error_cascade** — three or more tool failures (failed `patch_apply_end`, or error-looking tool `output`).

--- a/daymade-claude-code/continue-codex-work/scripts/_core/__init__.py
+++ b/daymade-claude-code/continue-codex-work/scripts/_core/__init__.py
@@ -1,0 +1,36 @@
+"""Shared core for the local conversation-history skills.
+
+Single source of truth for logic that would otherwise be re-implemented (and
+drift) across `claude-code-history-files-finder`, `local-conversation-history`,
+`continue-claude-work`, and `continue-codex-work`. This package is authored here
+and BUNDLED (copied) into each skill's `scripts/_core/` by `sync_core.py`, so
+every skill stays self-contained and installable on its own while sharing one
+implementation.
+
+Modules:
+    homes  — discover every Claude config home (main + per-model profiles).
+    parse  — pure parsing/formatting helpers (timestamps, and more over time).
+"""
+
+from .homes import discover_claude_homes, home_label
+from .parse import (
+    format_timestamp,
+    iso_timestamp,
+    looks_like_windows_path,
+    normalize_workspace,
+    parse_timestamp,
+    timezone_offset_colon,
+    workspace_matches,
+)
+
+__all__ = [
+    "discover_claude_homes",
+    "home_label",
+    "parse_timestamp",
+    "timezone_offset_colon",
+    "format_timestamp",
+    "iso_timestamp",
+    "looks_like_windows_path",
+    "normalize_workspace",
+    "workspace_matches",
+]

--- a/daymade-claude-code/continue-codex-work/scripts/_core/codex.py
+++ b/daymade-claude-code/continue-codex-work/scripts/_core/codex.py
@@ -1,0 +1,357 @@
+"""Shared Codex conversation provider for the local-history skills.
+
+Reading Codex history is subtle: recent builds keep a `state_*.sqlite` index whose
+schema drifts between versions, and older ones only leave raw `rollout-*.jsonl`
+files. This module encapsulates both backends (with the sqlite path degrading to a
+raw-rollout scan when the schema is incompatible or a query fails) so that every
+skill sees one `collect_codex(args, home) -> ProviderResult` entry point.
+
+It lives in the shared core (SSOT: `daymade-claude-code/_conversation_core/`,
+bundled into each skill's `scripts/_core/` by `sync_core.py`) so `list_local_history`
+and a future `continue-codex-work` skill reuse one implementation instead of
+re-deriving the schema-tolerance and subagent-detection heuristics that would drift
+apart. The model / parse / text helpers it builds on already live in the same core.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sqlite3
+from pathlib import Path
+from typing import Any, Iterable, Optional
+from urllib.parse import quote
+
+from .model import CodexDatabase, Conversation, ProviderResult
+from .parse import parse_timestamp, workspace_matches
+from .text import extract_text, first_meaningful_title, is_automated_title, iter_jsonl
+
+CODEX_REQUIRED_COLUMNS = {"id", "cwd", "updated_at", "source", "archived"}
+SESSION_ID_RE = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+    re.IGNORECASE,
+)
+
+
+def sqlite_uri(path: Path) -> str:
+    return "file:" + quote(path.resolve().as_posix(), safe="/:@") + "?mode=ro"
+
+
+def inspect_codex_database(path: Path) -> CodexDatabase:
+    connection = sqlite3.connect(sqlite_uri(path), uri=True, timeout=1.0)
+    try:
+        connection.execute("PRAGMA query_only = ON")
+        columns = {
+            str(row[1]) for row in connection.execute("PRAGMA table_info(threads)")
+        }
+        if not CODEX_REQUIRED_COLUMNS.issubset(columns):
+            missing = ", ".join(sorted(CODEX_REQUIRED_COLUMNS - columns))
+            raise ValueError(f"threads schema is missing: {missing}")
+        updated_expression = (
+            "COALESCE(MAX(CASE WHEN updated_at_ms > 0 THEN updated_at_ms "
+            "ELSE updated_at * 1000 END), 0)"
+            if "updated_at_ms" in columns
+            else "COALESCE(MAX(updated_at) * 1000, 0)"
+        )
+        value = connection.execute(
+            f"SELECT {updated_expression} FROM threads"
+        ).fetchone()[0]
+        return CodexDatabase(path=path, columns=columns, max_updated_ms=int(value or 0))
+    finally:
+        connection.close()
+
+
+def discover_codex_database(home: Path, warnings: list[str]) -> Optional[CodexDatabase]:
+    candidates: set[Path] = set()
+    for directory in (home, home / "sqlite"):
+        if not directory.is_dir():
+            continue
+        candidates.update(directory.glob("state_*.sqlite"))
+    compatible: list[CodexDatabase] = []
+    for path in sorted(candidates):
+        try:
+            compatible.append(inspect_codex_database(path))
+        except (OSError, sqlite3.Error, ValueError) as error:
+            warnings.append(f"Ignoring incompatible Codex database {path}: {error}")
+    if not compatible:
+        if candidates:
+            warnings.append(
+                "No compatible Codex state database; scanning raw rollout JSONL instead."
+            )
+        return None
+    return max(
+        compatible,
+        key=lambda item: (item.max_updated_ms, item.path.stat().st_mtime_ns),
+    )
+
+
+def nested_key_exists(value: Any, wanted: str) -> bool:
+    if isinstance(value, str):
+        stripped = value.lstrip()
+        if stripped.startswith("{") or stripped.startswith("["):
+            try:
+                value = json.loads(value)
+            except json.JSONDecodeError:
+                return False
+        else:
+            return False
+    if isinstance(value, dict):
+        return wanted in value or any(
+            nested_key_exists(item, wanted) for item in value.values()
+        )
+    if isinstance(value, list):
+        return any(nested_key_exists(item, wanted) for item in value)
+    return False
+
+
+def codex_row_is_subagent(row: sqlite3.Row) -> bool:
+    role = row["agent_role"]
+    thread_source = row["thread_source"]
+    source = row["source"]
+    return bool(role) or str(thread_source or "").casefold() == "subagent" or nested_key_exists(
+        source, "subagent"
+    )
+
+
+def choose_row_title(row: sqlite3.Row, max_chars: int) -> str:
+    title = first_meaningful_title(
+        (row["title"], row["first_user_message"], row["preview"]), max_chars
+    )
+    return title or f"(untitled: {row['id']})"
+
+
+def value_or_none(row: sqlite3.Row, key: str) -> Any:
+    try:
+        return row[key]
+    except (IndexError, KeyError):
+        return None
+
+
+def dynamic_select(columns: set[str], names: Iterable[str]) -> str:
+    return ", ".join(
+        name if name in columns else f"NULL AS {name}" for name in names
+    )
+
+
+def collect_codex_from_database(
+    args: argparse.Namespace, home: Path, database: CodexDatabase, result: ProviderResult
+) -> None:
+    fields = (
+        "id",
+        "title",
+        "first_user_message",
+        "preview",
+        "cwd",
+        "created_at",
+        "created_at_ms",
+        "updated_at",
+        "updated_at_ms",
+        "source",
+        "thread_source",
+        "agent_role",
+        "archived",
+        "rollout_path",
+    )
+    query = f"SELECT {dynamic_select(database.columns, fields)} FROM threads"
+    connection = sqlite3.connect(sqlite_uri(database.path), uri=True, timeout=1.0)
+    connection.row_factory = sqlite3.Row
+    try:
+        connection.execute("PRAGMA query_only = ON")
+        rows = connection.execute(query)
+        for row in rows:
+            cwd = str(row["cwd"] or "")
+            if not args.all_projects and not workspace_matches(
+                cwd, args.cwd, args.recursive
+            ):
+                continue
+            archived = bool(row["archived"] or False)
+            if archived and not args.include_archived:
+                result.excluded_archived += 1
+                continue
+            subagent = codex_row_is_subagent(row)
+            if subagent and not args.include_subagents:
+                result.excluded_subagents += 1
+                continue
+            title = choose_row_title(row, args.max_title_chars)
+            if is_automated_title(title) and not args.include_automated:
+                result.excluded_automated += 1
+                continue
+            updated_at = parse_timestamp(value_or_none(row, "updated_at_ms"))
+            if updated_at is None:
+                updated_at = parse_timestamp(value_or_none(row, "updated_at"))
+            created_at = parse_timestamp(value_or_none(row, "created_at_ms"))
+            if created_at is None:
+                created_at = parse_timestamp(value_or_none(row, "created_at"))
+            result.conversations.append(
+                Conversation(
+                    provider="codex",
+                    session_id=str(row["id"]),
+                    title=title,
+                    cwd=cwd,
+                    updated_at=updated_at,
+                    created_at=created_at,
+                    archived=archived,
+                    kind="subagent" if subagent else "main",
+                    path=str(row["rollout_path"] or ""),
+                    metadata_source="state-db",
+                    timestamp_source="state-db",
+                )
+            )
+    finally:
+        connection.close()
+
+
+def load_codex_session_index(home: Path, max_chars: int) -> dict[str, str]:
+    titles: dict[str, str] = {}
+    path = home / "session_index.jsonl"
+    if not path.is_file():
+        return titles
+    for record in iter_jsonl(path):
+        session_id = record.get("id")
+        title = first_meaningful_title((record.get("thread_name"),), max_chars)
+        if isinstance(session_id, str) and title:
+            titles[session_id] = title
+    return titles
+
+
+def codex_meta_from_rollout(path: Path) -> Optional[dict[str, Any]]:
+    for record in iter_jsonl(path, bounded=True):
+        if record.get("type") == "session_meta" and isinstance(
+            record.get("payload"), dict
+        ):
+            return record["payload"]
+    return None
+
+
+def codex_session_id(meta: dict[str, Any], path: Path) -> Optional[str]:
+    """Read the authoritative ID, with a UUID filename fallback when unambiguous."""
+    value = meta.get("id")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    match = SESSION_ID_RE.search(path.name)
+    return match.group(0) if match else None
+
+
+def codex_prompt_from_rollout(path: Path, max_chars: int) -> Optional[str]:
+    short_candidate: Optional[str] = None
+    for record in iter_jsonl(path, bounded=True):
+        candidate = ""
+        if record.get("type") == "response_item":
+            payload = record.get("payload")
+            if (
+                isinstance(payload, dict)
+                and payload.get("type") == "message"
+                and payload.get("role") == "user"
+            ):
+                candidate = extract_text(payload.get("content"))
+        elif record.get("type") == "event_msg":
+            payload = record.get("payload")
+            if isinstance(payload, dict) and payload.get("type") == "user_message":
+                candidate = str(payload.get("message") or "")
+        if not candidate:
+            continue
+        title = first_meaningful_title((candidate,), max_chars)
+        if not title:
+            continue
+        if len(title) >= 4:
+            return title
+        short_candidate = short_candidate or title
+    return short_candidate
+
+
+def collect_codex_from_rollouts(
+    args: argparse.Namespace, home: Path, result: ProviderResult
+) -> None:
+    titles = load_codex_session_index(home, args.max_title_chars)
+    files: list[tuple[Path, bool]] = []
+    sessions_dir = home / "sessions"
+    if sessions_dir.is_dir():
+        files.extend((path, False) for path in sessions_dir.rglob("rollout-*.jsonl"))
+    archived_dir = home / "archived_sessions"
+    if archived_dir.is_dir():
+        files.extend((path, True) for path in archived_dir.rglob("rollout-*.jsonl"))
+    if not files:
+        result.warnings.append(f"No Codex rollout files found under {home}")
+        return
+    for path, archived in files:
+        meta = codex_meta_from_rollout(path)
+        if meta is None:
+            result.warnings.append(f"Skipping rollout without session_meta: {path}")
+            continue
+        session_id = codex_session_id(meta, path)
+        if session_id is None:
+            result.warnings.append(f"Skipping rollout without a session ID: {path}")
+            continue
+        cwd = str(meta.get("cwd") or "")
+        if not args.all_projects and not workspace_matches(cwd, args.cwd, args.recursive):
+            continue
+        if archived and not args.include_archived:
+            result.excluded_archived += 1
+            continue
+        subagent = nested_key_exists(meta.get("source"), "subagent")
+        if subagent and not args.include_subagents:
+            result.excluded_subagents += 1
+            continue
+        title = titles.get(session_id)
+        if not title:
+            title = codex_prompt_from_rollout(path, args.max_title_chars)
+        title = title or f"(untitled: {session_id})"
+        if is_automated_title(title) and not args.include_automated:
+            result.excluded_automated += 1
+            continue
+        try:
+            updated_at = path.stat().st_mtime
+            timestamp_source = "file-mtime"
+        except OSError:
+            updated_at = parse_timestamp(meta.get("timestamp"))
+            timestamp_source = "session-meta"
+        result.conversations.append(
+            Conversation(
+                provider="codex",
+                session_id=session_id,
+                title=title,
+                cwd=cwd,
+                updated_at=updated_at,
+                created_at=parse_timestamp(meta.get("timestamp")),
+                archived=archived,
+                kind="subagent" if subagent else "main",
+                path=str(path),
+                metadata_source="rollout-jsonl",
+                timestamp_source=timestamp_source,
+            )
+        )
+
+
+def collect_codex(args: argparse.Namespace, home: Path) -> ProviderResult:
+    result = ProviderResult(provider="codex", backend="none", home=str(home))
+    if not home.is_dir():
+        result.warnings.append(f"Codex home directory not found: {home}")
+        return result
+    database = discover_codex_database(home, result.warnings)
+    if database is not None:
+        relative = os.path.relpath(database.path, home).replace(os.sep, "/")
+        result.backend = f"sqlite:{relative}"
+        try:
+            collect_codex_from_database(args, home, database, result)
+        except sqlite3.Error as error:
+            result.warnings.append(
+                f"Codex database query failed ({error}); scanning raw rollout JSONL instead."
+            )
+            result.backend = "rollout-jsonl"
+            result.conversations.clear()
+            result.excluded_subagents = 0
+            result.excluded_archived = 0
+            result.excluded_automated = 0
+            collect_codex_from_rollouts(args, home, result)
+    else:
+        result.backend = "rollout-jsonl"
+        collect_codex_from_rollouts(args, home, result)
+    deduplicated = {item.session_id: item for item in result.conversations}
+    result.conversations = sorted(
+        deduplicated.values(),
+        key=lambda item: item.updated_at if item.updated_at is not None else float("-inf"),
+        reverse=True,
+    )
+    return result

--- a/daymade-claude-code/continue-codex-work/scripts/_core/homes.py
+++ b/daymade-claude-code/continue-codex-work/scripts/_core/homes.py
@@ -1,0 +1,106 @@
+"""Discover every Claude config home that holds conversation history.
+
+Claude Code stores session history under ``<home>/projects/``. The default home
+is ``~/.claude``, but a user who runs third-party models through per-model
+*profiles* — each profile is its own ``CLAUDE_CONFIG_DIR`` — keeps a parallel
+history under ``~/.claude-profiles/<name>/`` and sometimes a sibling
+``~/.claude-<name>/``. A tool that only looks at ``~/.claude`` silently misses
+every conversation held under a profile, which is the #1 reason a real session
+is wrongly reported as "not found".
+
+This module is the single source of truth for that discovery. It is bundled
+(copied) into each conversation-history skill's ``scripts/_core/`` so every skill
+stays self-contained yet shares one implementation — fix the blind spot once,
+not once per skill.
+"""
+
+import os
+from pathlib import Path
+from typing import List, Optional, Union
+
+
+def discover_claude_homes(
+    explicit: Optional[Union[str, Path, List[Union[str, Path]]]] = None,
+) -> List[Path]:
+    """Return every Claude config home that has a ``projects/`` history dir.
+
+    Discovery is dynamic (glob), never a hardcoded profile list, so it adapts to
+    whatever profiles happen to exist on the machine.
+
+    Args:
+        explicit: ``None`` (default) auto-discovers all homes. A single path or a
+            list of paths restricts the search to exactly those homes (each must
+            contain a ``projects/`` subdir). An explicit request that matches no
+            home-with-history returns ``[]`` — callers MUST treat that as "your
+            selection matched nothing", never as a cue to auto-discover, or a
+            scope-narrowing flag would silently widen to the widest scope.
+
+    Returns:
+        De-duplicated, existence-checked list of home ``Path`` objects, each with
+        a ``projects/`` subdirectory. Order: ``CLAUDE_CONFIG_DIR`` (if set),
+        ``~/.claude``, then ``~/.claude-profiles/*`` and sibling ``~/.claude-*``
+        sorted by name.
+    """
+    homes: List[Path] = []
+    seen = set()
+
+    def add(candidate: Union[str, Path]) -> None:
+        try:
+            home = Path(candidate).expanduser()
+        except Exception:
+            return
+        if not (home / "projects").is_dir():
+            return
+        try:
+            key = str(home.resolve())
+        except Exception:
+            key = str(home)
+        if key in seen:
+            return
+        seen.add(key)
+        homes.append(home)
+
+    # An explicit override (single path or list) short-circuits discovery.
+    if explicit is not None:
+        candidates = explicit if isinstance(explicit, (list, tuple)) else [explicit]
+        for candidate in candidates:
+            add(candidate)
+        return homes
+
+    # CLAUDE_CONFIG_DIR wins first when set, then the default home.
+    env_home = os.environ.get("CLAUDE_CONFIG_DIR")
+    if env_home:
+        add(env_home)
+    add(Path.home() / ".claude")
+
+    # Per-model profile homes: ~/.claude-profiles/*/
+    profiles_root = Path.home() / ".claude-profiles"
+    if profiles_root.is_dir():
+        for child in sorted(profiles_root.iterdir()):
+            add(child)
+
+    # Sibling homes: ~/.claude-<name>/ that carry their own projects/
+    for child in sorted(Path.home().glob(".claude-*")):
+        if child.name != ".claude-profiles":
+            add(child)
+
+    return homes
+
+
+def home_label(home: Union[str, Path]) -> str:
+    """Short, human-readable provenance label for a home path.
+
+    ``~/.claude`` -> ``main``; ``~/.claude-profiles/kimi`` -> ``kimi``;
+    ``~/.claude-deepseek`` -> ``claude-deepseek``. A sibling ``~/.claude-<name>``
+    home keeps its ``claude-`` prefix so it never collides with a same-named
+    ``~/.claude-profiles/<name>`` profile. Used so output shows which profile a
+    session came from instead of an opaque absolute path.
+    """
+    home = Path(home)
+    if home.name == ".claude":
+        return "main"
+    if home.parent.name == ".claude-profiles":
+        return home.name
+    if home.name.startswith(".claude-"):
+        return home.name[len("."):]
+    return home.name

--- a/daymade-claude-code/continue-codex-work/scripts/_core/model.py
+++ b/daymade-claude-code/continue-codex-work/scripts/_core/model.py
@@ -1,0 +1,64 @@
+"""Shared conversation data model for the local-history skills.
+
+`Conversation` / `ProviderResult` / `CodexDatabase` are used by both the Claude
+and Codex providers and by the renderers, so they live in the shared core (SSOT:
+`daymade-claude-code/_conversation_core/`, bundled into each skill's
+`scripts/_core/` by `sync_core.py`). Extracting them here lets a skill like
+`continue-codex-work` reuse the same model without re-declaring it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+from .parse import iso_timestamp
+
+
+@dataclass
+class Conversation:
+    provider: str
+    session_id: str
+    title: str
+    cwd: str
+    updated_at: Optional[float]
+    created_at: Optional[float]
+    archived: bool
+    kind: str
+    path: str
+    metadata_source: str
+    timestamp_source: str
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["updated_at"] = (
+            iso_timestamp(self.updated_at) if self.updated_at is not None else None
+        )
+        data["created_at"] = (
+            iso_timestamp(self.created_at) if self.created_at is not None else None
+        )
+        return data
+
+
+@dataclass
+class ProviderResult:
+    provider: str
+    backend: str
+    home: str
+    conversations: list[Conversation] = field(default_factory=list)
+    excluded_subagents: int = 0
+    excluded_archived: int = 0
+    excluded_automated: int = 0
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def total(self) -> int:
+        return len(self.conversations)
+
+
+@dataclass
+class CodexDatabase:
+    path: Path
+    columns: set[str]
+    max_updated_ms: int

--- a/daymade-claude-code/continue-codex-work/scripts/_core/parse.py
+++ b/daymade-claude-code/continue-codex-work/scripts/_core/parse.py
@@ -1,0 +1,102 @@
+"""Shared parsing / formatting helpers for the conversation-history skills.
+
+Pure, self-contained utilities that every skill re-implements otherwise. Bundled
+into each skill's ``scripts/_core/`` by ``sync_core.py`` (see homes.py for why
+bundling rather than importing a sibling). This is the parsing counterpart to
+``homes.py``; more helpers (text/title extraction, workspace matching, JSONL
+iteration) move here in later phases as they are de-duplicated from the skills.
+"""
+
+import os
+import re
+import sys
+from datetime import datetime
+from typing import Any, Optional
+
+WINDOWS_DRIVE_RE = re.compile(r"^(?:[/\\]{2}\?[/\\])?[A-Za-z]:[/\\]")
+
+
+def parse_timestamp(value: Any) -> Optional[float]:
+    """Parse a seconds/millis epoch number or ISO-8601 string to epoch seconds.
+
+    Returns None for empty/invalid input. Values above 10^10 are treated as
+    milliseconds (Claude/Codex both persist ms in places), everything else as
+    seconds.
+    """
+    if value is None or value == "":
+        return None
+    if isinstance(value, (int, float)):
+        numeric = float(value)
+        if numeric <= 0:
+            return None
+        return numeric / 1000 if numeric > 10_000_000_000 else numeric
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            numeric = float(text)
+            if numeric <= 0:
+                return None
+            return numeric / 1000 if numeric > 10_000_000_000 else numeric
+        except ValueError:
+            pass
+        try:
+            return datetime.fromisoformat(text.replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            return None
+    return None
+
+
+def timezone_offset_colon(value: str) -> str:
+    """Insert the colon in a ``+0800`` style offset -> ``+08:00`` (else as-is)."""
+    if len(value) == 5 and value[0] in "+-":
+        return value[:3] + ":" + value[3:]
+    return value
+
+
+def format_timestamp(value: float) -> str:
+    """Human-readable local time with an explicit timezone offset."""
+    local = datetime.fromtimestamp(value).astimezone()
+    return local.strftime("%Y-%m-%d %H:%M ") + timezone_offset_colon(
+        local.strftime("%z")
+    )
+
+
+def iso_timestamp(value: float) -> str:
+    """ISO-8601 local timestamp (seconds precision, with offset)."""
+    return datetime.fromtimestamp(value).astimezone().isoformat(timespec="seconds")
+
+
+def looks_like_windows_path(value: str) -> bool:
+    """True for a Windows drive path (``C:\\...``) or a UNC path (``\\\\host``)."""
+    return bool(WINDOWS_DRIVE_RE.match(value)) or value.startswith("\\\\")
+
+
+def normalize_workspace(value: str) -> str:
+    """Normalize a persisted cwd without guessing Windows/WSL equivalence."""
+    value = os.path.expandvars(os.path.expanduser(str(value).strip()))
+    if looks_like_windows_path(value):
+        normalized = value.replace("\\", "/")
+        if normalized.startswith("//?/"):
+            normalized = normalized[4:]
+        normalized = re.sub(r"/+", "/", normalized).rstrip("/")
+        return normalized.casefold()
+    normalized = os.path.abspath(os.path.normpath(value)).rstrip(os.sep)
+    if sys.platform == "darwin":
+        return normalized.casefold()
+    return os.path.normcase(normalized)
+
+
+def workspace_matches(candidate: str, target: Optional[str], recursive: bool) -> bool:
+    """Whether a ``candidate`` cwd matches ``target`` (exact, or nested if recursive)."""
+    if target is None:
+        return True
+    normalized_candidate = normalize_workspace(candidate)
+    normalized_target = normalize_workspace(target)
+    if normalized_candidate == normalized_target:
+        return True
+    if not recursive:
+        return False
+    separator = "/" if "/" in normalized_target else os.sep
+    return normalized_candidate.startswith(normalized_target.rstrip(separator) + separator)

--- a/daymade-claude-code/continue-codex-work/scripts/_core/text.py
+++ b/daymade-claude-code/continue-codex-work/scripts/_core/text.py
@@ -1,0 +1,171 @@
+"""Shared text / title / JSONL parsing helpers for the local-history skills.
+
+These turn raw session content into a readable one-line title and iterate JSONL
+transcripts safely. Both the Claude and Codex providers use them, so they live in
+the shared core (SSOT: `daymade-claude-code/_conversation_core/`, bundled into
+each skill's `scripts/_core/` by `sync_core.py`). Keeping them here lets the Codex
+provider and a future `continue-codex-work` skill reuse one implementation instead
+of re-deriving title/noise heuristics that would drift apart.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Iterable, Iterator, Optional
+
+from .parse import looks_like_windows_path
+
+MAX_PREFIX_BYTES = 2 * 1024 * 1024
+MAX_PREFIX_LINES = 5000
+NOISE_PREFIXES = (
+    "# agents.md instructions for ",
+    "<app-context",
+    "<collaboration_mode",
+    "<command-message",
+    "<command-name",
+    "<codex_internal_context",
+    "<environment_context",
+    "<local-command-caveat",
+    "<local-command-stdout",
+    "<permissions instructions",
+    "<recommended_plugins",
+    "<system-reminder",
+)
+AUTOMATED_TITLE_RE = re.compile(
+    r"^(?:reply|respond|return|print)\s+(?:with\s+)?exactly\b", re.IGNORECASE
+)
+ATTACHMENT_IMAGE_RE = re.compile(
+    r"^(?:<image\b|\[Image\s+#\d+\])", re.IGNORECASE
+)
+FILE_SUFFIX_RE = re.compile(r"\.[A-Za-z0-9]{1,16}$")
+SLASH_COMMAND_RE = re.compile(r"^/[A-Za-z0-9_:-]+(?:[ \t].*)?$")
+
+
+def looks_like_attachment_prefix(value: str) -> bool:
+    """Recognize attachment metadata without guessing from prompt length."""
+    stripped = value.strip()
+    if ATTACHMENT_IMAGE_RE.match(stripped):
+        return True
+    if "\n" in stripped:
+        return False
+    candidate = stripped.strip("`'\"")
+    path_like = candidate.startswith(("/", "~/")) or looks_like_windows_path(
+        candidate
+    )
+    return path_like and bool(FILE_SUFFIX_RE.search(candidate))
+
+
+def strip_structural_metadata_lines(value: str) -> tuple[str, bool]:
+    """Remove attachment and slash-command wrapper lines around a request."""
+    lines = [line.strip() for line in value.splitlines() if line.strip()]
+    removed_attachment = False
+    while lines:
+        if looks_like_attachment_prefix(lines[0]):
+            removed_attachment = True
+            lines.pop(0)
+            continue
+        if SLASH_COMMAND_RE.fullmatch(lines[0]):
+            lines.pop(0)
+            continue
+        break
+    while lines and SLASH_COMMAND_RE.fullmatch(lines[-1]):
+        lines.pop()
+    return "\n".join(lines).strip(), removed_attachment
+
+
+def iter_jsonl(path: Path, *, bounded: bool = False) -> Iterator[dict[str, Any]]:
+    consumed = 0
+    lines = 0
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                consumed += len(line.encode("utf-8", errors="replace"))
+                lines += 1
+                if bounded and (consumed > MAX_PREFIX_BYTES or lines > MAX_PREFIX_LINES):
+                    return
+                try:
+                    value = json.loads(line)
+                except (json.JSONDecodeError, TypeError):
+                    continue
+                if isinstance(value, dict):
+                    yield value
+    except (OSError, UnicodeError):
+        return
+
+
+def extract_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for item in content:
+        if not isinstance(item, dict):
+            continue
+        if item.get("type") in {"text", "input_text"} and isinstance(
+            item.get("text"), str
+        ):
+            parts.append(item["text"])
+    return " ".join(parts)
+
+
+def is_noise_text(text: str) -> bool:
+    lowered = text.lstrip().casefold()
+    return not lowered or any(lowered.startswith(prefix) for prefix in NOISE_PREFIXES)
+
+
+def clean_title(text: str, max_chars: int) -> str:
+    separator_parts = re.split(r"(?:^|\n)\s*-{4,}\s*(?:\n|$)", text)
+    if len(separator_parts) > 1:
+        raw_candidates = [part.strip() for part in separator_parts if part.strip()]
+        processed_candidates = [
+            strip_structural_metadata_lines(part) for part in raw_candidates
+        ]
+        attachment_requests = [
+            candidate
+            for candidate, removed_attachment in processed_candidates
+            if candidate and removed_attachment
+        ]
+        candidates = [candidate for candidate, _ in processed_candidates if candidate]
+        candidates = candidates or raw_candidates
+        if attachment_requests:
+            text = attachment_requests[-1]
+        elif candidates:
+            prefix = candidates[0]
+            tail = candidates[-1]
+            text = tail if len(tail) >= 20 else prefix
+    text = re.sub(r"^<image\b[^>]*>\s*", "", text, flags=re.IGNORECASE)
+    text = re.sub(r"</?image>\s*", "", text, flags=re.IGNORECASE)
+    text = re.sub(r"^\[Image\s+#\d+\]\s*", "", text, flags=re.IGNORECASE)
+    home = str(Path.home())
+    for home_variant in {home, home.replace("\\", "/"), home.replace("/", "\\")}:
+        if home_variant:
+            text = text.replace(home_variant, "~")
+    text = re.sub(r"[\r\n\t]+", " ", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    if len(text) <= max_chars:
+        return text
+    return text[: max_chars - 1].rstrip() + "…"
+
+
+def is_automated_title(title: str) -> bool:
+    return bool(AUTOMATED_TITLE_RE.match(title.strip()))
+
+
+def first_meaningful_title(
+    candidates: Iterable[Any], max_chars: int
+) -> Optional[str]:
+    short_candidate: Optional[str] = None
+    for candidate in candidates:
+        if not isinstance(candidate, str):
+            continue
+        cleaned = clean_title(candidate, max_chars)
+        if is_noise_text(cleaned):
+            continue
+        if len(cleaned) >= 4:
+            return cleaned
+        if cleaned and short_candidate is None:
+            short_candidate = cleaned
+    return short_candidate

--- a/daymade-claude-code/continue-codex-work/scripts/extract_codex_resume.py
+++ b/daymade-claude-code/continue-codex-work/scripts/extract_codex_resume.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python3
+"""Extract actionable resume context from a Codex CLI session's rollout JSONL.
+
+The Codex analog of continue-claude-work's extract_resume_context.py. Codex stores
+each session as a rollout JSONL under ~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl
+with a different schema than Claude Code — so this script reuses the shared _core
+for session discovery (_core.codex) and timestamp/text helpers, and adds a
+Codex-rollout-specific parser + briefing renderer.
+
+Why not `codex resume`: replaying a full rollout burns the context window on
+resolved turns and stale tool output. This selectively reconstructs only the
+high-signal context — the last compaction summary, recent user/assistant turns,
+tool calls, files edited, and how the session ended.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Optional
+
+# The shared core is bundled into this skill's scripts/_core/ by sync_core.py
+# (see _core/homes.py for why we bundle rather than import a sibling skill).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _core.codex import collect_codex  # noqa: E402
+from _core.parse import format_timestamp  # noqa: E402
+from _core.text import extract_text, is_noise_text, iter_jsonl  # noqa: E402
+
+CODEX_HOME = Path(os.environ.get("CODEX_HOME") or (Path.home() / ".codex"))
+MAX_SUMMARY_CHARS = 8000
+MAX_USER_REQUESTS = 6
+MAX_ASSISTANT_RESPONSES = 4
+MAX_TOOL_CALLS = 20
+MAX_FILES = 40
+
+END_REASON_LABELS = {
+    "completed": "Clean exit — the last turn completed",
+    "interrupted": "Interrupted — tool calls were dispatched but never resolved",
+    "in_progress": "In progress — tools ran but the agent left no closing message (resume mid-task)",
+    "abandoned": "Abandoned — a user message got no response",
+    "error_cascade": "Error cascade — repeated tool failures",
+    "unknown": "Unknown",
+}
+
+
+# ── Session discovery (reuses the tested _core.codex provider) ────────────────
+
+
+def _discovery_args(project_path: Optional[str], all_projects: bool) -> SimpleNamespace:
+    """Build the argparse-like namespace collect_codex expects."""
+    return SimpleNamespace(
+        cwd=project_path,
+        all_projects=all_projects,
+        recursive=False,
+        include_archived=False,
+        include_subagents=False,
+        include_automated=False,
+        max_title_chars=100,
+    )
+
+
+def list_sessions(
+    project_path: Optional[str], all_projects: bool, exclude_current: Optional[str] = None
+) -> tuple[list, list[str]]:
+    """Return (conversations newest-first, warnings) for a project or all projects."""
+    result = collect_codex(_discovery_args(project_path, all_projects), CODEX_HOME)
+    convs = [c for c in result.conversations if c.session_id != exclude_current]
+    return convs, result.warnings
+
+
+def resolve_rollout(conv) -> Optional[Path]:
+    """Resolve a conversation to its rollout JSONL file on disk.
+
+    Prefer the path the state DB recorded; fall back to globbing sessions/ by the
+    session id (the id is embedded in the rollout filename).
+    """
+    if conv.path:
+        candidate = Path(conv.path)
+        if candidate.is_file():
+            return candidate
+    sessions_dir = CODEX_HOME / "sessions"
+    if sessions_dir.is_dir():
+        for match in sessions_dir.rglob(f"rollout-*{conv.session_id}*.jsonl"):
+            return match
+    return None
+
+
+# ── Rollout parsing ──────────────────────────────────────────────────────────
+
+
+def _compacted_summary(payload: dict) -> str:
+    """Distill a compaction record into the surviving conversation thread.
+
+    Codex compaction stores a `replacement_history` of messages that replace the
+    compacted window, NOT a single summary string. That history also re-injects
+    the system preamble (the permissions block, the agent-role message, the
+    project's AGENTS.md), so we keep only user/assistant turns and drop the
+    noise-prefixed system dumps that is_noise_text recognizes.
+    """
+    parts: list[str] = []
+    message = payload.get("message")
+    if isinstance(message, str) and message.strip() and not is_noise_text(message):
+        parts.append(message.strip())
+    history = payload.get("replacement_history")
+    if isinstance(history, list):
+        for item in history:
+            if not isinstance(item, dict):
+                continue
+            if item.get("role") not in ("user", "assistant"):
+                continue
+            text = extract_text(item.get("content")).strip()
+            if text and not is_noise_text(text):
+                parts.append(text[:800])
+    return "\n\n".join(parts).strip()
+
+
+def _looks_like_error(text: str) -> bool:
+    lowered = text[:200].lower()
+    return any(
+        marker in lowered
+        for marker in ("traceback", "exception", "command failed", "fatal:", "no such file")
+    )
+
+
+def _detect_end_reason(data: dict) -> str:
+    if data["open_calls"]:
+        return "interrupted"
+    if data["last_sig"] == "user_message":
+        return "abandoned"
+    if data["last_sig"] in ("task_complete", "agent_message"):
+        return "completed"
+    if data["last_sig"] in ("tool_call", "tool_output", "patch"):
+        return "in_progress"
+    if len(data["errors"]) >= 3:
+        return "error_cascade"
+    return "unknown"
+
+
+def parse_codex_rollout(path: Path) -> dict:
+    """Stream a rollout JSONL into a structured resume payload.
+
+    User/assistant text is read from the event stream (`event_msg/user_message`,
+    `event_msg/agent_message`, `task_complete`), which stores plain strings and
+    mirrors the `response_item/message` items — so we avoid double-counting and
+    sidestep `output_text` content that the shared extract_text does not decode.
+    """
+    data: dict[str, Any] = {
+        "file_size": path.stat().st_size,
+        "total_lines": 0,
+        "meta": None,
+        "compact_summaries": [],
+        "user_messages": [],
+        "assistant_messages": [],
+        "tool_calls": [],  # (name, preview)
+        "files_touched": set(),
+        "errors": [],
+        "open_calls": {},  # call_id -> tool name (dispatched, awaiting output)
+        "last_sig": None,
+    }
+
+    for record in iter_jsonl(path):
+        data["total_lines"] += 1
+        rtype = record.get("type")
+        payload = record.get("payload") if isinstance(record.get("payload"), dict) else {}
+        ptype = payload.get("type")
+
+        if rtype == "session_meta":
+            data["meta"] = payload
+        elif rtype == "compacted":
+            summary = _compacted_summary(payload)
+            if summary:
+                data["compact_summaries"].append(summary)
+        elif rtype == "event_msg":
+            if ptype == "user_message":
+                message = str(payload.get("message") or "").strip()
+                if message and not is_noise_text(message):
+                    data["user_messages"].append(message)
+                    data["last_sig"] = "user_message"
+            elif ptype == "agent_message":
+                message = str(payload.get("message") or "").strip()
+                if message:
+                    data["assistant_messages"].append(message)
+                    data["last_sig"] = "agent_message"
+            elif ptype == "patch_apply_end":
+                changes = payload.get("changes")
+                if isinstance(changes, dict):
+                    for filepath in changes:
+                        data["files_touched"].add(filepath)
+                if not payload.get("success", True):
+                    stderr = str(payload.get("stderr") or "patch failed").strip()
+                    if stderr:
+                        data["errors"].append(stderr[:300])
+                data["last_sig"] = "patch"
+            elif ptype == "task_complete":
+                last_message = str(payload.get("last_agent_message") or "").strip()
+                if last_message:
+                    data["assistant_messages"].append(last_message)
+                data["last_sig"] = "task_complete"
+        elif rtype == "response_item":
+            if ptype in ("function_call", "custom_tool_call"):
+                name = str(payload.get("name") or "?")
+                raw = payload.get("input") if ptype == "custom_tool_call" else payload.get("arguments")
+                preview = " ".join(str(raw or "").split())[:120]
+                data["tool_calls"].append((name, preview))
+                call_id = payload.get("call_id")
+                if call_id:
+                    data["open_calls"][call_id] = name
+                data["last_sig"] = "tool_call"
+            elif ptype in ("function_call_output", "custom_tool_call_output"):
+                call_id = payload.get("call_id")
+                if call_id:
+                    data["open_calls"].pop(call_id, None)
+                output = extract_text(payload.get("output"))
+                if output and _looks_like_error(output):
+                    data["errors"].append(output[:300])
+                data["last_sig"] = "tool_output"
+
+    data["end_reason"] = _detect_end_reason(data)
+    return data
+
+
+# ── Workspace state ──────────────────────────────────────────────────────────
+
+
+def get_git_state(project_path: str) -> str:
+    """Current branch, short status, and recent log — best effort."""
+    def run(cmd: list[str]) -> str:
+        try:
+            out = subprocess.run(
+                cmd, cwd=project_path, capture_output=True, text=True, timeout=5
+            )
+            return out.stdout.strip()
+        except (subprocess.SubprocessError, OSError):
+            return ""
+
+    if not run(["git", "rev-parse", "--is-inside-work-tree"]):
+        return "_(not a git repository)_"
+    branch = run(["git", "branch", "--show-current"]) or "(detached)"
+    status = run(["git", "status", "--short"])
+    log = run(["git", "log", "--oneline", "-5"])
+    lines = [f"- **Branch**: `{branch}`"]
+    if status:
+        lines.append(f"- **Uncommitted changes**:\n```\n{status}\n```")
+    else:
+        lines.append("- **Working tree**: clean")
+    if log:
+        lines.append(f"- **Recent commits**:\n```\n{log}\n```")
+    return "\n".join(lines)
+
+
+# ── Briefing ─────────────────────────────────────────────────────────────────
+
+
+def build_briefing(conv, data: dict, project_path: str) -> str:
+    sections = ["# Codex Resume Context Briefing\n"]
+
+    meta = data["meta"] or {}
+    session_id = (meta.get("id") or (conv.session_id if conv else "?"))
+    cwd = meta.get("cwd") or (conv.cwd if conv else "?")
+    updated = format_timestamp(conv.updated_at) if conv and conv.updated_at else "?"
+    sections.append("## Session Info\n")
+    sections.append(f"- **ID**: `{session_id}`")
+    sections.append(f"- **Project (cwd)**: `{cwd}`")
+    sections.append(f"- **Last active**: {updated}")
+    if conv and conv.title:
+        sections.append(f"- **Title**: {conv.title}")
+    if meta.get("cli_version"):
+        sections.append(f"- **Codex version**: {meta['cli_version']}")
+
+    file_mb = data["file_size"] / 1_000_000
+    end_label = END_REASON_LABELS.get(data["end_reason"], data["end_reason"])
+    sections.append(
+        f"\n**Rollout file**: {file_mb:.1f} MB, {data['total_lines']} records, "
+        f"{len(data['compact_summaries'])} compaction(s)"
+    )
+    sections.append(f"**Session end reason**: {end_label}")
+    if data["open_calls"]:
+        pending = ", ".join(sorted(set(data["open_calls"].values())))
+        sections.append(f"**Unresolved tool calls**: {len(data['open_calls'])} ({pending})")
+
+    if data["compact_summaries"]:
+        summary = data["compact_summaries"][-1]
+        display = summary[:MAX_SUMMARY_CHARS]
+        if len(summary) > MAX_SUMMARY_CHARS:
+            display += f"\n\n... (truncated, full summary: {len(summary)} chars)"
+        sections.append("\n## Compact Summary (from the session's last compaction)\n")
+        sections.append(display)
+
+    user_messages = data["user_messages"][-MAX_USER_REQUESTS:]
+    if user_messages:
+        sections.append("\n## Last User Requests\n")
+        for i, text in enumerate(user_messages, 1):
+            display = text[:500] + ("..." if len(text) > 500 else "")
+            sections.append(f"### Request {i}\n{display}\n")
+
+    assistant_messages = data["assistant_messages"][-MAX_ASSISTANT_RESPONSES:]
+    if assistant_messages:
+        sections.append("\n## Last Assistant Responses\n")
+        for i, text in enumerate(assistant_messages, 1):
+            display = text[:1000] + ("..." if len(text) > 1000 else "")
+            sections.append(f"### Response {i}\n{display}\n")
+
+    if data["tool_calls"]:
+        recent = data["tool_calls"][-MAX_TOOL_CALLS:]
+        sections.append(f"\n## Recent Tool Calls ({len(data['tool_calls'])} total)\n")
+        for name, preview in recent:
+            sections.append(f"- **{name}**: `{preview}`" if preview else f"- **{name}**")
+
+    if data["files_touched"]:
+        sections.append("\n## Files Edited in Session\n")
+        for filepath in sorted(data["files_touched"])[:MAX_FILES]:
+            sections.append(f"- `{filepath}`")
+        if len(data["files_touched"]) > MAX_FILES:
+            sections.append(f"- ... ({len(data['files_touched']) - MAX_FILES} more)")
+
+    if data["errors"]:
+        sections.append("\n## Errors Encountered\n")
+        seen = set()
+        for error in data["errors"]:
+            short = error[:200]
+            if short not in seen:
+                seen.add(short)
+                sections.append(f"```\n{error}\n```")
+
+    sections.append("\n## Current Workspace State\n")
+    sections.append(get_git_state(project_path))
+
+    return "\n".join(sections)
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────────
+
+
+def _print_session_list(convs: list, limit: int) -> None:
+    for conv in convs[:limit]:
+        updated = format_timestamp(conv.updated_at) if conv.updated_at else "?"
+        print(f"- {conv.session_id}  [{updated}]")
+        print(f"    {conv.title}")
+        print(f"    cwd: {conv.cwd}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Extract actionable resume context from a Codex CLI session.",
+    )
+    parser.add_argument("--project", "-p", default=os.getcwd(),
+                        help="Project path (default: current directory)")
+    parser.add_argument("--session", "-s", default=None,
+                        help="Session ID to extract context from")
+    parser.add_argument("--query", "-q", default=None,
+                        help="Search sessions by keyword in the title")
+    parser.add_argument("--list", "-l", action="store_true",
+                        help="List recent Codex sessions for the project")
+    parser.add_argument("--all-projects", "-a", action="store_true",
+                        help="Do not filter by the current project's cwd")
+    parser.add_argument("--limit", "-n", type=int, default=10,
+                        help="Number of sessions to list (default: 10)")
+    parser.add_argument("--exclude-current", default=None,
+                        help="Session ID to exclude (e.g. a currently active session)")
+    args = parser.parse_args()
+
+    project_path = os.path.abspath(args.project)
+
+    if not CODEX_HOME.is_dir():
+        print(f"Error: Codex home not found: {CODEX_HOME}", file=sys.stderr)
+        print("Set CODEX_HOME or install the Codex CLI first.", file=sys.stderr)
+        return 1
+
+    # ── List mode ──
+    if args.list:
+        convs, warnings = list_sessions(project_path, args.all_projects, args.exclude_current)
+        scope = "all projects" if args.all_projects else project_path
+        if not convs:
+            print(f"No Codex sessions found for {scope}.")
+            for warning in warnings:
+                print(f"  note: {warning}", file=sys.stderr)
+            return 0
+        print(f"Codex sessions for {scope} ({len(convs)} found):\n")
+        _print_session_list(convs, args.limit)
+        return 0
+
+    # ── Query mode ──
+    if args.query:
+        convs, _ = list_sessions(project_path, all_projects=True, exclude_current=args.exclude_current)
+        needle = args.query.casefold()
+        matches = [c for c in convs if needle in (c.title or "").casefold()]
+        if not matches:
+            print(f"No Codex sessions matching '{args.query}'.", file=sys.stderr)
+            return 1
+        if len(matches) > 1:
+            print(f"Codex sessions matching '{args.query}' ({len(matches)} found):\n")
+            _print_session_list(matches, args.limit)
+            return 0
+        args.session = matches[0].session_id
+
+    # ── Extract mode ──
+    conv = None
+    if args.session:
+        convs, _ = list_sessions(project_path, all_projects=True, exclude_current=None)
+        for candidate in convs:
+            if candidate.session_id == args.session or args.session in candidate.session_id:
+                conv = candidate
+                break
+        if conv is None:
+            print(f"Error: no Codex session found for id {args.session}", file=sys.stderr)
+            return 1
+    else:
+        convs, warnings = list_sessions(project_path, args.all_projects, args.exclude_current)
+        if not convs:
+            print(f"No Codex sessions found for {project_path}.", file=sys.stderr)
+            for warning in warnings:
+                print(f"  note: {warning}", file=sys.stderr)
+            return 1
+        conv = convs[0]  # newest-first
+
+    rollout = resolve_rollout(conv)
+    if rollout is None:
+        print(f"Error: rollout file not found for session {conv.session_id}", file=sys.stderr)
+        return 1
+
+    print(f"Parsing Codex session {conv.session_id} "
+          f"({rollout.stat().st_size / 1_000_000:.1f} MB)...", file=sys.stderr)
+    data = parse_codex_rollout(rollout)
+    print(build_briefing(conv, data, project_path))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/daymade-claude-code/sync_core.py
+++ b/daymade-claude-code/sync_core.py
@@ -30,6 +30,7 @@ TARGET_SKILLS = [
     "claude-code-history-files-finder",
     "local-conversation-history",
     "continue-claude-work",
+    "continue-codex-work",
 ]
 
 HERE = Path(__file__).resolve().parent


### PR DESCRIPTION
## What

New skill **`continue-codex-work`** — the Codex CLI analog of `continue-claude-work`. It recovers actionable resume context from a prior Codex session's rollout JSONL (`~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`) so you can pick up interrupted Codex work **without** replaying the whole transcript via `codex resume`.

Closes the P3 item of the shared-`_core` refactor series (after P2a model #151, P2b-1 text #152, P2b-2 codex #153).

## How it works

- **`scripts/extract_codex_resume.py`** reuses the shared `_core` (`collect_codex` for session discovery; `parse`/`text` helpers) and adds a Codex-rollout parser + Markdown briefing: session info, **end reason** (incl. a new `in_progress` = tools ran but no closing message — the common resume case), compact summary, recent user/assistant turns, tool calls, **files edited** (from `patch_apply_end.changes`), errors, and git state.
- **Schema verified against real sessions** (Codex `0.144.4`): user/assistant text is read from the event stream (`user_message`/`agent_message`/`task_complete`) to sidestep `output_text` content that the shared `extract_text` doesn't decode; the compact summary strips Codex's re-injected system preamble + `AGENTS.md`.
- `_core` bundled via `sync_core.py` (`continue-codex-work` added to `TARGET_SKILLS`).
- `SKILL.md` description is scoped to Codex/`~/.codex` so it does **not** collide with `continue-claude-work`'s triggering. `references/file_structure.md` documents the verified rollout schema.

## Verified

- `--list` / `--all-projects --list` / `--session <id>` / `--query` / default extract all run against **real** Codex sessions (1268 discovered; briefings render correctly for both fresh and 3-month-old rollouts).
- `quick_validate` passes; `security_scan` clean.

## Note

Two focused commits (skill; marketplace registration) rather than one cross-domain commit, to keep each within a single top-level directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)