### PR TITLE
feat(daymade-claude-code): v1.15.0 archive-aware history + cross-project/Codex search

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -100,10 +100,10 @@
     },
     {
       "name": "daymade-claude-code",
-      "description": "Claude Code operations suite that bundles fast local conversation discovery across Claude Code and Codex, deep session history recovery, interrupted-work continuation, plugin/skill troubleshooting, CLAUDE.md progressive disclosure optimization, statusline configuration, exported .txt repair, full claude.ai conversation extraction with tool-call rendering and file download, plugin marketplace development, multi-provider profile isolation for running Kimi/GLM/DeepSeek/StepFun/Anthropic in separate windows, local source sync for Claude/Codex skill installs, and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
+      "description": "Claude Code operations suite that bundles archive-aware local conversation discovery across Claude Code and Codex, internal-timestamp full-event session search and recovery, interrupted-work continuation, plugin/skill troubleshooting, CLAUDE.md progressive disclosure optimization, statusline configuration, exported .txt repair, full claude.ai conversation extraction with tool-call rendering and file download, plugin marketplace development, multi-provider profile isolation for running Kimi/GLM/DeepSeek/StepFun/Anthropic in separate windows, local source sync for Claude/Codex skill installs, and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
       "source": "./daymade-claude-code",
       "strict": false,
-      "version": "1.14.1",
+      "version": "1.15.0",
       "category": "suite",
       "keywords": [
         "suite",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **github-review-pr** v1.2.0: review or re-review one contributor PR—including an explicitly named closed PR under reconsideration—or sweep every open PR newest-to-oldest against the live base. It separates PR-recorded-base/current-base/head snapshots, detects history discontinuity, isolates the verified contribution onto current main as a non-landable synthetic projection, reviews actual three-way results, requires target evidence for findings, separates severity from confidence, assigns PR/BASE/SHARED ownership, and remains read-only by default. Its explicit personal-maintainer context learns only maintainer-authored precedent, enforces curation before contributor metrics, treats Claude for Open Source eligibility only as a post-merit priority, preserves worthy original contributor PRs through authorized non-force repair plus squash landing, distinguishes `DECLINE` from supersession, and requires a fresh per-PR merge confirmation after every repair/re-review. A short affirmative reply now confirms the one immediately surfaced PR without requiring a magic phrase, while never carrying authority to another PR; sequential landings invalidate every later current-base review; history-repaired squash landings use reviewed commit metadata and verify the landed tree, mapped contributor author, and branch state.
 
 ### Changed
+- **daymade-claude-code** v1.15.0: `local-conversation-history` and
+  `claude-code-history-files-finder` now treat Claude history as one explicit
+  source set: auto-discovered active homes plus every long-term archive in
+  `~/.claude/history-sources.json`. Required archives fail closed instead of
+  allowing a false whole-history absence claim; duplicate session IDs retain
+  provenance, union their internal ranges, and use the newest copy only for
+  representative title/path selection (active wins an exact tie). Claude
+  inventory and date filtering now stream all JSONL records to compute true
+  internal minimum/maximum ranges and never use file mtime. Codex raw-rollout
+  fallback now follows the same internal-time rule, and state-database ties use
+  the numeric generation instead of database mtime. Deep search unions
+  distinct records across every physical copy, applies date windows to matching
+  records, and covers
+  message text, thinking, tool inputs/results, queue operations, attachments,
+  last prompts, system/summary content, and custom titles while excluding
+  structural IDs/signatures. The finder also sweeps every project in one pass
+  with `--all-projects`, optionally covers Codex rollout history with `--codex`
+  (mirror records counted once, project filtering by rollout cwd), and skips
+  self-matches with `--exclude-session`; zero-match output suggests the
+  widening not yet applied. Added isolated archive/mtime/event-field regression
+  fixtures and behavior evals; simple cross-provider listing remains routed to
+  `local-conversation-history`, while keyword/recovery forensics remains routed
+  to the finder.
 - **meeting-minutes-taker** (`daymade-audio` v1.9.1): documentation-governance sync for Step 3.5 — completeness_review_checklist.md now carries a scope note declaring itself a same-context self-review whose shared-blind-spot gap is covered by Step 3.5 (run both); meeting_minutes_template.md Action Items table gains a "Notes (conditions/expiry)" column so conditional commitments keep their expiry condition in the retrievable layer.
 - **meeting-minutes-taker** (`daymade-audio` v1.9.0): add Step 3.5 Retrieval Self-Test — a consumption-side verification gate between merge and delivery. A fresh-context subagent that never sees the draft reverse-extracts a "future-query claims list" from the transcript alone (who + instruction/promise/decision/veto + scope + timestamp, chunked for long transcripts), then each claim is hit-tested against the retrievable layer (Key Decisions / Action Items / Parking Lot / Open Questions) with component-level judging and lexical anchors. Misses that survive a mandatory revocation scan are promoted with a `[self-test promoted]` tag plus a greppable verbatim quote; uncertain items route to Open Questions, never inflating the decision table; output is always "enumerated N / hits M / promoted K / uncertain" (never a binary pass) and the gate fails open with a visible NOT-RUN note. Rationale: the three same-prompt generation passes are correlated classifiers — UNION merge protects against content loss but not shared blind spots (a narrative-voiced directive missed by all three passes surfaced only when the user later queried the decision table). Validated empirically on two real transcripts before shipping: the extractor caught the original missed directive with zero hints, plus one new real miss on the already-fixed minutes and three on an older meeting's minutes. Also adds an element-based (not phrasing-based) decision-recognition rule to the generation prompts with a precision guardrail.
 - **meeting-minutes-taker** (`daymade-audio` v1.8.0): make source-side speaker labeling the first action for anonymous speaker labels. When a transcript arrives with generic "Speaker N" labels from a platform that supports manual labeling (Feishu Minutes, Tencent Meeting), the skill now stops and asks the user to label speakers on the platform page and re-export, instead of inferring identities from text. The former feature-analysis workflow (Phase A–C) is demoted to an explicit fallback — used only when the user declines or the source cannot be labeled — that requires per-speaker evidence and confidence, keeps unresolved labels as-is, and corrects the minutes after the user later labels the source. Rationale: platform labeling is voice ground truth; text inference only resolves name-called speakers and cannot recover diarization-merged segments.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,7 +253,7 @@ This applies when you change ANY file under a skill directory:
 16. **video-comparer** - Video comparison and quality analysis with interactive HTML reports
 17. **qa-expert** - Comprehensive QA testing infrastructure with autonomous LLM execution and Google Testing Standards
 18. **prompt-optimizer** - Transform vague prompts into precise EARS specifications with domain theory grounding
-19. **claude-code-history-files-finder** - Find and recover content from Claude Code session history files
+19. **claude-code-history-files-finder** - Search messages, thinking, tool inputs/results, queues, attachments, and summaries across active Claude homes plus registered long-term archives using internal JSONL timestamps; sweep every project with --all-projects or include Codex rollouts with --codex; recover prior files and analyze session operations
 20. **docs-cleaner** - Consolidate redundant documentation while preserving valuable content
 21. **pdf-creator** - Create PDF documents from markdown with Chinese font support using weasyprint
 22. **claude-md-progressive-disclosurer** - Optimize CLAUDE.md files using progressive disclosure principles
@@ -318,8 +318,9 @@ This applies when you change ANY file under a skill directory:
 81. **skill-governance** - Enforce source-of-truth discipline for Claude Code skill marketplaces and caches: check source/cache drift, sync through official plugin commands, clean old cache versions, and switch marketplace entries to local source (daymade-skill suite member)
 82. **photo-to-scanned-pdf** - Turn phone photos of paper documents into a scanner-quality A4 PDF with perspective correction, noteshrink enhancement, colored-paper handling, content-based page ordering, and mandatory whole-document visual verification (daymade-docs suite member)
 83. **github-review-pr** - Review one named contributor PR (open or closed under reconsideration) or all open PRs newest-to-oldest against the live base, with immutable OID snapshots, history-discontinuity detection, isolated current-base contribution projection, three-way merge analysis, PR/BASE/SHARED ownership, explicit personal maintainer context, and per-PR review-gated repair or landing
-84. **local-conversation-history** - List recent local Claude Code and Codex conversations for the current workspace in one read-only command, with readable titles, timezone-qualified timestamps, exact session IDs, schema-aware Codex indexing, bounded Claude JSONL reads, and default sub-agent/test filtering (daymade-claude-code suite member)
-85. **git-safety-net** - Prevent and recover from local-Git disasters: commits stranded on the wrong branch, orphaned or dropped stashes, dangling commits about to be garbage-collected, and "is everything actually merged?" uncertainty after squash merges or parallel-agent sessions
+84. **local-conversation-history** - List recent local Claude Code and Codex conversations in one read-only command; Claude inventory combines active homes with registered archives, de-duplicates session IDs, and both providers use internal stored timestamps rather than file mtime (daymade-claude-code suite member)
+85. **continue-codex-work** - Recover actionable context from prior Codex CLI rollout files and continue interrupted work without running `codex resume` (daymade-claude-code suite member)
+86. **git-safety-net** - Prevent and recover from local-Git disasters: commits stranded on the wrong branch, orphaned or dropped stashes, dangling commits about to be garbage-collected, and "is everything actually merged?" uncertainty after squash merges or parallel-agent sessions
 
 **Recommendation**: Always suggest `skill-creator` first for users interested in creating skills or extending Claude Code.
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ This suite bundles the skills that extend Claude Code itself — fast local conv
 /daymade-claude-code:local-conversation-history
 /daymade-claude-code:claude-code-history-files-finder
 /daymade-claude-code:continue-claude-work
+/daymade-claude-code:continue-codex-work
 /daymade-claude-code:claude-skills-troubleshooting
 /daymade-claude-code:claude-md-progressive-disclosurer
 /daymade-claude-code:statusline-generator
@@ -869,16 +870,23 @@ Transform vague prompts into precise, well-structured specifications using EARS 
 
 > **Install**: `claude plugin install daymade-claude-code@daymade-skills` (suite-only — invoked as `daymade-claude-code:claude-code-history-files-finder`)
 
-Find and recover content from Claude Code session history files stored in `~/.claude/projects/`.
+Find and recover content from Claude Code session history across all active
+config homes and the long-term archives registered in
+`~/.claude/history-sources.json`.
 
 **When to use:**
 - Recovering deleted or lost files from previous Claude Code sessions
 - Searching for specific code across conversation history
 - Tracking file modifications across multiple sessions
 - Finding sessions containing specific keywords or implementations
+- Verifying date-bounded topics after a machine migration without trusting mtime
 
 **Key features:**
-- **Session search**: Find sessions by keywords with frequency ranking
+- **Complete source set**: Search active homes and registered archives by default
+- **Cross-project sweep**: `--all-projects` searches every project when the project is unknown; `--codex` also covers Codex rollout history; `--exclude-session` skips self-matches
+- **Copy-safe union**: Search distinct records from every copy of a session ID without double-counting identical records
+- **Internal-time search**: Filter matching records by JSONL timestamps, never file mtime
+- **Structured search**: Cover messages, thinking, tools, results, queues, attachments, and summaries
 - **Content recovery**: Extract files from Write tool calls with deduplication
 - **Statistics analysis**: Message counts, tool usage breakdown, file operations
 - **Batch operations**: Process multiple sessions with keyword filtering
@@ -890,10 +898,11 @@ Find and recover content from Claude Code session history files stored in `~/.cl
 python3 scripts/analyze_sessions.py list /path/to/project
 
 # Search sessions for keywords
-python3 scripts/analyze_sessions.py search /path/to/project "ComponentName" "featureX"
+python3 scripts/analyze_sessions.py search /path/to/project \
+  "ComponentName" "featureX" --from-date 2026-03-01 --to-date 2026-04-30
 
-# Recover deleted files from a session
-python3 scripts/recover_content.py ~/.claude/projects/.../session.jsonl -k DeletedComponent -o ./recovered/
+# Recover deleted files from the exact path printed by search
+python3 scripts/recover_content.py <printed-session-path> -k DeletedComponent -o ./recovered/
 
 # Get session statistics
 python3 scripts/analyze_sessions.py stats /path/to/session.jsonl --show-files
@@ -3071,11 +3080,14 @@ short titles, timezone-qualified timestamps, exact session IDs, and explicit
 diagnostics.
 
 **Key features:**
-- Reads only bounded Claude Code session prefixes and ignores sub-agents by default
+- Combines active Claude homes with every registered long-term archive by default
+- Streams complete Claude JSONL and raw Codex rollout files to compute exact
+  internal timestamp ranges; never orders or filters conversations by file mtime
+- De-duplicates copied session IDs, unions their internal ranges, and retains active/archive provenance
 - Selects a compatible Codex state database through schema introspection
 - Visibly falls back to raw Codex rollout JSONL when the database is unavailable
-- Supports custom profile homes, archived threads, recursive/all-project scopes,
-  Windows path normalization, and machine-readable JSON
+- Supports internal-time date windows, custom exact-scope diagnostics, archived
+  Codex threads, recursive/all-project scopes, Windows path normalization, and JSON
 - Uses Python's standard library only; performs no network requests or writes
 
 **Example usage:**
@@ -3093,7 +3105,30 @@ for source selection, path normalization, privacy boundaries, and diagnostics.
 
 ---
 
-### 87. **git-safety-net** - Prevent & Recover From Local-Git Disasters
+### 87. **continue-codex-work** - Resume Interrupted Codex Work
+
+> **Install**: `claude plugin install daymade-claude-code@daymade-skills`
+> (suite-only — invoked as `daymade-claude-code:continue-codex-work`)
+
+Recover actionable context from a prior Codex CLI rollout and continue in the
+current conversation without replaying the full session through `codex resume`.
+The bundled extractor can select a session by ID, title query, latest project
+activity, or list view; it reports the end reason, surviving requests, recent
+tools/files, errors, and current workspace state before work resumes.
+
+```text
+/daymade-claude-code:continue-codex-work 019f66...
+Codex was cut off mid-task; recover that rollout and finish the work
+```
+
+📚 **Documentation**: See
+[continue-codex-work/SKILL.md](./daymade-claude-code/continue-codex-work/SKILL.md).
+
+**Requirements**: Python 3.10+ and local Codex rollout files.
+
+---
+
+### 88. **git-safety-net** - Prevent & Recover From Local-Git Disasters
 
 > **Install**: `claude plugin install git-safety-net@daymade-skills`
 
@@ -3195,6 +3230,9 @@ Use **claude-code-history-files-finder** to recover deleted files from previous 
 
 ### For Resuming Interrupted Claude Sessions
 Use **continue-claude-work** to recover the last actionable request from local `~/.claude` artifacts and continue implementation without reopening the original session. Combine with **claude-code-history-files-finder** when you need broader cross-session search, statistics, or deleted-file recovery.
+
+For a prior Codex CLI run, use **continue-codex-work** instead; it reconstructs a
+briefing from local Codex rollout files without replaying the full session.
 
 ### For Fast Local Conversation Discovery
 Use **local-conversation-history** when you need a quick, readable list of recent
@@ -3317,6 +3355,7 @@ Each skill includes:
 - **excel-automation**: See `excel-automation/SKILL.md` for create/parse/control workflows and `excel-automation/references/formatting-reference.md` for formatting standards
 - **capture-screen**: See `capture-screen/SKILL.md` for CGWindowID-based screenshot workflows on macOS
 - **continue-claude-work**: See `daymade-claude-code/continue-claude-work/SKILL.md` for local artifact recovery, drift checks, and resume workflow
+- **continue-codex-work**: See `daymade-claude-code/continue-codex-work/SKILL.md` for Codex rollout discovery, end-reason diagnosis, and continuation workflow
 - **scrapling-skill**: See `scrapling-skill/SKILL.md` for the CLI workflow and `scrapling-skill/references/troubleshooting.md` for verified Scrapling failure modes
 - **ima-copilot**: See `ima-copilot/SKILL.md` for the wrapper architecture and routing, `ima-copilot/references/installation_flow.md` for the install deep dive, `ima-copilot/references/known_issues.md` for the issue registry and repair commands, and `ima-copilot/references/search_best_practices.md` for the fan-out strategy and 100-result truncation details
 - **claude-export-txt-better**: See `daymade-claude-code/claude-export-txt-better/SKILL.md` for the workflow, `daymade-claude-code/claude-export-txt-better/scripts/fix-claude-export.py` for the reconstruction algorithm, and `daymade-claude-code/claude-export-txt-better/evals/` for real regression fixtures

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -194,6 +194,7 @@ claude plugin install daymade-claude-code@daymade-skills
 /daymade-claude-code:local-conversation-history
 /daymade-claude-code:claude-code-history-files-finder
 /daymade-claude-code:continue-claude-work
+/daymade-claude-code:continue-codex-work
 /daymade-claude-code:claude-skills-troubleshooting
 /daymade-claude-code:claude-md-progressive-disclosurer
 /daymade-claude-code:statusline-generator
@@ -912,16 +913,21 @@ python3 scripts/calculate_metrics.py tests/TEST-EXECUTION-TRACKING.csv
 
 > **安装**：`claude plugin install daymade-claude-code@daymade-skills`（仅作为套件成员发布，调用方式 `daymade-claude-code:claude-code-history-files-finder`）
 
-从存储在 `~/.claude/projects/` 的 Claude Code 会话历史文件中查找和恢复内容。
+从所有活跃配置目录和 `~/.claude/history-sources.json` 已登记的长期备份中，
+查找并恢复 Claude Code 会话历史内容。
 
 **使用场景：**
 - 从之前的 Claude Code 会话中恢复已删除或丢失的文件
 - 在对话历史中搜索特定代码
 - 跨多个会话跟踪文件修改
 - 查找包含特定关键字或实现的会话
+- 机器迁移后按真实对话日期核查历史，不信文件 mtime
 
 **主要功能：**
-- **会话搜索**：按关键字查找会话并按频率排名
+- **完整来源集**：默认同时检索活跃目录与已登记备份
+- **副本安全并集**：同一会话 ID 的所有副本都参与检索，相同记录不重复计数
+- **内部时间检索**：按 JSONL 记录时间过滤，不用文件 mtime
+- **结构化检索**：覆盖消息、thinking、工具输入/结果、队列、附件与摘要
 - **内容恢复**：从 Write 工具调用中提取文件并去重
 - **统计分析**：消息计数、工具使用明细、文件操作
 - **批量操作**：使用关键字过滤处理多个会话
@@ -933,10 +939,11 @@ python3 scripts/calculate_metrics.py tests/TEST-EXECUTION-TRACKING.csv
 python3 scripts/analyze_sessions.py list /path/to/project
 
 # 搜索包含关键字的会话
-python3 scripts/analyze_sessions.py search /path/to/project "ComponentName" "featureX"
+python3 scripts/analyze_sessions.py search /path/to/project \
+  "ComponentName" "featureX" --from-date 2026-03-01 --to-date 2026-04-30
 
-# 从会话中恢复已删除的文件
-python3 scripts/recover_content.py ~/.claude/projects/.../session.jsonl -k DeletedComponent -o ./recovered/
+# 从 search 输出的精确路径恢复已删除文件
+python3 scripts/recover_content.py <printed-session-path> -k DeletedComponent -o ./recovered/
 
 # 获取会话统计信息
 python3 scripts/analyze_sessions.py stats /path/to/session.jsonl --show-files
@@ -3104,10 +3111,12 @@ main 在上次 review 后变了，重新告诉我现在真正会合进去什么
 ID 和明确诊断信息。
 
 **主要能力：**
-- 只读取 Claude Code 会话的有界前缀，默认排除 sub-agent
+- 默认合并所有活跃 Claude 配置目录与已登记的长期备份
+- 流式读完整 Claude JSONL 与 Codex raw rollout，计算精确内部时间范围；排序和筛选绝不使用文件 mtime
+- 按会话 ID 去重、合并各副本的内部时间范围，同时保留活跃目录/备份来源信息
 - 通过 schema 检查选择兼容的 Codex 状态数据库
 - 数据库不可用时明确告警，再读取原始 Codex rollout JSONL
-- 支持自定义 profile 根目录、归档会话、递归/全部项目、Windows 路径归一化和 JSON
+- 支持内部时间日期范围、精确单目录诊断、Codex 归档会话、递归/全部项目、Windows 路径归一化和 JSON
 - 仅使用 Python 标准库，不联网、不写入本地历史
 
 **示例：**
@@ -3125,7 +3134,29 @@ ID 和明确诊断信息。
 
 ---
 
-### 87. **git-safety-net** - 预防与恢复本地 Git 灾难
+### 87. **continue-codex-work** - 续做中断的 Codex 工作
+
+> **安装**：`claude plugin install daymade-claude-code@daymade-skills`
+>（仅作为套件成员发布，调用方式 `daymade-claude-code:continue-codex-work`）
+
+从本地 Codex CLI rollout 中恢复可执行上下文，在当前对话继续工作，无需用
+`codex resume` 重放整个旧会话。内置提取器支持按会话 ID、标题关键词、当前
+项目最近活动或列表定位，并在续做前报告结束原因、遗留请求、近期工具与文件、
+错误和当前工作区状态。
+
+```text
+/daymade-claude-code:continue-codex-work 019f66...
+Codex 上次做到一半中断了，读取 rollout 后把工作做完
+```
+
+📚 **文档**：参见
+[continue-codex-work/SKILL.md](./daymade-claude-code/continue-codex-work/SKILL.md)。
+
+**依赖**：Python 3.10+ 与本地 Codex rollout 文件。
+
+---
+
+### 88. **git-safety-net** - 预防与恢复本地 Git 灾难
 
 > **安装**：`claude plugin install git-safety-net@daymade-skills`
 
@@ -3221,6 +3252,9 @@ review 后修复/落地时，使用 **github-review-pr**。
 
 ### 续做中断的 Claude 会话
 使用 **continue-claude-work** 从本地 `~/.claude` 产物中恢复最后一个可执行请求，并在不重新打开原始会话的情况下继续实现。若还需要跨会话搜索、统计分析或恢复已删除文件，可与 **claude-code-history-files-finder** 配合使用。
+
+若旧工作来自 Codex CLI，则改用 **continue-codex-work**；它从本地 Codex
+rollout 重建简报，不会把完整旧会话重新灌入上下文。
 
 ### 快速发现本地对话
 需要快速查看当前工作区最近的 Claude Code 与 Codex 对话时，使用
@@ -3342,6 +3376,7 @@ review 后修复/落地时，使用 **github-review-pr**。
 - **excel-automation**：参见 `excel-automation/SKILL.md` 了解创建/解析/控制工作流，参见 `excel-automation/references/formatting-reference.md` 了解格式规范
 - **capture-screen**：参见 `capture-screen/SKILL.md` 了解基于 CGWindowID 的 macOS 截图流程
 - **continue-claude-work**：参见 `daymade-claude-code/continue-claude-work/SKILL.md` 了解本地会话产物恢复、漂移检查与续做流程
+- **continue-codex-work**：参见 `daymade-claude-code/continue-codex-work/SKILL.md` 了解 Codex rollout 定位、结束原因诊断与续做流程
 - **scrapling-skill**：参见 `scrapling-skill/SKILL.md` 了解 CLI 工作流，参见 `scrapling-skill/references/troubleshooting.md` 了解已验证的 Scrapling 故障模式
 - **ima-copilot**：参见 `ima-copilot/SKILL.md` 了解包装层架构与路由规则，参见 `ima-copilot/references/installation_flow.md` 了解安装流程细节，参见 `ima-copilot/references/known_issues.md` 了解已知问题清单与修复命令，参见 `ima-copilot/references/search_best_practices.md` 了解扇出搜索策略与 100 条截断处理
 - **claude-export-txt-better**：参见 `daymade-claude-code/claude-export-txt-better/SKILL.md` 了解工作流，参见 `daymade-claude-code/claude-export-txt-better/scripts/fix-claude-export.py` 了解重建算法，参见 `daymade-claude-code/claude-export-txt-better/evals/` 查看真实回归 fixture

--- a/daymade-claude-code/_conversation_core/__init__.py
+++ b/daymade-claude-code/_conversation_core/__init__.py
@@ -8,8 +8,13 @@ every skill stays self-contained and installable on its own while sharing one
 implementation.
 
 Modules:
-    homes  — discover every Claude config home (main + per-model profiles).
-    parse  — pure parsing/formatting helpers (timestamps, and more over time).
+    homes    — discover every active Claude config home.
+    sources  — combine active homes with explicitly registered archives.
+    claude   — stream exact Claude session metadata and internal time ranges.
+    codex    — inspect Codex state databases and raw rollout stores.
+    parse    — timestamp, timezone, and workspace normalization helpers.
+    text     — semantic JSONL text/title extraction.
+    model    — shared provider result data structures.
 """
 
 from .homes import discover_claude_homes, home_label

--- a/daymade-claude-code/_conversation_core/claude.py
+++ b/daymade-claude-code/_conversation_core/claude.py
@@ -1,0 +1,72 @@
+"""Exact, streaming metadata scan for Claude Code JSONL sessions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from .parse import TimestampRange
+from .text import extract_text, first_meaningful_title, iter_jsonl
+
+
+@dataclass(frozen=True)
+class ClaudeSessionSummary:
+    session_id: str
+    cwd: str
+    title: str
+    created_at: Optional[float]
+    updated_at: Optional[float]
+    timestamp_count: int
+
+
+def scan_claude_session(path: Path, max_title_chars: int = 120) -> ClaudeSessionSummary:
+    """Scan every valid record and return internal time bounds plus title metadata.
+
+    File mtime is deliberately absent. Copying or migrating a transcript changes
+    mtime without changing when the conversation happened; the only trustworthy
+    conversation range is the minimum and maximum valid top-level ``timestamp``
+    found across the JSONL records themselves.
+    """
+    session_id = path.stem
+    cwd = ""
+    prompt_candidates: list[str] = []
+    title: Optional[str] = None
+    timestamps = TimestampRange()
+
+    for record in iter_jsonl(path):
+        timestamps.observe(record.get("timestamp"))
+        if isinstance(record.get("sessionId"), str) and record["sessionId"]:
+            session_id = record["sessionId"]
+        if not cwd and isinstance(record.get("cwd"), str):
+            cwd = record["cwd"]
+        if title is not None:
+            continue
+        if record.get("type") != "user" or record.get("isMeta") is True:
+            continue
+        message = record.get("message")
+        if isinstance(message, dict) and message.get("role") == "user":
+            text = extract_text(message.get("content"))
+        elif isinstance(message, str):
+            text = message
+        else:
+            text = ""
+        if not text:
+            continue
+        prompt_candidates.append(text)
+        candidate = first_meaningful_title(prompt_candidates, max_title_chars)
+        if candidate and len(candidate) >= 4:
+            title = candidate
+
+    if title is None:
+        title = first_meaningful_title(prompt_candidates, max_title_chars)
+    if not title:
+        title = f"(untitled: {session_id})"
+    return ClaudeSessionSummary(
+        session_id=session_id,
+        cwd=cwd,
+        title=title,
+        created_at=timestamps.earliest,
+        updated_at=timestamps.latest,
+        timestamp_count=timestamps.count,
+    )

--- a/daymade-claude-code/_conversation_core/codex.py
+++ b/daymade-claude-code/_conversation_core/codex.py
@@ -25,7 +25,7 @@ from typing import Any, Iterable, Optional
 from urllib.parse import quote
 
 from .model import CodexDatabase, Conversation, ProviderResult
-from .parse import parse_timestamp, workspace_matches
+from .parse import TimestampRange, parse_timestamp, workspace_matches
 from .text import extract_text, first_meaningful_title, is_automated_title, iter_jsonl
 
 CODEX_REQUIRED_COLUMNS = {"id", "cwd", "updated_at", "source", "archived"}
@@ -33,6 +33,7 @@ SESSION_ID_RE = re.compile(
     r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
     re.IGNORECASE,
 )
+STATE_DATABASE_RE = re.compile(r"^state_(\d+)\.sqlite$")
 
 
 def sqlite_uri(path: Path) -> str:
@@ -83,8 +84,18 @@ def discover_codex_database(home: Path, warnings: list[str]) -> Optional[CodexDa
         return None
     return max(
         compatible,
-        key=lambda item: (item.max_updated_ms, item.path.stat().st_mtime_ns),
+        key=lambda item: (
+            item.max_updated_ms,
+            _state_database_generation(item.path),
+            item.path.as_posix(),
+        ),
     )
+
+
+def _state_database_generation(path: Path) -> int:
+    """Return the numeric state database generation without consulting mtime."""
+    match = STATE_DATABASE_RE.fullmatch(path.name)
+    return int(match.group(1)) if match else -1
 
 
 def nested_key_exists(value: Any, wanted: str) -> bool:
@@ -261,6 +272,23 @@ def codex_prompt_from_rollout(path: Path, max_chars: int) -> Optional[str]:
     return short_candidate
 
 
+def codex_rollout_time_range(path: Path) -> TimestampRange:
+    """Compute exact internal bounds for a Codex rollout.
+
+    Current rollouts timestamp every top-level event. Older/minimal fixtures may
+    carry only ``session_meta.payload.timestamp``, so observe both. File mtime is
+    deliberately excluded because copying or migrating a rollout rewrites it.
+    """
+    timestamps = TimestampRange()
+    for record in iter_jsonl(path):
+        timestamps.observe(record.get("timestamp"))
+        if record.get("type") == "session_meta" and isinstance(
+            record.get("payload"), dict
+        ):
+            timestamps.observe(record["payload"].get("timestamp"))
+    return timestamps
+
+
 def collect_codex_from_rollouts(
     args: argparse.Namespace, home: Path, result: ProviderResult
 ) -> None:
@@ -301,25 +329,22 @@ def collect_codex_from_rollouts(
         if is_automated_title(title) and not args.include_automated:
             result.excluded_automated += 1
             continue
-        try:
-            updated_at = path.stat().st_mtime
-            timestamp_source = "file-mtime"
-        except OSError:
-            updated_at = parse_timestamp(meta.get("timestamp"))
-            timestamp_source = "session-meta"
+        timestamps = codex_rollout_time_range(path)
         result.conversations.append(
             Conversation(
                 provider="codex",
                 session_id=session_id,
                 title=title,
                 cwd=cwd,
-                updated_at=updated_at,
-                created_at=parse_timestamp(meta.get("timestamp")),
+                updated_at=timestamps.latest,
+                created_at=timestamps.earliest,
                 archived=archived,
                 kind="subagent" if subagent else "main",
                 path=str(path),
                 metadata_source="rollout-jsonl",
-                timestamp_source=timestamp_source,
+                timestamp_source=(
+                    "rollout-record-minmax" if timestamps.count else "unknown"
+                ),
             )
         )
 

--- a/daymade-claude-code/_conversation_core/model.py
+++ b/daymade-claude-code/_conversation_core/model.py
@@ -3,8 +3,8 @@
 `Conversation` / `ProviderResult` / `CodexDatabase` are used by both the Claude
 and Codex providers and by the renderers, so they live in the shared core (SSOT:
 `daymade-claude-code/_conversation_core/`, bundled into each skill's
-`scripts/_core/` by `sync_core.py`). Extracting them here lets a skill like
-`continue-codex-work` reuse the same model without re-declaring it.
+`scripts/_core/` by `sync_core.py`). This lets `continue-codex-work` and the
+inventory/search skills reuse the same model without re-declaring it.
 """
 
 from __future__ import annotations
@@ -29,6 +29,8 @@ class Conversation:
     path: str
     metadata_source: str
     timestamp_source: str
+    source_kind: str = ""
+    source_labels: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         data = asdict(self)

--- a/daymade-claude-code/_conversation_core/parse.py
+++ b/daymade-claude-code/_conversation_core/parse.py
@@ -1,19 +1,39 @@
 """Shared parsing / formatting helpers for the conversation-history skills.
 
-Pure, self-contained utilities that every skill re-implements otherwise. Bundled
-into each skill's ``scripts/_core/`` by ``sync_core.py`` (see homes.py for why
-bundling rather than importing a sibling). This is the parsing counterpart to
-``homes.py``; more helpers (text/title extraction, workspace matching, JSONL
-iteration) move here in later phases as they are de-duplicated from the skills.
+Pure, self-contained utilities that every skill would otherwise re-implement.
+Bundled into each skill's ``scripts/_core/`` by ``sync_core.py`` (see homes.py
+for why bundling is used instead of importing a sibling).
 """
 
 import os
 import re
 import sys
-from datetime import datetime
+from dataclasses import dataclass
+from datetime import date, datetime, time
 from typing import Any, Optional
 
 WINDOWS_DRIVE_RE = re.compile(r"^(?:[/\\]{2}\?[/\\])?[A-Za-z]:[/\\]")
+DATE_ONLY_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+@dataclass
+class TimestampRange:
+    """Minimum/maximum valid internal timestamp observed while streaming."""
+
+    earliest: Optional[float] = None
+    latest: Optional[float] = None
+    count: int = 0
+
+    def observe(self, value: Any) -> Optional[float]:
+        parsed = parse_timestamp(value)
+        if parsed is None:
+            return None
+        self.count += 1
+        if self.earliest is None or parsed < self.earliest:
+            self.earliest = parsed
+        if self.latest is None or parsed > self.latest:
+            self.latest = parsed
+        return parsed
 
 
 def parse_timestamp(value: Any) -> Optional[float]:
@@ -66,6 +86,61 @@ def format_timestamp(value: float) -> str:
 def iso_timestamp(value: float) -> str:
     """ISO-8601 local timestamp (seconds precision, with offset)."""
     return datetime.fromtimestamp(value).astimezone().isoformat(timespec="seconds")
+
+
+def parse_date_boundary(value: str, *, end: bool = False) -> float:
+    """Parse a date-only local boundary or a timezone-qualified ISO datetime.
+
+    Date-only input uses the machine's local timezone and covers the full day.
+    Datetime input must carry ``Z`` or an explicit UTC offset; accepting a naive
+    datetime would make a cross-machine history query change meaning silently.
+    """
+    text_value = value.strip()
+    if DATE_ONLY_RE.fullmatch(text_value):
+        parsed_date = date.fromisoformat(text_value)
+        wall_time = time.max if end else time.min
+        return datetime.combine(parsed_date, wall_time).astimezone().timestamp()
+    try:
+        parsed = datetime.fromisoformat(text_value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError(
+            f"invalid ISO date/time {value!r}; use YYYY-MM-DD or include a timezone offset"
+        ) from error
+    if parsed.tzinfo is None:
+        raise ValueError(
+            f"datetime {value!r} has no timezone; use Z or an explicit UTC offset"
+        )
+    return parsed.timestamp()
+
+
+def timestamp_in_window(
+    value: Optional[float],
+    from_timestamp: Optional[float],
+    to_timestamp: Optional[float],
+) -> bool:
+    if value is None:
+        return from_timestamp is None and to_timestamp is None
+    if from_timestamp is not None and value < from_timestamp:
+        return False
+    if to_timestamp is not None and value > to_timestamp:
+        return False
+    return True
+
+
+def range_overlaps_window(
+    earliest: Optional[float],
+    latest: Optional[float],
+    from_timestamp: Optional[float],
+    to_timestamp: Optional[float],
+) -> bool:
+    """Whether an internal session range overlaps an inclusive query window."""
+    if earliest is None or latest is None:
+        return from_timestamp is None and to_timestamp is None
+    if from_timestamp is not None and latest < from_timestamp:
+        return False
+    if to_timestamp is not None and earliest > to_timestamp:
+        return False
+    return True
 
 
 def looks_like_windows_path(value: str) -> bool:

--- a/daymade-claude-code/_conversation_core/sources.py
+++ b/daymade-claude-code/_conversation_core/sources.py
@@ -1,0 +1,201 @@
+"""Discover active and explicitly registered Claude conversation sources.
+
+Active Claude homes are auto-discovered by :mod:`homes`. Long-term archives are
+different: their location is user configuration, not a filename convention that
+the public skill should guess. A small manifest at
+``~/.claude/history-sources.json`` registers those archives explicitly.
+
+The manifest is intentionally fail-fast. A malformed file, duplicate archive, or
+missing required source is configuration damage, not a cue to silently fall back
+to the active homes and produce an incomplete history result.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Sequence, Union
+
+from .homes import discover_claude_homes, home_label
+
+
+MANIFEST_VERSION = 1
+SOURCE_LABEL_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+class HistorySourceConfigError(ValueError):
+    """Raised when an explicit history-source registry cannot be trusted."""
+
+
+@dataclass(frozen=True)
+class HistorySource:
+    """One Claude configuration root that contains a ``projects/`` directory."""
+
+    provider: str
+    kind: str
+    label: str
+    home: Path
+    required: bool = True
+
+    @property
+    def display_label(self) -> str:
+        return f"{self.kind}:{self.label}"
+
+
+def default_history_sources_path() -> Path:
+    """Return the per-user registry path without caching ``Path.home()``."""
+    return Path.home() / ".claude" / "history-sources.json"
+
+
+def _resolved_key(path: Path) -> str:
+    try:
+        return str(path.resolve())
+    except (OSError, RuntimeError):
+        return str(path.absolute())
+
+
+def _active_sources(
+    homes: Sequence[Union[str, Path]],
+) -> list[HistorySource]:
+    return [
+        HistorySource(
+            provider="claude",
+            kind="active",
+            label=home_label(home),
+            home=Path(home).expanduser(),
+            required=True,
+        )
+        for home in homes
+    ]
+
+
+def _read_manifest(path: Path) -> dict:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise HistorySourceConfigError(
+            f"Cannot read history source registry {path}: {error}"
+        ) from error
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise HistorySourceConfigError(
+            f"Invalid JSON in history source registry {path}: {error}"
+        ) from error
+    if not isinstance(payload, dict):
+        raise HistorySourceConfigError(
+            f"History source registry {path} must contain a JSON object"
+        )
+    if payload.get("version") != MANIFEST_VERSION:
+        raise HistorySourceConfigError(
+            f"History source registry {path} must use version {MANIFEST_VERSION}"
+        )
+    if not isinstance(payload.get("sources"), list):
+        raise HistorySourceConfigError(
+            f"History source registry {path} must contain a sources array"
+        )
+    return payload
+
+
+def _manifest_archive_sources(
+    path: Path,
+    active: Sequence[HistorySource],
+) -> tuple[list[HistorySource], list[str]]:
+    payload = _read_manifest(path)
+    warnings: list[str] = []
+    archives: list[HistorySource] = []
+    seen_paths = {_resolved_key(source.home) for source in active}
+    seen_labels: set[str] = set()
+
+    for index, entry in enumerate(payload["sources"]):
+        location = f"{path}: sources[{index}]"
+        if not isinstance(entry, dict):
+            raise HistorySourceConfigError(f"{location} must be an object")
+        provider = entry.get("provider")
+        kind = entry.get("kind")
+        label = entry.get("label")
+        home_value = entry.get("home")
+        required = entry.get("required", True)
+        if provider != "claude":
+            raise HistorySourceConfigError(
+                f"{location} has unsupported provider {provider!r}; only 'claude' is supported"
+            )
+        if kind != "archive":
+            raise HistorySourceConfigError(
+                f"{location} has unsupported kind {kind!r}; registered sources must be 'archive'"
+            )
+        if not isinstance(label, str) or not SOURCE_LABEL_RE.fullmatch(label):
+            raise HistorySourceConfigError(
+                f"{location}.label must use letters, numbers, dot, underscore, or hyphen"
+            )
+        if label in seen_labels:
+            raise HistorySourceConfigError(
+                f"Duplicate archive label {label!r} in history source registry {path}"
+            )
+        seen_labels.add(label)
+        if not isinstance(home_value, str) or not home_value.strip():
+            raise HistorySourceConfigError(f"{location}.home must be a non-empty string")
+        if not isinstance(required, bool):
+            raise HistorySourceConfigError(f"{location}.required must be true or false")
+
+        expanded = Path(os.path.expandvars(home_value)).expanduser()
+        home = expanded if expanded.is_absolute() else path.parent / expanded
+        key = _resolved_key(home)
+        if key in seen_paths:
+            raise HistorySourceConfigError(
+                f"Duplicate history source path in {path}: {home}"
+            )
+        seen_paths.add(key)
+        if not (home / "projects").is_dir():
+            message = f"Registered history source {label!r} has no projects/ directory: {home}"
+            if required:
+                raise HistorySourceConfigError(f"Required history source is unavailable. {message}")
+            warnings.append(message)
+            continue
+        archives.append(
+            HistorySource(
+                provider="claude",
+                kind="archive",
+                label=label,
+                home=home,
+                required=required,
+            )
+        )
+    return archives, warnings
+
+
+def discover_claude_sources(
+    *,
+    explicit_homes: Optional[
+        Union[str, Path, Sequence[Union[str, Path]]]
+    ] = None,
+    manifest_path: Optional[Union[str, Path]] = None,
+) -> tuple[list[HistorySource], list[str]]:
+    """Return Claude history sources plus non-fatal registry warnings.
+
+    ``explicit_homes`` is an exact scope: registered archives are intentionally
+    not added. With no explicit scope, active homes are auto-discovered and the
+    default registry is loaded when present. Passing ``manifest_path`` makes that
+    file itself required, so a typo cannot silently disable archive coverage.
+    """
+    if explicit_homes is not None:
+        return _active_sources(discover_claude_homes(explicit_homes)), []
+
+    active = _active_sources(discover_claude_homes())
+    explicit_manifest = manifest_path is not None
+    registry = (
+        Path(manifest_path).expanduser()
+        if explicit_manifest
+        else default_history_sources_path()
+    )
+    if not registry.is_file():
+        if explicit_manifest:
+            raise HistorySourceConfigError(
+                f"History source registry not found: {registry}"
+            )
+        return active, []
+    archives, warnings = _manifest_archive_sources(registry, active)
+    return active + archives, warnings

--- a/daymade-claude-code/_conversation_core/text.py
+++ b/daymade-claude-code/_conversation_core/text.py
@@ -4,14 +4,15 @@ These turn raw session content into a readable one-line title and iterate JSONL
 transcripts safely. Both the Claude and Codex providers use them, so they live in
 the shared core (SSOT: `daymade-claude-code/_conversation_core/`, bundled into
 each skill's `scripts/_core/` by `sync_core.py`). Keeping them here lets the Codex
-provider and a future `continue-codex-work` skill reuse one implementation instead
-of re-deriving title/noise heuristics that would drift apart.
+provider and `continue-codex-work` reuse one implementation instead of
+re-deriving title/noise heuristics that would drift apart.
 """
 
 from __future__ import annotations
 
 import json
 import re
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable, Iterator, Optional
 
@@ -41,6 +42,14 @@ ATTACHMENT_IMAGE_RE = re.compile(
 )
 FILE_SUFFIX_RE = re.compile(r"\.[A-Za-z0-9]{1,16}$")
 SLASH_COMMAND_RE = re.compile(r"^/[A-Za-z0-9_:-]+(?:[ \t].*)?$")
+
+
+@dataclass(frozen=True)
+class SearchSegment:
+    """One searchable text field with its semantic provenance."""
+
+    source: str
+    text: str
 
 
 def looks_like_attachment_prefix(value: str) -> bool:
@@ -109,6 +118,117 @@ def extract_text(content: Any) -> str:
         ):
             parts.append(item["text"])
     return " ".join(parts)
+
+
+def _flatten_search_strings(value: Any) -> Iterator[str]:
+    """Yield string values while excluding structural/signature metadata."""
+    if isinstance(value, str):
+        if value:
+            yield value
+        return
+    if isinstance(value, list):
+        for item in value:
+            yield from _flatten_search_strings(item)
+        return
+    if not isinstance(value, dict):
+        return
+    for key, child in value.items():
+        if key in {"type", "id", "tool_use_id", "signature"}:
+            continue
+        yield from _flatten_search_strings(child)
+
+
+def searchable_segments(record: dict[str, Any]) -> list[SearchSegment]:
+    """Extract user-visible/search-relevant fields from one Claude event.
+
+    Raw JSON serialization is intentionally not searched: keys, UUIDs, and
+    cryptographic thinking signatures create false positives. Instead this
+    covers message text, thinking text, tool inputs/results, queue content,
+    last-prompt/system summaries, and attachment payloads with a source label for
+    every segment.
+    """
+    segments: list[SearchSegment] = []
+
+    def add(source: str, value: Any) -> None:
+        for text_value in _flatten_search_strings(value):
+            segments.append(SearchSegment(source=source, text=text_value))
+
+    event_type = record.get("type")
+    message = record.get("message")
+    content: Any
+    if isinstance(message, dict):
+        content = message.get("content", [])
+    elif isinstance(message, str):
+        content = message
+    elif event_type in {"user", "assistant"} or record.get("role") in {
+        "user",
+        "assistant",
+    }:
+        content = record.get("content", [])
+    else:
+        content = []
+
+    if isinstance(content, str):
+        add("message", content)
+    elif isinstance(content, list):
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            block_type = block.get("type")
+            if block_type in {"text", "input_text"}:
+                add("message", block.get("text"))
+            elif block_type == "thinking":
+                add("thinking", block.get("thinking"))
+            elif block_type == "tool_use":
+                tool_name = block.get("name")
+                source = (
+                    f"tool_input:{tool_name}"
+                    if isinstance(tool_name, str) and tool_name
+                    else "tool_input"
+                )
+                add(source, block.get("input"))
+            elif block_type == "tool_result":
+                add("tool_result", block.get("content"))
+            else:
+                # Preserve textual payloads of future/older block types without
+                # indexing structural keys or binary image data.
+                add("message", {key: block.get(key) for key in ("text", "content")})
+
+    if event_type == "queue-operation":
+        add("queue-operation", record.get("content"))
+    elif event_type == "attachment":
+        attachment = record.get("attachment")
+        if isinstance(attachment, dict):
+            add(
+                "attachment",
+                {
+                    key: attachment.get(key)
+                    for key in (
+                        "content",
+                        "prompt",
+                        "path",
+                        "displayPath",
+                        "command",
+                        "stdout",
+                        "stderr",
+                    )
+                },
+            )
+    elif event_type == "last-prompt":
+        add("last-prompt", record.get("lastPrompt"))
+    elif event_type == "system":
+        add("system", record.get("content"))
+    elif event_type == "summary":
+        add("summary", {"content": record.get("content"), "summary": record.get("summary")})
+    elif event_type == "custom-title":
+        add(
+            "custom-title",
+            {"title": record.get("title"), "customTitle": record.get("customTitle")},
+        )
+
+    # Some event variants mirror the same payload in more than one compatible
+    # field. Count each semantic source/text pair once per record.
+    return list(dict.fromkeys(segments))
 
 
 def is_noise_text(text: str) -> bool:

--- a/daymade-claude-code/claude-code-history-files-finder/.security-scan-passed
+++ b/daymade-claude-code/claude-code-history-files-finder/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2025-11-26T00:38:49.440767
+Scanned at: 2026-07-16T06:59:30.069326+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 592122abb9a569998dfe7130eb891a5038eab3af0e8d46e0008c9d45640b4dad
+Content hash: 3889a9d33024a7d1482649118441f7f97fff852224f0607296e5db23de767f49

--- a/daymade-claude-code/claude-code-history-files-finder/SKILL.md
+++ b/daymade-claude-code/claude-code-history-files-finder/SKILL.md
@@ -1,11 +1,23 @@
 ---
 name: claude-code-history-files-finder
-description: Finds and recovers content from Claude Code session history files. This skill should be used when searching for deleted files, tracking changes across sessions, analyzing conversation history, or recovering code from previous Claude interactions. Triggers include mentions of "session history", "recover deleted", "find in history", "previous conversation", or ".claude/projects".
+description: >-
+  Searches and recovers content from Claude Code JSONL session history across
+  all active config homes and every long-term archive registered in
+  ~/.claude/history-sources.json — sweeping every project at once with
+  --all-projects when the project is unknown, and optionally covering Codex
+  rollout history with --codex. Uses internal record timestamps rather than
+  file mtime and searches message text, thinking, tool inputs/results,
+  queue-operation content, attachments, summaries, and titles. Use for keyword
+  or date-bounded history search, prior-conversation forensics, deleted-file
+  recovery, tool/file-operation analysis, or requests mentioning session
+  history, find in history, previous conversation, or .claude/projects. Do not
+  use for a simple recent Claude+Codex inventory; use local-conversation-history.
 ---
 
 # Claude Code History Files Finder
 
-Extract and recover content from Claude Code's session history files stored in `~/.claude/projects/`.
+Search and recover content from Claude Code session history stored in active
+homes and explicitly registered long-term archives.
 
 ## Capabilities
 
@@ -15,28 +27,64 @@ Extract and recover content from Claude Code's session history files stored in `
 - Track tool usage and file operations over time
 - Find sessions containing specific keywords or topics
 
+## Completeness invariant
+
+A normal history search must cover both source classes:
+
+1. auto-discovered active homes (`~/.claude`, profile homes, and the current
+   `CLAUDE_CONFIG_DIR`), and
+2. every archive registered in `~/.claude/history-sources.json`.
+
+Do not conclude that a session, topic, file, or action is absent unless the
+command output confirms that the registered archives were searched. A required
+archive that is unavailable is a hard configuration error. `--home` and
+`--main-only` are exact diagnostic scopes that intentionally bypass the archive
+registry; results from either flag cannot support a whole-history absence claim.
+
+A complete source set is necessary but not sufficient — three more failure
+modes produce a false "not found" even with every source covered, and each has
+a dedicated widening (the script prints these automatically on zero matches):
+
+1. **Wrong project guess.** You searched one project, the conversation lived
+   in another. Widening: `--all-projects` sweeps every project in one pass.
+2. **Wrong tool.** The conversation happened in Codex, whose rollouts are a
+   separate store the Claude registry never covers. Widening: `--codex`.
+3. **Wording drift.** A remembered quote differs from the real wording in
+   punctuation or a few words, so the exact phrase misses. Widening: retry
+   shorter distinctive substrings.
+
+One trap pairs with all three: **the current session always matches the
+phrase you just typed** (the skill args, your commands, and this reasoning all
+land in its records). A top hit whose range starts a few minutes ago is
+almost certainly this session — confirm with the internal range, then rerun
+with `--exclude-session <id>` to see the real results.
+
 ## Session File Locations
 
-Session files are stored at `~/.claude/projects/<encoded-project-path>/<session-id>.jsonl`.
+Each Claude history root stores sessions at
+`<history-root>/projects/<encoded-project-path>/<session-id>.jsonl`. Active roots
+are discovered automatically. Durable archive roots are configured once in
+`~/.claude/history-sources.json` and then included by default.
 
 **The directory name is the project's ABSOLUTE working-directory path with every `/` replaced by `-` — never the basename.** For example `/Users/<name>/Desktop/my-app` becomes `-Users-<name>-Desktop-my-app`, so a bare `my-app` cannot match a directory directly.
 
-**Before concluding a project "has no history", reverse-look-up the encoded name — do not infer absence from a failed `ls`:**
+**Before concluding that a project has no history, run the bundled command with
+its default source set. Do not infer absence from a failed `ls`:**
 
 ```bash
-# search the default home AND every profile home — not just ~/.claude
-ls -d ~/.claude ~/.claude-profiles/* ~/.claude-* 2>/dev/null
-find ~/.claude/projects ~/.claude-profiles/*/projects ~/.claude-*/projects \
-  -maxdepth 1 -iname '*<project-name>*' 2>/dev/null
-# grep session content across all homes at once:
-grep -rl '<keyword>' ~/.claude/projects/ ~/.claude-profiles/*/projects/ ~/.claude-*/projects/ 2>/dev/null
+python3 scripts/analyze_sessions.py list /path/to/project
+python3 scripts/analyze_sessions.py search /path/to/project '<keyword>'
 ```
 
-A `ls <basename>` that returns nothing means the lookup used the wrong name, NOT that history is absent. The bundled `analyze_sessions.py` already expands `~`, resolves to an absolute path, falls back to a basename reverse-lookup, **and searches every profile home** — prefer passing it the path (absolute, `~`, relative, or bare name all work).
+A `ls <basename>` that returns nothing means the lookup used the wrong name, NOT
+that history is absent. The bundled `analyze_sessions.py` expands `~`, resolves
+an absolute path, falls back to an unambiguous basename reverse lookup, and
+searches every configured source. Prefer passing it the full absolute project
+path; `~`, relative paths, and bare names are also accepted.
 
 Note: sessions run from **Claude Desktop's cowork / built-in Claude Code mode** also land here (Desktop runs a bundled CLI); only Desktop's *native* chat lives elsewhere (a LevelDB store, not JSONL). So "it ran inside Desktop" does not mean it is missing from `~/.claude/projects/`.
 
-### Multiple config homes (profiles) — searched by default, and why it matters
+### Active profiles and long-term archives — searched together by default
 
 `~/.claude` is only the *default* home. Anyone who runs Claude Code against **third-party models through per-model profiles** (each profile is its own `CLAUDE_CONFIG_DIR`) accumulates **parallel history that never touches `~/.claude`**:
 
@@ -44,22 +92,37 @@ Note: sessions run from **Claude Desktop's cowork / built-in Claude Code mode** 
 - `~/.claude-<name>/projects/…` — occasional sibling homes
 - whatever `CLAUDE_CONFIG_DIR` points at in the current shell
 
-**This is the #1 silent blind spot.** A conversation held in a profile is completely invisible to any search that only looks at `~/.claude/projects/`. Concluding "no session did X" — or worse, "this file wasn't generated by any conversation" — from a main-home-only search is a false negative: the session may be sitting in a profile home you never looked at.
+Long-term archives are a second independent source class. Active directories can
+retain only recent sessions, while an archive keeps older JSONL files after they
+disappear from the active tree. A search limited to active homes can therefore
+produce the same false negative as a main-home-only search.
 
-`analyze_sessions.py` handles this for you: **`list` and `search` auto-discover every home** (`~/.claude` + all `~/.claude-profiles/*` + sibling `~/.claude-*`), de-duplicate sessions by id (a conversation shared across profiles is reported once), and label each result with its source profile (`Profile: main` / `Profile: kimi` / `Profile: main, deepseek, …`). Scope it when needed:
+`analyze_sessions.py` handles both classes: **`list` and `search` auto-discover
+every active home and load the archive registry**, de-duplicate sessions by ID,
+union the internal range across copies, and retain every source label as
+provenance. Keyword search streams every physical copy and de-duplicates
+identical records, so an archive-only record cannot disappear merely because a
+newer active copy has the same session ID. Scope it only for a deliberate
+diagnostic:
 
 ```bash
-# default: all homes
+# default: active homes + registered archives
 scripts/analyze_sessions.py search /path/to/project keyword
 
-# only ~/.claude (reproduces the old main-only behavior)
+# exact diagnostic scope; not a completeness check
 scripts/analyze_sessions.py search /path/to/project keyword --main-only
 
-# restrict to specific home(s)
+# exact diagnostic scope (repeatable)
 scripts/analyze_sessions.py search /path/to/project keyword --home ~/.claude-profiles/kimi
+
+# test a non-default source registry
+scripts/analyze_sessions.py search /path/to/project keyword \
+  --history-sources /path/to/history-sources.json
 ```
 
-**If you grep the raw JSONL by hand instead of using the script, you MUST include the profile homes** — see the manual-lookup snippet below. A bare `~/.claude/projects/` grep will lie to you.
+**Do not use an ad hoc raw grep to prove absence.** It must independently parse
+the registry, cover every active root, search non-message event payloads, and
+apply dates to internal record timestamps; the bundled script already does so.
 
 For detailed JSONL structure and extraction patterns, see `references/session_file_format.md`.
 
@@ -73,9 +136,13 @@ Find all session files for a specific project:
 python3 scripts/analyze_sessions.py list /path/to/project
 ```
 
-Shows most recent sessions with timestamps and sizes.
+Shows sessions ordered by their maximum internal JSONL timestamp, with the full
+internal range, size, path, and source provenance. File mtime is never used.
 
-Optional: `--limit N` to show only N sessions (default: 10).
+Optional: `--limit N` to show only N sessions (default: 10), and `--from-date`
+or `--to-date` to keep sessions whose internal range overlaps the requested
+window. `--all-projects` lists every project (grouped by encoded project
+name); `--exclude-session <id>` (repeatable) skips sessions.
 
 ### 2. Search Sessions for Keywords
 
@@ -88,16 +155,66 @@ python3 scripts/analyze_sessions.py search /path/to/project keyword1 keyword2
 Returns sessions ranked by keyword frequency with:
 - Total mention count
 - Per-keyword breakdown
-- Session date and path
+- Session and matching-record internal time ranges
+- Matching field types, session provenance, and match provenance
+- Primary matching path plus any other matching copies
 
-Optional: `--case-sensitive` for exact matching.
+Search covers messages, thinking text (not signatures), tool inputs/results,
+queue-operation content, attachments, last prompts, system/summary content, and
+custom titles. Optional: `--case-sensitive` for exact casing; `--from-date` and
+`--to-date` constrain matching records by their own internal timestamps, not by
+session mtime. `--exclude-session <id>` (repeatable) drops sessions — pass the
+current session's id whenever you search for a phrase you just typed, because
+your own command makes this session match.
+
+Date-only bounds cover the whole local calendar day. Datetime bounds must carry
+`Z` or an explicit UTC offset. Records without a valid internal timestamp are
+excluded with a visible note while a date filter is active; never substitute
+file mtime after a migration or copy.
+
+### 2a. Search when the project is unknown — `--all-projects`
+
+The required project argument encodes a guess; when the guess is wrong, a
+project-scoped search reports a false "not found". Drop the positional and
+sweep every project instead (`list` accepts the same flag):
+
+```bash
+python3 scripts/analyze_sessions.py search --all-projects 'some phrase'
+```
+
+Expected output: one pass over every project's sessions across all sources,
+with a `Project:` line naming the encoded project dir on each hit. This is a
+full-history sweep — expect minutes, not seconds, on a large tree.
+
+### 2b. Include Codex history — `--codex`
+
+Claude Code is not the only tool with history. Codex keeps rollouts at
+`<codex-home>/sessions/<YYYY>/<MM>/<DD>/rollout-*.jsonl` plus
+`archived_sessions/` (codex home = `--codex-home`, `$CODEX_HOME`, or
+`~/.codex`). Their schema differs from Claude's, so the default search skips
+them entirely; `--codex` adds a rollout pass:
+
+```bash
+python3 scripts/analyze_sessions.py search /path/to/project 'some phrase' --codex
+```
+
+Codex hits print in their own section (📦) with session id, cwd, internal
+ranges, mention counts, and match fields. A project positional filters
+rollouts by their `session_meta` cwd (recursive match); with `--all-projects`
+every rollout is searched. `event_msg` message mirrors are strict duplicates
+of `response_item` message text and are counted once. Rollout record shapes
+are documented in `references/session_file_format.md`.
+
+The zero-match hint printed by the script already suggests whichever of
+`--all-projects` / `--codex` / shorter substrings was not yet applied — read
+stderr before concluding anything is absent.
 
 ### 3. Recover Deleted Content
 
 Extract files from session history:
 
 ```bash
-python3 scripts/recover_content.py /path/to/session.jsonl
+python3 scripts/recover_content.py <session-path-from-search>
 ```
 
 Extracts all Write tool calls and saves files to `./recovered_content/`, preserving the original directory structure.
@@ -105,7 +222,8 @@ Extracts all Write tool calls and saves files to `./recovered_content/`, preserv
 **Filtering by keywords**:
 
 ```bash
-python3 scripts/recover_content.py session.jsonl -k ModelLoading FRONTEND deleted
+python3 scripts/recover_content.py <session-path-from-search> \
+  -k ModelLoading FRONTEND deleted
 ```
 
 Recovers only files matching any keyword in their path.
@@ -113,7 +231,7 @@ Recovers only files matching any keyword in their path.
 **Custom output directory**:
 
 ```bash
-python3 scripts/recover_content.py session.jsonl -o ./my_recovery/
+python3 scripts/recover_content.py <session-path-from-search> -o ./my_recovery/
 ```
 
 ### 4. Analyze Session Statistics
@@ -203,14 +321,22 @@ head -20 ./recovered_content/src/components/ImportantFile.jsx
 ### No Sessions Found
 
 ```bash
-# Verify project path normalization — check the default home AND profile homes
-ls ~/.claude/projects/ ~/.claude-profiles/*/projects/ 2>/dev/null | grep -i "project-name"
+# Re-run with the full absolute project path and the default source set.
+python3 scripts/analyze_sessions.py list /absolute/path/to/project
 
-# Check actual projects directories across all homes
-ls -la ~/.claude/projects/ ~/.claude-profiles/*/projects/ 2>/dev/null
+# Inspect a custom registry only when diagnosing its configuration.
+python3 scripts/analyze_sessions.py list /absolute/path/to/project \
+  --history-sources /path/to/history-sources.json
 ```
 
-**"Not found" is far more often a wrong-home than a truly-absent session.** If `analyze_sessions.py` reports a match count of 0, confirm it actually searched the profile homes (its output prints `Searched N home(s): main, …`). A result that only says `Searched 1 home(s): main` means profiles were skipped (e.g. `--main-only` was passed) — re-run without that flag before concluding the session does not exist.
+**"Not found" is often a wrong project identity or an incomplete source set.**
+Confirm that output says `Searched N source(s)` and includes both the expected
+`active:<label>` and `archive:<label>` entries. If `--main-only` or `--home` was
+used, re-run without it. A missing required archive must be repaired or its
+registry entry deliberately changed; do not silently ignore the error and claim
+the session does not exist. If the source set is confirmed complete, work the
+widening ladder from the Completeness invariant section: `--all-projects` →
+`--codex` → shorter substrings, and `--exclude-session` the current session.
 
 ### Empty Recovery
 
@@ -264,4 +390,20 @@ Found [N] relevant sessions with recoverable context.
 Options:
 A) Resume work — run /daymade-claude-code:continue-claude-work to pick up where you left off (Recommended)
 B) Just show me the content — I'll decide what to do with it
+```
+
+## Maintainer verification
+
+In the source repository, `daymade-claude-code/_conversation_core/` is the code
+SSOT shared by this skill, `local-conversation-history`,
+`continue-claude-work`, and `continue-codex-work`. `sync_core.py` bundles that
+package into each skill's `scripts/_core/`; never edit a bundled copy directly.
+
+After shared-code changes, synchronize and verify all four bundles, then run the
+finder's isolated fixtures:
+
+```text
+uv run python ../sync_core.py sync
+uv run python ../sync_core.py check
+python -m unittest discover -s tests -p "test_*.py"
 ```

--- a/daymade-claude-code/claude-code-history-files-finder/evals/evals.json
+++ b/daymade-claude-code/claude-code-history-files-finder/evals/evals.json
@@ -1,0 +1,41 @@
+{
+  "skill_name": "claude-code-history-files-finder",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "查这个项目 3 月到 4 月有没有提过某个方案。旧会话可能只在已经登记的长期备份仓里，关键词也可能藏在 tool_result 或附件里。",
+      "expected_output": "Runs analyze_sessions.py search with the default active-plus-registered-archive source set and an internal-timestamp date window; searches structured message, tool-result, and attachment payloads and reports source and match-range provenance.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "The archive was copied during migration, so its file modification dates all look recent. Find the conversations that actually happened in April.",
+      "expected_output": "Uses --from-date/--to-date and internal per-record JSONL timestamps. It never filters or orders by file mtime and visibly excludes untimed records rather than guessing.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "Recover the deleted implementation of WidgetPanel from whichever previous Claude Code session wrote it, including sessions that are no longer in the active directory.",
+      "expected_output": "Searches all active homes and registered archives first, selects a printed matching session path, then uses recover_content.py while preserving the existing recovery and verification workflow.",
+      "files": []
+    },
+    {
+      "id": 4,
+      "prompt": "The required history archive is offline. Ignore that error and tell me definitively whether any conversation ever mentioned the release codename.",
+      "expected_output": "Refuses to make a definitive whole-history absence claim from an incomplete source set. The missing required archive remains a hard source-configuration error.",
+      "files": []
+    },
+    {
+      "id": 5,
+      "prompt": "Just show the ten most recent Claude Code and Codex chats for this folder; I don't need keyword search or recovery.",
+      "expected_output": "Routes the simple cross-provider inventory to local-conversation-history instead of invoking the deep Claude-only finder.",
+      "files": []
+    },
+    {
+      "id": 6,
+      "prompt": "找一下我们说「在测试机上配一条内容流水线」这句话的那次会话，大概昨天或今天说的，我忘了在哪个项目目录里开的，也可能是用 Codex 跑的。",
+      "expected_output": "Uses --all-projects because the project is unknown, adds --codex because the conversation may have been a Codex one, retries shorter distinctive substrings if the exact phrase misses, and --exclude-session's the current session so the phrase inside its own search command cannot self-match.",
+      "files": []
+    }
+  ]
+}

--- a/daymade-claude-code/claude-code-history-files-finder/references/session_file_format.md
+++ b/daymade-claude-code/claude-code-history-files-finder/references/session_file_format.md
@@ -4,13 +4,22 @@
 
 Claude Code stores conversation history in JSONL (JSON Lines) format, where each line is a complete JSON object representing a message or event in the conversation.
 
+Codex uses a different JSONL store — see "Codex Rollout File Format" at the
+end of this document.
+
 ## File Locations
 
 ### Session Files
 
+```text
+<history-root>/projects/<normalized-project-path>/<session-id>.jsonl
 ```
-~/.claude/projects/<normalized-project-path>/<session-id>.jsonl
-```
+
+The default source set combines auto-discovered active roots with every archive
+registered in `~/.claude/history-sources.json`. A registry entry points at a
+Claude-style root containing `projects/`, not at `projects/` itself. Use the
+bundled analyzer rather than hardcoding one root when making a completeness
+claim.
 
 **Path normalization**: the project's **absolute** working-directory path is encoded by replacing every `/` with `-`. It is the full absolute path, **not** the basename — a bare project name never matches.
 
@@ -18,10 +27,12 @@ Example:
 - Project (absolute): `/Users/<username>/Workspace/js/myproject`
 - Directory: `~/.claude/projects/-Users-<username>-Workspace-js-myproject/`
 
-To locate a project's directory, reverse-look-up the encoded name instead of guessing — a failed `ls` of the basename does NOT mean the history is absent:
+To locate a project's directory, let the bundled analyzer resolve the full
+absolute path across every configured source. A failed `ls` of the basename does
+not mean the history is absent:
 
 ```bash
-ls ~/.claude/projects/ | grep -i <project-name>
+python3 scripts/analyze_sessions.py list /absolute/path/to/project
 ```
 
 ### File Types
@@ -61,7 +72,17 @@ Conversation messages are the lines you usually want. In current Claude Code (>=
 
 ### Non-message event lines
 
-Recent sessions also interleave non-conversation event lines. Their `type` is one of `attachment`, `system`, `summary`, `last-prompt`, `queue-operation`, `custom-title`, `mode`, etc. These carry no `message.role` and no recoverable text/tool content — extractors should skip any line whose role is neither `user` nor `assistant` (the bundled scripts skip them naturally, so counts stay correct).
+Recent sessions also interleave non-message event lines. Their `type` can be
+`attachment`, `system`, `summary`, `last-prompt`, `queue-operation`,
+`custom-title`, `mode`, and others. They carry no `message.role`, but several do
+carry search-relevant or recoverable text. A conversation-message counter may
+skip them; a history search must inspect their known payload fields.
+
+The bundled search extracts semantic text segments instead of searching raw JSON
+serialization. It covers message text, thinking text, tool inputs/results,
+queue-operation content, attachment payloads, last prompts, system/summary
+content, and custom titles. Structural keys, UUIDs, tool-use IDs, and thinking
+signatures are excluded to avoid false positives.
 
 ### Content Types
 
@@ -193,6 +214,13 @@ content = data.get("content") or data.get("message", {}).get("content", [])
 timestamp = data.get("timestamp", "")
 ```
 
+Treat valid top-level record timestamps as the only conversation-time evidence.
+Physical line order is not guaranteed to be chronological, so session bounds are
+the minimum and maximum values observed across the entire JSONL. File mtime is
+not a fallback: copying or migrating a history changes it. A date-bounded keyword
+search applies the window to each matching record's timestamp, not merely to the
+file or the session's overall range.
+
 ## Common Use Cases
 
 ### Recover Deleted Files
@@ -209,9 +237,16 @@ timestamp = data.get("timestamp", "")
 
 ### Search Conversations
 
-1. Extract all `text` content from messages
-2. Search for keywords or patterns
-3. Return matching sessions
+1. Stream every valid record.
+2. Extract only semantic, search-relevant segments from messages, tool blocks,
+   and supported non-message events.
+3. If a date window is active, retain only records whose internal timestamp is
+   within the window; report untimed exclusions.
+4. Search segments for keywords and retain their field provenance.
+5. When the same session ID exists in multiple roots, union distinct records
+   from every physical copy; identical records count once, but every matching
+   copy remains visible as provenance.
+6. Return matching sessions with both session and match timestamp ranges.
 
 ### Analyze Tool Usage
 
@@ -270,9 +305,10 @@ with open(session_file, 'r') as f:
 
 ### Search Optimization
 
-- Early exit when keyword count threshold met
-- Case-insensitive search: normalize once
-- Use `in` operator for substring matching
+- Stream line by line; do not load a session into memory.
+- Case-insensitive search: normalize each segment and keyword consistently.
+- Count substring occurrences per semantic segment rather than serializing the
+  whole record and matching JSON keys or signatures.
 
 ### Deduplication
 
@@ -301,3 +337,39 @@ Before sharing extracted content:
 2. Redact sensitive information
 3. Use placeholders for usernames
 4. Verify no credentials present
+
+## Codex Rollout File Format
+
+Codex keeps its own conversation store, outside the Claude history registry:
+
+```text
+<codex-home>/sessions/<YYYY>/<MM>/<DD>/rollout-<timestamp>-<session-id>.jsonl
+<codex-home>/archived_sessions/rollout-<timestamp>-<session-id>.jsonl
+```
+
+The codex home is `$CODEX_HOME` or `~/.codex`. A rollout is also JSONL, but the
+record schema is not the Claude one. Every top-level record carries an ISO
+`timestamp`; the shapes below were observed on a current (2026-07) rollout:
+
+| Record `type` | `payload.type` | Searchable content |
+|---|---|---|
+| `session_meta` | — (once, first record) | none — carries `id`, `cwd`, `timestamp` used for identity and project filtering |
+| `response_item` | `message` | `content[]` blocks of type `input_text` (user) / `output_text` (assistant) |
+| `response_item` | `reasoning` | `summary[]` blocks of type `summary_text` |
+| `response_item` | `function_call`, `custom_tool_call` | `name` + `arguments` / `input` |
+| `response_item` | `function_call_output`, `custom_tool_call_output` | `output` |
+| `compacted` | — | `message` (summary of compacted earlier context) |
+| `event_msg` | `user_message`, `agent_message` | strict mirrors of `response_item` message text — skip or counts double (verified subset on a real rollout, 2026-07-16) |
+| `event_msg` | `token_count`, `task_started`, … | none |
+| `turn_context`, `world_state` | — | none |
+
+Notes:
+
+- The same rollout can exist under both `sessions/` and `archived_sessions/`;
+  de-duplicate by `session_meta.payload.id` (fall back to the UUID in the
+  filename).
+- Project filtering uses `session_meta.payload.cwd` with a recursive workspace
+  match — a rollout belongs to the project whose path is, or is a parent of,
+  that cwd.
+- `analyze_sessions.py search --codex` implements exactly this table; prefer
+  it over hand-rolled grep so mirrors and duplicates stay handled.

--- a/daymade-claude-code/claude-code-history-files-finder/references/workflow_examples.md
+++ b/daymade-claude-code/claude-code-history-files-finder/references/workflow_examples.md
@@ -11,8 +11,8 @@ Detailed workflow examples for common session history recovery scenarios.
 python3 scripts/analyze_sessions.py search /path/to/project \
     DeletedComponent ModelScreen RemovedFeature
 
-# 2. Recover content from most relevant session
-python3 scripts/recover_content.py ~/.claude/projects/.../session-id.jsonl \
+# 2. Copy the exact Path printed for the most relevant active/archive session
+python3 scripts/recover_content.py <printed-session-path> \
     -k DeletedComponent ModelScreen \
     -o ./recovered/
 
@@ -52,7 +52,8 @@ find ./v1/ -name "componentName.jsx" -exec diff {} ./v2/{} \;
 ```bash
 # Search for distinctive keywords from that implementation
 python3 scripts/analyze_sessions.py search /path/to/project \
-    "useModelStatus" "downloadProgress" "ModelScope"
+    "useModelStatus" "downloadProgress" "ModelScope" \
+    --from-date 2026-03-01 --to-date 2026-04-30
 
 # Review top match
 python3 scripts/analyze_sessions.py stats <top-result-session.jsonl>
@@ -65,7 +66,7 @@ python3 scripts/analyze_sessions.py stats <top-result-session.jsonl>
 ```bash
 # Find relevant sessions
 sessions=$(python3 scripts/analyze_sessions.py search /path/to/project \
-    keyword --limit 999 | grep "Path:" | awk '{print $2}')
+    keyword | grep "Path:" | awk '{print $2}')
 
 # Recover from each session
 for session in $sessions; do
@@ -74,9 +75,32 @@ for session in $sessions; do
 done
 ```
 
+The default `list` and `search` commands cover active homes plus registered
+archives. Do not add `--main-only` or `--home` to these workflows unless the
+task is explicitly to diagnose one store. A required missing archive stops the
+search instead of silently returning a partial result.
+
+## Verify a Topic Across a Migrated History
+
+**Scenario**: A machine migration reset file mtimes, and older sessions may live
+only in a registered archive.
+
+```bash
+python3 scripts/analyze_sessions.py search /path/to/project \
+    "distinctive topic" "library-name" \
+    --from-date 2026-03-01 --to-date 2026-04-30
+```
+
+Verify three fields before reporting absence: the `Searched ... source(s)` line
+includes the expected `archive:<label>`, the command did not emit a source
+configuration error, and the date window was applied to internal matching-record
+timestamps. File mtime is not evidence.
+
 ## Custom Extraction from Raw JSONL
 
-For extraction needs not covered by bundled scripts:
+For extraction needs not covered by bundled scripts, first use the analyzer to
+locate the exact active/archive session. A one-file custom extractor is not a
+replacement for whole-history source discovery:
 
 ```python
 import json
@@ -84,6 +108,6 @@ import json
 with open('session.jsonl', 'r') as f:
     for line in f:
         data = json.loads(line)
-        # Custom extraction logic
+        # Custom extraction logic; use data.get("timestamp") for time evidence.
         # See references/session_file_format.md for structure
 ```

--- a/daymade-claude-code/claude-code-history-files-finder/scripts/_core/__init__.py
+++ b/daymade-claude-code/claude-code-history-files-finder/scripts/_core/__init__.py
@@ -8,8 +8,13 @@ every skill stays self-contained and installable on its own while sharing one
 implementation.
 
 Modules:
-    homes  — discover every Claude config home (main + per-model profiles).
-    parse  — pure parsing/formatting helpers (timestamps, and more over time).
+    homes    — discover every active Claude config home.
+    sources  — combine active homes with explicitly registered archives.
+    claude   — stream exact Claude session metadata and internal time ranges.
+    codex    — inspect Codex state databases and raw rollout stores.
+    parse    — timestamp, timezone, and workspace normalization helpers.
+    text     — semantic JSONL text/title extraction.
+    model    — shared provider result data structures.
 """
 
 from .homes import discover_claude_homes, home_label

--- a/daymade-claude-code/claude-code-history-files-finder/scripts/_core/claude.py
+++ b/daymade-claude-code/claude-code-history-files-finder/scripts/_core/claude.py
@@ -1,0 +1,72 @@
+"""Exact, streaming metadata scan for Claude Code JSONL sessions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from .parse import TimestampRange
+from .text import extract_text, first_meaningful_title, iter_jsonl
+
+
+@dataclass(frozen=True)
+class ClaudeSessionSummary:
+    session_id: str
+    cwd: str
+    title: str
+    created_at: Optional[float]
+    updated_at: Optional[float]
+    timestamp_count: int
+
+
+def scan_claude_session(path: Path, max_title_chars: int = 120) -> ClaudeSessionSummary:
+    """Scan every valid record and return internal time bounds plus title metadata.
+
+    File mtime is deliberately absent. Copying or migrating a transcript changes
+    mtime without changing when the conversation happened; the only trustworthy
+    conversation range is the minimum and maximum valid top-level ``timestamp``
+    found across the JSONL records themselves.
+    """
+    session_id = path.stem
+    cwd = ""
+    prompt_candidates: list[str] = []
+    title: Optional[str] = None
+    timestamps = TimestampRange()
+
+    for record in iter_jsonl(path):
+        timestamps.observe(record.get("timestamp"))
+        if isinstance(record.get("sessionId"), str) and record["sessionId"]:
+            session_id = record["sessionId"]
+        if not cwd and isinstance(record.get("cwd"), str):
+            cwd = record["cwd"]
+        if title is not None:
+            continue
+        if record.get("type") != "user" or record.get("isMeta") is True:
+            continue
+        message = record.get("message")
+        if isinstance(message, dict) and message.get("role") == "user":
+            text = extract_text(message.get("content"))
+        elif isinstance(message, str):
+            text = message
+        else:
+            text = ""
+        if not text:
+            continue
+        prompt_candidates.append(text)
+        candidate = first_meaningful_title(prompt_candidates, max_title_chars)
+        if candidate and len(candidate) >= 4:
+            title = candidate
+
+    if title is None:
+        title = first_meaningful_title(prompt_candidates, max_title_chars)
+    if not title:
+        title = f"(untitled: {session_id})"
+    return ClaudeSessionSummary(
+        session_id=session_id,
+        cwd=cwd,
+        title=title,
+        created_at=timestamps.earliest,
+        updated_at=timestamps.latest,
+        timestamp_count=timestamps.count,
+    )

--- a/daymade-claude-code/claude-code-history-files-finder/scripts/_core/codex.py
+++ b/daymade-claude-code/claude-code-history-files-finder/scripts/_core/codex.py
@@ -25,7 +25,7 @@ from typing import Any, Iterable, Optional
 from urllib.parse import quote
 
 from .model import CodexDatabase, Conversation, ProviderResult
-from .parse import parse_timestamp, workspace_matches
+from .parse import TimestampRange, parse_timestamp, workspace_matches
 from .text import extract_text, first_meaningful_title, is_automated_title, iter_jsonl
 
 CODEX_REQUIRED_COLUMNS = {"id", "cwd", "updated_at", "source", "archived"}
@@ -33,6 +33,7 @@ SESSION_ID_RE = re.compile(
     r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
     re.IGNORECASE,
 )
+STATE_DATABASE_RE = re.compile(r"^state_(\d+)\.sqlite$")
 
 
 def sqlite_uri(path: Path) -> str:
@@ -83,8 +84,18 @@ def discover_codex_database(home: Path, warnings: list[str]) -> Optional[CodexDa
         return None
     return max(
         compatible,
-        key=lambda item: (item.max_updated_ms, item.path.stat().st_mtime_ns),
+        key=lambda item: (
+            item.max_updated_ms,
+            _state_database_generation(item.path),
+            item.path.as_posix(),
+        ),
     )
+
+
+def _state_database_generation(path: Path) -> int:
+    """Return the numeric state database generation without consulting mtime."""
+    match = STATE_DATABASE_RE.fullmatch(path.name)
+    return int(match.group(1)) if match else -1
 
 
 def nested_key_exists(value: Any, wanted: str) -> bool:
@@ -261,6 +272,23 @@ def codex_prompt_from_rollout(path: Path, max_chars: int) -> Optional[str]:
     return short_candidate
 
 
+def codex_rollout_time_range(path: Path) -> TimestampRange:
+    """Compute exact internal bounds for a Codex rollout.
+
+    Current rollouts timestamp every top-level event. Older/minimal fixtures may
+    carry only ``session_meta.payload.timestamp``, so observe both. File mtime is
+    deliberately excluded because copying or migrating a rollout rewrites it.
+    """
+    timestamps = TimestampRange()
+    for record in iter_jsonl(path):
+        timestamps.observe(record.get("timestamp"))
+        if record.get("type") == "session_meta" and isinstance(
+            record.get("payload"), dict
+        ):
+            timestamps.observe(record["payload"].get("timestamp"))
+    return timestamps
+
+
 def collect_codex_from_rollouts(
     args: argparse.Namespace, home: Path, result: ProviderResult
 ) -> None:
@@ -301,25 +329,22 @@ def collect_codex_from_rollouts(
         if is_automated_title(title) and not args.include_automated:
             result.excluded_automated += 1
             continue
-        try:
-            updated_at = path.stat().st_mtime
-            timestamp_source = "file-mtime"
-        except OSError:
-            updated_at = parse_timestamp(meta.get("timestamp"))
-            timestamp_source = "session-meta"
+        timestamps = codex_rollout_time_range(path)
         result.conversations.append(
             Conversation(
                 provider="codex",
                 session_id=session_id,
                 title=title,
                 cwd=cwd,
-                updated_at=updated_at,
-                created_at=parse_timestamp(meta.get("timestamp")),
+                updated_at=timestamps.latest,
+                created_at=timestamps.earliest,
                 archived=archived,
                 kind="subagent" if subagent else "main",
                 path=str(path),
                 metadata_source="rollout-jsonl",
-                timestamp_source=timestamp_source,
+                timestamp_source=(
+                    "rollout-record-minmax" if timestamps.count else "unknown"
+                ),
             )
         )
 

--- a/daymade-claude-code/claude-code-history-files-finder/scripts/_core/model.py
+++ b/daymade-claude-code/claude-code-history-files-finder/scripts/_core/model.py
@@ -3,8 +3,8 @@
 `Conversation` / `ProviderResult` / `CodexDatabase` are used by both the Claude
 and Codex providers and by the renderers, so they live in the shared core (SSOT:
 `daymade-claude-code/_conversation_core/`, bundled into each skill's
-`scripts/_core/` by `sync_core.py`). Extracting them here lets a skill like
-`continue-codex-work` reuse the same model without re-declaring it.
+`scripts/_core/` by `sync_core.py`). This lets `continue-codex-work` and the
+inventory/search skills reuse the same model without re-declaring it.
 """
 
 from __future__ import annotations
@@ -29,6 +29,8 @@ class Conversation:
     path: str
     metadata_source: str
     timestamp_source: str
+    source_kind: str = ""
+    source_labels: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         data = asdict(self)

--- a/daymade-claude-code/claude-code-history-files-finder/scripts/_core/parse.py
+++ b/daymade-claude-code/claude-code-history-files-finder/scripts/_core/parse.py
@@ -1,19 +1,39 @@
 """Shared parsing / formatting helpers for the conversation-history skills.
 
-Pure, self-contained utilities that every skill re-implements otherwise. Bundled
-into each skill's ``scripts/_core/`` by ``sync_core.py`` (see homes.py for why
-bundling rather than importing a sibling). This is the parsing counterpart to
-``homes.py``; more helpers (text/title extraction, workspace matching, JSONL
-iteration) move here in later phases as they are de-duplicated from the skills.
+Pure, self-contained utilities that every skill would otherwise re-implement.
+Bundled into each skill's ``scripts/_core/`` by ``sync_core.py`` (see homes.py
+for why bundling is used instead of importing a sibling).
 """
 
 import os
 import re
 import sys
-from datetime import datetime
+from dataclasses import dataclass
+from datetime import date, datetime, time
 from typing import Any, Optional
 
 WINDOWS_DRIVE_RE = re.compile(r"^(?:[/\\]{2}\?[/\\])?[A-Za-z]:[/\\]")
+DATE_ONLY_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+@dataclass
+class TimestampRange:
+    """Minimum/maximum valid internal timestamp observed while streaming."""
+
+    earliest: Optional[float] = None
+    latest: Optional[float] = None
+    count: int = 0
+
+    def observe(self, value: Any) -> Optional[float]:
+        parsed = parse_timestamp(value)
+        if parsed is None:
+            return None
+        self.count += 1
+        if self.earliest is None or parsed < self.earliest:
+            self.earliest = parsed
+        if self.latest is None or parsed > self.latest:
+            self.latest = parsed
+        return parsed
 
 
 def parse_timestamp(value: Any) -> Optional[float]:
@@ -66,6 +86,61 @@ def format_timestamp(value: float) -> str:
 def iso_timestamp(value: float) -> str:
     """ISO-8601 local timestamp (seconds precision, with offset)."""
     return datetime.fromtimestamp(value).astimezone().isoformat(timespec="seconds")
+
+
+def parse_date_boundary(value: str, *, end: bool = False) -> float:
+    """Parse a date-only local boundary or a timezone-qualified ISO datetime.
+
+    Date-only input uses the machine's local timezone and covers the full day.
+    Datetime input must carry ``Z`` or an explicit UTC offset; accepting a naive
+    datetime would make a cross-machine history query change meaning silently.
+    """
+    text_value = value.strip()
+    if DATE_ONLY_RE.fullmatch(text_value):
+        parsed_date = date.fromisoformat(text_value)
+        wall_time = time.max if end else time.min
+        return datetime.combine(parsed_date, wall_time).astimezone().timestamp()
+    try:
+        parsed = datetime.fromisoformat(text_value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError(
+            f"invalid ISO date/time {value!r}; use YYYY-MM-DD or include a timezone offset"
+        ) from error
+    if parsed.tzinfo is None:
+        raise ValueError(
+            f"datetime {value!r} has no timezone; use Z or an explicit UTC offset"
+        )
+    return parsed.timestamp()
+
+
+def timestamp_in_window(
+    value: Optional[float],
+    from_timestamp: Optional[float],
+    to_timestamp: Optional[float],
+) -> bool:
+    if value is None:
+        return from_timestamp is None and to_timestamp is None
+    if from_timestamp is not None and value < from_timestamp:
+        return False
+    if to_timestamp is not None and value > to_timestamp:
+        return False
+    return True
+
+
+def range_overlaps_window(
+    earliest: Optional[float],
+    latest: Optional[float],
+    from_timestamp: Optional[float],
+    to_timestamp: Optional[float],
+) -> bool:
+    """Whether an internal session range overlaps an inclusive query window."""
+    if earliest is None or latest is None:
+        return from_timestamp is None and to_timestamp is None
+    if from_timestamp is not None and latest < from_timestamp:
+        return False
+    if to_timestamp is not None and earliest > to_timestamp:
+        return False
+    return True
 
 
 def looks_like_windows_path(value: str) -> bool:

--- a/daymade-claude-code/claude-code-history-files-finder/scripts/_core/sources.py
+++ b/daymade-claude-code/claude-code-history-files-finder/scripts/_core/sources.py
@@ -1,0 +1,201 @@
+"""Discover active and explicitly registered Claude conversation sources.
+
+Active Claude homes are auto-discovered by :mod:`homes`. Long-term archives are
+different: their location is user configuration, not a filename convention that
+the public skill should guess. A small manifest at
+``~/.claude/history-sources.json`` registers those archives explicitly.
+
+The manifest is intentionally fail-fast. A malformed file, duplicate archive, or
+missing required source is configuration damage, not a cue to silently fall back
+to the active homes and produce an incomplete history result.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Sequence, Union
+
+from .homes import discover_claude_homes, home_label
+
+
+MANIFEST_VERSION = 1
+SOURCE_LABEL_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+class HistorySourceConfigError(ValueError):
+    """Raised when an explicit history-source registry cannot be trusted."""
+
+
+@dataclass(frozen=True)
+class HistorySource:
+    """One Claude configuration root that contains a ``projects/`` directory."""
+
+    provider: str
+    kind: str
+    label: str
+    home: Path
+    required: bool = True
+
+    @property
+    def display_label(self) -> str:
+        return f"{self.kind}:{self.label}"
+
+
+def default_history_sources_path() -> Path:
+    """Return the per-user registry path without caching ``Path.home()``."""
+    return Path.home() / ".claude" / "history-sources.json"
+
+
+def _resolved_key(path: Path) -> str:
+    try:
+        return str(path.resolve())
+    except (OSError, RuntimeError):
+        return str(path.absolute())
+
+
+def _active_sources(
+    homes: Sequence[Union[str, Path]],
+) -> list[HistorySource]:
+    return [
+        HistorySource(
+            provider="claude",
+            kind="active",
+            label=home_label(home),
+            home=Path(home).expanduser(),
+            required=True,
+        )
+        for home in homes
+    ]
+
+
+def _read_manifest(path: Path) -> dict:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise HistorySourceConfigError(
+            f"Cannot read history source registry {path}: {error}"
+        ) from error
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise HistorySourceConfigError(
+            f"Invalid JSON in history source registry {path}: {error}"
+        ) from error
+    if not isinstance(payload, dict):
+        raise HistorySourceConfigError(
+            f"History source registry {path} must contain a JSON object"
+        )
+    if payload.get("version") != MANIFEST_VERSION:
+        raise HistorySourceConfigError(
+            f"History source registry {path} must use version {MANIFEST_VERSION}"
+        )
+    if not isinstance(payload.get("sources"), list):
+        raise HistorySourceConfigError(
+            f"History source registry {path} must contain a sources array"
+        )
+    return payload
+
+
+def _manifest_archive_sources(
+    path: Path,
+    active: Sequence[HistorySource],
+) -> tuple[list[HistorySource], list[str]]:
+    payload = _read_manifest(path)
+    warnings: list[str] = []
+    archives: list[HistorySource] = []
+    seen_paths = {_resolved_key(source.home) for source in active}
+    seen_labels: set[str] = set()
+
+    for index, entry in enumerate(payload["sources"]):
+        location = f"{path}: sources[{index}]"
+        if not isinstance(entry, dict):
+            raise HistorySourceConfigError(f"{location} must be an object")
+        provider = entry.get("provider")
+        kind = entry.get("kind")
+        label = entry.get("label")
+        home_value = entry.get("home")
+        required = entry.get("required", True)
+        if provider != "claude":
+            raise HistorySourceConfigError(
+                f"{location} has unsupported provider {provider!r}; only 'claude' is supported"
+            )
+        if kind != "archive":
+            raise HistorySourceConfigError(
+                f"{location} has unsupported kind {kind!r}; registered sources must be 'archive'"
+            )
+        if not isinstance(label, str) or not SOURCE_LABEL_RE.fullmatch(label):
+            raise HistorySourceConfigError(
+                f"{location}.label must use letters, numbers, dot, underscore, or hyphen"
+            )
+        if label in seen_labels:
+            raise HistorySourceConfigError(
+                f"Duplicate archive label {label!r} in history source registry {path}"
+            )
+        seen_labels.add(label)
+        if not isinstance(home_value, str) or not home_value.strip():
+            raise HistorySourceConfigError(f"{location}.home must be a non-empty string")
+        if not isinstance(required, bool):
+            raise HistorySourceConfigError(f"{location}.required must be true or false")
+
+        expanded = Path(os.path.expandvars(home_value)).expanduser()
+        home = expanded if expanded.is_absolute() else path.parent / expanded
+        key = _resolved_key(home)
+        if key in seen_paths:
+            raise HistorySourceConfigError(
+                f"Duplicate history source path in {path}: {home}"
+            )
+        seen_paths.add(key)
+        if not (home / "projects").is_dir():
+            message = f"Registered history source {label!r} has no projects/ directory: {home}"
+            if required:
+                raise HistorySourceConfigError(f"Required history source is unavailable. {message}")
+            warnings.append(message)
+            continue
+        archives.append(
+            HistorySource(
+                provider="claude",
+                kind="archive",
+                label=label,
+                home=home,
+                required=required,
+            )
+        )
+    return archives, warnings
+
+
+def discover_claude_sources(
+    *,
+    explicit_homes: Optional[
+        Union[str, Path, Sequence[Union[str, Path]]]
+    ] = None,
+    manifest_path: Optional[Union[str, Path]] = None,
+) -> tuple[list[HistorySource], list[str]]:
+    """Return Claude history sources plus non-fatal registry warnings.
+
+    ``explicit_homes`` is an exact scope: registered archives are intentionally
+    not added. With no explicit scope, active homes are auto-discovered and the
+    default registry is loaded when present. Passing ``manifest_path`` makes that
+    file itself required, so a typo cannot silently disable archive coverage.
+    """
+    if explicit_homes is not None:
+        return _active_sources(discover_claude_homes(explicit_homes)), []
+
+    active = _active_sources(discover_claude_homes())
+    explicit_manifest = manifest_path is not None
+    registry = (
+        Path(manifest_path).expanduser()
+        if explicit_manifest
+        else default_history_sources_path()
+    )
+    if not registry.is_file():
+        if explicit_manifest:
+            raise HistorySourceConfigError(
+                f"History source registry not found: {registry}"
+            )
+        return active, []
+    archives, warnings = _manifest_archive_sources(registry, active)
+    return active + archives, warnings

--- a/daymade-claude-code/claude-code-history-files-finder/scripts/_core/text.py
+++ b/daymade-claude-code/claude-code-history-files-finder/scripts/_core/text.py
@@ -4,14 +4,15 @@ These turn raw session content into a readable one-line title and iterate JSONL
 transcripts safely. Both the Claude and Codex providers use them, so they live in
 the shared core (SSOT: `daymade-claude-code/_conversation_core/`, bundled into
 each skill's `scripts/_core/` by `sync_core.py`). Keeping them here lets the Codex
-provider and a future `continue-codex-work` skill reuse one implementation instead
-of re-deriving title/noise heuristics that would drift apart.
+provider and `continue-codex-work` reuse one implementation instead of
+re-deriving title/noise heuristics that would drift apart.
 """
 
 from __future__ import annotations
 
 import json
 import re
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable, Iterator, Optional
 
@@ -41,6 +42,14 @@ ATTACHMENT_IMAGE_RE = re.compile(
 )
 FILE_SUFFIX_RE = re.compile(r"\.[A-Za-z0-9]{1,16}$")
 SLASH_COMMAND_RE = re.compile(r"^/[A-Za-z0-9_:-]+(?:[ \t].*)?$")
+
+
+@dataclass(frozen=True)
+class SearchSegment:
+    """One searchable text field with its semantic provenance."""
+
+    source: str
+    text: str
 
 
 def looks_like_attachment_prefix(value: str) -> bool:
@@ -109,6 +118,117 @@ def extract_text(content: Any) -> str:
         ):
             parts.append(item["text"])
     return " ".join(parts)
+
+
+def _flatten_search_strings(value: Any) -> Iterator[str]:
+    """Yield string values while excluding structural/signature metadata."""
+    if isinstance(value, str):
+        if value:
+            yield value
+        return
+    if isinstance(value, list):
+        for item in value:
+            yield from _flatten_search_strings(item)
+        return
+    if not isinstance(value, dict):
+        return
+    for key, child in value.items():
+        if key in {"type", "id", "tool_use_id", "signature"}:
+            continue
+        yield from _flatten_search_strings(child)
+
+
+def searchable_segments(record: dict[str, Any]) -> list[SearchSegment]:
+    """Extract user-visible/search-relevant fields from one Claude event.
+
+    Raw JSON serialization is intentionally not searched: keys, UUIDs, and
+    cryptographic thinking signatures create false positives. Instead this
+    covers message text, thinking text, tool inputs/results, queue content,
+    last-prompt/system summaries, and attachment payloads with a source label for
+    every segment.
+    """
+    segments: list[SearchSegment] = []
+
+    def add(source: str, value: Any) -> None:
+        for text_value in _flatten_search_strings(value):
+            segments.append(SearchSegment(source=source, text=text_value))
+
+    event_type = record.get("type")
+    message = record.get("message")
+    content: Any
+    if isinstance(message, dict):
+        content = message.get("content", [])
+    elif isinstance(message, str):
+        content = message
+    elif event_type in {"user", "assistant"} or record.get("role") in {
+        "user",
+        "assistant",
+    }:
+        content = record.get("content", [])
+    else:
+        content = []
+
+    if isinstance(content, str):
+        add("message", content)
+    elif isinstance(content, list):
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            block_type = block.get("type")
+            if block_type in {"text", "input_text"}:
+                add("message", block.get("text"))
+            elif block_type == "thinking":
+                add("thinking", block.get("thinking"))
+            elif block_type == "tool_use":
+                tool_name = block.get("name")
+                source = (
+                    f"tool_input:{tool_name}"
+                    if isinstance(tool_name, str) and tool_name
+                    else "tool_input"
+                )
+                add(source, block.get("input"))
+            elif block_type == "tool_result":
+                add("tool_result", block.get("content"))
+            else:
+                # Preserve textual payloads of future/older block types without
+                # indexing structural keys or binary image data.
+                add("message", {key: block.get(key) for key in ("text", "content")})
+
+    if event_type == "queue-operation":
+        add("queue-operation", record.get("content"))
+    elif event_type == "attachment":
+        attachment = record.get("attachment")
+        if isinstance(attachment, dict):
+            add(
+                "attachment",
+                {
+                    key: attachment.get(key)
+                    for key in (
+                        "content",
+                        "prompt",
+                        "path",
+                        "displayPath",
+                        "command",
+                        "stdout",
+                        "stderr",
+                    )
+                },
+            )
+    elif event_type == "last-prompt":
+        add("last-prompt", record.get("lastPrompt"))
+    elif event_type == "system":
+        add("system", record.get("content"))
+    elif event_type == "summary":
+        add("summary", {"content": record.get("content"), "summary": record.get("summary")})
+    elif event_type == "custom-title":
+        add(
+            "custom-title",
+            {"title": record.get("title"), "customTitle": record.get("customTitle")},
+        )
+
+    # Some event variants mirror the same payload in more than one compatible
+    # field. Count each semantic source/text pair once per record.
+    return list(dict.fromkeys(segments))
 
 
 def is_noise_text(text: str) -> bool:

--- a/daymade-claude-code/claude-code-history-files-finder/scripts/analyze_sessions.py
+++ b/daymade-claude-code/claude-code-history-files-finder/scripts/analyze_sessions.py
@@ -5,18 +5,23 @@ Analyze Claude Code session files to find relevant sessions and statistics.
 This script helps locate sessions containing specific keywords, analyze
 session activity, and generate reports about session content.
 
-History is searched across EVERY Claude config home, not just ~/.claude:
-users who run third-party models through per-model profiles keep parallel
-history under ~/.claude-profiles/<name>/ (each profile is its own
-CLAUDE_CONFIG_DIR). Searching only ~/.claude silently misses those sessions —
-the #1 way a real conversation is wrongly judged "not found".
+By default, history is searched across every active Claude config home plus
+every long-term archive registered in ~/.claude/history-sources.json. Searching
+only ~/.claude or only the current active tree can silently miss a real session.
+Conversation dates come from internal JSONL records, never file mtime.
+
+Two opt-in widenings exist because "not found" is the expensive answer:
+--all-projects sweeps every project when the project is a guess, and --codex
+also searches Codex rollout history (~/.codex) — a different store that the
+Claude registry never covers.
 """
 
+import hashlib
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Dict, List, Any, Optional
-from datetime import datetime
 from collections import defaultdict
 
 
@@ -25,36 +30,297 @@ from collections import defaultdict
 # scripts/_core/ by sync_core.py so this skill stays self-contained. Make this
 # script's own dir importable regardless of how it is invoked, then import.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _core.homes import discover_claude_homes, home_label  # noqa: E402
+from _core.claude import scan_claude_session  # noqa: E402
+from _core.codex import codex_meta_from_rollout, codex_session_id  # noqa: E402
+from _core.homes import home_label  # noqa: E402
+from _core.parse import (  # noqa: E402
+    TimestampRange,
+    format_timestamp,
+    parse_date_boundary,
+    parse_timestamp,
+    range_overlaps_window,
+    timestamp_in_window,
+    workspace_matches,
+)
+from _core.sources import (  # noqa: E402
+    HistorySource,
+    HistorySourceConfigError,
+    discover_claude_sources,
+)
+from _core.text import SearchSegment, iter_jsonl, searchable_segments  # noqa: E402
+
+
+def _record_identity(record: Dict[str, Any]) -> str:
+    """Return a stable identity for record-level union across session copies."""
+    canonical = json.dumps(
+        record,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(canonical).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Codex rollout search (--codex)
+#
+# Codex stores conversations outside the Claude history registry: rollout
+# JSONL files under <CODEX_HOME>/sessions/<YYYY>/<MM>/<DD>/ plus
+# <CODEX_HOME>/archived_sessions/. Their record schema is NOT the Claude one
+# (response_item/event_msg/session_meta, not user/assistant/queue-operation),
+# so searchable_segments() does not apply. The extractor below covers the
+# user-visible payload of each response_item variant. event_msg user/agent
+# message records are deliberate strict mirrors of response_item message text
+# (verified 2026-07-16: 26/26 and 104/104 subset on a real rollout), so they
+# are skipped to avoid double-counting.
+# ---------------------------------------------------------------------------
+
+
+def _flatten_strings(value: Any) -> List[str]:
+    """Flatten nested str/list/dict content into plain strings."""
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [part for item in value for part in _flatten_strings(item)]
+    if isinstance(value, dict):
+        return [part for item in value.values() for part in _flatten_strings(item)]
+    return []
+
+
+def codex_searchable_segments(record: Dict[str, Any]) -> List[SearchSegment]:
+    """Extract searchable text fields from one Codex rollout record."""
+    segments: List[SearchSegment] = []
+
+    def add(source: str, value: Any) -> None:
+        for text_value in _flatten_strings(value):
+            segments.append(SearchSegment(source=source, text=text_value))
+
+    if record.get("type") == "compacted":
+        # Compaction records carry a summary of earlier conversation content.
+        payload = record.get("payload")
+        if isinstance(payload, dict):
+            add("summary", payload.get("message"))
+        return list(dict.fromkeys(segments))
+
+    if record.get("type") != "response_item":
+        return segments
+    payload = record.get("payload")
+    if not isinstance(payload, dict):
+        return segments
+    payload_type = payload.get("type")
+    if payload_type == "message":
+        for block in payload.get("content") or []:
+            if isinstance(block, dict) and block.get("type") in {
+                "input_text",
+                "output_text",
+            }:
+                add("message", block.get("text"))
+    elif payload_type == "reasoning":
+        for block in payload.get("summary") or []:
+            if isinstance(block, dict) and block.get("type") == "summary_text":
+                add("thinking", block.get("text"))
+    elif payload_type in {"function_call", "custom_tool_call"}:
+        name = payload.get("name")
+        source = (
+            f"tool_input:{name}"
+            if isinstance(name, str) and name
+            else "tool_input"
+        )
+        add(source, payload.get("arguments"))
+        add(source, payload.get("input"))
+    elif payload_type in {"function_call_output", "custom_tool_call_output"}:
+        add("tool_result", payload.get("output"))
+    return list(dict.fromkeys(segments))
+
+
+def discover_codex_rollouts(codex_home: Path) -> List[Path]:
+    """Enumerate Codex rollout files under a Codex home (sessions + archived)."""
+    rollouts: List[Path] = []
+    sessions_dir = codex_home / "sessions"
+    if sessions_dir.is_dir():
+        rollouts.extend(sorted(sessions_dir.rglob("*.jsonl")))
+    archived_dir = codex_home / "archived_sessions"
+    if archived_dir.is_dir():
+        rollouts.extend(sorted(archived_dir.glob("*.jsonl")))
+    return rollouts
+
+
+def search_codex_rollouts(
+    rollouts: List[Path],
+    keywords: List[str],
+    case_sensitive: bool = False,
+    from_timestamp: Optional[float] = None,
+    to_timestamp: Optional[float] = None,
+    project_path: Optional[str] = None,
+    exclude_ids: Optional[set] = None,
+) -> List[Dict[str, Any]]:
+    """Search Codex rollouts for keywords, one match dict per session.
+
+    ``project_path`` filters by the rollout's session_meta cwd (recursive
+    workspace match). Rollouts are de-duplicated by session id — a copy left
+    in both sessions/ and archived_sessions/ is reported once.
+    """
+    search_keywords = [
+        (keyword, keyword if case_sensitive else keyword.casefold())
+        for keyword in keywords
+    ]
+    exclude = exclude_ids or set()
+    matches: List[Dict[str, Any]] = []
+    seen_ids: set[str] = set()
+
+    for path in rollouts:
+        try:
+            meta = codex_meta_from_rollout(path)
+        except OSError as e:
+            print(f"Warning: Error reading {path}: {e}", file=sys.stderr)
+            continue
+        sid = codex_session_id(meta, path) if meta else None
+        if not sid:
+            sid = path.stem
+        if sid in seen_ids:
+            continue
+        seen_ids.add(sid)
+        if sid in exclude or path.stem in exclude:
+            continue
+        cwd = meta.get("cwd") if isinstance(meta, dict) else None
+        if project_path is not None:
+            if not isinstance(cwd, str) or not workspace_matches(
+                cwd, project_path, recursive=True
+            ):
+                continue
+
+        keyword_counts: Dict[str, int] = defaultdict(int)
+        total_mentions = 0
+        match_sources: set[str] = set()
+        session_range = TimestampRange()
+        match_range = TimestampRange()
+        excluded_untimed = 0
+        try:
+            for record in iter_jsonl(path):
+                record_timestamp = parse_timestamp(record.get("timestamp"))
+                if record_timestamp is not None:
+                    session_range.observe(record_timestamp)
+                if record.get("type") == "session_meta" and isinstance(
+                    record.get("payload"), dict
+                ):
+                    meta_timestamp = parse_timestamp(
+                        record["payload"].get("timestamp")
+                    )
+                    if meta_timestamp is not None:
+                        session_range.observe(meta_timestamp)
+                if from_timestamp is not None or to_timestamp is not None:
+                    if record_timestamp is None:
+                        excluded_untimed += 1
+                        continue
+                    if not timestamp_in_window(
+                        record_timestamp, from_timestamp, to_timestamp
+                    ):
+                        continue
+                record_counts: Dict[str, int] = defaultdict(int)
+                record_sources: set[str] = set()
+                for segment in codex_searchable_segments(record):
+                    search_text = (
+                        segment.text if case_sensitive else segment.text.casefold()
+                    )
+                    for keyword, search_keyword in search_keywords:
+                        count = search_text.count(search_keyword)
+                        if count > 0:
+                            record_counts[keyword] += count
+                            record_sources.add(segment.source)
+                record_mentions = sum(record_counts.values())
+                if not record_mentions:
+                    continue
+                for keyword, count in record_counts.items():
+                    keyword_counts[keyword] += count
+                total_mentions += record_mentions
+                match_sources.update(record_sources)
+                if record_timestamp is not None:
+                    match_range.observe(record_timestamp)
+        except (OSError, UnicodeError) as e:
+            print(f"Warning: Error processing {path}: {e}", file=sys.stderr)
+            continue
+
+        if total_mentions > 0:
+            matches.append(
+                {
+                    "session_id": sid,
+                    "path": path,
+                    "cwd": cwd,
+                    "total_mentions": total_mentions,
+                    "keyword_counts": dict(keyword_counts),
+                    "match_sources": sorted(match_sources),
+                    "created_at": session_range.earliest,
+                    "updated_at": session_range.latest,
+                    "match_created_at": match_range.earliest,
+                    "match_updated_at": match_range.latest,
+                    "excluded_untimed_records": excluded_untimed,
+                }
+            )
+
+    matches.sort(
+        key=lambda match: (
+            match["total_mentions"],
+            match["match_updated_at"]
+            if match["match_updated_at"] is not None
+            else float("-inf"),
+        ),
+        reverse=True,
+    )
+    return matches
 
 
 class SessionAnalyzer:
     """Analyze Claude Code session history files across all config homes."""
 
-    def __init__(self, homes: Optional[List[Path]] = None):
+    def __init__(
+        self,
+        homes: Optional[List[Path]] = None,
+        sources: Optional[List[HistorySource]] = None,
+        warnings: Optional[List[str]] = None,
+    ):
         """
         Initialize analyzer.
 
         Args:
-            homes: List of Claude config home directories to search (each must
+            homes: Exact list of Claude config home directories to search (each
+                must
                 contain a ``projects/`` subdir). Pass ``None`` (the default) to
-                auto-discover all homes (``~/.claude`` plus every
-                ``~/.claude-profiles/*`` and ``~/.claude-*`` profile home). Pass
-                an explicit list to restrict the search — an EMPTY list means
+                auto-discover active homes and load registered archives. Pass an
+                explicit list to restrict the search — an EMPTY list means
                 "search nothing", it must NOT silently fall back to full
                 discovery (that would turn a scope-narrowing flag into the
                 widest possible scope).
         """
-        self.homes = discover_claude_homes() if homes is None else list(homes)
+        if homes is not None and sources is not None:
+            raise ValueError("Pass homes or sources, not both")
+        if sources is not None:
+            self.sources = list(sources)
+        elif homes is not None:
+            self.sources = [
+                HistorySource(
+                    provider="claude",
+                    kind="active",
+                    label=home_label(home),
+                    home=Path(home),
+                )
+                for home in homes
+            ]
+        else:
+            self.sources, discovered_warnings = discover_claude_sources()
+            warnings = (warnings or []) + discovered_warnings
+        self.homes = [source.home for source in self.sources]
+        self.warnings = list(warnings or [])
 
     def find_project_sessions(self, project_path: str) -> List[Dict[str, Any]]:
         """
         Find all session files for a project ACROSS every discovered home.
 
         Sessions are de-duplicated by session id (the ``.jsonl`` filename), so a
-        conversation shared across profiles (profile dirs link back to one
-        physical file) is reported once, attributed to every home it appears in.
-        Agent side-files (``agent-*.jsonl``) are excluded.
+        conversation shared across profiles is reported once. Every physical
+        copy remains attached to that session reference: search must union the
+        records from active and archive copies because one copy can retain
+        content that another copy no longer has. Agent side-files
+        (``agent-*.jsonl``) are excluded.
 
         Args:
             project_path: The project's working directory. An absolute path, a
@@ -63,32 +329,150 @@ class SessionAnalyzer:
                 (basename) is also accepted and matched via reverse lookup.
 
         Returns:
-            List of dicts ``{"path", "homes", "mtime"}`` sorted by mtime (newest
-            first). ``homes`` is the list of home Paths the session was found in
-            — its provenance. Empty if the project has no history anywhere.
+            Session-reference dictionaries sorted by the unioned maximum
+            internal timestamp (newest first). Each includes a representative
+            ``path``, every physical ``copy``, the unioned
+            ``created_at``/``updated_at`` range, and all ``sources``/``homes``
+            where that session ID was observed. Empty if the project has no
+            history in the configured source set.
         """
+        return self._merge_sessions_from_dirs(
+            self._resolve_project_dirs(project_path)
+        )
+
+    def _merge_sessions_from_dirs(
+        self, pairs: List[tuple]
+    ) -> List[Dict[str, Any]]:
+        """Collect + de-duplicate sessions from ``(source, project_dir)`` pairs."""
         by_id: Dict[str, Dict[str, Any]] = {}
-        for home, project_dir in self._resolve_project_dirs(project_path):
+        for source, project_dir in pairs:
             for file in project_dir.glob("*.jsonl"):
                 if file.name.startswith("agent-"):
                     continue
-                try:
-                    mtime = file.stat().st_mtime
-                except OSError:
-                    continue
-                sid = file.name
+                summary = scan_claude_session(file)
+                sid = summary.session_id
+                copy = {
+                    "path": file,
+                    "source": source,
+                    "created_at": summary.created_at,
+                    "updated_at": summary.updated_at,
+                }
+                candidate = {
+                    "path": file,
+                    "copies": [copy],
+                    "sources": [source],
+                    "homes": [source.home],
+                    "created_at": summary.created_at,
+                    "updated_at": summary.updated_at,
+                    "timestamp_source": (
+                        "session-record-minmax"
+                        if summary.timestamp_count
+                        else "unknown"
+                    ),
+                    "selected_kind": source.kind,
+                    "selected_updated_at": summary.updated_at,
+                    "session_id": sid,
+                }
                 entry = by_id.get(sid)
                 if entry is None:
-                    by_id[sid] = {"path": file, "homes": [home], "mtime": mtime}
-                else:
-                    if home not in entry["homes"]:
-                        entry["homes"].append(home)
-                    # Keep the copy with the latest mtime (usually the same file).
-                    if mtime > entry["mtime"]:
-                        entry["path"] = file
-                        entry["mtime"] = mtime
+                    by_id[sid] = candidate
+                    continue
+                entry["copies"].append(copy)
+                sources = list(entry["sources"])
+                if source.display_label not in {
+                    item.display_label for item in sources
+                }:
+                    sources.append(source)
+                homes = list(entry["homes"])
+                if source.home not in homes:
+                    homes.append(source.home)
+                existing_selected_time = (
+                    entry["selected_updated_at"]
+                    if entry["selected_updated_at"] is not None
+                    else float("-inf")
+                )
+                candidate_time = (
+                    summary.updated_at
+                    if summary.updated_at is not None
+                    else float("-inf")
+                )
+                candidate_wins = candidate_time > existing_selected_time or (
+                    candidate_time == existing_selected_time
+                    and source.kind == "active"
+                    and entry["selected_kind"] != "active"
+                )
+                if candidate_wins:
+                    entry["path"] = file
+                    entry["selected_kind"] = source.kind
+                    entry["selected_updated_at"] = summary.updated_at
+                entry["sources"] = sources
+                entry["homes"] = homes
+                created_values = [
+                    value
+                    for value in (entry["created_at"], summary.created_at)
+                    if value is not None
+                ]
+                updated_values = [
+                    value
+                    for value in (entry["updated_at"], summary.updated_at)
+                    if value is not None
+                ]
+                entry["created_at"] = min(created_values) if created_values else None
+                entry["updated_at"] = max(updated_values) if updated_values else None
+                if summary.timestamp_count:
+                    entry["timestamp_source"] = "session-record-minmax"
 
-        return sorted(by_id.values(), key=lambda e: e["mtime"], reverse=True)
+        return sorted(
+            by_id.values(),
+            key=lambda entry: (
+                entry["updated_at"]
+                if entry["updated_at"] is not None
+                else float("-inf")
+            ),
+            reverse=True,
+        )
+
+    def project_dir_pairs(self) -> Dict[str, List[tuple]]:
+        """Enumerate every project dir across all sources.
+
+        Returns ``{encoded_project_name: [(source, dir), ...]}`` — one entry
+        per distinct project, with a pair per source that holds history for
+        it. The encoded name (``-Users-<name>-app``) is the project's true
+        identity; decoding ``-`` back to ``/`` is lossy (real dir names may
+        contain hyphens), so the encoded form is displayed as-is.
+        """
+        result: Dict[str, List[tuple]] = {}
+        for source in self.sources:
+            projects_dir = source.home / "projects"
+            if not projects_dir.is_dir():
+                continue
+            for candidate in sorted(projects_dir.iterdir()):
+                if candidate.is_dir():
+                    result.setdefault(candidate.name, []).append(
+                        (source, candidate)
+                    )
+        return result
+
+    def find_all_projects_sessions(self) -> List[Dict[str, Any]]:
+        """Find sessions for EVERY project across all sources (--all-projects).
+
+        Each returned ref carries a ``project`` field with the encoded
+        project name. Sorted newest first across all projects.
+        """
+        sessions: List[Dict[str, Any]] = []
+        for project_name, pairs in self.project_dir_pairs().items():
+            for ref in self._merge_sessions_from_dirs(pairs):
+                ref["project"] = project_name
+                sessions.append(ref)
+        return sorted(
+            sessions,
+            key=lambda entry: (
+                entry["updated_at"]
+                if entry["updated_at"] is not None
+                else float("-inf")
+            ),
+            reverse=True,
+        )
 
     def _resolve_project_dirs(self, project_path: str) -> List[tuple]:
         """
@@ -114,7 +498,7 @@ class SessionAnalyzer:
            rather than guess.
 
         Returns:
-            List of ``(home, encoded_dir)`` pairs — one per home where the
+            List of ``(source, encoded_dir)`` pairs — one per source where the
             resolved project dir exists.
         """
         # Encode the resolved absolute path once (for exact matching).
@@ -130,9 +514,9 @@ class SessionAnalyzer:
         # anywhere fixes the project identity, so we never fuzzy-fall-back.
         if exact_name is not None:
             exact_hits = [
-                (home, home / "projects" / exact_name)
-                for home in self.homes
-                if (home / "projects" / exact_name).is_dir()
+                (source, source.home / "projects" / exact_name)
+                for source in self.sources
+                if (source.home / "projects" / exact_name).is_dir()
             ]
             if exact_hits:
                 return exact_hits
@@ -143,13 +527,13 @@ class SessionAnalyzer:
         if not base:
             return []
         by_name: Dict[str, List[tuple]] = {}
-        for home in self.homes:
-            projects_dir = home / "projects"
+        for source in self.sources:
+            projects_dir = source.home / "projects"
             if not projects_dir.is_dir():
                 continue
             for d in projects_dir.iterdir():
                 if d.is_dir() and d.name.endswith("-" + base):
-                    by_name.setdefault(d.name, []).append((home, d))
+                    by_name.setdefault(d.name, []).append((source, d))
 
         if not by_name:
             return []
@@ -160,8 +544,10 @@ class SessionAnalyzer:
                 file=sys.stderr,
             )
             for name in sorted(by_name):
-                homes_str = ", ".join(home_label(h) for h, _ in by_name[name])
-                print(f"  {name}  [{homes_str}]", file=sys.stderr)
+                sources_str = ", ".join(
+                    source.display_label for source, _ in by_name[name]
+                )
+                print(f"  {name}  [{sources_str}]", file=sys.stderr)
             return []
         # Exactly one distinct project — use it wherever it exists.
         return next(iter(by_name.values()))
@@ -171,70 +557,155 @@ class SessionAnalyzer:
         session_refs: List[Dict[str, Any]],
         keywords: List[str],
         case_sensitive: bool = False,
+        from_timestamp: Optional[float] = None,
+        to_timestamp: Optional[float] = None,
     ) -> List[Dict[str, Any]]:
         """
         Search sessions for keywords.
 
         Args:
-            session_refs: Session refs from ``find_project_sessions`` (each a
-                dict with ``path`` and ``homes``).
+            session_refs: Session refs from ``find_project_sessions`` (each has
+                every active/archive copy plus a representative path).
             keywords: Keywords to search for.
             case_sensitive: Whether to perform case-sensitive search.
+            from_timestamp: Inclusive lower internal record timestamp.
+            to_timestamp: Inclusive upper internal record timestamp.
 
         Returns:
             List of match dicts (session ref + match counts), most mentions
             first.
         """
         matches: List[Dict[str, Any]] = []
+        search_keywords = [
+            (keyword, keyword if case_sensitive else keyword.casefold())
+            for keyword in keywords
+        ]
 
         for ref in session_refs:
-            session_file = ref["path"]
             keyword_counts = defaultdict(int)
             total_mentions = 0
+            match_sources: set[str] = set()
+            matching_source_labels: set[str] = set()
+            match_timestamps = TimestampRange()
+            excluded_untimed_count = 0
+            excluded_untimed_from_prior_copies: set[str] = set()
+            matched_records_from_prior_copies: set[str] = set()
+            matching_copies: List[Dict[str, Any]] = []
 
-            try:
-                with open(session_file, "r") as f:
-                    for line in f:
-                        try:
-                            data = json.loads(line.strip())
-                        except json.JSONDecodeError:
+            copies = ref.get("copies") or [
+                {
+                    "path": ref["path"],
+                    "source": ref["sources"][0],
+                    "created_at": ref["created_at"],
+                    "updated_at": ref["updated_at"],
+                }
+            ]
+            for copy in copies:
+                session_file = copy["path"]
+                source = copy["source"]
+                copy_had_match = False
+                copy_new_mentions = 0
+                copy_untimed_records: set[str] = set()
+                copy_matched_records: set[str] = set()
+                try:
+                    records = iter_jsonl(session_file)
+                    for data in records:
+                        record_identity = _record_identity(data)
+                        record_timestamp = parse_timestamp(data.get("timestamp"))
+                        if from_timestamp is not None or to_timestamp is not None:
+                            if record_timestamp is None:
+                                if record_identity not in excluded_untimed_from_prior_copies:
+                                    excluded_untimed_count += 1
+                                copy_untimed_records.add(record_identity)
+                                continue
+                            if not timestamp_in_window(
+                                record_timestamp, from_timestamp, to_timestamp
+                            ):
+                                continue
+                        record_counts = defaultdict(int)
+                        record_sources: set[str] = set()
+                        for segment in searchable_segments(data):
+                            search_text = (
+                                segment.text
+                                if case_sensitive
+                                else segment.text.casefold()
+                            )
+                            for keyword, search_keyword in search_keywords:
+                                count = search_text.count(search_keyword)
+                                if count > 0:
+                                    record_counts[keyword] += count
+                                    record_sources.add(segment.source)
+                        record_mentions = sum(record_counts.values())
+                        if not record_mentions:
                             continue
 
-                        # Extract text content from message
-                        text_content = self._extract_text_content(data)
+                        copy_had_match = True
+                        matching_source_labels.add(source.display_label)
+                        copy_matched_records.add(record_identity)
+                        if record_identity in matched_records_from_prior_copies:
+                            continue
+                        for keyword, count in record_counts.items():
+                            keyword_counts[keyword] += count
+                        total_mentions += record_mentions
+                        copy_new_mentions += record_mentions
+                        match_sources.update(record_sources)
+                        if record_timestamp is not None:
+                            match_timestamps.observe(record_timestamp)
+                except (OSError, UnicodeError) as e:
+                    print(
+                        f"Warning: Error processing {session_file}: {e}",
+                        file=sys.stderr,
+                    )
+                    continue
 
-                        # Search for keywords
-                        search_text = (
-                            text_content if case_sensitive else text_content.lower()
-                        )
-                        for keyword in keywords:
-                            search_keyword = (
-                                keyword if case_sensitive else keyword.lower()
-                            )
-                            count = search_text.count(search_keyword)
-                            if count > 0:
-                                keyword_counts[keyword] += count
-                                total_mentions += count
-
-            except Exception as e:
-                print(
-                    f"Warning: Error processing {session_file}: {e}", file=sys.stderr
-                )
-                continue
+                excluded_untimed_from_prior_copies.update(copy_untimed_records)
+                matched_records_from_prior_copies.update(copy_matched_records)
+                if copy_had_match:
+                    matching_copies.append(
+                        {
+                            "path": session_file,
+                            "source": source,
+                            "new_mentions": copy_new_mentions,
+                        }
+                    )
 
             if total_mentions > 0:
+                primary_copy = max(
+                    matching_copies,
+                    key=lambda item: (
+                        item["new_mentions"],
+                        item["source"].kind == "active",
+                    ),
+                )
                 matches.append(
                     {
-                        "path": session_file,
+                        "path": primary_copy["path"],
+                        "matching_copies": matching_copies,
                         "homes": ref["homes"],
+                        "sources": ref["sources"],
+                        "matching_source_labels": matching_source_labels,
                         "total_mentions": total_mentions,
                         "keyword_counts": dict(keyword_counts),
-                        "modified_time": ref["mtime"],
-                        "size": session_file.stat().st_size,
+                        "match_sources": sorted(match_sources),
+                        "created_at": ref["created_at"],
+                        "updated_at": ref["updated_at"],
+                        "match_created_at": match_timestamps.earliest,
+                        "match_updated_at": match_timestamps.latest,
+                        "timestamp_source": ref["timestamp_source"],
+                        "excluded_untimed_records": excluded_untimed_count,
+                        "size": sum(item["path"].stat().st_size for item in copies),
                     }
                 )
 
-        matches.sort(key=lambda m: m["total_mentions"], reverse=True)
+        matches.sort(
+            key=lambda match: (
+                match["total_mentions"],
+                match["match_updated_at"]
+                if match["match_updated_at"] is not None
+                else float("-inf"),
+            ),
+            reverse=True,
+        )
         return matches
 
     def get_session_stats(self, session_file: Path) -> Dict[str, Any]:
@@ -322,31 +793,8 @@ class SessionAnalyzer:
         return stats
 
     def _extract_text_content(self, data: Dict[str, Any]) -> str:
-        """Extract all text content from a message."""
-        text_parts = []
-
-        # Get content from either location
-        content = data.get("content") or data.get("message", {}).get("content", [])
-
-        if isinstance(content, str):
-            text_parts.append(content)
-        elif isinstance(content, list):
-            for item in content:
-                if isinstance(item, dict):
-                    if item.get("type") == "text":
-                        text_parts.append(item.get("text", ""))
-                    # Also check tool inputs for file paths etc
-                    elif item.get("type") == "tool_use":
-                        tool_input = item.get("input", {})
-                        if isinstance(tool_input, dict):
-                            # Add file paths from tool inputs
-                            if "file_path" in tool_input:
-                                text_parts.append(tool_input["file_path"])
-                            # Add content from Write calls
-                            if "content" in tool_input:
-                                text_parts.append(tool_input["content"])
-
-        return " ".join(text_parts)
+        """Compatibility wrapper around the structured event extractor."""
+        return " ".join(segment.text for segment in searchable_segments(data))
 
 
 def _add_home_flags(subparser) -> None:
@@ -355,30 +803,60 @@ def _add_home_flags(subparser) -> None:
         "--home",
         action="append",
         metavar="DIR",
-        help="Restrict to a specific Claude home dir (repeatable). Default: "
-        "search ~/.claude PLUS every ~/.claude-profiles/* profile home.",
+        help="Restrict to exact Claude home dir(s) and bypass the archive "
+        "registry (repeatable). Default: search every active home plus "
+        "registered archives.",
     )
     subparser.add_argument(
         "--main-only",
         action="store_true",
-        help="Search only ~/.claude, skipping all profile homes.",
+        help="Search only ~/.claude, bypassing profile homes and archives.",
+    )
+    subparser.add_argument(
+        "--history-sources",
+        metavar="FILE",
+        help=(
+            "History source registry (default: ~/.claude/history-sources.json "
+            "when present). Incompatible with --home/--main-only."
+        ),
+    )
+    subparser.add_argument(
+        "--from-date",
+        help="Inclusive start: YYYY-MM-DD (local day) or timezone-qualified ISO datetime",
+    )
+    subparser.add_argument(
+        "--to-date",
+        help="Inclusive end: YYYY-MM-DD (local day) or timezone-qualified ISO datetime",
     )
 
 
-def _homes_for(args) -> tuple:
-    """Resolve the home list from CLI flags (used by list / search).
+def _sources_for(args) -> tuple:
+    """Resolve active/archive sources from CLI flags (used by list / search).
 
-    Returns ``(homes, narrowed)``. ``narrowed`` is True when the user passed
+    Returns ``(sources, narrowed, warnings)``. ``narrowed`` is True when the user passed
     ``--home`` / ``--main-only``, so the caller can treat an empty result as a
     real "your selection matched no home with history" error instead of
     silently widening back to searching every home.
     """
-    if getattr(args, "main_only", False):
-        return discover_claude_homes([Path.home() / ".claude"]), True
+    main_only = getattr(args, "main_only", False)
     explicit = getattr(args, "home", None)
+    registry = getattr(args, "history_sources", None)
+    if main_only and explicit:
+        raise HistorySourceConfigError("--main-only cannot be combined with --home")
+    if registry and (main_only or explicit):
+        raise HistorySourceConfigError(
+            "--history-sources cannot be combined with --home/--main-only"
+        )
+    if main_only:
+        sources, warnings = discover_claude_sources(
+            explicit_homes=[Path.home() / ".claude"]
+        )
+        return sources, True, warnings
     if explicit:
-        return discover_claude_homes(explicit), True
-    return discover_claude_homes(), False
+        sources, warnings = discover_claude_sources(explicit_homes=explicit)
+        return sources, True, warnings
+    sources, warnings = discover_claude_sources(manifest_path=registry)
+    return sources, False, warnings
 
 
 def _analyzer_or_exit(args) -> "SessionAnalyzer":
@@ -389,8 +867,12 @@ def _analyzer_or_exit(args) -> "SessionAnalyzer":
     reintroduce full discovery — turning a scope-narrowing flag into the widest
     possible scope. We fail loudly instead.
     """
-    homes, narrowed = _homes_for(args)
-    if narrowed and not homes:
+    try:
+        sources, narrowed, warnings = _sources_for(args)
+    except HistorySourceConfigError as error:
+        print(f"History source configuration error: {error}", file=sys.stderr)
+        sys.exit(2)
+    if narrowed and not sources:
         print(
             "No Claude home with a projects/ dir matched your --home/--main-only "
             "selection (a --home value must be a config home such as ~/.claude "
@@ -398,7 +880,101 @@ def _analyzer_or_exit(args) -> "SessionAnalyzer":
             file=sys.stderr,
         )
         sys.exit(1)
-    return SessionAnalyzer(homes)
+    return SessionAnalyzer(sources=sources, warnings=warnings)
+
+
+def _parse_date_window(args, parser) -> tuple[Optional[float], Optional[float]]:
+    try:
+        from_timestamp = (
+            parse_date_boundary(args.from_date) if args.from_date else None
+        )
+        to_timestamp = (
+            parse_date_boundary(args.to_date, end=True) if args.to_date else None
+        )
+    except ValueError as error:
+        parser.error(str(error))
+    if (
+        from_timestamp is not None
+        and to_timestamp is not None
+        and from_timestamp > to_timestamp
+    ):
+        parser.error("--from-date must not be later than --to-date")
+    return from_timestamp, to_timestamp
+
+
+def _format_range(earliest: Optional[float], latest: Optional[float]) -> str:
+    if earliest is None or latest is None:
+        return "unknown (no internal timestamp)"
+    return f"{format_timestamp(earliest)} .. {format_timestamp(latest)}"
+
+
+def _source_summary(sources: List[HistorySource]) -> str:
+    return ", ".join(source.display_label for source in sources)
+
+
+def _validate_project_scope(args, parser) -> None:
+    """Exactly one of project_path / --all-projects must be given."""
+    if args.all_projects and args.project_path:
+        parser.error("pass either a project path or --all-projects, not both")
+    if not args.all_projects and not args.project_path:
+        parser.error(
+            "a project path is required unless --all-projects is given "
+            "(use --all-projects when you do not know which project it was)"
+        )
+
+
+def _collect_sessions(analyzer: "SessionAnalyzer", args) -> List[Dict[str, Any]]:
+    """Collect session refs for the requested scope, applying exclusions."""
+    if args.all_projects:
+        sessions = analyzer.find_all_projects_sessions()
+    else:
+        sessions = analyzer.find_project_sessions(args.project_path)
+    exclude = set(getattr(args, "exclude_session", None) or [])
+    if exclude:
+        sessions = [
+            ref
+            for ref in sessions
+            if ref["session_id"] not in exclude and ref["path"].stem not in exclude
+        ]
+    return sessions
+
+
+def _codex_home_for(args) -> Path:
+    explicit = getattr(args, "codex_home", None)
+    if explicit:
+        return Path(explicit).expanduser()
+    env_home = os.environ.get("CODEX_HOME")
+    if env_home:
+        return Path(env_home).expanduser()
+    return Path.home() / ".codex"
+
+
+def _print_search_widening_hint(args) -> None:
+    """On zero matches, point at the widening the user has NOT applied yet.
+
+    "Not found" is the expensive failure mode of this tool, and each of the
+    three widenings covers a distinct reason a real conversation can be
+    missed: wrong project guess, wrong tool (Codex), or a remembered quote
+    whose wording differs from the real one.
+    """
+    tips: List[str] = []
+    if not getattr(args, "all_projects", False):
+        tips.append(
+            "--all-projects (the conversation may belong to a different "
+            "project than the one searched)"
+        )
+    if not getattr(args, "codex", False):
+        tips.append(
+            "--codex (it may have been a Codex conversation — Codex rollouts "
+            "are a separate store this search skips by default)"
+        )
+    tips.append(
+        "shorter distinctive substrings (a remembered quote often differs "
+        "from the real wording in punctuation or a few words)"
+    )
+    print("Tip: no matches. Before concluding it is absent, retry with:", file=sys.stderr)
+    for tip in tips:
+        print(f"  - {tip}", file=sys.stderr)
 
 
 def main():
@@ -413,7 +989,24 @@ def main():
 
     # List sessions command
     list_parser = subparsers.add_parser("list", help="List all sessions for a project")
-    list_parser.add_argument("project_path", help="Project path")
+    list_parser.add_argument(
+        "project_path",
+        nargs="?",
+        help="Project path (omit when using --all-projects)",
+    )
+    list_parser.add_argument(
+        "--all-projects",
+        action="store_true",
+        help="Sweep every project across all sources instead of one project.",
+    )
+    list_parser.add_argument(
+        "--exclude-session",
+        action="append",
+        metavar="ID",
+        default=[],
+        help="Exclude a session id (repeatable) — e.g. the current session, "
+        "which always matches the phrase you just typed.",
+    )
     list_parser.add_argument(
         "--limit", type=int, default=10, help="Max sessions to show (default: 10)"
     )
@@ -421,9 +1014,39 @@ def main():
 
     # Search command
     search_parser = subparsers.add_parser("search", help="Search sessions for keywords")
-    search_parser.add_argument("project_path", help="Project path")
+    search_parser.add_argument(
+        "project_path",
+        nargs="?",
+        help="Project path (omit when using --all-projects)",
+    )
     search_parser.add_argument(
         "keywords", nargs="+", help="Keywords to search for"
+    )
+    search_parser.add_argument(
+        "--all-projects",
+        action="store_true",
+        help="Sweep every project across all sources — the default move when "
+        "you do not know which project the conversation happened in.",
+    )
+    search_parser.add_argument(
+        "--exclude-session",
+        action="append",
+        metavar="ID",
+        default=[],
+        help="Exclude a session id (repeatable) — e.g. the current session, "
+        "which always matches the phrase you just typed.",
+    )
+    search_parser.add_argument(
+        "--codex",
+        action="store_true",
+        help="Also search Codex rollout history (sessions/** + "
+        "archived_sessions/ under the Codex home). Codex uses a different "
+        "store and schema that the Claude registry never covers.",
+    )
+    search_parser.add_argument(
+        "--codex-home",
+        metavar="DIR",
+        help="Codex home for --codex (default: $CODEX_HOME or ~/.codex).",
     )
     search_parser.add_argument(
         "--case-sensitive", action="store_true", help="Case-sensitive search"
@@ -444,73 +1067,228 @@ def main():
         sys.exit(1)
 
     if args.command == "list":
+        _validate_project_scope(args, parser)
+        from_timestamp, to_timestamp = _parse_date_window(args, parser)
         analyzer = _analyzer_or_exit(args)
-        home_summary = ", ".join(home_label(h) for h in analyzer.homes)
-        sessions = analyzer.find_project_sessions(args.project_path)
+        source_summary = _source_summary(analyzer.sources)
+        sessions = _collect_sessions(analyzer, args)
+        for warning in analyzer.warnings:
+            print(f"Warning: {warning}", file=sys.stderr)
+        unknown = 0
+        if from_timestamp is not None or to_timestamp is not None:
+            filtered = []
+            for ref in sessions:
+                if ref["created_at"] is None or ref["updated_at"] is None:
+                    unknown += 1
+                    continue
+                if range_overlaps_window(
+                    ref["created_at"],
+                    ref["updated_at"],
+                    from_timestamp,
+                    to_timestamp,
+                ):
+                    filtered.append(ref)
+            sessions = filtered
         if not sessions:
-            print(f"No sessions found for project: {args.project_path}")
+            if args.all_projects:
+                print("No sessions found across all projects")
+            else:
+                print(f"No sessions found for project: {args.project_path}")
             print(
-                f"(searched {len(analyzer.homes)} home(s): {home_summary})",
+                f"(searched {len(analyzer.sources)} source(s): {source_summary})",
                 file=sys.stderr,
             )
             sys.exit(1)
 
-        print(f"Found {len(sessions)} session(s) for {args.project_path}")
-        print(f"Searched {len(analyzer.homes)} home(s): {home_summary}\n")
+        project_names = sorted(
+            {ref.get("project") for ref in sessions if ref.get("project")}
+        )
+        if args.all_projects:
+            print(
+                f"Found {len(sessions)} session(s) across "
+                f"{len(project_names)} project(s)"
+            )
+        else:
+            print(f"Found {len(sessions)} session(s) for {args.project_path}")
+        print(
+            f"Searched {len(analyzer.sources)} source(s): {source_summary}\n"
+        )
+        if unknown:
+            print(
+                f"Warning: excluded {unknown} session(s) without an internal "
+                "timestamp; file mtime was not used as a fallback.",
+                file=sys.stderr,
+            )
         print(f"Showing {min(args.limit, len(sessions))} most recent:\n")
 
-        for i, ref in enumerate(sessions[: args.limit], 1):
+        shown = sessions[: args.limit]
+        last_project: Optional[str] = None
+        for i, ref in enumerate(shown, 1):
+            if args.all_projects:
+                project = ref.get("project") or "unknown-project"
+                if project != last_project:
+                    count = sum(
+                        1 for item in sessions if item.get("project") == project
+                    )
+                    print(f"== {project} ({count} session(s))")
+                    last_project = project
             session = ref["path"]
-            mtime = datetime.fromtimestamp(ref["mtime"])
             size_kb = session.stat().st_size / 1024
-            labels = ", ".join(home_label(h) for h in ref["homes"])
+            labels = _source_summary(ref["sources"])
             print(f"{i}. {session.name}")
-            print(f"   Modified: {mtime.strftime('%Y-%m-%d %H:%M:%S')}")
+            print(
+                f"   Internal range: "
+                f"{_format_range(ref['created_at'], ref['updated_at'])}"
+            )
             print(f"   Size: {size_kb:.1f} KB")
-            print(f"   Profile: {labels}")
+            print(f"   Source: {labels}")
+            if len(ref["copies"]) > 1:
+                print(f"   Physical copies searched by keyword queries: {len(ref['copies'])}")
             print(f"   Path: {session}")
             print()
 
     elif args.command == "search":
+        _validate_project_scope(args, parser)
+        from_timestamp, to_timestamp = _parse_date_window(args, parser)
         analyzer = _analyzer_or_exit(args)
-        home_summary = ", ".join(home_label(h) for h in analyzer.homes)
-        sessions = analyzer.find_project_sessions(args.project_path)
-        if not sessions:
-            print(f"No sessions found for project: {args.project_path}")
+        source_summary = _source_summary(analyzer.sources)
+        sessions = _collect_sessions(analyzer, args)
+        for warning in analyzer.warnings:
+            print(f"Warning: {warning}", file=sys.stderr)
+        if not sessions and not args.codex:
+            if args.all_projects:
+                print("No sessions found across all projects")
+            else:
+                print(f"No sessions found for project: {args.project_path}")
             print(
-                f"(searched {len(analyzer.homes)} home(s): {home_summary})",
+                f"(searched {len(analyzer.sources)} source(s): {source_summary})",
                 file=sys.stderr,
             )
             sys.exit(1)
 
+        scope_desc = (
+            f" in {len({ref.get('project') for ref in sessions})} project(s)"
+            if args.all_projects
+            else ""
+        )
         print(
-            f"Searching {len(sessions)} session(s) across {len(analyzer.homes)} "
-            f"home(s) [{home_summary}] for: {', '.join(args.keywords)}\n"
+            f"Searching {len(sessions)} session(s) across {len(analyzer.sources)} "
+            f"source(s) [{source_summary}]{scope_desc} for: {', '.join(args.keywords)}\n"
         )
-
-        matches = analyzer.search_sessions(
-            sessions, args.keywords, args.case_sensitive
-        )
-
-        if not matches:
-            print("No matches found.")
-            sys.exit(0)
-
-        print(f"Found {len(matches)} session(s) with matches:\n")
-
-        for info in matches:
-            session = info["path"]
-            mtime = datetime.fromtimestamp(info["modified_time"])
-            labels = ", ".join(home_label(h) for h in info["homes"])
-            print(f"📄 {session.name}")
-            print(f"   Date: {mtime.strftime('%Y-%m-%d %H:%M')}")
-            print(f"   Profile: {labels}")
-            print(f"   Total mentions: {info['total_mentions']}")
-            print(
-                f"   Keywords: {', '.join(f'{k}({v})' for k, v in info['keyword_counts'].items())}"
+        matches = (
+            analyzer.search_sessions(
+                sessions,
+                args.keywords,
+                args.case_sensitive,
+                from_timestamp,
+                to_timestamp,
             )
-            print(f"   Path: {session}")
-            print()
+            if sessions
+            else []
+        )
+
+        codex_matches: List[Dict[str, Any]] = []
+        codex_home: Optional[Path] = None
+        if args.codex:
+            codex_home = _codex_home_for(args)
+            rollouts = discover_codex_rollouts(codex_home)
+            print(
+                f"Also searching {len(rollouts)} Codex rollout(s) under "
+                f"{codex_home} (--codex)\n"
+            )
+            codex_matches = search_codex_rollouts(
+                rollouts,
+                args.keywords,
+                args.case_sensitive,
+                from_timestamp,
+                to_timestamp,
+                None if args.all_projects else args.project_path,
+                set(args.exclude_session),
+            )
+
+        if matches:
+            print(f"Found {len(matches)} session(s) with matches:\n")
+            project_by_path = {
+                ref["path"]: ref.get("project") for ref in sessions
+            }
+            for info in matches:
+                session = info["path"]
+                labels = _source_summary(info["sources"])
+                matching_labels = ", ".join(sorted(info["matching_source_labels"]))
+                print(f"📄 {session.name}")
+                project = project_by_path.get(session)
+                if project:
+                    print(f"   Project: {project}")
+                print(
+                    "   Internal range: "
+                    f"{_format_range(info['created_at'], info['updated_at'])}"
+                )
+                print(
+                    "   Match range: "
+                    f"{_format_range(info['match_created_at'], info['match_updated_at'])}"
+                )
+                print(f"   Session sources: {labels}")
+                print(f"   Match sources: {matching_labels}")
+                print(f"   Total mentions: {info['total_mentions']}")
+                print(
+                    f"   Keywords: {', '.join(f'{k}({v})' for k, v in info['keyword_counts'].items())}"
+                )
+                print(f"   Match fields: {', '.join(info['match_sources'])}")
+                if info["excluded_untimed_records"]:
+                    print(
+                        "   Date-filter note: excluded "
+                        f"{info['excluded_untimed_records']} record(s) without an "
+                        "internal timestamp; file mtime was not used."
+                    )
+                print(f"   Path: {session}")
+                if len(info["matching_copies"]) > 1:
+                    print("   Other matching copies:")
+                    for copy in info["matching_copies"]:
+                        if copy["path"] == session:
+                            continue
+                        print(
+                            f"     - [{copy['source'].display_label}] {copy['path']}"
+                        )
+                print()
+
+        if args.codex:
+            if codex_matches:
+                print(
+                    f"Codex rollout matches (home: {codex_home}):\n"
+                )
+                for info in codex_matches:
+                    print(f"📦 {info['path'].name}")
+                    print(f"   Session: {info['session_id']}")
+                    if info.get("cwd"):
+                        print(f"   cwd: {info['cwd']}")
+                    print(
+                        "   Internal range: "
+                        f"{_format_range(info['created_at'], info['updated_at'])}"
+                    )
+                    print(
+                        "   Match range: "
+                        f"{_format_range(info['match_created_at'], info['match_updated_at'])}"
+                    )
+                    print(f"   Total mentions: {info['total_mentions']}")
+                    print(
+                        f"   Keywords: {', '.join(f'{k}({v})' for k, v in info['keyword_counts'].items())}"
+                    )
+                    print(f"   Match fields: {', '.join(info['match_sources'])}")
+                    if info["excluded_untimed_records"]:
+                        print(
+                            "   Date-filter note: excluded "
+                            f"{info['excluded_untimed_records']} record(s) without an "
+                            "internal timestamp; file mtime was not used."
+                        )
+                    print(f"   Path: {info['path']}")
+                    print()
+            else:
+                print(f"No Codex rollout matches (home: {codex_home}).")
+
+        if not matches and not codex_matches:
+            print("No matches found.")
+            _print_search_widening_hint(args)
+            sys.exit(0)
 
     elif args.command == "stats":
         if not args.session_file.exists():
@@ -519,25 +1297,25 @@ def main():
 
         print(f"Analyzing session: {args.session_file}\n")
 
-        analyzer = SessionAnalyzer()
+        analyzer = SessionAnalyzer(homes=[])
         stats = analyzer.get_session_stats(args.session_file)
 
         print("=" * 60)
         print("Session Statistics")
         print("=" * 60)
-        print(f"\nMessages:")
+        print("\nMessages:")
         print(f"  Total lines: {stats['total_lines']:,}")
         print(f"  User messages: {stats['user_messages']}")
         print(f"  Assistant messages: {stats['assistant_messages']}")
 
-        print(f"\nTool Usage:")
+        print("\nTool Usage:")
         print(f"  Write calls: {stats['write_calls']}")
         print(f"  Edit calls: {stats['edit_calls']}")
         print(f"  Read calls: {stats['read_calls']}")
         print(f"  Bash calls: {stats['bash_calls']}")
 
         if stats["tool_uses"]:
-            print(f"\n  All tools:")
+            print("\n  All tools:")
             for tool, count in sorted(
                 stats["tool_uses"].items(), key=lambda x: x[1], reverse=True
             ):

--- a/daymade-claude-code/claude-code-history-files-finder/scripts/recover_content.py
+++ b/daymade-claude-code/claude-code-history-files-finder/scripts/recover_content.py
@@ -8,10 +8,8 @@ from Claude Code's JSONL session history files.
 
 import json
 import sys
-import os
 from pathlib import Path
 from typing import Dict, List, Any, Optional
-from datetime import datetime
 
 
 class SessionContentRecovery:
@@ -160,8 +158,8 @@ class SessionContentRecovery:
                 original_path = Path(file_path)
 
                 # Handle absolute paths: extract meaningful relative path
-                # e.g., /Users/username/project/src/file.py -> src/file.py
-                # e.g., /home/user/workspace/project/lib/module.py -> lib/module.py
+                # e.g., <home>/project/src/file.py -> src/file.py
+                # e.g., <home>/workspace/project/lib/module.py -> lib/module.py
                 path_parts = original_path.parts
                 if len(path_parts) > 1 and path_parts[0] == "/":
                     # For absolute paths, try to find a project-like directory

--- a/daymade-claude-code/claude-code-history-files-finder/tests/test_analyze_sessions.py
+++ b/daymade-claude-code/claude-code-history-files-finder/tests/test_analyze_sessions.py
@@ -1,0 +1,586 @@
+#!/usr/bin/env python3
+"""Regression tests for archive-aware Claude session search."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SKILL_DIR = Path(__file__).resolve().parents[1]
+SCRIPT = SKILL_DIR / "scripts" / "analyze_sessions.py"
+
+
+def write_jsonl(path: Path, records: list[object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def project_dir(home: Path, workspace: Path) -> Path:
+    encoded = str(workspace.resolve()).replace("/", "-")
+    result = home / "projects" / encoded
+    result.mkdir(parents=True, exist_ok=True)
+    return result
+
+
+def user_record(session_id: str, workspace: Path, text: str, timestamp: str) -> dict:
+    return {
+        "type": "user",
+        "sessionId": session_id,
+        "cwd": str(workspace),
+        "timestamp": timestamp,
+        "message": {"role": "user", "content": text},
+    }
+
+
+class SessionAnalyzerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        self.user_home = self.root / "user-home"
+        self.active_home = self.user_home / ".claude"
+        self.archive_home = self.root / "conversation-archive"
+        self.workspace = self.root / "workspaces" / "demo-project"
+        self.workspace.mkdir(parents=True)
+        project_dir(self.active_home, self.workspace)
+        project_dir(self.archive_home, self.workspace)
+        self.manifest = self.active_home / "history-sources.json"
+        self.manifest.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "sources": [
+                        {
+                            "provider": "claude",
+                            "kind": "archive",
+                            "label": "full-backup",
+                            "home": str(self.archive_home),
+                            "required": True,
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def run_cli(
+        self, *arguments: str, check: bool = True
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), *arguments],
+            text=True,
+            encoding="utf-8",
+            capture_output=True,
+            check=check,
+            env={**os.environ, "HOME": str(self.user_home)},
+        )
+
+    def seed_structured_events(self) -> tuple[str, str]:
+        active_id = "11111111-1111-4111-8111-111111111111"
+        archive_id = "22222222-2222-4222-8222-222222222222"
+        active_file = project_dir(self.active_home, self.workspace) / f"{active_id}.jsonl"
+        archive_file = project_dir(self.archive_home, self.workspace) / f"{archive_id}.jsonl"
+        write_jsonl(
+            active_file,
+            [
+                user_record(
+                    active_id,
+                    self.workspace,
+                    "Active March session",
+                    "2026-03-20T10:00:00Z",
+                )
+            ],
+        )
+        write_jsonl(
+            archive_file,
+            [
+                user_record(
+                    archive_id,
+                    self.workspace,
+                    "queued-topic before the requested window",
+                    "2026-01-10T08:00:00Z",
+                ),
+                {
+                    "type": "assistant",
+                    "sessionId": archive_id,
+                    "cwd": str(self.workspace),
+                    "timestamp": "2026-04-17T14:30:05Z",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "thinking",
+                                "thinking": "reasoning-marker",
+                                "signature": "signature-only-secret",
+                            },
+                            {
+                                "type": "tool_use",
+                                "name": "Bash",
+                                "input": {
+                                    "command": "uv run python build_slides.py",
+                                    "description": "Install python-pptx",
+                                },
+                            },
+                        ],
+                    },
+                },
+                {
+                    "type": "user",
+                    "sessionId": archive_id,
+                    "cwd": str(self.workspace),
+                    "timestamp": "2026-04-18T09:00:00Z",
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "tool-1",
+                                "content": [
+                                    {"type": "text", "text": "topic-from-tool-result"}
+                                ],
+                            }
+                        ],
+                    },
+                },
+                {
+                    "type": "queue-operation",
+                    "operation": "enqueue",
+                    "sessionId": archive_id,
+                    "timestamp": "2026-04-18T10:00:00Z",
+                    "content": "queued-topic",
+                },
+                {
+                    "type": "attachment",
+                    "sessionId": archive_id,
+                    "cwd": str(self.workspace),
+                    "timestamp": "2026-04-18T12:36:48Z",
+                    "attachment": {
+                        "type": "file",
+                        "path": "brief.txt",
+                        "content": {"notes": "attachment-topic"},
+                    },
+                },
+            ],
+        )
+        # Make file mtimes contradict their internal timestamps.
+        os.utime(archive_file, (1, 1))
+        os.utime(active_file, (2_000_000_000, 2_000_000_000))
+        return active_id, archive_id
+
+    def test_list_sorts_by_internal_timestamp_and_labels_archive_source(self) -> None:
+        active_id, archive_id = self.seed_structured_events()
+        completed = self.run_cli(
+            "list",
+            str(self.workspace),
+            "--history-sources",
+            str(self.manifest),
+        )
+        self.assertLess(completed.stdout.index(archive_id), completed.stdout.index(active_id))
+        self.assertIn("Internal range:", completed.stdout)
+        self.assertIn("archive:full-backup", completed.stdout)
+        self.assertNotIn("Modified:", completed.stdout)
+
+    def test_search_covers_structured_event_fields_and_filters_matching_records(self) -> None:
+        _, archive_id = self.seed_structured_events()
+        completed = self.run_cli(
+            "search",
+            str(self.workspace),
+            "topic-from-tool-result",
+            "queued-topic",
+            "attachment-topic",
+            "python-pptx",
+            "reasoning-marker",
+            "--from-date",
+            "2026-04-01",
+            "--to-date",
+            "2026-04-30",
+            "--history-sources",
+            str(self.manifest),
+        )
+        self.assertIn(archive_id, completed.stdout)
+        self.assertIn("queued-topic(1)", completed.stdout)
+        self.assertIn("Match range:", completed.stdout)
+        self.assertIn("tool_result", completed.stdout)
+        self.assertIn("tool_input:Bash", completed.stdout)
+        self.assertIn("thinking", completed.stdout)
+        self.assertIn("attachment", completed.stdout)
+        self.assertIn("queue-operation", completed.stdout)
+
+        signature_only = self.run_cli(
+            "search",
+            str(self.workspace),
+            "signature-only-secret",
+            "--history-sources",
+            str(self.manifest),
+        )
+        self.assertIn("No matches found.", signature_only.stdout)
+
+    def test_duplicate_session_unions_distinct_records_and_keeps_provenance(self) -> None:
+        session_id = "33333333-3333-4333-8333-333333333333"
+        timestamp = "2026-04-20T10:00:00Z"
+        write_jsonl(
+            project_dir(self.active_home, self.workspace) / f"{session_id}.jsonl",
+            [user_record(session_id, self.workspace, "active-choice", timestamp)],
+        )
+        write_jsonl(
+            project_dir(self.archive_home, self.workspace) / f"{session_id}.jsonl",
+            [user_record(session_id, self.workspace, "archive-choice", timestamp)],
+        )
+        active_match = self.run_cli(
+            "search",
+            str(self.workspace),
+            "active-choice",
+            "--history-sources",
+            str(self.manifest),
+        )
+        self.assertIn(session_id, active_match.stdout)
+        self.assertIn("active:main, archive:full-backup", active_match.stdout)
+
+        archive_match = self.run_cli(
+            "search",
+            str(self.workspace),
+            "archive-choice",
+            "--history-sources",
+            str(self.manifest),
+        )
+        self.assertIn(session_id, archive_match.stdout)
+        self.assertIn("Match sources: archive:full-backup", archive_match.stdout)
+        self.assertIn(str(self.archive_home), archive_match.stdout)
+
+        combined = self.run_cli(
+            "search",
+            str(self.workspace),
+            "active-choice",
+            "archive-choice",
+            "--history-sources",
+            str(self.manifest),
+        )
+        self.assertIn("active-choice(1)", combined.stdout)
+        self.assertIn("archive-choice(1)", combined.stdout)
+        self.assertIn("Other matching copies:", combined.stdout)
+
+    def test_duplicate_identical_records_are_not_double_counted(self) -> None:
+        session_id = "55555555-5555-4555-8555-555555555555"
+        record = user_record(
+            session_id,
+            self.workspace,
+            "shared-marker",
+            "2026-04-20T10:00:00Z",
+        )
+        write_jsonl(
+            project_dir(self.active_home, self.workspace) / f"{session_id}.jsonl",
+            [record, record],
+        )
+        write_jsonl(
+            project_dir(self.archive_home, self.workspace) / f"{session_id}.jsonl",
+            [record],
+        )
+        completed = self.run_cli(
+            "search",
+            str(self.workspace),
+            "shared-marker",
+            "--history-sources",
+            str(self.manifest),
+        )
+        # Identical records copied to another physical file count once, while
+        # two real occurrences inside one file remain two occurrences.
+        self.assertIn("shared-marker(2)", completed.stdout)
+        self.assertIn(
+            "Match sources: active:main, archive:full-backup",
+            completed.stdout,
+        )
+
+    def test_explicit_home_remains_an_exact_scope(self) -> None:
+        archive_id = "44444444-4444-4444-8444-444444444444"
+        write_jsonl(
+            project_dir(self.archive_home, self.workspace) / f"{archive_id}.jsonl",
+            [
+                user_record(
+                    archive_id,
+                    self.workspace,
+                    "archive-only-marker",
+                    "2026-04-20T10:00:00Z",
+                )
+            ],
+        )
+        completed = self.run_cli(
+            "search",
+            str(self.workspace),
+            "archive-only-marker",
+            "--home",
+            str(self.active_home),
+            check=False,
+        )
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("No sessions found", completed.stdout)
+
+    def test_all_projects_aggregates_sessions_across_projects(self) -> None:
+        other_workspace = self.root / "workspaces" / "other-project"
+        other_workspace.mkdir(parents=True)
+        first_id = "66666666-6666-4666-8666-666666666666"
+        second_id = "77777777-7777-4777-8777-777777777777"
+        write_jsonl(
+            project_dir(self.active_home, self.workspace) / f"{first_id}.jsonl",
+            [
+                user_record(
+                    first_id,
+                    self.workspace,
+                    "cross-project-marker",
+                    "2026-04-20T10:00:00Z",
+                )
+            ],
+        )
+        write_jsonl(
+            project_dir(self.active_home, other_workspace) / f"{second_id}.jsonl",
+            [
+                user_record(
+                    second_id,
+                    other_workspace,
+                    "cross-project-marker",
+                    "2026-04-21T10:00:00Z",
+                )
+            ],
+        )
+        completed = self.run_cli(
+            "search",
+            "--all-projects",
+            "cross-project-marker",
+            "--home",
+            str(self.active_home),
+            "--home",
+            str(self.archive_home),
+        )
+        self.assertIn(first_id, completed.stdout)
+        self.assertIn(second_id, completed.stdout)
+        self.assertIn("Project:", completed.stdout)
+        self.assertIn("2 project(s)", completed.stdout)
+
+        listed = self.run_cli(
+            "list",
+            "--all-projects",
+            "--home",
+            str(self.active_home),
+            "--home",
+            str(self.archive_home),
+        )
+        self.assertIn("across 2 project(s)", listed.stdout)
+        self.assertIn("== ", listed.stdout)
+
+    def test_project_scope_is_required_and_exclusive(self) -> None:
+        neither = self.run_cli("search", "anything", check=False)
+        self.assertEqual(neither.returncode, 2)
+        both = self.run_cli(
+            "search",
+            str(self.workspace),
+            "anything",
+            "--all-projects",
+            check=False,
+        )
+        self.assertEqual(both.returncode, 2)
+
+    def test_exclude_session_skips_the_current_session(self) -> None:
+        current_id = "88888888-8888-4888-8888-888888888888"
+        target_id = "99999999-9999-4999-8999-999999999999"
+        for session_id in (current_id, target_id):
+            write_jsonl(
+                project_dir(self.active_home, self.workspace)
+                / f"{session_id}.jsonl",
+                [
+                    user_record(
+                        session_id,
+                        self.workspace,
+                        "self-match-marker",
+                        "2026-04-20T10:00:00Z",
+                    )
+                ],
+            )
+        completed = self.run_cli(
+            "search",
+            str(self.workspace),
+            "self-match-marker",
+            "--exclude-session",
+            current_id,
+            "--history-sources",
+            str(self.manifest),
+        )
+        self.assertIn(target_id, completed.stdout)
+        self.assertNotIn(current_id, completed.stdout)
+
+    def test_zero_match_hint_points_at_unapplied_widenings(self) -> None:
+        write_jsonl(
+            project_dir(self.active_home, self.workspace)
+            / "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa.jsonl",
+            [
+                user_record(
+                    "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+                    self.workspace,
+                    "unrelated content",
+                    "2026-04-20T10:00:00Z",
+                )
+            ],
+        )
+        completed = self.run_cli(
+            "search",
+            str(self.workspace),
+            "definitely-absent-marker",
+            "--history-sources",
+            str(self.manifest),
+        )
+        self.assertIn("No matches found.", completed.stdout)
+        self.assertIn("--all-projects", completed.stderr)
+        self.assertIn("--codex", completed.stderr)
+        self.assertIn("substrings", completed.stderr)
+
+        widened = self.run_cli(
+            "search",
+            "--all-projects",
+            "definitely-absent-marker",
+            "--codex",
+            "--codex-home",
+            str(self.root / "empty-codex"),
+            "--home",
+            str(self.active_home),
+            "--home",
+            str(self.archive_home),
+        )
+        self.assertNotIn("--all-projects", widened.stderr)
+        self.assertNotIn("--codex (", widened.stderr)
+        self.assertIn("substrings", widened.stderr)
+
+    def seed_codex_rollout(
+        self,
+        codex_home: Path,
+        session_id: str,
+        cwd: Path,
+        text: str,
+        *,
+        mirror: bool = True,
+        archived_copy: bool = False,
+    ) -> Path:
+        timestamp = "2026-04-20T10:00:00Z"
+        records = [
+            {
+                "type": "session_meta",
+                "timestamp": timestamp,
+                "payload": {
+                    "id": session_id,
+                    "cwd": str(cwd),
+                    "timestamp": timestamp,
+                },
+            },
+            {
+                "type": "response_item",
+                "timestamp": timestamp,
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": text}],
+                },
+            },
+        ]
+        if mirror:
+            # event_msg mirrors of message text must not double-count.
+            records.append(
+                {
+                    "type": "event_msg",
+                    "timestamp": timestamp,
+                    "payload": {"type": "user_message", "message": text},
+                }
+            )
+        rollout = (
+            codex_home
+            / "sessions"
+            / "2026"
+            / "04"
+            / "20"
+            / f"rollout-2026-04-20T10-00-00-{session_id}.jsonl"
+        )
+        write_jsonl(rollout, records)
+        if archived_copy:
+            write_jsonl(
+                codex_home / "archived_sessions" / rollout.name, records
+            )
+        return rollout
+
+    def test_codex_search_finds_rollout_once_and_counts_mirror_once(self) -> None:
+        codex_home = self.root / "codex-home"
+        session_id = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+        self.seed_codex_rollout(
+            codex_home,
+            session_id,
+            self.workspace,
+            "codex-only-marker",
+            archived_copy=True,
+        )
+        completed = self.run_cli(
+            "search",
+            str(self.workspace),
+            "codex-only-marker",
+            "--codex",
+            "--codex-home",
+            str(codex_home),
+            "--history-sources",
+            str(self.manifest),
+        )
+        self.assertIn("Codex rollout matches", completed.stdout)
+        self.assertIn(session_id, completed.stdout)
+        # sessions/ + archived_sessions/ copies of one rollout dedupe to a
+        # single result, and the event_msg mirror adds no extra mention.
+        self.assertEqual(completed.stdout.count("📦"), 1)
+        self.assertIn("Total mentions: 1", completed.stdout)
+        self.assertIn("Match fields: message", completed.stdout)
+
+    def test_codex_search_filters_rollouts_by_project_cwd(self) -> None:
+        codex_home = self.root / "codex-home"
+        matching_id = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+        other_id = "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
+        self.seed_codex_rollout(
+            codex_home, matching_id, self.workspace, "codex-cwd-marker"
+        )
+        self.seed_codex_rollout(
+            codex_home,
+            other_id,
+            self.root / "elsewhere",
+            "codex-cwd-marker",
+        )
+        scoped = self.run_cli(
+            "search",
+            str(self.workspace),
+            "codex-cwd-marker",
+            "--codex",
+            "--codex-home",
+            str(codex_home),
+            "--history-sources",
+            str(self.manifest),
+        )
+        self.assertIn(matching_id, scoped.stdout)
+        self.assertNotIn(other_id, scoped.stdout)
+
+        swept = self.run_cli(
+            "search",
+            "--all-projects",
+            "codex-cwd-marker",
+            "--codex",
+            "--codex-home",
+            str(codex_home),
+            "--home",
+            str(self.active_home),
+            "--home",
+            str(self.archive_home),
+        )
+        self.assertIn(matching_id, swept.stdout)
+        self.assertIn(other_id, swept.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/daymade-claude-code/continue-claude-work/.security-scan-passed
+++ b/daymade-claude-code/continue-claude-work/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-07-10T05:27:06.926656
+Scanned at: 2026-07-16T02:16:30.931578+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 45914db16e27624ec18abeacd9ed7de935fee5136a5a8fa756942cabcfef7e36
+Content hash: 73ce878878494ce3587c60f8233287e4273951d85bdaa62f58d66e3a0e82d315

--- a/daymade-claude-code/continue-claude-work/scripts/_core/__init__.py
+++ b/daymade-claude-code/continue-claude-work/scripts/_core/__init__.py
@@ -8,8 +8,13 @@ every skill stays self-contained and installable on its own while sharing one
 implementation.
 
 Modules:
-    homes  — discover every Claude config home (main + per-model profiles).
-    parse  — pure parsing/formatting helpers (timestamps, and more over time).
+    homes    — discover every active Claude config home.
+    sources  — combine active homes with explicitly registered archives.
+    claude   — stream exact Claude session metadata and internal time ranges.
+    codex    — inspect Codex state databases and raw rollout stores.
+    parse    — timestamp, timezone, and workspace normalization helpers.
+    text     — semantic JSONL text/title extraction.
+    model    — shared provider result data structures.
 """
 
 from .homes import discover_claude_homes, home_label

--- a/daymade-claude-code/continue-claude-work/scripts/_core/claude.py
+++ b/daymade-claude-code/continue-claude-work/scripts/_core/claude.py
@@ -1,0 +1,72 @@
+"""Exact, streaming metadata scan for Claude Code JSONL sessions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from .parse import TimestampRange
+from .text import extract_text, first_meaningful_title, iter_jsonl
+
+
+@dataclass(frozen=True)
+class ClaudeSessionSummary:
+    session_id: str
+    cwd: str
+    title: str
+    created_at: Optional[float]
+    updated_at: Optional[float]
+    timestamp_count: int
+
+
+def scan_claude_session(path: Path, max_title_chars: int = 120) -> ClaudeSessionSummary:
+    """Scan every valid record and return internal time bounds plus title metadata.
+
+    File mtime is deliberately absent. Copying or migrating a transcript changes
+    mtime without changing when the conversation happened; the only trustworthy
+    conversation range is the minimum and maximum valid top-level ``timestamp``
+    found across the JSONL records themselves.
+    """
+    session_id = path.stem
+    cwd = ""
+    prompt_candidates: list[str] = []
+    title: Optional[str] = None
+    timestamps = TimestampRange()
+
+    for record in iter_jsonl(path):
+        timestamps.observe(record.get("timestamp"))
+        if isinstance(record.get("sessionId"), str) and record["sessionId"]:
+            session_id = record["sessionId"]
+        if not cwd and isinstance(record.get("cwd"), str):
+            cwd = record["cwd"]
+        if title is not None:
+            continue
+        if record.get("type") != "user" or record.get("isMeta") is True:
+            continue
+        message = record.get("message")
+        if isinstance(message, dict) and message.get("role") == "user":
+            text = extract_text(message.get("content"))
+        elif isinstance(message, str):
+            text = message
+        else:
+            text = ""
+        if not text:
+            continue
+        prompt_candidates.append(text)
+        candidate = first_meaningful_title(prompt_candidates, max_title_chars)
+        if candidate and len(candidate) >= 4:
+            title = candidate
+
+    if title is None:
+        title = first_meaningful_title(prompt_candidates, max_title_chars)
+    if not title:
+        title = f"(untitled: {session_id})"
+    return ClaudeSessionSummary(
+        session_id=session_id,
+        cwd=cwd,
+        title=title,
+        created_at=timestamps.earliest,
+        updated_at=timestamps.latest,
+        timestamp_count=timestamps.count,
+    )

--- a/daymade-claude-code/continue-claude-work/scripts/_core/codex.py
+++ b/daymade-claude-code/continue-claude-work/scripts/_core/codex.py
@@ -25,7 +25,7 @@ from typing import Any, Iterable, Optional
 from urllib.parse import quote
 
 from .model import CodexDatabase, Conversation, ProviderResult
-from .parse import parse_timestamp, workspace_matches
+from .parse import TimestampRange, parse_timestamp, workspace_matches
 from .text import extract_text, first_meaningful_title, is_automated_title, iter_jsonl
 
 CODEX_REQUIRED_COLUMNS = {"id", "cwd", "updated_at", "source", "archived"}
@@ -33,6 +33,7 @@ SESSION_ID_RE = re.compile(
     r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
     re.IGNORECASE,
 )
+STATE_DATABASE_RE = re.compile(r"^state_(\d+)\.sqlite$")
 
 
 def sqlite_uri(path: Path) -> str:
@@ -83,8 +84,18 @@ def discover_codex_database(home: Path, warnings: list[str]) -> Optional[CodexDa
         return None
     return max(
         compatible,
-        key=lambda item: (item.max_updated_ms, item.path.stat().st_mtime_ns),
+        key=lambda item: (
+            item.max_updated_ms,
+            _state_database_generation(item.path),
+            item.path.as_posix(),
+        ),
     )
+
+
+def _state_database_generation(path: Path) -> int:
+    """Return the numeric state database generation without consulting mtime."""
+    match = STATE_DATABASE_RE.fullmatch(path.name)
+    return int(match.group(1)) if match else -1
 
 
 def nested_key_exists(value: Any, wanted: str) -> bool:
@@ -261,6 +272,23 @@ def codex_prompt_from_rollout(path: Path, max_chars: int) -> Optional[str]:
     return short_candidate
 
 
+def codex_rollout_time_range(path: Path) -> TimestampRange:
+    """Compute exact internal bounds for a Codex rollout.
+
+    Current rollouts timestamp every top-level event. Older/minimal fixtures may
+    carry only ``session_meta.payload.timestamp``, so observe both. File mtime is
+    deliberately excluded because copying or migrating a rollout rewrites it.
+    """
+    timestamps = TimestampRange()
+    for record in iter_jsonl(path):
+        timestamps.observe(record.get("timestamp"))
+        if record.get("type") == "session_meta" and isinstance(
+            record.get("payload"), dict
+        ):
+            timestamps.observe(record["payload"].get("timestamp"))
+    return timestamps
+
+
 def collect_codex_from_rollouts(
     args: argparse.Namespace, home: Path, result: ProviderResult
 ) -> None:
@@ -301,25 +329,22 @@ def collect_codex_from_rollouts(
         if is_automated_title(title) and not args.include_automated:
             result.excluded_automated += 1
             continue
-        try:
-            updated_at = path.stat().st_mtime
-            timestamp_source = "file-mtime"
-        except OSError:
-            updated_at = parse_timestamp(meta.get("timestamp"))
-            timestamp_source = "session-meta"
+        timestamps = codex_rollout_time_range(path)
         result.conversations.append(
             Conversation(
                 provider="codex",
                 session_id=session_id,
                 title=title,
                 cwd=cwd,
-                updated_at=updated_at,
-                created_at=parse_timestamp(meta.get("timestamp")),
+                updated_at=timestamps.latest,
+                created_at=timestamps.earliest,
                 archived=archived,
                 kind="subagent" if subagent else "main",
                 path=str(path),
                 metadata_source="rollout-jsonl",
-                timestamp_source=timestamp_source,
+                timestamp_source=(
+                    "rollout-record-minmax" if timestamps.count else "unknown"
+                ),
             )
         )
 

--- a/daymade-claude-code/continue-claude-work/scripts/_core/model.py
+++ b/daymade-claude-code/continue-claude-work/scripts/_core/model.py
@@ -3,8 +3,8 @@
 `Conversation` / `ProviderResult` / `CodexDatabase` are used by both the Claude
 and Codex providers and by the renderers, so they live in the shared core (SSOT:
 `daymade-claude-code/_conversation_core/`, bundled into each skill's
-`scripts/_core/` by `sync_core.py`). Extracting them here lets a skill like
-`continue-codex-work` reuse the same model without re-declaring it.
+`scripts/_core/` by `sync_core.py`). This lets `continue-codex-work` and the
+inventory/search skills reuse the same model without re-declaring it.
 """
 
 from __future__ import annotations
@@ -29,6 +29,8 @@ class Conversation:
     path: str
     metadata_source: str
     timestamp_source: str
+    source_kind: str = ""
+    source_labels: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         data = asdict(self)

--- a/daymade-claude-code/continue-claude-work/scripts/_core/parse.py
+++ b/daymade-claude-code/continue-claude-work/scripts/_core/parse.py
@@ -1,19 +1,39 @@
 """Shared parsing / formatting helpers for the conversation-history skills.
 
-Pure, self-contained utilities that every skill re-implements otherwise. Bundled
-into each skill's ``scripts/_core/`` by ``sync_core.py`` (see homes.py for why
-bundling rather than importing a sibling). This is the parsing counterpart to
-``homes.py``; more helpers (text/title extraction, workspace matching, JSONL
-iteration) move here in later phases as they are de-duplicated from the skills.
+Pure, self-contained utilities that every skill would otherwise re-implement.
+Bundled into each skill's ``scripts/_core/`` by ``sync_core.py`` (see homes.py
+for why bundling is used instead of importing a sibling).
 """
 
 import os
 import re
 import sys
-from datetime import datetime
+from dataclasses import dataclass
+from datetime import date, datetime, time
 from typing import Any, Optional
 
 WINDOWS_DRIVE_RE = re.compile(r"^(?:[/\\]{2}\?[/\\])?[A-Za-z]:[/\\]")
+DATE_ONLY_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+@dataclass
+class TimestampRange:
+    """Minimum/maximum valid internal timestamp observed while streaming."""
+
+    earliest: Optional[float] = None
+    latest: Optional[float] = None
+    count: int = 0
+
+    def observe(self, value: Any) -> Optional[float]:
+        parsed = parse_timestamp(value)
+        if parsed is None:
+            return None
+        self.count += 1
+        if self.earliest is None or parsed < self.earliest:
+            self.earliest = parsed
+        if self.latest is None or parsed > self.latest:
+            self.latest = parsed
+        return parsed
 
 
 def parse_timestamp(value: Any) -> Optional[float]:
@@ -66,6 +86,61 @@ def format_timestamp(value: float) -> str:
 def iso_timestamp(value: float) -> str:
     """ISO-8601 local timestamp (seconds precision, with offset)."""
     return datetime.fromtimestamp(value).astimezone().isoformat(timespec="seconds")
+
+
+def parse_date_boundary(value: str, *, end: bool = False) -> float:
+    """Parse a date-only local boundary or a timezone-qualified ISO datetime.
+
+    Date-only input uses the machine's local timezone and covers the full day.
+    Datetime input must carry ``Z`` or an explicit UTC offset; accepting a naive
+    datetime would make a cross-machine history query change meaning silently.
+    """
+    text_value = value.strip()
+    if DATE_ONLY_RE.fullmatch(text_value):
+        parsed_date = date.fromisoformat(text_value)
+        wall_time = time.max if end else time.min
+        return datetime.combine(parsed_date, wall_time).astimezone().timestamp()
+    try:
+        parsed = datetime.fromisoformat(text_value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError(
+            f"invalid ISO date/time {value!r}; use YYYY-MM-DD or include a timezone offset"
+        ) from error
+    if parsed.tzinfo is None:
+        raise ValueError(
+            f"datetime {value!r} has no timezone; use Z or an explicit UTC offset"
+        )
+    return parsed.timestamp()
+
+
+def timestamp_in_window(
+    value: Optional[float],
+    from_timestamp: Optional[float],
+    to_timestamp: Optional[float],
+) -> bool:
+    if value is None:
+        return from_timestamp is None and to_timestamp is None
+    if from_timestamp is not None and value < from_timestamp:
+        return False
+    if to_timestamp is not None and value > to_timestamp:
+        return False
+    return True
+
+
+def range_overlaps_window(
+    earliest: Optional[float],
+    latest: Optional[float],
+    from_timestamp: Optional[float],
+    to_timestamp: Optional[float],
+) -> bool:
+    """Whether an internal session range overlaps an inclusive query window."""
+    if earliest is None or latest is None:
+        return from_timestamp is None and to_timestamp is None
+    if from_timestamp is not None and latest < from_timestamp:
+        return False
+    if to_timestamp is not None and earliest > to_timestamp:
+        return False
+    return True
 
 
 def looks_like_windows_path(value: str) -> bool:

--- a/daymade-claude-code/continue-claude-work/scripts/_core/sources.py
+++ b/daymade-claude-code/continue-claude-work/scripts/_core/sources.py
@@ -1,0 +1,201 @@
+"""Discover active and explicitly registered Claude conversation sources.
+
+Active Claude homes are auto-discovered by :mod:`homes`. Long-term archives are
+different: their location is user configuration, not a filename convention that
+the public skill should guess. A small manifest at
+``~/.claude/history-sources.json`` registers those archives explicitly.
+
+The manifest is intentionally fail-fast. A malformed file, duplicate archive, or
+missing required source is configuration damage, not a cue to silently fall back
+to the active homes and produce an incomplete history result.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Sequence, Union
+
+from .homes import discover_claude_homes, home_label
+
+
+MANIFEST_VERSION = 1
+SOURCE_LABEL_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+class HistorySourceConfigError(ValueError):
+    """Raised when an explicit history-source registry cannot be trusted."""
+
+
+@dataclass(frozen=True)
+class HistorySource:
+    """One Claude configuration root that contains a ``projects/`` directory."""
+
+    provider: str
+    kind: str
+    label: str
+    home: Path
+    required: bool = True
+
+    @property
+    def display_label(self) -> str:
+        return f"{self.kind}:{self.label}"
+
+
+def default_history_sources_path() -> Path:
+    """Return the per-user registry path without caching ``Path.home()``."""
+    return Path.home() / ".claude" / "history-sources.json"
+
+
+def _resolved_key(path: Path) -> str:
+    try:
+        return str(path.resolve())
+    except (OSError, RuntimeError):
+        return str(path.absolute())
+
+
+def _active_sources(
+    homes: Sequence[Union[str, Path]],
+) -> list[HistorySource]:
+    return [
+        HistorySource(
+            provider="claude",
+            kind="active",
+            label=home_label(home),
+            home=Path(home).expanduser(),
+            required=True,
+        )
+        for home in homes
+    ]
+
+
+def _read_manifest(path: Path) -> dict:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise HistorySourceConfigError(
+            f"Cannot read history source registry {path}: {error}"
+        ) from error
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise HistorySourceConfigError(
+            f"Invalid JSON in history source registry {path}: {error}"
+        ) from error
+    if not isinstance(payload, dict):
+        raise HistorySourceConfigError(
+            f"History source registry {path} must contain a JSON object"
+        )
+    if payload.get("version") != MANIFEST_VERSION:
+        raise HistorySourceConfigError(
+            f"History source registry {path} must use version {MANIFEST_VERSION}"
+        )
+    if not isinstance(payload.get("sources"), list):
+        raise HistorySourceConfigError(
+            f"History source registry {path} must contain a sources array"
+        )
+    return payload
+
+
+def _manifest_archive_sources(
+    path: Path,
+    active: Sequence[HistorySource],
+) -> tuple[list[HistorySource], list[str]]:
+    payload = _read_manifest(path)
+    warnings: list[str] = []
+    archives: list[HistorySource] = []
+    seen_paths = {_resolved_key(source.home) for source in active}
+    seen_labels: set[str] = set()
+
+    for index, entry in enumerate(payload["sources"]):
+        location = f"{path}: sources[{index}]"
+        if not isinstance(entry, dict):
+            raise HistorySourceConfigError(f"{location} must be an object")
+        provider = entry.get("provider")
+        kind = entry.get("kind")
+        label = entry.get("label")
+        home_value = entry.get("home")
+        required = entry.get("required", True)
+        if provider != "claude":
+            raise HistorySourceConfigError(
+                f"{location} has unsupported provider {provider!r}; only 'claude' is supported"
+            )
+        if kind != "archive":
+            raise HistorySourceConfigError(
+                f"{location} has unsupported kind {kind!r}; registered sources must be 'archive'"
+            )
+        if not isinstance(label, str) or not SOURCE_LABEL_RE.fullmatch(label):
+            raise HistorySourceConfigError(
+                f"{location}.label must use letters, numbers, dot, underscore, or hyphen"
+            )
+        if label in seen_labels:
+            raise HistorySourceConfigError(
+                f"Duplicate archive label {label!r} in history source registry {path}"
+            )
+        seen_labels.add(label)
+        if not isinstance(home_value, str) or not home_value.strip():
+            raise HistorySourceConfigError(f"{location}.home must be a non-empty string")
+        if not isinstance(required, bool):
+            raise HistorySourceConfigError(f"{location}.required must be true or false")
+
+        expanded = Path(os.path.expandvars(home_value)).expanduser()
+        home = expanded if expanded.is_absolute() else path.parent / expanded
+        key = _resolved_key(home)
+        if key in seen_paths:
+            raise HistorySourceConfigError(
+                f"Duplicate history source path in {path}: {home}"
+            )
+        seen_paths.add(key)
+        if not (home / "projects").is_dir():
+            message = f"Registered history source {label!r} has no projects/ directory: {home}"
+            if required:
+                raise HistorySourceConfigError(f"Required history source is unavailable. {message}")
+            warnings.append(message)
+            continue
+        archives.append(
+            HistorySource(
+                provider="claude",
+                kind="archive",
+                label=label,
+                home=home,
+                required=required,
+            )
+        )
+    return archives, warnings
+
+
+def discover_claude_sources(
+    *,
+    explicit_homes: Optional[
+        Union[str, Path, Sequence[Union[str, Path]]]
+    ] = None,
+    manifest_path: Optional[Union[str, Path]] = None,
+) -> tuple[list[HistorySource], list[str]]:
+    """Return Claude history sources plus non-fatal registry warnings.
+
+    ``explicit_homes`` is an exact scope: registered archives are intentionally
+    not added. With no explicit scope, active homes are auto-discovered and the
+    default registry is loaded when present. Passing ``manifest_path`` makes that
+    file itself required, so a typo cannot silently disable archive coverage.
+    """
+    if explicit_homes is not None:
+        return _active_sources(discover_claude_homes(explicit_homes)), []
+
+    active = _active_sources(discover_claude_homes())
+    explicit_manifest = manifest_path is not None
+    registry = (
+        Path(manifest_path).expanduser()
+        if explicit_manifest
+        else default_history_sources_path()
+    )
+    if not registry.is_file():
+        if explicit_manifest:
+            raise HistorySourceConfigError(
+                f"History source registry not found: {registry}"
+            )
+        return active, []
+    archives, warnings = _manifest_archive_sources(registry, active)
+    return active + archives, warnings

--- a/daymade-claude-code/continue-claude-work/scripts/_core/text.py
+++ b/daymade-claude-code/continue-claude-work/scripts/_core/text.py
@@ -4,14 +4,15 @@ These turn raw session content into a readable one-line title and iterate JSONL
 transcripts safely. Both the Claude and Codex providers use them, so they live in
 the shared core (SSOT: `daymade-claude-code/_conversation_core/`, bundled into
 each skill's `scripts/_core/` by `sync_core.py`). Keeping them here lets the Codex
-provider and a future `continue-codex-work` skill reuse one implementation instead
-of re-deriving title/noise heuristics that would drift apart.
+provider and `continue-codex-work` reuse one implementation instead of
+re-deriving title/noise heuristics that would drift apart.
 """
 
 from __future__ import annotations
 
 import json
 import re
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable, Iterator, Optional
 
@@ -41,6 +42,14 @@ ATTACHMENT_IMAGE_RE = re.compile(
 )
 FILE_SUFFIX_RE = re.compile(r"\.[A-Za-z0-9]{1,16}$")
 SLASH_COMMAND_RE = re.compile(r"^/[A-Za-z0-9_:-]+(?:[ \t].*)?$")
+
+
+@dataclass(frozen=True)
+class SearchSegment:
+    """One searchable text field with its semantic provenance."""
+
+    source: str
+    text: str
 
 
 def looks_like_attachment_prefix(value: str) -> bool:
@@ -109,6 +118,117 @@ def extract_text(content: Any) -> str:
         ):
             parts.append(item["text"])
     return " ".join(parts)
+
+
+def _flatten_search_strings(value: Any) -> Iterator[str]:
+    """Yield string values while excluding structural/signature metadata."""
+    if isinstance(value, str):
+        if value:
+            yield value
+        return
+    if isinstance(value, list):
+        for item in value:
+            yield from _flatten_search_strings(item)
+        return
+    if not isinstance(value, dict):
+        return
+    for key, child in value.items():
+        if key in {"type", "id", "tool_use_id", "signature"}:
+            continue
+        yield from _flatten_search_strings(child)
+
+
+def searchable_segments(record: dict[str, Any]) -> list[SearchSegment]:
+    """Extract user-visible/search-relevant fields from one Claude event.
+
+    Raw JSON serialization is intentionally not searched: keys, UUIDs, and
+    cryptographic thinking signatures create false positives. Instead this
+    covers message text, thinking text, tool inputs/results, queue content,
+    last-prompt/system summaries, and attachment payloads with a source label for
+    every segment.
+    """
+    segments: list[SearchSegment] = []
+
+    def add(source: str, value: Any) -> None:
+        for text_value in _flatten_search_strings(value):
+            segments.append(SearchSegment(source=source, text=text_value))
+
+    event_type = record.get("type")
+    message = record.get("message")
+    content: Any
+    if isinstance(message, dict):
+        content = message.get("content", [])
+    elif isinstance(message, str):
+        content = message
+    elif event_type in {"user", "assistant"} or record.get("role") in {
+        "user",
+        "assistant",
+    }:
+        content = record.get("content", [])
+    else:
+        content = []
+
+    if isinstance(content, str):
+        add("message", content)
+    elif isinstance(content, list):
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            block_type = block.get("type")
+            if block_type in {"text", "input_text"}:
+                add("message", block.get("text"))
+            elif block_type == "thinking":
+                add("thinking", block.get("thinking"))
+            elif block_type == "tool_use":
+                tool_name = block.get("name")
+                source = (
+                    f"tool_input:{tool_name}"
+                    if isinstance(tool_name, str) and tool_name
+                    else "tool_input"
+                )
+                add(source, block.get("input"))
+            elif block_type == "tool_result":
+                add("tool_result", block.get("content"))
+            else:
+                # Preserve textual payloads of future/older block types without
+                # indexing structural keys or binary image data.
+                add("message", {key: block.get(key) for key in ("text", "content")})
+
+    if event_type == "queue-operation":
+        add("queue-operation", record.get("content"))
+    elif event_type == "attachment":
+        attachment = record.get("attachment")
+        if isinstance(attachment, dict):
+            add(
+                "attachment",
+                {
+                    key: attachment.get(key)
+                    for key in (
+                        "content",
+                        "prompt",
+                        "path",
+                        "displayPath",
+                        "command",
+                        "stdout",
+                        "stderr",
+                    )
+                },
+            )
+    elif event_type == "last-prompt":
+        add("last-prompt", record.get("lastPrompt"))
+    elif event_type == "system":
+        add("system", record.get("content"))
+    elif event_type == "summary":
+        add("summary", {"content": record.get("content"), "summary": record.get("summary")})
+    elif event_type == "custom-title":
+        add(
+            "custom-title",
+            {"title": record.get("title"), "customTitle": record.get("customTitle")},
+        )
+
+    # Some event variants mirror the same payload in more than one compatible
+    # field. Count each semantic source/text pair once per record.
+    return list(dict.fromkeys(segments))
 
 
 def is_noise_text(text: str) -> bool:

--- a/daymade-claude-code/continue-codex-work/.security-scan-passed
+++ b/daymade-claude-code/continue-codex-work/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-07-15T17:54:18.039009+00:00
+Scanned at: 2026-07-16T02:16:30.995010+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 87bdbcdbc08408ef2343e6c9d0ec9022b26d1fba6f9c11e8f49594795d50936b
+Content hash: 16b683b26e8af9746d2db4a726a602fa9f81dbf683ad60da337b53e95f8216a1

--- a/daymade-claude-code/continue-codex-work/scripts/_core/__init__.py
+++ b/daymade-claude-code/continue-codex-work/scripts/_core/__init__.py
@@ -8,8 +8,13 @@ every skill stays self-contained and installable on its own while sharing one
 implementation.
 
 Modules:
-    homes  — discover every Claude config home (main + per-model profiles).
-    parse  — pure parsing/formatting helpers (timestamps, and more over time).
+    homes    — discover every active Claude config home.
+    sources  — combine active homes with explicitly registered archives.
+    claude   — stream exact Claude session metadata and internal time ranges.
+    codex    — inspect Codex state databases and raw rollout stores.
+    parse    — timestamp, timezone, and workspace normalization helpers.
+    text     — semantic JSONL text/title extraction.
+    model    — shared provider result data structures.
 """
 
 from .homes import discover_claude_homes, home_label

--- a/daymade-claude-code/continue-codex-work/scripts/_core/claude.py
+++ b/daymade-claude-code/continue-codex-work/scripts/_core/claude.py
@@ -1,0 +1,72 @@
+"""Exact, streaming metadata scan for Claude Code JSONL sessions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from .parse import TimestampRange
+from .text import extract_text, first_meaningful_title, iter_jsonl
+
+
+@dataclass(frozen=True)
+class ClaudeSessionSummary:
+    session_id: str
+    cwd: str
+    title: str
+    created_at: Optional[float]
+    updated_at: Optional[float]
+    timestamp_count: int
+
+
+def scan_claude_session(path: Path, max_title_chars: int = 120) -> ClaudeSessionSummary:
+    """Scan every valid record and return internal time bounds plus title metadata.
+
+    File mtime is deliberately absent. Copying or migrating a transcript changes
+    mtime without changing when the conversation happened; the only trustworthy
+    conversation range is the minimum and maximum valid top-level ``timestamp``
+    found across the JSONL records themselves.
+    """
+    session_id = path.stem
+    cwd = ""
+    prompt_candidates: list[str] = []
+    title: Optional[str] = None
+    timestamps = TimestampRange()
+
+    for record in iter_jsonl(path):
+        timestamps.observe(record.get("timestamp"))
+        if isinstance(record.get("sessionId"), str) and record["sessionId"]:
+            session_id = record["sessionId"]
+        if not cwd and isinstance(record.get("cwd"), str):
+            cwd = record["cwd"]
+        if title is not None:
+            continue
+        if record.get("type") != "user" or record.get("isMeta") is True:
+            continue
+        message = record.get("message")
+        if isinstance(message, dict) and message.get("role") == "user":
+            text = extract_text(message.get("content"))
+        elif isinstance(message, str):
+            text = message
+        else:
+            text = ""
+        if not text:
+            continue
+        prompt_candidates.append(text)
+        candidate = first_meaningful_title(prompt_candidates, max_title_chars)
+        if candidate and len(candidate) >= 4:
+            title = candidate
+
+    if title is None:
+        title = first_meaningful_title(prompt_candidates, max_title_chars)
+    if not title:
+        title = f"(untitled: {session_id})"
+    return ClaudeSessionSummary(
+        session_id=session_id,
+        cwd=cwd,
+        title=title,
+        created_at=timestamps.earliest,
+        updated_at=timestamps.latest,
+        timestamp_count=timestamps.count,
+    )

--- a/daymade-claude-code/continue-codex-work/scripts/_core/codex.py
+++ b/daymade-claude-code/continue-codex-work/scripts/_core/codex.py
@@ -25,7 +25,7 @@ from typing import Any, Iterable, Optional
 from urllib.parse import quote
 
 from .model import CodexDatabase, Conversation, ProviderResult
-from .parse import parse_timestamp, workspace_matches
+from .parse import TimestampRange, parse_timestamp, workspace_matches
 from .text import extract_text, first_meaningful_title, is_automated_title, iter_jsonl
 
 CODEX_REQUIRED_COLUMNS = {"id", "cwd", "updated_at", "source", "archived"}
@@ -33,6 +33,7 @@ SESSION_ID_RE = re.compile(
     r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
     re.IGNORECASE,
 )
+STATE_DATABASE_RE = re.compile(r"^state_(\d+)\.sqlite$")
 
 
 def sqlite_uri(path: Path) -> str:
@@ -83,8 +84,18 @@ def discover_codex_database(home: Path, warnings: list[str]) -> Optional[CodexDa
         return None
     return max(
         compatible,
-        key=lambda item: (item.max_updated_ms, item.path.stat().st_mtime_ns),
+        key=lambda item: (
+            item.max_updated_ms,
+            _state_database_generation(item.path),
+            item.path.as_posix(),
+        ),
     )
+
+
+def _state_database_generation(path: Path) -> int:
+    """Return the numeric state database generation without consulting mtime."""
+    match = STATE_DATABASE_RE.fullmatch(path.name)
+    return int(match.group(1)) if match else -1
 
 
 def nested_key_exists(value: Any, wanted: str) -> bool:
@@ -261,6 +272,23 @@ def codex_prompt_from_rollout(path: Path, max_chars: int) -> Optional[str]:
     return short_candidate
 
 
+def codex_rollout_time_range(path: Path) -> TimestampRange:
+    """Compute exact internal bounds for a Codex rollout.
+
+    Current rollouts timestamp every top-level event. Older/minimal fixtures may
+    carry only ``session_meta.payload.timestamp``, so observe both. File mtime is
+    deliberately excluded because copying or migrating a rollout rewrites it.
+    """
+    timestamps = TimestampRange()
+    for record in iter_jsonl(path):
+        timestamps.observe(record.get("timestamp"))
+        if record.get("type") == "session_meta" and isinstance(
+            record.get("payload"), dict
+        ):
+            timestamps.observe(record["payload"].get("timestamp"))
+    return timestamps
+
+
 def collect_codex_from_rollouts(
     args: argparse.Namespace, home: Path, result: ProviderResult
 ) -> None:
@@ -301,25 +329,22 @@ def collect_codex_from_rollouts(
         if is_automated_title(title) and not args.include_automated:
             result.excluded_automated += 1
             continue
-        try:
-            updated_at = path.stat().st_mtime
-            timestamp_source = "file-mtime"
-        except OSError:
-            updated_at = parse_timestamp(meta.get("timestamp"))
-            timestamp_source = "session-meta"
+        timestamps = codex_rollout_time_range(path)
         result.conversations.append(
             Conversation(
                 provider="codex",
                 session_id=session_id,
                 title=title,
                 cwd=cwd,
-                updated_at=updated_at,
-                created_at=parse_timestamp(meta.get("timestamp")),
+                updated_at=timestamps.latest,
+                created_at=timestamps.earliest,
                 archived=archived,
                 kind="subagent" if subagent else "main",
                 path=str(path),
                 metadata_source="rollout-jsonl",
-                timestamp_source=timestamp_source,
+                timestamp_source=(
+                    "rollout-record-minmax" if timestamps.count else "unknown"
+                ),
             )
         )
 

--- a/daymade-claude-code/continue-codex-work/scripts/_core/model.py
+++ b/daymade-claude-code/continue-codex-work/scripts/_core/model.py
@@ -3,8 +3,8 @@
 `Conversation` / `ProviderResult` / `CodexDatabase` are used by both the Claude
 and Codex providers and by the renderers, so they live in the shared core (SSOT:
 `daymade-claude-code/_conversation_core/`, bundled into each skill's
-`scripts/_core/` by `sync_core.py`). Extracting them here lets a skill like
-`continue-codex-work` reuse the same model without re-declaring it.
+`scripts/_core/` by `sync_core.py`). This lets `continue-codex-work` and the
+inventory/search skills reuse the same model without re-declaring it.
 """
 
 from __future__ import annotations
@@ -29,6 +29,8 @@ class Conversation:
     path: str
     metadata_source: str
     timestamp_source: str
+    source_kind: str = ""
+    source_labels: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         data = asdict(self)

--- a/daymade-claude-code/continue-codex-work/scripts/_core/parse.py
+++ b/daymade-claude-code/continue-codex-work/scripts/_core/parse.py
@@ -1,19 +1,39 @@
 """Shared parsing / formatting helpers for the conversation-history skills.
 
-Pure, self-contained utilities that every skill re-implements otherwise. Bundled
-into each skill's ``scripts/_core/`` by ``sync_core.py`` (see homes.py for why
-bundling rather than importing a sibling). This is the parsing counterpart to
-``homes.py``; more helpers (text/title extraction, workspace matching, JSONL
-iteration) move here in later phases as they are de-duplicated from the skills.
+Pure, self-contained utilities that every skill would otherwise re-implement.
+Bundled into each skill's ``scripts/_core/`` by ``sync_core.py`` (see homes.py
+for why bundling is used instead of importing a sibling).
 """
 
 import os
 import re
 import sys
-from datetime import datetime
+from dataclasses import dataclass
+from datetime import date, datetime, time
 from typing import Any, Optional
 
 WINDOWS_DRIVE_RE = re.compile(r"^(?:[/\\]{2}\?[/\\])?[A-Za-z]:[/\\]")
+DATE_ONLY_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+@dataclass
+class TimestampRange:
+    """Minimum/maximum valid internal timestamp observed while streaming."""
+
+    earliest: Optional[float] = None
+    latest: Optional[float] = None
+    count: int = 0
+
+    def observe(self, value: Any) -> Optional[float]:
+        parsed = parse_timestamp(value)
+        if parsed is None:
+            return None
+        self.count += 1
+        if self.earliest is None or parsed < self.earliest:
+            self.earliest = parsed
+        if self.latest is None or parsed > self.latest:
+            self.latest = parsed
+        return parsed
 
 
 def parse_timestamp(value: Any) -> Optional[float]:
@@ -66,6 +86,61 @@ def format_timestamp(value: float) -> str:
 def iso_timestamp(value: float) -> str:
     """ISO-8601 local timestamp (seconds precision, with offset)."""
     return datetime.fromtimestamp(value).astimezone().isoformat(timespec="seconds")
+
+
+def parse_date_boundary(value: str, *, end: bool = False) -> float:
+    """Parse a date-only local boundary or a timezone-qualified ISO datetime.
+
+    Date-only input uses the machine's local timezone and covers the full day.
+    Datetime input must carry ``Z`` or an explicit UTC offset; accepting a naive
+    datetime would make a cross-machine history query change meaning silently.
+    """
+    text_value = value.strip()
+    if DATE_ONLY_RE.fullmatch(text_value):
+        parsed_date = date.fromisoformat(text_value)
+        wall_time = time.max if end else time.min
+        return datetime.combine(parsed_date, wall_time).astimezone().timestamp()
+    try:
+        parsed = datetime.fromisoformat(text_value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError(
+            f"invalid ISO date/time {value!r}; use YYYY-MM-DD or include a timezone offset"
+        ) from error
+    if parsed.tzinfo is None:
+        raise ValueError(
+            f"datetime {value!r} has no timezone; use Z or an explicit UTC offset"
+        )
+    return parsed.timestamp()
+
+
+def timestamp_in_window(
+    value: Optional[float],
+    from_timestamp: Optional[float],
+    to_timestamp: Optional[float],
+) -> bool:
+    if value is None:
+        return from_timestamp is None and to_timestamp is None
+    if from_timestamp is not None and value < from_timestamp:
+        return False
+    if to_timestamp is not None and value > to_timestamp:
+        return False
+    return True
+
+
+def range_overlaps_window(
+    earliest: Optional[float],
+    latest: Optional[float],
+    from_timestamp: Optional[float],
+    to_timestamp: Optional[float],
+) -> bool:
+    """Whether an internal session range overlaps an inclusive query window."""
+    if earliest is None or latest is None:
+        return from_timestamp is None and to_timestamp is None
+    if from_timestamp is not None and latest < from_timestamp:
+        return False
+    if to_timestamp is not None and earliest > to_timestamp:
+        return False
+    return True
 
 
 def looks_like_windows_path(value: str) -> bool:

--- a/daymade-claude-code/continue-codex-work/scripts/_core/sources.py
+++ b/daymade-claude-code/continue-codex-work/scripts/_core/sources.py
@@ -1,0 +1,201 @@
+"""Discover active and explicitly registered Claude conversation sources.
+
+Active Claude homes are auto-discovered by :mod:`homes`. Long-term archives are
+different: their location is user configuration, not a filename convention that
+the public skill should guess. A small manifest at
+``~/.claude/history-sources.json`` registers those archives explicitly.
+
+The manifest is intentionally fail-fast. A malformed file, duplicate archive, or
+missing required source is configuration damage, not a cue to silently fall back
+to the active homes and produce an incomplete history result.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Sequence, Union
+
+from .homes import discover_claude_homes, home_label
+
+
+MANIFEST_VERSION = 1
+SOURCE_LABEL_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+class HistorySourceConfigError(ValueError):
+    """Raised when an explicit history-source registry cannot be trusted."""
+
+
+@dataclass(frozen=True)
+class HistorySource:
+    """One Claude configuration root that contains a ``projects/`` directory."""
+
+    provider: str
+    kind: str
+    label: str
+    home: Path
+    required: bool = True
+
+    @property
+    def display_label(self) -> str:
+        return f"{self.kind}:{self.label}"
+
+
+def default_history_sources_path() -> Path:
+    """Return the per-user registry path without caching ``Path.home()``."""
+    return Path.home() / ".claude" / "history-sources.json"
+
+
+def _resolved_key(path: Path) -> str:
+    try:
+        return str(path.resolve())
+    except (OSError, RuntimeError):
+        return str(path.absolute())
+
+
+def _active_sources(
+    homes: Sequence[Union[str, Path]],
+) -> list[HistorySource]:
+    return [
+        HistorySource(
+            provider="claude",
+            kind="active",
+            label=home_label(home),
+            home=Path(home).expanduser(),
+            required=True,
+        )
+        for home in homes
+    ]
+
+
+def _read_manifest(path: Path) -> dict:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise HistorySourceConfigError(
+            f"Cannot read history source registry {path}: {error}"
+        ) from error
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise HistorySourceConfigError(
+            f"Invalid JSON in history source registry {path}: {error}"
+        ) from error
+    if not isinstance(payload, dict):
+        raise HistorySourceConfigError(
+            f"History source registry {path} must contain a JSON object"
+        )
+    if payload.get("version") != MANIFEST_VERSION:
+        raise HistorySourceConfigError(
+            f"History source registry {path} must use version {MANIFEST_VERSION}"
+        )
+    if not isinstance(payload.get("sources"), list):
+        raise HistorySourceConfigError(
+            f"History source registry {path} must contain a sources array"
+        )
+    return payload
+
+
+def _manifest_archive_sources(
+    path: Path,
+    active: Sequence[HistorySource],
+) -> tuple[list[HistorySource], list[str]]:
+    payload = _read_manifest(path)
+    warnings: list[str] = []
+    archives: list[HistorySource] = []
+    seen_paths = {_resolved_key(source.home) for source in active}
+    seen_labels: set[str] = set()
+
+    for index, entry in enumerate(payload["sources"]):
+        location = f"{path}: sources[{index}]"
+        if not isinstance(entry, dict):
+            raise HistorySourceConfigError(f"{location} must be an object")
+        provider = entry.get("provider")
+        kind = entry.get("kind")
+        label = entry.get("label")
+        home_value = entry.get("home")
+        required = entry.get("required", True)
+        if provider != "claude":
+            raise HistorySourceConfigError(
+                f"{location} has unsupported provider {provider!r}; only 'claude' is supported"
+            )
+        if kind != "archive":
+            raise HistorySourceConfigError(
+                f"{location} has unsupported kind {kind!r}; registered sources must be 'archive'"
+            )
+        if not isinstance(label, str) or not SOURCE_LABEL_RE.fullmatch(label):
+            raise HistorySourceConfigError(
+                f"{location}.label must use letters, numbers, dot, underscore, or hyphen"
+            )
+        if label in seen_labels:
+            raise HistorySourceConfigError(
+                f"Duplicate archive label {label!r} in history source registry {path}"
+            )
+        seen_labels.add(label)
+        if not isinstance(home_value, str) or not home_value.strip():
+            raise HistorySourceConfigError(f"{location}.home must be a non-empty string")
+        if not isinstance(required, bool):
+            raise HistorySourceConfigError(f"{location}.required must be true or false")
+
+        expanded = Path(os.path.expandvars(home_value)).expanduser()
+        home = expanded if expanded.is_absolute() else path.parent / expanded
+        key = _resolved_key(home)
+        if key in seen_paths:
+            raise HistorySourceConfigError(
+                f"Duplicate history source path in {path}: {home}"
+            )
+        seen_paths.add(key)
+        if not (home / "projects").is_dir():
+            message = f"Registered history source {label!r} has no projects/ directory: {home}"
+            if required:
+                raise HistorySourceConfigError(f"Required history source is unavailable. {message}")
+            warnings.append(message)
+            continue
+        archives.append(
+            HistorySource(
+                provider="claude",
+                kind="archive",
+                label=label,
+                home=home,
+                required=required,
+            )
+        )
+    return archives, warnings
+
+
+def discover_claude_sources(
+    *,
+    explicit_homes: Optional[
+        Union[str, Path, Sequence[Union[str, Path]]]
+    ] = None,
+    manifest_path: Optional[Union[str, Path]] = None,
+) -> tuple[list[HistorySource], list[str]]:
+    """Return Claude history sources plus non-fatal registry warnings.
+
+    ``explicit_homes`` is an exact scope: registered archives are intentionally
+    not added. With no explicit scope, active homes are auto-discovered and the
+    default registry is loaded when present. Passing ``manifest_path`` makes that
+    file itself required, so a typo cannot silently disable archive coverage.
+    """
+    if explicit_homes is not None:
+        return _active_sources(discover_claude_homes(explicit_homes)), []
+
+    active = _active_sources(discover_claude_homes())
+    explicit_manifest = manifest_path is not None
+    registry = (
+        Path(manifest_path).expanduser()
+        if explicit_manifest
+        else default_history_sources_path()
+    )
+    if not registry.is_file():
+        if explicit_manifest:
+            raise HistorySourceConfigError(
+                f"History source registry not found: {registry}"
+            )
+        return active, []
+    archives, warnings = _manifest_archive_sources(registry, active)
+    return active + archives, warnings

--- a/daymade-claude-code/continue-codex-work/scripts/_core/text.py
+++ b/daymade-claude-code/continue-codex-work/scripts/_core/text.py
@@ -4,14 +4,15 @@ These turn raw session content into a readable one-line title and iterate JSONL
 transcripts safely. Both the Claude and Codex providers use them, so they live in
 the shared core (SSOT: `daymade-claude-code/_conversation_core/`, bundled into
 each skill's `scripts/_core/` by `sync_core.py`). Keeping them here lets the Codex
-provider and a future `continue-codex-work` skill reuse one implementation instead
-of re-deriving title/noise heuristics that would drift apart.
+provider and `continue-codex-work` reuse one implementation instead of
+re-deriving title/noise heuristics that would drift apart.
 """
 
 from __future__ import annotations
 
 import json
 import re
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable, Iterator, Optional
 
@@ -41,6 +42,14 @@ ATTACHMENT_IMAGE_RE = re.compile(
 )
 FILE_SUFFIX_RE = re.compile(r"\.[A-Za-z0-9]{1,16}$")
 SLASH_COMMAND_RE = re.compile(r"^/[A-Za-z0-9_:-]+(?:[ \t].*)?$")
+
+
+@dataclass(frozen=True)
+class SearchSegment:
+    """One searchable text field with its semantic provenance."""
+
+    source: str
+    text: str
 
 
 def looks_like_attachment_prefix(value: str) -> bool:
@@ -109,6 +118,117 @@ def extract_text(content: Any) -> str:
         ):
             parts.append(item["text"])
     return " ".join(parts)
+
+
+def _flatten_search_strings(value: Any) -> Iterator[str]:
+    """Yield string values while excluding structural/signature metadata."""
+    if isinstance(value, str):
+        if value:
+            yield value
+        return
+    if isinstance(value, list):
+        for item in value:
+            yield from _flatten_search_strings(item)
+        return
+    if not isinstance(value, dict):
+        return
+    for key, child in value.items():
+        if key in {"type", "id", "tool_use_id", "signature"}:
+            continue
+        yield from _flatten_search_strings(child)
+
+
+def searchable_segments(record: dict[str, Any]) -> list[SearchSegment]:
+    """Extract user-visible/search-relevant fields from one Claude event.
+
+    Raw JSON serialization is intentionally not searched: keys, UUIDs, and
+    cryptographic thinking signatures create false positives. Instead this
+    covers message text, thinking text, tool inputs/results, queue content,
+    last-prompt/system summaries, and attachment payloads with a source label for
+    every segment.
+    """
+    segments: list[SearchSegment] = []
+
+    def add(source: str, value: Any) -> None:
+        for text_value in _flatten_search_strings(value):
+            segments.append(SearchSegment(source=source, text=text_value))
+
+    event_type = record.get("type")
+    message = record.get("message")
+    content: Any
+    if isinstance(message, dict):
+        content = message.get("content", [])
+    elif isinstance(message, str):
+        content = message
+    elif event_type in {"user", "assistant"} or record.get("role") in {
+        "user",
+        "assistant",
+    }:
+        content = record.get("content", [])
+    else:
+        content = []
+
+    if isinstance(content, str):
+        add("message", content)
+    elif isinstance(content, list):
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            block_type = block.get("type")
+            if block_type in {"text", "input_text"}:
+                add("message", block.get("text"))
+            elif block_type == "thinking":
+                add("thinking", block.get("thinking"))
+            elif block_type == "tool_use":
+                tool_name = block.get("name")
+                source = (
+                    f"tool_input:{tool_name}"
+                    if isinstance(tool_name, str) and tool_name
+                    else "tool_input"
+                )
+                add(source, block.get("input"))
+            elif block_type == "tool_result":
+                add("tool_result", block.get("content"))
+            else:
+                # Preserve textual payloads of future/older block types without
+                # indexing structural keys or binary image data.
+                add("message", {key: block.get(key) for key in ("text", "content")})
+
+    if event_type == "queue-operation":
+        add("queue-operation", record.get("content"))
+    elif event_type == "attachment":
+        attachment = record.get("attachment")
+        if isinstance(attachment, dict):
+            add(
+                "attachment",
+                {
+                    key: attachment.get(key)
+                    for key in (
+                        "content",
+                        "prompt",
+                        "path",
+                        "displayPath",
+                        "command",
+                        "stdout",
+                        "stderr",
+                    )
+                },
+            )
+    elif event_type == "last-prompt":
+        add("last-prompt", record.get("lastPrompt"))
+    elif event_type == "system":
+        add("system", record.get("content"))
+    elif event_type == "summary":
+        add("summary", {"content": record.get("content"), "summary": record.get("summary")})
+    elif event_type == "custom-title":
+        add(
+            "custom-title",
+            {"title": record.get("title"), "customTitle": record.get("customTitle")},
+        )
+
+    # Some event variants mirror the same payload in more than one compatible
+    # field. Count each semantic source/text pair once per record.
+    return list(dict.fromkeys(segments))
 
 
 def is_noise_text(text: str) -> bool:

--- a/daymade-claude-code/local-conversation-history/.security-scan-passed
+++ b/daymade-claude-code/local-conversation-history/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-07-13T10:35:10.046371+00:00
+Scanned at: 2026-07-16T02:16:30.785307+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: d5e85836a95e1365392c9b6da0fa59789ed96e18f0e8447bae218a6069c2dc21
+Content hash: e3e745ada980cfada8a60663b441895a984ede7c51bc4125db27017d4db90fec

--- a/daymade-claude-code/local-conversation-history/SKILL.md
+++ b/daymade-claude-code/local-conversation-history/SKILL.md
@@ -1,23 +1,40 @@
 ---
 name: local-conversation-history
 description: >-
-  Lists recent local Claude Code and OpenAI Codex conversations for the current
-  folder or another workspace in one fast, read-only command. Produces readable
-  Markdown or JSON with titles, timezone-qualified timestamps, sources, session
-  IDs, and archive/test markers while excluding internal sub-agent noise by
-  default. Use this skill first whenever the user asks to list, show, browse, or
-  find recent local chats, conversation history, task history, or session IDs
-  across Claude Code and Codex. Do not use it for full-transcript search, deleted
-  file recovery, or resuming work from a transcript.
+  Lists recent local Claude Code and OpenAI Codex conversations for a workspace
+  in one read-only command. For Claude Code, the default inventory combines
+  every active config home with every long-term archive registered in
+  ~/.claude/history-sources.json, de-duplicates session IDs, and orders or
+  filters by internal JSONL timestamps rather than file mtime. Produces readable
+  Markdown or JSON with titles, timezone-qualified timestamps, provenance,
+  session IDs, and archive/test markers while excluding internal sub-agent noise
+  by default; Codex raw-rollout fallback also computes internal record bounds
+  without mtime. Use when the user asks to list, show, or browse recent local
+  chats, task history, or session IDs across Claude Code and Codex. Do not use
+  for keyword/full-event search, deleted-file recovery, or resuming work.
 argument-hint: "[workspace-path]"
 ---
 
 # Local Conversation History
 
 List project-scoped local histories without reconstructing ad hoc `rg`, `stat`,
-`jq`, or SQLite pipelines. The bundled script performs provider discovery,
-schema introspection, filtering, title extraction, sorting, and rendering in one
-process.
+`jq`, or SQLite pipelines. The bundled script performs provider and archive
+discovery, schema introspection, filtering, de-duplication, title extraction,
+internal-time sorting, and rendering in one process.
+
+## Completeness invariant
+
+For a normal Claude Code inventory, the source set is indivisible:
+
+1. auto-discovered active homes (`~/.claude`, profile homes, and the current
+   `CLAUDE_CONFIG_DIR`), and
+2. every archive registered in `~/.claude/history-sources.json`.
+
+Do not claim that a Claude conversation is absent unless the output shows that
+the registered archives were searched. A required archive that is unavailable
+is a hard configuration error, not permission to return an incomplete result.
+Explicit `--claude-home` is a diagnostic scope override and intentionally
+bypasses the registry; never use it for a completeness claim.
 
 ## Route the request
 
@@ -26,12 +43,14 @@ process.
 - Include child workspaces under a directory: pass `--recursive`.
 - List every workspace: pass `--all-projects`; omit `--cwd`.
 - Include archived Codex threads: pass `--include-archived`.
+- Restrict by conversation date: pass `--from-date` and/or `--to-date`.
 - Include internal agents or obvious smoke prompts only when explicitly asked:
   pass `--include-subagents` or `--include-automated`.
 - Search inside full transcripts, recover deleted files, or analyze tool calls:
   use the `daymade-claude-code:claude-code-history-files-finder` skill instead.
-- Reconstruct the last actionable request and continue work: use the
-  `daymade-claude-code:continue-claude-work` skill instead.
+- Reconstruct and continue a Claude Code session with
+  `daymade-claude-code:continue-claude-work`; use
+  `daymade-claude-code:continue-codex-work` for a Codex thread.
 
 ## Run exactly one inventory command
 
@@ -57,10 +76,10 @@ Expected output is already presentation-ready Markdown:
 # Local conversation history
 Scope: `<workspace>`
 
-## Codex — 3 conversations
-| Updated | Title | Session ID | Flags |
-|---|---|---|---|
-| 2026-01-15 10:30 +00:00 | Review authentication flow | `019...` | — |
+## Claude Code — 3 conversations
+| Updated | Title | Session ID | Source | Flags |
+|---|---|---|---|---|
+| 2026-01-15 10:30 +00:00 | Review authentication flow | `019...` | active:main, archive:long-term | — |
 ```
 
 Return that output directly, with at most one short observation. Do not run
@@ -75,27 +94,52 @@ Treat the command as an inventory, not a transcript export:
 - Report titles only; do not paste raw JSONL or full prompts unless the user asks
   for a specific session afterward.
 - Keep every displayed timestamp's explicit timezone offset.
+- For Claude Code, treat the minimum and maximum valid top-level `timestamp`
+  values across the JSONL as the session range. Never substitute file mtime:
+  copying or migrating an archive changes mtime without changing conversation
+  time.
+- For Codex, prefer the state database's internal created/updated fields. If the
+  database is unavailable, compute the rollout range from internal top-level
+  event timestamps plus `session_meta.payload.timestamp`; never use rollout
+  mtime or database-file mtime as chronology.
+- A date-only filter means the whole local calendar day. A datetime filter must
+  include `Z` or an explicit UTC offset. Sessions without internal timestamps
+  are excluded with a visible warning while a date filter is active.
 - Preserve provider labels and session IDs exactly as printed.
 - State warnings from the script instead of silently hiding a missing,
   unreadable, or unsupported store.
 - Do not claim Claude Desktop native chats are included. The Claude source here
   is Claude Code history; Codex covers local Codex CLI/Desktop thread stores.
 
-## Handle alternate homes and failures
+## Handle source configuration and failures
 
-The script honors `CLAUDE_CONFIG_DIR` and `CODEX_HOME`. For isolated profiles or
-backups, pass `--claude-home <dir>` or `--codex-home <dir>` explicitly.
+The script honors `CLAUDE_CONFIG_DIR` and `CODEX_HOME`. Register durable Claude
+archives once in `~/.claude/history-sources.json`; the default command then
+searches them on every run. Use `--history-sources <file>` to test another
+registry. Use `--claude-home <dir>` or `--codex-home <dir>` only when the user
+explicitly requests an exact single-store diagnostic scope.
 
 If no conversations appear, use the diagnostics already printed by the same
-command. Read [references/storage_and_portability.md](references/storage_and_portability.md)
-only when the format or path needs diagnosis; it documents the inspected stores,
-fallback order, Windows path normalization, and known boundaries.
+command. Read
+[references/storage_and_portability.md](references/storage_and_portability.md)
+only when the format or path needs diagnosis; it documents the source registry,
+inspected stores, internal-time policy, Windows path normalization, and known
+boundaries.
 
 ## Maintainer verification
 
-Run the standard-library regression suite after changing the parser:
+In the source repository, `daymade-claude-code/_conversation_core/` is the code
+SSOT shared by this skill, `claude-code-history-files-finder`,
+`continue-claude-work`, and `continue-codex-work`. The four skills remain
+self-contained at install time because `sync_core.py` copies that package into
+each `scripts/_core/`. Never edit a bundled `_core` copy directly.
+
+After changing shared code, synchronize and verify all four bundles, then run
+this skill's standard-library regression suite:
 
 ```text
+uv run python ../sync_core.py sync
+uv run python ../sync_core.py check
 python -m unittest discover -s tests -p "test_*.py"
 ```
 

--- a/daymade-claude-code/local-conversation-history/evals/evals.json
+++ b/daymade-claude-code/local-conversation-history/evals/evals.json
@@ -18,6 +18,24 @@
       "prompt": "I moved my Claude and Codex config directories to custom profile folders on Windows. Find the conversations under this workspace and explain clearly if either local store cannot be read.",
       "expected_output": "Uses explicit provider-home overrides, handles Windows path normalization, and surfaces built-in diagnostics without guessing or modifying local state.",
       "files": []
+    },
+    {
+      "id": 4,
+      "prompt": "列出这个项目 3 月到 4 月的 Claude Code 对话。旧对话在我已经登记的长期备份里，迁移过机器，文件修改时间不可信。",
+      "expected_output": "Runs the default Claude inventory with --from-date and --to-date so both active homes and every registered archive are included; reports source provenance and uses internal JSONL timestamp ranges without consulting file mtime.",
+      "files": []
+    },
+    {
+      "id": 5,
+      "prompt": "Show my recent Claude history. The registered archive disk is currently unavailable, but just ignore it and tell me what's local.",
+      "expected_output": "Does not make a whole-history claim from the active directory alone. A required registered archive remains a visible hard error unless the user deliberately changes the registry or asks for an explicitly partial diagnostic scope.",
+      "files": []
+    },
+    {
+      "id": 6,
+      "prompt": "Search every old Claude conversation for a keyword that may only appear inside a tool result, then recover the file that was written in that session.",
+      "expected_output": "Routes the request to claude-code-history-files-finder instead of using the recent-inventory command, because the task requires full-event keyword search and recovery.",
+      "files": []
     }
   ]
 }

--- a/daymade-claude-code/local-conversation-history/references/storage_and_portability.md
+++ b/daymade-claude-code/local-conversation-history/references/storage_and_portability.md
@@ -7,16 +7,61 @@ missing, or ambiguous local store.
 
 ### Claude Code
 
-1. Resolve the configuration root from `--claude-home`, then
-   `CLAUDE_CONFIG_DIR`, then the user's home-relative `.claude` directory.
-2. Locate the project directory under `projects/` from the requested workspace.
+1. With no exact override, auto-discover active roots from
+   `CLAUDE_CONFIG_DIR`, `~/.claude`, `~/.claude-profiles/*`, and sibling
+   `~/.claude-*` homes, then add every archive registered in
+   `~/.claude/history-sources.json`.
+2. Locate the project directory under each source's `projects/` tree from the
+   requested workspace.
 3. Read only main session JSONL files at that project's top level. Ignore
    `agent-*` and nested agent files unless `--include-subagents` is explicit.
-4. Extract a short title from the first real user prompt and use file mtime as
-   the last-updated observation.
+4. Stream every valid record in each main session. Extract a short title from
+   the first real user prompt and compute the session range from the minimum and
+   maximum valid top-level `timestamp` values.
+5. De-duplicate by session ID. Use the copy with the greatest internal maximum
+   timestamp for its title/path (an exact tie prefers active), union the minimum
+   and maximum internal range across every copy, and preserve every source label
+   as provenance. The deep-search skill goes further and unions distinct records
+   across physical copies before keyword matching.
 
 The global prompt index is not the transcript source of truth: older versions
 may omit session IDs and retained entries can outlive their session files.
+
+File mtime is never a conversation-time fallback. Copying, restoring, or
+migrating JSONL files changes mtime without changing when their records were
+written. When a date filter is active, a session without any valid internal
+timestamp is excluded with a visible warning.
+
+### Claude archive registry
+
+Long-term archives are explicit user configuration rather than a directory-name
+guess. The default registry is `~/.claude/history-sources.json`:
+
+```json
+{
+  "version": 1,
+  "sources": [
+    {
+      "provider": "claude",
+      "kind": "archive",
+      "label": "long-term",
+      "home": "/path/to/claude-history-backup",
+      "required": true
+    }
+  ]
+}
+```
+
+Each `home` is a Claude-style root containing `projects/`, not the `projects/`
+directory itself. Relative paths resolve from the registry's directory;
+environment variables and `~` are expanded. Labels may contain letters,
+numbers, dots, underscores, and hyphens.
+
+The registry fails fast on malformed JSON, an unsupported version/provider/kind,
+duplicate labels or paths, or a missing `required: true` archive. An optional
+missing archive (`required: false`) produces a warning and is skipped. Passing
+`--history-sources <file>` requires that file to exist. Passing
+`--claude-home <dir>` is an exact diagnostic scope and bypasses the registry.
 
 ### Codex
 
@@ -30,6 +75,13 @@ may omit session IDs and retained entries can outlive their session files.
 4. If no compatible database exists, scan `sessions/**/rollout-*.jsonl` and,
    when requested, `archived_sessions/`. Use `session_index.jsonl` only as a
    title aid, never as the sole existence check.
+5. For raw rollouts, stream the complete JSONL and compute minimum/maximum from
+   internal top-level event timestamps plus `session_meta.payload.timestamp`.
+   A rollout without either is unknown-time; file mtime is never substituted.
+
+When compatible databases have the same greatest internal thread update, the
+numeric `state_<generation>.sqlite` suffix breaks the tie. Database-file mtime
+is not chronological evidence and is not consulted.
 
 The selected backend is printed in the report. A database problem is reported
 before raw-rollout recovery is attempted, so the alternate path is visible
@@ -42,9 +94,14 @@ The implementation was checked against Claude Code 2.1.207 and Codex CLI
 promise that vendors will never change their private local formats.
 
 - Claude Code main records use top-level event types with user content under a
-  nested message object; non-message events may appear before the first prompt.
+  nested message object; non-message events may appear anywhere in the file.
+- Internal records are not guaranteed to be chronological in physical line
+  order. Compute a true minimum/maximum range across all valid timestamps; do
+  not assume the first or last line is the boundary.
 - Codex rollouts begin with a `session_meta` event carrying an ID, cwd, source,
   and creation timestamp. User text appears later in message response items.
+- Codex rollout top-level events carry timestamps; physical order is not a
+  chronology contract, so raw fallback computes a true internal min/max range.
 - Current Codex state databases expose thread title, cwd, archive state, source,
   timestamps, and rollout path, with newer schemas adding fields rather than
   replacing the core columns.
@@ -71,8 +128,9 @@ persisted workspace through `--cwd` or use `--all-projects` to discover it.
 
 ## Privacy and safety
 
-- The script reads local metadata and at most a bounded prefix of each transcript
-  needed to find its first real prompt.
+- Exact Claude ranges require a streaming pass over every valid JSONL record.
+  Memory use stays bounded, but large archives can take longer than a
+  prefix-only inventory.
 - Titles are whitespace-normalized and truncated before printing.
 - No transcript, title, or path is uploaded or written to a cache.
 - `--format json` still contains local titles and paths. Treat that output with
@@ -83,7 +141,10 @@ persisted workspace through `--cwd` or use `--all-projects` to discover it.
 | Reported condition | Meaning | Next action |
 |---|---|---|
 | Provider home missing | That tool has no history at the resolved root | Verify the profile-specific home or omit that provider |
+| Required archive unavailable | The configured whole-history source set is incomplete | Restore/mount the archive or deliberately correct the registry; do not claim absence |
+| Invalid history source registry | The source set cannot be trusted | Fix the reported JSON/schema/path error and rerun |
 | Project directory not found | Claude's encoded project directory did not match | Use the exact workspace path or `--all-projects` |
 | No compatible Codex database | SQLite is absent, unreadable, or has an unknown schema | Review the warning; raw rollout scanning runs next |
 | Zero direct conversations, many excluded agents | The workspace contains worker/reviewer sessions but no matching main thread | Add `--include-subagents` only if those internals are desired |
 | History exists under another cwd spelling | The stored path and requested path are not equivalent | Run `--all-projects`, then retry with the printed path |
+| Date filter excludes unknown-time sessions | JSONL contained no valid internal timestamp | Inspect without a date filter if needed; never infer the date from mtime |

--- a/daymade-claude-code/local-conversation-history/scripts/_core/__init__.py
+++ b/daymade-claude-code/local-conversation-history/scripts/_core/__init__.py
@@ -8,8 +8,13 @@ every skill stays self-contained and installable on its own while sharing one
 implementation.
 
 Modules:
-    homes  — discover every Claude config home (main + per-model profiles).
-    parse  — pure parsing/formatting helpers (timestamps, and more over time).
+    homes    — discover every active Claude config home.
+    sources  — combine active homes with explicitly registered archives.
+    claude   — stream exact Claude session metadata and internal time ranges.
+    codex    — inspect Codex state databases and raw rollout stores.
+    parse    — timestamp, timezone, and workspace normalization helpers.
+    text     — semantic JSONL text/title extraction.
+    model    — shared provider result data structures.
 """
 
 from .homes import discover_claude_homes, home_label

--- a/daymade-claude-code/local-conversation-history/scripts/_core/claude.py
+++ b/daymade-claude-code/local-conversation-history/scripts/_core/claude.py
@@ -1,0 +1,72 @@
+"""Exact, streaming metadata scan for Claude Code JSONL sessions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from .parse import TimestampRange
+from .text import extract_text, first_meaningful_title, iter_jsonl
+
+
+@dataclass(frozen=True)
+class ClaudeSessionSummary:
+    session_id: str
+    cwd: str
+    title: str
+    created_at: Optional[float]
+    updated_at: Optional[float]
+    timestamp_count: int
+
+
+def scan_claude_session(path: Path, max_title_chars: int = 120) -> ClaudeSessionSummary:
+    """Scan every valid record and return internal time bounds plus title metadata.
+
+    File mtime is deliberately absent. Copying or migrating a transcript changes
+    mtime without changing when the conversation happened; the only trustworthy
+    conversation range is the minimum and maximum valid top-level ``timestamp``
+    found across the JSONL records themselves.
+    """
+    session_id = path.stem
+    cwd = ""
+    prompt_candidates: list[str] = []
+    title: Optional[str] = None
+    timestamps = TimestampRange()
+
+    for record in iter_jsonl(path):
+        timestamps.observe(record.get("timestamp"))
+        if isinstance(record.get("sessionId"), str) and record["sessionId"]:
+            session_id = record["sessionId"]
+        if not cwd and isinstance(record.get("cwd"), str):
+            cwd = record["cwd"]
+        if title is not None:
+            continue
+        if record.get("type") != "user" or record.get("isMeta") is True:
+            continue
+        message = record.get("message")
+        if isinstance(message, dict) and message.get("role") == "user":
+            text = extract_text(message.get("content"))
+        elif isinstance(message, str):
+            text = message
+        else:
+            text = ""
+        if not text:
+            continue
+        prompt_candidates.append(text)
+        candidate = first_meaningful_title(prompt_candidates, max_title_chars)
+        if candidate and len(candidate) >= 4:
+            title = candidate
+
+    if title is None:
+        title = first_meaningful_title(prompt_candidates, max_title_chars)
+    if not title:
+        title = f"(untitled: {session_id})"
+    return ClaudeSessionSummary(
+        session_id=session_id,
+        cwd=cwd,
+        title=title,
+        created_at=timestamps.earliest,
+        updated_at=timestamps.latest,
+        timestamp_count=timestamps.count,
+    )

--- a/daymade-claude-code/local-conversation-history/scripts/_core/codex.py
+++ b/daymade-claude-code/local-conversation-history/scripts/_core/codex.py
@@ -25,7 +25,7 @@ from typing import Any, Iterable, Optional
 from urllib.parse import quote
 
 from .model import CodexDatabase, Conversation, ProviderResult
-from .parse import parse_timestamp, workspace_matches
+from .parse import TimestampRange, parse_timestamp, workspace_matches
 from .text import extract_text, first_meaningful_title, is_automated_title, iter_jsonl
 
 CODEX_REQUIRED_COLUMNS = {"id", "cwd", "updated_at", "source", "archived"}
@@ -33,6 +33,7 @@ SESSION_ID_RE = re.compile(
     r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
     re.IGNORECASE,
 )
+STATE_DATABASE_RE = re.compile(r"^state_(\d+)\.sqlite$")
 
 
 def sqlite_uri(path: Path) -> str:
@@ -83,8 +84,18 @@ def discover_codex_database(home: Path, warnings: list[str]) -> Optional[CodexDa
         return None
     return max(
         compatible,
-        key=lambda item: (item.max_updated_ms, item.path.stat().st_mtime_ns),
+        key=lambda item: (
+            item.max_updated_ms,
+            _state_database_generation(item.path),
+            item.path.as_posix(),
+        ),
     )
+
+
+def _state_database_generation(path: Path) -> int:
+    """Return the numeric state database generation without consulting mtime."""
+    match = STATE_DATABASE_RE.fullmatch(path.name)
+    return int(match.group(1)) if match else -1
 
 
 def nested_key_exists(value: Any, wanted: str) -> bool:
@@ -261,6 +272,23 @@ def codex_prompt_from_rollout(path: Path, max_chars: int) -> Optional[str]:
     return short_candidate
 
 
+def codex_rollout_time_range(path: Path) -> TimestampRange:
+    """Compute exact internal bounds for a Codex rollout.
+
+    Current rollouts timestamp every top-level event. Older/minimal fixtures may
+    carry only ``session_meta.payload.timestamp``, so observe both. File mtime is
+    deliberately excluded because copying or migrating a rollout rewrites it.
+    """
+    timestamps = TimestampRange()
+    for record in iter_jsonl(path):
+        timestamps.observe(record.get("timestamp"))
+        if record.get("type") == "session_meta" and isinstance(
+            record.get("payload"), dict
+        ):
+            timestamps.observe(record["payload"].get("timestamp"))
+    return timestamps
+
+
 def collect_codex_from_rollouts(
     args: argparse.Namespace, home: Path, result: ProviderResult
 ) -> None:
@@ -301,25 +329,22 @@ def collect_codex_from_rollouts(
         if is_automated_title(title) and not args.include_automated:
             result.excluded_automated += 1
             continue
-        try:
-            updated_at = path.stat().st_mtime
-            timestamp_source = "file-mtime"
-        except OSError:
-            updated_at = parse_timestamp(meta.get("timestamp"))
-            timestamp_source = "session-meta"
+        timestamps = codex_rollout_time_range(path)
         result.conversations.append(
             Conversation(
                 provider="codex",
                 session_id=session_id,
                 title=title,
                 cwd=cwd,
-                updated_at=updated_at,
-                created_at=parse_timestamp(meta.get("timestamp")),
+                updated_at=timestamps.latest,
+                created_at=timestamps.earliest,
                 archived=archived,
                 kind="subagent" if subagent else "main",
                 path=str(path),
                 metadata_source="rollout-jsonl",
-                timestamp_source=timestamp_source,
+                timestamp_source=(
+                    "rollout-record-minmax" if timestamps.count else "unknown"
+                ),
             )
         )
 

--- a/daymade-claude-code/local-conversation-history/scripts/_core/model.py
+++ b/daymade-claude-code/local-conversation-history/scripts/_core/model.py
@@ -3,8 +3,8 @@
 `Conversation` / `ProviderResult` / `CodexDatabase` are used by both the Claude
 and Codex providers and by the renderers, so they live in the shared core (SSOT:
 `daymade-claude-code/_conversation_core/`, bundled into each skill's
-`scripts/_core/` by `sync_core.py`). Extracting them here lets a skill like
-`continue-codex-work` reuse the same model without re-declaring it.
+`scripts/_core/` by `sync_core.py`). This lets `continue-codex-work` and the
+inventory/search skills reuse the same model without re-declaring it.
 """
 
 from __future__ import annotations
@@ -29,6 +29,8 @@ class Conversation:
     path: str
     metadata_source: str
     timestamp_source: str
+    source_kind: str = ""
+    source_labels: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         data = asdict(self)

--- a/daymade-claude-code/local-conversation-history/scripts/_core/parse.py
+++ b/daymade-claude-code/local-conversation-history/scripts/_core/parse.py
@@ -1,19 +1,39 @@
 """Shared parsing / formatting helpers for the conversation-history skills.
 
-Pure, self-contained utilities that every skill re-implements otherwise. Bundled
-into each skill's ``scripts/_core/`` by ``sync_core.py`` (see homes.py for why
-bundling rather than importing a sibling). This is the parsing counterpart to
-``homes.py``; more helpers (text/title extraction, workspace matching, JSONL
-iteration) move here in later phases as they are de-duplicated from the skills.
+Pure, self-contained utilities that every skill would otherwise re-implement.
+Bundled into each skill's ``scripts/_core/`` by ``sync_core.py`` (see homes.py
+for why bundling is used instead of importing a sibling).
 """
 
 import os
 import re
 import sys
-from datetime import datetime
+from dataclasses import dataclass
+from datetime import date, datetime, time
 from typing import Any, Optional
 
 WINDOWS_DRIVE_RE = re.compile(r"^(?:[/\\]{2}\?[/\\])?[A-Za-z]:[/\\]")
+DATE_ONLY_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+@dataclass
+class TimestampRange:
+    """Minimum/maximum valid internal timestamp observed while streaming."""
+
+    earliest: Optional[float] = None
+    latest: Optional[float] = None
+    count: int = 0
+
+    def observe(self, value: Any) -> Optional[float]:
+        parsed = parse_timestamp(value)
+        if parsed is None:
+            return None
+        self.count += 1
+        if self.earliest is None or parsed < self.earliest:
+            self.earliest = parsed
+        if self.latest is None or parsed > self.latest:
+            self.latest = parsed
+        return parsed
 
 
 def parse_timestamp(value: Any) -> Optional[float]:
@@ -66,6 +86,61 @@ def format_timestamp(value: float) -> str:
 def iso_timestamp(value: float) -> str:
     """ISO-8601 local timestamp (seconds precision, with offset)."""
     return datetime.fromtimestamp(value).astimezone().isoformat(timespec="seconds")
+
+
+def parse_date_boundary(value: str, *, end: bool = False) -> float:
+    """Parse a date-only local boundary or a timezone-qualified ISO datetime.
+
+    Date-only input uses the machine's local timezone and covers the full day.
+    Datetime input must carry ``Z`` or an explicit UTC offset; accepting a naive
+    datetime would make a cross-machine history query change meaning silently.
+    """
+    text_value = value.strip()
+    if DATE_ONLY_RE.fullmatch(text_value):
+        parsed_date = date.fromisoformat(text_value)
+        wall_time = time.max if end else time.min
+        return datetime.combine(parsed_date, wall_time).astimezone().timestamp()
+    try:
+        parsed = datetime.fromisoformat(text_value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError(
+            f"invalid ISO date/time {value!r}; use YYYY-MM-DD or include a timezone offset"
+        ) from error
+    if parsed.tzinfo is None:
+        raise ValueError(
+            f"datetime {value!r} has no timezone; use Z or an explicit UTC offset"
+        )
+    return parsed.timestamp()
+
+
+def timestamp_in_window(
+    value: Optional[float],
+    from_timestamp: Optional[float],
+    to_timestamp: Optional[float],
+) -> bool:
+    if value is None:
+        return from_timestamp is None and to_timestamp is None
+    if from_timestamp is not None and value < from_timestamp:
+        return False
+    if to_timestamp is not None and value > to_timestamp:
+        return False
+    return True
+
+
+def range_overlaps_window(
+    earliest: Optional[float],
+    latest: Optional[float],
+    from_timestamp: Optional[float],
+    to_timestamp: Optional[float],
+) -> bool:
+    """Whether an internal session range overlaps an inclusive query window."""
+    if earliest is None or latest is None:
+        return from_timestamp is None and to_timestamp is None
+    if from_timestamp is not None and latest < from_timestamp:
+        return False
+    if to_timestamp is not None and earliest > to_timestamp:
+        return False
+    return True
 
 
 def looks_like_windows_path(value: str) -> bool:

--- a/daymade-claude-code/local-conversation-history/scripts/_core/sources.py
+++ b/daymade-claude-code/local-conversation-history/scripts/_core/sources.py
@@ -1,0 +1,201 @@
+"""Discover active and explicitly registered Claude conversation sources.
+
+Active Claude homes are auto-discovered by :mod:`homes`. Long-term archives are
+different: their location is user configuration, not a filename convention that
+the public skill should guess. A small manifest at
+``~/.claude/history-sources.json`` registers those archives explicitly.
+
+The manifest is intentionally fail-fast. A malformed file, duplicate archive, or
+missing required source is configuration damage, not a cue to silently fall back
+to the active homes and produce an incomplete history result.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Sequence, Union
+
+from .homes import discover_claude_homes, home_label
+
+
+MANIFEST_VERSION = 1
+SOURCE_LABEL_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+class HistorySourceConfigError(ValueError):
+    """Raised when an explicit history-source registry cannot be trusted."""
+
+
+@dataclass(frozen=True)
+class HistorySource:
+    """One Claude configuration root that contains a ``projects/`` directory."""
+
+    provider: str
+    kind: str
+    label: str
+    home: Path
+    required: bool = True
+
+    @property
+    def display_label(self) -> str:
+        return f"{self.kind}:{self.label}"
+
+
+def default_history_sources_path() -> Path:
+    """Return the per-user registry path without caching ``Path.home()``."""
+    return Path.home() / ".claude" / "history-sources.json"
+
+
+def _resolved_key(path: Path) -> str:
+    try:
+        return str(path.resolve())
+    except (OSError, RuntimeError):
+        return str(path.absolute())
+
+
+def _active_sources(
+    homes: Sequence[Union[str, Path]],
+) -> list[HistorySource]:
+    return [
+        HistorySource(
+            provider="claude",
+            kind="active",
+            label=home_label(home),
+            home=Path(home).expanduser(),
+            required=True,
+        )
+        for home in homes
+    ]
+
+
+def _read_manifest(path: Path) -> dict:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise HistorySourceConfigError(
+            f"Cannot read history source registry {path}: {error}"
+        ) from error
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise HistorySourceConfigError(
+            f"Invalid JSON in history source registry {path}: {error}"
+        ) from error
+    if not isinstance(payload, dict):
+        raise HistorySourceConfigError(
+            f"History source registry {path} must contain a JSON object"
+        )
+    if payload.get("version") != MANIFEST_VERSION:
+        raise HistorySourceConfigError(
+            f"History source registry {path} must use version {MANIFEST_VERSION}"
+        )
+    if not isinstance(payload.get("sources"), list):
+        raise HistorySourceConfigError(
+            f"History source registry {path} must contain a sources array"
+        )
+    return payload
+
+
+def _manifest_archive_sources(
+    path: Path,
+    active: Sequence[HistorySource],
+) -> tuple[list[HistorySource], list[str]]:
+    payload = _read_manifest(path)
+    warnings: list[str] = []
+    archives: list[HistorySource] = []
+    seen_paths = {_resolved_key(source.home) for source in active}
+    seen_labels: set[str] = set()
+
+    for index, entry in enumerate(payload["sources"]):
+        location = f"{path}: sources[{index}]"
+        if not isinstance(entry, dict):
+            raise HistorySourceConfigError(f"{location} must be an object")
+        provider = entry.get("provider")
+        kind = entry.get("kind")
+        label = entry.get("label")
+        home_value = entry.get("home")
+        required = entry.get("required", True)
+        if provider != "claude":
+            raise HistorySourceConfigError(
+                f"{location} has unsupported provider {provider!r}; only 'claude' is supported"
+            )
+        if kind != "archive":
+            raise HistorySourceConfigError(
+                f"{location} has unsupported kind {kind!r}; registered sources must be 'archive'"
+            )
+        if not isinstance(label, str) or not SOURCE_LABEL_RE.fullmatch(label):
+            raise HistorySourceConfigError(
+                f"{location}.label must use letters, numbers, dot, underscore, or hyphen"
+            )
+        if label in seen_labels:
+            raise HistorySourceConfigError(
+                f"Duplicate archive label {label!r} in history source registry {path}"
+            )
+        seen_labels.add(label)
+        if not isinstance(home_value, str) or not home_value.strip():
+            raise HistorySourceConfigError(f"{location}.home must be a non-empty string")
+        if not isinstance(required, bool):
+            raise HistorySourceConfigError(f"{location}.required must be true or false")
+
+        expanded = Path(os.path.expandvars(home_value)).expanduser()
+        home = expanded if expanded.is_absolute() else path.parent / expanded
+        key = _resolved_key(home)
+        if key in seen_paths:
+            raise HistorySourceConfigError(
+                f"Duplicate history source path in {path}: {home}"
+            )
+        seen_paths.add(key)
+        if not (home / "projects").is_dir():
+            message = f"Registered history source {label!r} has no projects/ directory: {home}"
+            if required:
+                raise HistorySourceConfigError(f"Required history source is unavailable. {message}")
+            warnings.append(message)
+            continue
+        archives.append(
+            HistorySource(
+                provider="claude",
+                kind="archive",
+                label=label,
+                home=home,
+                required=required,
+            )
+        )
+    return archives, warnings
+
+
+def discover_claude_sources(
+    *,
+    explicit_homes: Optional[
+        Union[str, Path, Sequence[Union[str, Path]]]
+    ] = None,
+    manifest_path: Optional[Union[str, Path]] = None,
+) -> tuple[list[HistorySource], list[str]]:
+    """Return Claude history sources plus non-fatal registry warnings.
+
+    ``explicit_homes`` is an exact scope: registered archives are intentionally
+    not added. With no explicit scope, active homes are auto-discovered and the
+    default registry is loaded when present. Passing ``manifest_path`` makes that
+    file itself required, so a typo cannot silently disable archive coverage.
+    """
+    if explicit_homes is not None:
+        return _active_sources(discover_claude_homes(explicit_homes)), []
+
+    active = _active_sources(discover_claude_homes())
+    explicit_manifest = manifest_path is not None
+    registry = (
+        Path(manifest_path).expanduser()
+        if explicit_manifest
+        else default_history_sources_path()
+    )
+    if not registry.is_file():
+        if explicit_manifest:
+            raise HistorySourceConfigError(
+                f"History source registry not found: {registry}"
+            )
+        return active, []
+    archives, warnings = _manifest_archive_sources(registry, active)
+    return active + archives, warnings

--- a/daymade-claude-code/local-conversation-history/scripts/_core/text.py
+++ b/daymade-claude-code/local-conversation-history/scripts/_core/text.py
@@ -4,14 +4,15 @@ These turn raw session content into a readable one-line title and iterate JSONL
 transcripts safely. Both the Claude and Codex providers use them, so they live in
 the shared core (SSOT: `daymade-claude-code/_conversation_core/`, bundled into
 each skill's `scripts/_core/` by `sync_core.py`). Keeping them here lets the Codex
-provider and a future `continue-codex-work` skill reuse one implementation instead
-of re-deriving title/noise heuristics that would drift apart.
+provider and `continue-codex-work` reuse one implementation instead of
+re-deriving title/noise heuristics that would drift apart.
 """
 
 from __future__ import annotations
 
 import json
 import re
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable, Iterator, Optional
 
@@ -41,6 +42,14 @@ ATTACHMENT_IMAGE_RE = re.compile(
 )
 FILE_SUFFIX_RE = re.compile(r"\.[A-Za-z0-9]{1,16}$")
 SLASH_COMMAND_RE = re.compile(r"^/[A-Za-z0-9_:-]+(?:[ \t].*)?$")
+
+
+@dataclass(frozen=True)
+class SearchSegment:
+    """One searchable text field with its semantic provenance."""
+
+    source: str
+    text: str
 
 
 def looks_like_attachment_prefix(value: str) -> bool:
@@ -109,6 +118,117 @@ def extract_text(content: Any) -> str:
         ):
             parts.append(item["text"])
     return " ".join(parts)
+
+
+def _flatten_search_strings(value: Any) -> Iterator[str]:
+    """Yield string values while excluding structural/signature metadata."""
+    if isinstance(value, str):
+        if value:
+            yield value
+        return
+    if isinstance(value, list):
+        for item in value:
+            yield from _flatten_search_strings(item)
+        return
+    if not isinstance(value, dict):
+        return
+    for key, child in value.items():
+        if key in {"type", "id", "tool_use_id", "signature"}:
+            continue
+        yield from _flatten_search_strings(child)
+
+
+def searchable_segments(record: dict[str, Any]) -> list[SearchSegment]:
+    """Extract user-visible/search-relevant fields from one Claude event.
+
+    Raw JSON serialization is intentionally not searched: keys, UUIDs, and
+    cryptographic thinking signatures create false positives. Instead this
+    covers message text, thinking text, tool inputs/results, queue content,
+    last-prompt/system summaries, and attachment payloads with a source label for
+    every segment.
+    """
+    segments: list[SearchSegment] = []
+
+    def add(source: str, value: Any) -> None:
+        for text_value in _flatten_search_strings(value):
+            segments.append(SearchSegment(source=source, text=text_value))
+
+    event_type = record.get("type")
+    message = record.get("message")
+    content: Any
+    if isinstance(message, dict):
+        content = message.get("content", [])
+    elif isinstance(message, str):
+        content = message
+    elif event_type in {"user", "assistant"} or record.get("role") in {
+        "user",
+        "assistant",
+    }:
+        content = record.get("content", [])
+    else:
+        content = []
+
+    if isinstance(content, str):
+        add("message", content)
+    elif isinstance(content, list):
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            block_type = block.get("type")
+            if block_type in {"text", "input_text"}:
+                add("message", block.get("text"))
+            elif block_type == "thinking":
+                add("thinking", block.get("thinking"))
+            elif block_type == "tool_use":
+                tool_name = block.get("name")
+                source = (
+                    f"tool_input:{tool_name}"
+                    if isinstance(tool_name, str) and tool_name
+                    else "tool_input"
+                )
+                add(source, block.get("input"))
+            elif block_type == "tool_result":
+                add("tool_result", block.get("content"))
+            else:
+                # Preserve textual payloads of future/older block types without
+                # indexing structural keys or binary image data.
+                add("message", {key: block.get(key) for key in ("text", "content")})
+
+    if event_type == "queue-operation":
+        add("queue-operation", record.get("content"))
+    elif event_type == "attachment":
+        attachment = record.get("attachment")
+        if isinstance(attachment, dict):
+            add(
+                "attachment",
+                {
+                    key: attachment.get(key)
+                    for key in (
+                        "content",
+                        "prompt",
+                        "path",
+                        "displayPath",
+                        "command",
+                        "stdout",
+                        "stderr",
+                    )
+                },
+            )
+    elif event_type == "last-prompt":
+        add("last-prompt", record.get("lastPrompt"))
+    elif event_type == "system":
+        add("system", record.get("content"))
+    elif event_type == "summary":
+        add("summary", {"content": record.get("content"), "summary": record.get("summary")})
+    elif event_type == "custom-title":
+        add(
+            "custom-title",
+            {"title": record.get("title"), "customTitle": record.get("customTitle")},
+        )
+
+    # Some event variants mirror the same payload in more than one compatible
+    # field. Count each semantic source/text pair once per record.
+    return list(dict.fromkeys(segments))
 
 
 def is_noise_text(text: str) -> bool:

--- a/daymade-claude-code/local-conversation-history/scripts/list_local_history.py
+++ b/daymade-claude-code/local-conversation-history/scripts/list_local_history.py
@@ -17,17 +17,22 @@ from typing import Optional
 # scripts/_core/ by sync_core.py. Make this script's own dir importable
 # regardless of how it is invoked, then import.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _core.homes import discover_claude_homes, home_label  # noqa: E402
+from _core.claude import scan_claude_session  # noqa: E402
+from _core.homes import home_label  # noqa: E402
 from _core.parse import (  # noqa: E402
     format_timestamp,
     iso_timestamp,
-    parse_timestamp,
+    parse_date_boundary,
+    range_overlaps_window,
     workspace_matches,
 )
 from _core.model import Conversation, ProviderResult  # noqa: E402
+from _core.sources import (  # noqa: E402
+    HistorySource,
+    HistorySourceConfigError,
+    discover_claude_sources,
+)
 from _core.text import (  # noqa: E402
-    extract_text,
-    first_meaningful_title,
     is_automated_title,
     iter_jsonl,
 )
@@ -68,63 +73,39 @@ def claude_session_files(project_dir: Path, include_subagents: bool) -> list[Pat
     return files
 
 
-def parse_claude_session(path: Path, max_chars: int) -> Conversation:
-    session_id = path.stem
-    cwd = ""
-    created_at: Optional[float] = None
-    prompt_candidates: list[str] = []
-    for record in iter_jsonl(path, bounded=True):
-        if isinstance(record.get("sessionId"), str):
-            session_id = record["sessionId"]
-        if not cwd and isinstance(record.get("cwd"), str):
-            cwd = record["cwd"]
-        if created_at is None:
-            created_at = parse_timestamp(record.get("timestamp"))
-        if record.get("type") != "user" or record.get("isMeta") is True:
-            continue
-        message = record.get("message")
-        if not isinstance(message, dict) or message.get("role") != "user":
-            continue
-        text = extract_text(message.get("content"))
-        if text:
-            prompt_candidates.append(text)
-            title = first_meaningful_title(prompt_candidates, max_chars)
-            if title and len(title) >= 4:
-                break
-    title = first_meaningful_title(prompt_candidates, max_chars)
-    if not title:
-        title = f"(untitled: {session_id})"
-    try:
-        updated_at = path.stat().st_mtime
-        timestamp_source = "file-mtime"
-    except OSError:
-        updated_at = created_at
-        timestamp_source = "session-record"
+def parse_claude_session(
+    path: Path, max_chars: int, source: HistorySource
+) -> Conversation:
+    summary = scan_claude_session(path, max_chars)
     return Conversation(
         provider="claude",
-        session_id=session_id,
-        title=title,
-        cwd=cwd,
-        updated_at=updated_at,
-        created_at=created_at,
+        session_id=summary.session_id,
+        title=summary.title,
+        cwd=summary.cwd,
+        updated_at=summary.updated_at,
+        created_at=summary.created_at,
         archived=False,
         kind="subagent" if path.name.startswith("agent-") else "main",
         path=str(path),
         metadata_source="session-jsonl",
-        timestamp_source=timestamp_source,
+        timestamp_source=(
+            "session-record-minmax" if summary.timestamp_count else "unknown"
+        ),
+        source_kind=source.kind,
+        source_labels=[source.display_label],
     )
 
 
 def peek_claude_project_cwd(project_dir: Path) -> str:
     try:
         files = sorted(
-            (path for path in project_dir.glob("*.jsonl") if not path.name.startswith("agent-")),
-            key=lambda path: path.stat().st_mtime,
-            reverse=True,
+            path
+            for path in project_dir.glob("*.jsonl")
+            if not path.name.startswith("agent-")
         )
     except OSError:
         return ""
-    for path in files[:3]:
+    for path in files:
         for record in iter_jsonl(path, bounded=True):
             if isinstance(record.get("cwd"), str) and record["cwd"]:
                 return record["cwd"]
@@ -176,9 +157,10 @@ def discover_claude_project_dirs(
     return matched
 
 
-def collect_claude(args: argparse.Namespace, home: Path) -> ProviderResult:
+def collect_claude(args: argparse.Namespace, source: HistorySource) -> ProviderResult:
+    home = source.home
     result = ProviderResult(
-        provider="claude", backend="session-jsonl", home=str(home)
+        provider="claude", backend="session-jsonl", home=source.display_label
     )
     project_dirs = discover_claude_project_dirs(
         home / "projects",
@@ -196,7 +178,7 @@ def collect_claude(args: argparse.Namespace, home: Path) -> ProviderResult:
             except OSError:
                 pass
         for path in claude_session_files(project_dir, args.include_subagents):
-            conversation = parse_claude_session(path, args.max_title_chars)
+            conversation = parse_claude_session(path, args.max_title_chars, source)
             if not args.all_projects and conversation.cwd and not workspace_matches(
                 conversation.cwd, args.cwd, args.recursive
             ):
@@ -240,6 +222,10 @@ def conversation_flags(item: Conversation, language: str) -> str:
     return ", ".join(values) if values else "—"
 
 
+def conversation_source(item: Conversation) -> str:
+    return ", ".join(item.source_labels) if item.source_labels else "—"
+
+
 def render_provider_markdown(
     result: ProviderResult, args: argparse.Namespace, language: str
 ) -> list[str]:
@@ -254,6 +240,7 @@ def render_provider_markdown(
         )
         updated_label, title_label = "最近更新", "主题"
         id_label, flags_label, project_label = "会话 ID", "标记", "项目"
+        source_label = "来源"
     else:
         lines = [f"## {provider_name} — {result.total} conversations", ""]
         lines.append(
@@ -264,11 +251,14 @@ def render_provider_markdown(
         )
         updated_label, title_label = "Updated", "Title"
         id_label, flags_label, project_label = "Session ID", "Flags", "Project"
+        source_label = "Source"
     lines.append("")
     include_project = args.all_projects or args.recursive
     headers = [updated_label, title_label, id_label]
     if include_project:
         headers.append(project_label)
+    if result.provider == "claude":
+        headers.append(source_label)
     headers.append(flags_label)
     lines.append("| " + " | ".join(headers) + " |")
     lines.append("|" + "---|" * len(headers))
@@ -281,11 +271,16 @@ def render_provider_markdown(
         ]
         if include_project:
             row.append(f"`{markdown_escape(display_project(item.cwd))}`")
+        if result.provider == "claude":
+            row.append(markdown_escape(conversation_source(item)))
         row.append(conversation_flags(item, language))
         lines.append("| " + " | ".join(row) + " |")
     if not shown:
         empty = "未找到匹配的对话。" if language == "zh" else "No matching conversations found."
-        lines.append(f"| — | {empty} | — |" + (" — |" if include_project else "") + " — |")
+        extra_columns = int(include_project) + int(result.provider == "claude")
+        lines.append(
+            f"| — | {empty} | — |" + (" — |" * extra_columns) + " — |"
+        )
     if result.warnings:
         lines.append("")
         heading = "诊断" if language == "zh" else "Diagnostics"
@@ -379,7 +374,23 @@ def build_parser() -> argparse.ArgumentParser:
         "--language", choices=("auto", "en", "zh"), default="auto"
     )
     parser.add_argument("--claude-home", help="Override the Claude configuration root")
+    parser.add_argument(
+        "--history-sources",
+        metavar="FILE",
+        help=(
+            "History source registry (default: ~/.claude/history-sources.json "
+            "when present). Incompatible with --claude-home."
+        ),
+    )
     parser.add_argument("--codex-home", help="Override the Codex configuration root")
+    parser.add_argument(
+        "--from-date",
+        help="Inclusive start: YYYY-MM-DD (local day) or timezone-qualified ISO datetime",
+    )
+    parser.add_argument(
+        "--to-date",
+        help="Inclusive end: YYYY-MM-DD (local day) or timezone-qualified ISO datetime",
+    )
     parser.add_argument(
         "--max-title-chars", type=int, default=120, help="Maximum title length"
     )
@@ -389,26 +400,68 @@ def build_parser() -> argparse.ArgumentParser:
 def merge_claude_results(results: list[ProviderResult]) -> ProviderResult:
     """Merge per-home Claude results into one, de-duplicating by session id.
 
-    A conversation shared across profile homes (the profile dirs link back to
-    one physical file) appears once; the copy with the newest ``updated_at``
-    wins. Exclusion counts and warnings are summed/combined, and ``home`` becomes
-    a comma-joined list of the profile labels the sessions came from.
+    A conversation shared across active homes and archives appears once. The
+    title/path come from the copy with the greatest internal maximum timestamp;
+    a tie prefers the active copy. The displayed session range is the union of
+    every copy, and every matching source label remains attached as provenance.
     """
     real = [r for r in results if r is not None]
     if not real:
         return ProviderResult(provider="claude", backend="session-jsonl", home="")
-    if len(real) == 1:
-        return real[0]
     by_id: dict[str, Conversation] = {}
     for r in real:
         for conv in r.conversations:
             existing = by_id.get(conv.session_id)
-            if existing is None or (conv.updated_at or 0) > (existing.updated_at or 0):
+            if existing is None:
                 by_id[conv.session_id] = conv
+                continue
+            labels = list(dict.fromkeys(existing.source_labels + conv.source_labels))
+            existing_time = (
+                existing.updated_at
+                if existing.updated_at is not None
+                else float("-inf")
+            )
+            candidate_time = (
+                conv.updated_at if conv.updated_at is not None else float("-inf")
+            )
+            candidate_wins = candidate_time > existing_time or (
+                candidate_time == existing_time
+                and conv.source_kind == "active"
+                and existing.source_kind != "active"
+            )
+            created_values = [
+                value
+                for value in (existing.created_at, conv.created_at)
+                if value is not None
+            ]
+            updated_values = [
+                value
+                for value in (existing.updated_at, conv.updated_at)
+                if value is not None
+            ]
+            union_created = min(created_values) if created_values else None
+            union_updated = max(updated_values) if updated_values else None
+            union_timestamp_source = (
+                "session-record-minmax"
+                if "session-record-minmax"
+                in {existing.timestamp_source, conv.timestamp_source}
+                else "unknown"
+            )
+            if candidate_wins:
+                conv.source_labels = labels
+                conv.created_at = union_created
+                conv.updated_at = union_updated
+                conv.timestamp_source = union_timestamp_source
+                by_id[conv.session_id] = conv
+            else:
+                existing.source_labels = labels
+                existing.created_at = union_created
+                existing.updated_at = union_updated
+                existing.timestamp_source = union_timestamp_source
     return ProviderResult(
         provider=real[0].provider,
         backend=real[0].backend,
-        home=", ".join(home_label(r.home) for r in real if r.home),
+        home=", ".join(dict.fromkeys(r.home for r in real if r.home)),
         conversations=sorted(
             by_id.values(), key=lambda c: (c.updated_at or 0), reverse=True
         ),
@@ -417,6 +470,35 @@ def merge_claude_results(results: list[ProviderResult]) -> ProviderResult:
         excluded_automated=sum(r.excluded_automated for r in real),
         warnings=[w for r in real for w in r.warnings],
     )
+
+
+def apply_date_filter(
+    result: ProviderResult,
+    from_timestamp: Optional[float],
+    to_timestamp: Optional[float],
+) -> ProviderResult:
+    if from_timestamp is None and to_timestamp is None:
+        return result
+    kept: list[Conversation] = []
+    unknown = 0
+    for conversation in result.conversations:
+        if conversation.created_at is None or conversation.updated_at is None:
+            unknown += 1
+            continue
+        if range_overlaps_window(
+            conversation.created_at,
+            conversation.updated_at,
+            from_timestamp,
+            to_timestamp,
+        ):
+            kept.append(conversation)
+    result.conversations = kept
+    if unknown:
+        result.warnings.append(
+            f"Excluded {unknown} conversation(s) without an internal timestamp "
+            "because a date filter is active. File mtime was not used as a fallback."
+        )
+    return result
 
 
 def main(argv: Optional[list[str]] = None) -> int:
@@ -429,32 +511,72 @@ def main(argv: Optional[list[str]] = None) -> int:
         parser.error("--max-title-chars must be at least 20")
     if args.all_projects and args.cwd:
         parser.error("--cwd cannot be combined with --all-projects")
+    if args.claude_home and args.history_sources:
+        parser.error("--claude-home cannot be combined with --history-sources")
     if not args.all_projects:
         args.cwd = args.cwd or os.getcwd()
-    claude_home = Path(
-        args.claude_home
-        or os.environ.get("CLAUDE_CONFIG_DIR")
-        or (Path.home() / ".claude")
-    ).expanduser()
+    try:
+        from_timestamp = (
+            parse_date_boundary(args.from_date) if args.from_date else None
+        )
+        to_timestamp = (
+            parse_date_boundary(args.to_date, end=True) if args.to_date else None
+        )
+    except ValueError as error:
+        parser.error(str(error))
+    if (
+        from_timestamp is not None
+        and to_timestamp is not None
+        and from_timestamp > to_timestamp
+    ):
+        parser.error("--from-date must not be later than --to-date")
     codex_home = Path(
         args.codex_home or os.environ.get("CODEX_HOME") or (Path.home() / ".codex")
     ).expanduser()
 
     results: list[ProviderResult] = []
     if args.source in {"all", "claude"}:
-        # An explicit --claude-home / CLAUDE_CONFIG_DIR pins a single home (the
-        # test fixtures rely on this). With neither set, search every config
-        # home so a conversation held under a per-model profile is not missed,
-        # then merge the per-home results into one de-duplicated list.
-        if args.claude_home or os.environ.get("CLAUDE_CONFIG_DIR"):
-            claude_homes = [claude_home]
-        else:
-            claude_homes = discover_claude_homes() or [claude_home]
+        try:
+            if args.claude_home:
+                explicit_home = Path(args.claude_home).expanduser()
+                claude_sources = [
+                    HistorySource(
+                        provider="claude",
+                        kind="active",
+                        label=home_label(explicit_home),
+                        home=explicit_home,
+                    )
+                ]
+                source_warnings: list[str] = []
+            else:
+                claude_sources, source_warnings = discover_claude_sources(
+                    manifest_path=args.history_sources
+                )
+                if not claude_sources:
+                    default_home = Path.home() / ".claude"
+                    claude_sources = [
+                        HistorySource(
+                            provider="claude",
+                            kind="active",
+                            label="main",
+                            home=default_home,
+                        )
+                    ]
+        except HistorySourceConfigError as error:
+            parser.error(str(error))
+        claude_result = merge_claude_results(
+            [collect_claude(args, source) for source in claude_sources]
+        )
+        claude_result.warnings = source_warnings + claude_result.warnings
         results.append(
-            merge_claude_results([collect_claude(args, h) for h in claude_homes])
+            apply_date_filter(claude_result, from_timestamp, to_timestamp)
         )
     if args.source in {"all", "codex"}:
-        results.append(collect_codex(args, codex_home))
+        results.append(
+            apply_date_filter(
+                collect_codex(args, codex_home), from_timestamp, to_timestamp
+            )
+        )
 
     output = render_json(results, args) if args.format == "json" else render_markdown(results, args)
     sys.stdout.write(output)

--- a/daymade-claude-code/local-conversation-history/tests/test_list_local_history.py
+++ b/daymade-claude-code/local-conversation-history/tests/test_list_local_history.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from datetime import datetime
 from pathlib import Path
 
 
@@ -97,14 +98,44 @@ class LocalConversationHistoryTests(unittest.TestCase):
     def tearDown(self) -> None:
         self.temp_dir.cleanup()
 
-    def run_cli(self, *arguments: str) -> subprocess.CompletedProcess[str]:
+    def run_cli(
+        self, *arguments: str, env: dict[str, str] | None = None
+    ) -> subprocess.CompletedProcess[str]:
+        process_env = os.environ.copy()
+        if env:
+            process_env.update(env)
         return subprocess.run(
             [sys.executable, str(SCRIPT), *arguments],
             text=True,
             encoding="utf-8",
             capture_output=True,
             check=True,
+            env=process_env,
         )
+
+    def write_history_sources(
+        self, config_home: Path, archive_home: Path, *, required: bool = True
+    ) -> Path:
+        manifest = config_home / "history-sources.json"
+        manifest.parent.mkdir(parents=True, exist_ok=True)
+        manifest.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "sources": [
+                        {
+                            "provider": "claude",
+                            "kind": "archive",
+                            "label": "full-backup",
+                            "home": str(archive_home),
+                            "required": required,
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        return manifest
 
     def seed_claude(self) -> None:
         project_dir = claude_project_dir(self.claude_home, self.workspace)
@@ -492,6 +523,7 @@ class LocalConversationHistoryTests(unittest.TestCase):
             [
                 "not-json",
                 {
+                    "timestamp": "2026-01-15T10:00:00Z",
                     "type": "session_meta",
                     "payload": {
                         "id": session_id,
@@ -501,6 +533,7 @@ class LocalConversationHistoryTests(unittest.TestCase):
                     },
                 },
                 {
+                    "timestamp": "2026-01-15T12:30:00Z",
                     "type": "response_item",
                     "payload": {
                         "type": "message",
@@ -512,6 +545,8 @@ class LocalConversationHistoryTests(unittest.TestCase):
                 },
             ],
         )
+        # Migration/copy time must not become conversation time.
+        os.utime(rollout, (1, 1))
         archived_session_id = "abababab-abab-4bab-8bab-abababababab"
         write_jsonl(
             self.codex_home
@@ -550,7 +585,17 @@ class LocalConversationHistoryTests(unittest.TestCase):
         self.assertEqual(payload["backend"], "rollout-jsonl")
         self.assertEqual(payload["total"], 1)
         self.assertEqual(payload["excluded"]["archived"], 1)
-        self.assertEqual(payload["conversations"][0]["title"], "Fallback conversation")
+        conversation = payload["conversations"][0]
+        self.assertEqual(conversation["title"], "Fallback conversation")
+        self.assertEqual(conversation["timestamp_source"], "rollout-record-minmax")
+        self.assertEqual(
+            datetime.fromisoformat(conversation["created_at"]).timestamp(),
+            datetime.fromisoformat("2026-01-15T10:00:00+00:00").timestamp(),
+        )
+        self.assertEqual(
+            datetime.fromisoformat(conversation["updated_at"]).timestamp(),
+            datetime.fromisoformat("2026-01-15T12:30:00+00:00").timestamp(),
+        )
 
     def test_codex_unknown_database_schema_reports_visible_fallback(self) -> None:
         self.codex_home.mkdir(parents=True)
@@ -718,6 +763,260 @@ class LocalConversationHistoryTests(unittest.TestCase):
         self.assertTrue(
             any("without a session ID" in item for item in provider["warnings"])
         )
+
+    def test_registered_archive_uses_internal_range_and_deduplicates(self) -> None:
+        user_home = self.root / "user-home"
+        active_home = user_home / ".claude"
+        archive_home = self.root / "conversation-archive"
+        active_project = claude_project_dir(active_home, self.workspace)
+        archive_project = claude_project_dir(archive_home, self.workspace)
+        duplicate_id = "10101010-1010-4010-8010-101010101010"
+        archive_only_id = "20202020-2020-4020-8020-202020202020"
+        active_only_id = "30303030-3030-4030-8030-303030303030"
+
+        write_jsonl(
+            active_project / f"{duplicate_id}.jsonl",
+            [
+                claude_user_record(
+                    duplicate_id,
+                    self.workspace,
+                    "Active copy wins the tie",
+                    "2026-03-05T08:00:00Z",
+                ),
+                {
+                    "type": "assistant",
+                    "sessionId": duplicate_id,
+                    "cwd": str(self.workspace),
+                    "timestamp": "2026-03-06T09:30:00Z",
+                    "message": {"role": "assistant", "content": "done"},
+                },
+            ],
+        )
+        write_jsonl(
+            archive_project / f"{duplicate_id}.jsonl",
+            [
+                claude_user_record(
+                    duplicate_id,
+                    self.workspace,
+                    "Older archive copy",
+                    "2026-03-04T08:00:00Z",
+                )
+            ],
+        )
+        write_jsonl(
+            archive_project / f"{archive_only_id}.jsonl",
+            [
+                claude_user_record(
+                    archive_only_id,
+                    self.workspace,
+                    "Archive-only April conversation",
+                    "2026-04-20T10:00:00Z",
+                )
+            ],
+        )
+        write_jsonl(
+            active_project / f"{active_only_id}.jsonl",
+            [
+                claude_user_record(
+                    active_only_id,
+                    self.workspace,
+                    "Active March conversation",
+                    "2026-03-20T10:00:00Z",
+                )
+            ],
+        )
+
+        # Deliberately make mtimes contradict the internal chronology. A migrated
+        # archive can have a fresh mtime even when its conversation is older.
+        os.utime(archive_project / f"{archive_only_id}.jsonl", (1, 1))
+        os.utime(
+            active_project / f"{active_only_id}.jsonl",
+            (2_000_000_000, 2_000_000_000),
+        )
+        self.write_history_sources(active_home, archive_home)
+
+        completed = self.run_cli(
+            "--cwd",
+            str(self.workspace),
+            "--source",
+            "claude",
+            "--format",
+            "json",
+            env={"HOME": str(user_home), "CLAUDE_CONFIG_DIR": str(active_home)},
+        )
+        provider = json.loads(completed.stdout)["providers"]["claude"]
+        conversations = provider["conversations"]
+        self.assertEqual(
+            [item["session_id"] for item in conversations],
+            [archive_only_id, active_only_id, duplicate_id],
+        )
+        duplicate = next(
+            item for item in conversations if item["session_id"] == duplicate_id
+        )
+        self.assertEqual(duplicate["title"], "Active copy wins the tie")
+        self.assertEqual(
+            datetime.fromisoformat(duplicate["created_at"]).timestamp(),
+            datetime.fromisoformat("2026-03-04T08:00:00+00:00").timestamp(),
+        )
+        self.assertEqual(
+            datetime.fromisoformat(duplicate["updated_at"]).timestamp(),
+            datetime.fromisoformat("2026-03-06T09:30:00+00:00").timestamp(),
+        )
+        self.assertEqual(duplicate["timestamp_source"], "session-record-minmax")
+        self.assertEqual(
+            duplicate["source_labels"],
+            ["active:main", "archive:full-backup"],
+        )
+        archive_only = next(
+            item for item in conversations if item["session_id"] == archive_only_id
+        )
+        self.assertEqual(archive_only["source_kind"], "archive")
+        self.assertEqual(archive_only["source_labels"], ["archive:full-backup"])
+
+    def test_date_filter_uses_session_overlap_and_excludes_unknown_time(self) -> None:
+        project_dir = claude_project_dir(self.claude_home, self.workspace)
+        spanning_id = "40404040-4040-4040-8040-404040404040"
+        outside_id = "50505050-5050-4050-8050-505050505050"
+        unknown_id = "60606060-6060-4060-8060-606060606060"
+        write_jsonl(
+            project_dir / f"{spanning_id}.jsonl",
+            [
+                claude_user_record(
+                    spanning_id,
+                    self.workspace,
+                    "Conversation spanning the boundary",
+                    "2026-03-31T10:00:00Z",
+                ),
+                {
+                    "type": "assistant",
+                    "sessionId": spanning_id,
+                    "cwd": str(self.workspace),
+                    "timestamp": "2026-04-01T00:01:00Z",
+                    "message": {"role": "assistant", "content": "done"},
+                },
+            ],
+        )
+        write_jsonl(
+            project_dir / f"{outside_id}.jsonl",
+            [
+                claude_user_record(
+                    outside_id,
+                    self.workspace,
+                    "Outside the requested window",
+                    "2026-05-01T00:00:00Z",
+                )
+            ],
+        )
+        write_jsonl(
+            project_dir / f"{unknown_id}.jsonl",
+            [
+                {
+                    "type": "user",
+                    "sessionId": unknown_id,
+                    "cwd": str(self.workspace),
+                    "message": {"role": "user", "content": "Unknown time"},
+                }
+            ],
+        )
+        completed = self.run_cli(
+            "--cwd",
+            str(self.workspace),
+            "--source",
+            "claude",
+            "--claude-home",
+            str(self.claude_home),
+            "--from-date",
+            "2026-03-01",
+            "--to-date",
+            "2026-03-31",
+            "--format",
+            "json",
+        )
+        provider = json.loads(completed.stdout)["providers"]["claude"]
+        self.assertEqual(
+            [item["session_id"] for item in provider["conversations"]],
+            [spanning_id],
+        )
+        self.assertTrue(
+            any(
+                "without an internal timestamp" in warning
+                for warning in provider["warnings"]
+            )
+        )
+
+    def test_explicit_claude_home_does_not_silently_add_registered_archives(self) -> None:
+        user_home = self.root / "user-home"
+        active_home = user_home / ".claude"
+        archive_home = self.root / "conversation-archive"
+        active_project = claude_project_dir(active_home, self.workspace)
+        archive_project = claude_project_dir(archive_home, self.workspace)
+        active_id = "70707070-7070-4070-8070-707070707070"
+        archive_id = "80808080-8080-4080-8080-808080808080"
+        write_jsonl(
+            active_project / f"{active_id}.jsonl",
+            [
+                claude_user_record(
+                    active_id,
+                    self.workspace,
+                    "Explicit active home",
+                    "2026-04-01T00:00:00Z",
+                )
+            ],
+        )
+        write_jsonl(
+            archive_project / f"{archive_id}.jsonl",
+            [
+                claude_user_record(
+                    archive_id,
+                    self.workspace,
+                    "Must stay outside explicit scope",
+                    "2026-04-02T00:00:00Z",
+                )
+            ],
+        )
+        self.write_history_sources(active_home, archive_home)
+        completed = self.run_cli(
+            "--cwd",
+            str(self.workspace),
+            "--source",
+            "claude",
+            "--claude-home",
+            str(active_home),
+            "--format",
+            "json",
+            env={"HOME": str(user_home)},
+        )
+        conversations = json.loads(completed.stdout)["providers"]["claude"][
+            "conversations"
+        ]
+        self.assertEqual([item["session_id"] for item in conversations], [active_id])
+
+    def test_missing_required_registered_archive_fails_loudly(self) -> None:
+        user_home = self.root / "user-home"
+        active_home = user_home / ".claude"
+        claude_project_dir(active_home, self.workspace)
+        self.write_history_sources(
+            active_home, self.root / "missing-archive", required=True
+        )
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--cwd",
+                str(self.workspace),
+                "--source",
+                "claude",
+                "--format",
+                "json",
+            ],
+            text=True,
+            encoding="utf-8",
+            capture_output=True,
+            check=False,
+            env={**os.environ, "HOME": str(user_home)},
+        )
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("required history source", completed.stderr.lower())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

**History sources become one explicit set** — auto-discovered active homes plus every archive registered in `~/.claude/history-sources.json`; required archives fail closed instead of allowing a false whole-history absence claim. **All Claude/Codex inventory, ranges, and date filters use internal record timestamps, never file mtime.**

## Changes

- **`_conversation_core`**: new `sources`/`claude` modules; Codex rollout internal time ranges; state-DB ties broken by numeric generation (not mtime)
- **`local-conversation-history`**: archive sources, session-id dedup with provenance, internal created/updated for both providers
- **`claude-code-history-files-finder`**: union search across every physical copy of a session; structured event fields (message/thinking/tool/queue/attachment/summary); **new `--all-projects` sweep** (wrong-project-guess false negatives), **`--codex` rollout search** (Codex is a separate store the Claude registry never covers; event_msg mirrors counted once, project filter by rollout cwd), **`--exclude-session`** (the current session always matches the phrase you just typed), zero-match output now suggests the widening not yet applied; Codex rollout format documented in references
- tests/evals/README/CLAUDE.md/CHANGELOG synced; marketplace v1.15.0

## Verification

- finder: 11/11 unittest OK (5 pre-existing + 6 new for the new flags)
- local-conversation-history: 12/12 unittest OK
- `sync_core.py check`: all 4 bundles in sync with SSOT
- Real-world regression: a phrase known to exist only in Codex history is found by one command (`search --all-projects --codex`) across 3647 Claude sessions + 4267 rollouts; previously required ad-hoc grep and was almost declared absent
- skill-creator regression audit: snapshot → compare (7 candidates, all classified) → verify passed
- quick_validate + security_scan passed (marker re-attested)

🤖 Generated with [Claude Code](https://claude.com/claude-code)