### PR TITLE
feat(frontend-visual-qa): v1.5.0 media evidence hardening

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1021,7 +1021,7 @@
       "description": "Audits already-rendered web, landing-page, HTML deck/slide, browser tool/game, dashboard/admin, design-system, and desktop UIs with real-browser or native-app journeys, inspected screenshots, DOM geometry, responsive or projection viewports, and a Playwright sweep. Use after implementation to find typography, wrapping, overlap, overflow, responsive, route, authorization-state, overlay, map, transient-state, data-visualization, runtime-label, browser-output, file-dialog, PDF/print, or Electron-shell defects. Not for greenfield UI design, design-system extraction, general QA-program setup, or nonvisual debugging.",
       "source": "./frontend-visual-qa",
       "strict": false,
-      "version": "1.4.0",
+      "version": "1.5.0",
       "category": "design",
       "keywords": [
         "frontend",

--- a/frontend-visual-qa/.security-scan-passed
+++ b/frontend-visual-qa/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-07-17T07:17:42.433774+00:00
+Scanned at: 2026-07-17T07:55:45.526583+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 627f499c9f19ea5cb89a4023f921ba5d2fbb4b78b28df9f954b0c713327dfa64
+Content hash: a9b296a0abf4819389ff83db7043ebadf0756a03673dedc0df4d5bb5e9f4cdb1

--- a/frontend-visual-qa/SKILL.md
+++ b/frontend-visual-qa/SKILL.md
@@ -171,6 +171,13 @@ load
 before filing any login/network finding — those failures are usually the
 driving harness or the environment impersonating a product defect.
 
+After authentication, do not drive from remembered sidebar labels or assume the
+target navigation is already mounted. Record the final URL, a short visible body
+excerpt, and the currently available links/buttons; then follow the canonical
+entry the rendered landing page actually exposes. If an expected locator is
+absent, treat navigation-contract or harness drift as the leading diagnosis
+until the target route/state is independently proven.
+
 ### 4. Capture And Inspect Rendered Evidence
 
 Capture the whole visible composition before zooming into a local defect. Then
@@ -219,6 +226,13 @@ the default responsive matrix:
     node <skill-root>/scripts/visual_layout_audit.mjs \
       --file deck.html --page-type deck --viewport 1920x1080 \
       --screenshot-sections
+
+For a long page whose evidence depends on below-the-fold covers or thumbnails,
+add --scroll-visible-media. It visits rendered media rows before capture so lazy
+loading can start, while excluding CSS-hidden responsive alternatives. Without
+that flag, offscreen lazy media is reported as deferred coverage rather than a
+broken asset. In either mode, inspect the screenshots: “not requested,” “still
+loading,” and “request completed but undecodable” are different states.
 
 Use repeated --forbid patterns only for project-specific stale names or rendered
 terms that the current product contract explicitly prohibits. Do not encode
@@ -339,15 +353,15 @@ check the available agent tools can perform.
 
 ## Bundled Resources
 
-- scripts/visual_layout_audit.mjs — Playwright-powered mechanical viewport and
-  layout sweep with screenshots and JSON evidence.
+- scripts/visual_layout_audit.mjs — Playwright-powered mechanical viewport,
+  layout, and media-state sweep with screenshots and JSON evidence.
 - references/history-derived-checklist.md — core visual/responsive defect
   catalog plus standards-backed checks.
 - references/journey-and-page-contracts.md — state, route, overlay,
   browser-output, native-shell, and page-type contracts.
-- references/auth-session-and-environment-traps.md — authenticated-SPA login
-  driving traps and environment hijack diagnostics (proxy, CSP entry point,
-  server-log triangulation).
+- references/auth-session-and-environment-traps.md — authenticated-SPA login and
+  post-login navigation driving traps plus environment hijack diagnostics
+  (proxy, CSP entry point, server-log triangulation).
 - references/data_viz_tier_and_token_audit.md — conditional data-viz,
   reference-tier, token, and palette audit.
 - evals/evals.json and evals/trigger-evals.json — behavior and routing

--- a/frontend-visual-qa/evals/evals.json
+++ b/frontend-visual-qa/evals/evals.json
@@ -176,6 +176,32 @@
         "Before closing, re-walks the path as a tired user and identifies likely misunderstanding, blocked recovery, internal language/manual burden, and the regression guard needed"
       ],
       "files": []
+    },
+    {
+      "id": 14,
+      "name": "post-login-navigation-contract-drift",
+      "prompt": "Audit an authenticated admin workspace. Login succeeds, but the remembered sidebar label is absent and the automation times out. The landing page exposes a differently named visible entry that may lead to the target. Decide whether this is a product defect or a stale harness, and state the evidence sequence before continuing. Audit only.",
+      "expected_output": "A post-login contract check that inventories the actual landing state, follows the rendered canonical entry, and withholds a product finding until route/state evidence distinguishes navigation failure from harness drift.",
+      "expectations": [
+        "Records the final URL, visible landing-page excerpt, and available visible links/buttons before retrying a remembered locator",
+        "Follows the visible canonical entry and proves the target with pathname plus a rendered state marker",
+        "Treats the absent remembered label as harness or navigation-contract drift when another visible path reaches the target",
+        "Files a product navigation finding only if neither the visible entry path nor the product's supported direct route can reach the promised workspace"
+      ],
+      "files": []
+    },
+    {
+      "id": 15,
+      "name": "lazy-media-and-responsive-branch-evidence",
+      "prompt": "Audit evals/files/lazy-responsive-media-fixture.html at 1440x900 and 390x844 with the bundled visual_layout_audit.mjs and an existing Playwright driver. First run without media scrolling, then run with --scroll-visible-media. Do not install dependencies or edit the fixture.",
+      "expected_output": "A media-state audit that distinguishes deferred lazy covers from broken assets, primes only the CSS-rendered desktop/mobile branch, and proves the requested visible covers load after their rows are visited.",
+      "expectations": [
+        "Without media scrolling, reports below-the-fold lazy covers as deferred coverage rather than image-broken or image-source-missing",
+        "With --scroll-visible-media, visits rendered media rows and reports the current viewport's covers loaded with no deferred or broken images",
+        "Counts the inactive responsive branch as not rendered and never waits for, scrolls to, or requires its images to load",
+        "Records commands, exit codes, report paths, and screenshot inspection; uses no dependency installation or project mutation"
+      ],
+      "files": ["evals/files/lazy-responsive-media-fixture.html"]
     }
   ]
 }

--- a/frontend-visual-qa/evals/files/lazy-responsive-media-fixture.html
+++ b/frontend-visual-qa/evals/files/lazy-responsive-media-fixture.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Lazy responsive media fixture</title>
+  <style>
+    * { box-sizing: border-box; }
+    body { margin: 0; font: 16px/1.5 Arial, sans-serif; color: #17312a; }
+    header { padding: 28px 32px; background: #eef7f3; }
+    h1 { margin: 0; font-size: 30px; }
+    .branch { padding: 24px 32px 80px; }
+    .media-row { display: flex; gap: 16px; align-items: center; min-height: 140px; }
+    .media-row + .media-row { margin-top: 1100px; }
+    img { width: 160px; height: 90px; object-fit: cover; background: #dce9e3; }
+    .mobile-branch { display: none; }
+    @media (max-width: 600px) {
+      .desktop-branch { display: none; }
+      .mobile-branch { display: block; }
+      .branch { padding-inline: 20px; }
+    }
+  </style>
+</head>
+<body>
+  <header><h1>Lazy media evidence</h1></header>
+
+  <main>
+    <section class="branch desktop-branch" aria-label="Desktop media">
+      <div class="media-row">
+        <img loading="lazy" data-src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='320' height='180'%3E%3Crect width='320' height='180' fill='%230f7b5c'/%3E%3C/svg%3E" alt="Desktop first cover">
+        <p>Desktop first row</p>
+      </div>
+      <div class="media-row">
+        <img loading="lazy" data-src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='320' height='180'%3E%3Crect width='320' height='180' fill='%231f8a70'/%3E%3C/svg%3E" alt="Desktop lower cover">
+        <p>Desktop lower row</p>
+      </div>
+    </section>
+
+    <section class="branch mobile-branch" aria-label="Mobile media">
+      <div class="media-row">
+        <img loading="lazy" data-src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='320' height='180'%3E%3Crect width='320' height='180' fill='%232d6f90'/%3E%3C/svg%3E" alt="Mobile first cover">
+        <p>Mobile first row</p>
+      </div>
+      <div class="media-row">
+        <img loading="lazy" data-src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='320' height='180'%3E%3Crect width='320' height='180' fill='%233d7fa0'/%3E%3C/svg%3E" alt="Mobile lower cover">
+        <p>Mobile lower row</p>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    const observer = new IntersectionObserver((entries) => {
+      for (const entry of entries) {
+        if (!entry.isIntersecting) continue;
+        const image = entry.target;
+        image.src = image.dataset.src;
+        delete image.dataset.src;
+        observer.unobserve(image);
+      }
+    }, { rootMargin: '80px' });
+
+    document.querySelectorAll('img[data-src]').forEach((image) => observer.observe(image));
+  </script>
+</body>
+</html>

--- a/frontend-visual-qa/evals/trigger-evals.json
+++ b/frontend-visual-qa/evals/trigger-evals.json
@@ -86,5 +86,9 @@
   {
     "query": "只审 Storybook 组件的 TypeScript props API、泛型和导出命名，不渲染 story。",
     "should_trigger": false
+  },
+  {
+    "query": "列表里有些封面像是坏了，但页面用了懒加载，而且桌面表格和手机卡片都留在 DOM 里。请在两个宽度实际滚动检查，别把没触发的图片当坏图。",
+    "should_trigger": true
   }
 ]

--- a/frontend-visual-qa/references/auth-session-and-environment-traps.md
+++ b/frontend-visual-qa/references/auth-session-and-environment-traps.md
@@ -10,6 +10,7 @@ environment.
 ## Contents
 
 - Login Driving Traps
+- Post-Login Navigation Contract Drift
 - Environment Hijack Diagnostics
 - Fixed-Overlay Screenshot Collapse
 
@@ -62,6 +63,35 @@ to disappear before capturing. Fresh headless profiles have no stored session
 at all, so an unauthenticated headless hit on a guarded route always shows
 either the interstitial or the login page — that is the guard working, not a
 defect.
+
+## Post-Login Navigation Contract Drift
+
+A successful login does not prove that a remembered sidebar item exists on the
+landing page. Products add home cards, rename entries, or mount navigation only
+after entering a workspace. A hard-coded label can therefore time out while the
+product is healthy.
+
+Before filing a missing-navigation finding, capture the post-login contract:
+
+    () => ({
+      href: location.href,
+      visibleText: document.body.innerText.replace(/\s+/g, " ").trim().slice(0, 600),
+      entries: [...document.querySelectorAll('a[href],button')]
+        .filter((element) => {
+          const rect = element.getBoundingClientRect();
+          const style = getComputedStyle(element);
+          return rect.width > 0 && rect.height > 0
+            && style.display !== 'none' && style.visibility !== 'hidden';
+        })
+        .map((element) => element.textContent?.replace(/\s+/g, " ").trim())
+        .filter(Boolean)
+        .slice(0, 40),
+    })
+
+Follow the visible canonical entry path, then prove the target with its pathname
+and a state marker. If the expected locator is absent but another visible entry
+reaches the target, the harness was stale. If no visible entry or direct route
+can reach the promised workspace, then the product has a navigation defect.
 
 ## Environment Hijack Diagnostics
 

--- a/frontend-visual-qa/references/history-derived-checklist.md
+++ b/frontend-visual-qa/references/history-derived-checklist.md
@@ -176,13 +176,34 @@ modal surfaces.
 
 Verify:
 
-- image completion and nonzero natural dimensions;
+- image request/load state and nonzero natural dimensions;
 - displayed ratio versus natural ratio;
 - intentional object-fit and focal position;
 - crop severity at each relevant viewport;
 - text/badge/caption collision with important image content;
 - asset relevance to the product/domain;
 - use of approved logo, imagery, and design-system assets.
+
+Classify media before calling it broken:
+
+- **not requested** — a rendered but offscreen lazy image has not entered its
+  loading threshold; visit the audited row/section before judging the asset;
+- **still loading** — a requested image has not completed at capture time;
+  record incomplete evidence rather than inventing a network or asset cause;
+- **broken** — the request completed but the image has zero natural dimensions
+  or cannot decode.
+
+Responsive implementations may keep desktop and mobile branches in the DOM at
+the same time. Scope image readiness, geometry, scrolling, and interaction to
+the branch that is CSS-rendered at the current viewport. Do not wait for or
+scroll to images inside display:none, visibility:hidden, zero-size, or otherwise
+inactive alternatives. Audit hidden alternatives separately only when they can
+remain focusable or intercept input.
+
+For a full-page media audit, scroll the relevant rendered rows or sections to
+trigger lazy loading, wait for those requests to settle, then inspect completion
+and natural dimensions. A blanket document.images.every(img => img.complete)
+wait is invalid because offscreen lazy media may correctly remain untouched.
 
 Flag default stretching and accidental heavy crop. Do not infer safe crop from
 object-fit: cover alone; inspect the focal content.
@@ -228,6 +249,7 @@ product domain, actor's job, or established project rules.
 | wrong scroll owner | wheel/keyboard journey | min-height contract and scoped overflow |
 | same-row drift | sibling bounding boxes | shared anatomy or reserved helper slot |
 | dense-item collision | opened dense-state screenshot + affected bounding boxes | collision-aware layout, reserved lanes, stacking, or a responsive alternative |
+| deferred/broken image | request state + visible-branch screenshot + natural dimensions | trigger the lazy row, then repair the actual asset or loader |
 | image ratio/crop | natural/display ratio + screenshot | matching aspect ratio and deliberate object-fit |
 | underfilled first viewport | inner/outer widths + content bounds | reset emulation or repair container/grid |
 | focus obstruction | keyboard traversal + screenshot | scroll-padding, overlay position, or modal contract |

--- a/frontend-visual-qa/scripts/visual_layout_audit.mjs
+++ b/frontend-visual-qa/scripts/visual_layout_audit.mjs
@@ -68,6 +68,7 @@ const usage = [
   "  [--wait-until domcontentloaded|load|networkidle|commit] [--ready-selector <css>]",
   "  [--settle-ms 750] [--forbid <regex>]... [--require <regex>]...",
   "  [--expected-window-width 1920] [--content-selector main] [--media-selector .hero]",
+  "  [--scroll-visible-media] (visit rendered media rows to trigger lazy loading)",
   "  [--section-selector section] [--screenshot-sections] [--max-section-screenshots 4]",
   "  [--out <new-empty-directory>] [--fail-on-warning]",
 ].join("\n");
@@ -85,7 +86,9 @@ function validateKnownFlags() {
     "--content-selector", "--media-selector", "--section-selector",
     "--max-section-screenshots", "--viewport",
   ]);
-  const booleanFlags = new Set(["--help", "-h", "--screenshot-sections", "--fail-on-warning"]);
+  const booleanFlags = new Set([
+    "--help", "-h", "--screenshot-sections", "--scroll-visible-media", "--fail-on-warning",
+  ]);
   for (let index = 2; index < process.argv.length; index += 1) {
     const arg = process.argv[index];
     if (valueFlags.has(arg)) {
@@ -153,6 +156,7 @@ const maxSectionScreenshots = parsePositiveInt(
   getArg("--max-section-screenshots", pageType === "deck" ? "50" : "4"),
 );
 const screenshotSections = process.argv.includes("--screenshot-sections");
+const scrollVisibleMedia = process.argv.includes("--scroll-visible-media");
 const failOnWarning = process.argv.includes("--fail-on-warning");
 
 const url = normalizeTarget(target);
@@ -202,7 +206,7 @@ const report = {
     "page and section overflow",
     "rendered text wrapping and clipping candidates",
     "custom interactive-role focusability candidates",
-    "image load and aspect candidates",
+    "rendered image request/load state and aspect candidates",
     "page-type contract heuristics",
     "viewport and optional section screenshots",
   ],
@@ -213,6 +217,7 @@ const report = {
     "complete WCAG conformance",
     "GIS interaction behavior",
     "subjective reference parity",
+    ...(!scrollVisibleMedia ? ["below-the-fold lazy-media activation"] : []),
   ],
   viewports: [],
   issues: [],
@@ -232,6 +237,9 @@ for (const viewport of viewports) {
       throw new Error("Navigation returned HTTP " + httpStatus + " for " + page.url());
     }
     await waitForVisualReadiness(page, readySelector, settleMs);
+  const mediaPreparation = scrollVisibleMedia
+    ? await primeVisibleMedia(page, mediaSelector, settleMs)
+    : null;
   await page.evaluate(() => window.scrollTo(0, 0));
   const screenshot = `${outDir}/${viewport.name}.png`;
   await page.screenshot({ path: screenshot, fullPage: false });
@@ -245,9 +253,27 @@ for (const viewport of viewports) {
     expectedWindowWidth,
     contentSelector,
     mediaSelector,
+    mediaWalkRequested: scrollVisibleMedia,
     sectionSelector,
     screenshotSections,
   });
+  result.meta.mediaPreparation = mediaPreparation;
+  if (mediaPreparation?.truncated) {
+    result.issues.push({
+      viewport: viewport.name,
+      type: "media-scroll-coverage-truncated",
+      severity: "warning",
+      detail: `Lazy-media preparation visited ${mediaPreparation.visitedRows}/${mediaPreparation.renderedRows} rendered media row(s); narrow the media scope or use the product harness for complete coverage.`,
+    });
+  }
+  if (mediaPreparation?.failures?.length) {
+    result.issues.push({
+      viewport: viewport.name,
+      type: "media-scroll-preparation-failed",
+      severity: "warning",
+      detail: `${mediaPreparation.failures.length} rendered media row(s) could not be visited before the audit.`,
+    });
+  }
   const sectionScreenshots = screenshotSections
     ? await captureSectionScreenshots(
       page,
@@ -327,7 +353,10 @@ for (const viewport of report.viewports) {
   const sections = viewport.sections
     ? `sections=${viewport.sections.count}, worstSectionOverflowX=${viewport.sections.worstOverflowX}`
     : "";
-  console.log(`${viewport.viewport}: outer=${viewport.outerWidth}x${viewport.outerHeight}, inner=${viewport.width}x${viewport.height}, outerMinusInner=${viewport.outerMinusInner}, client=${viewport.clientWidth}, scroll=${viewport.scrollWidth}, overflowX=${viewport.overflowX}${visual}${content}${primaryImage}${typography}, title="${viewport.title}", h1="${viewport.h1}", screenshot=${viewport.screenshot}`);
+  const media = viewport.media
+    ? `, media=${viewport.media.loaded} loaded/${viewport.media.broken} broken/${viewport.media.stillLoading} loading/${viewport.media.deferredLazy} deferred/${viewport.media.notRendered} not-rendered`
+    : "";
+  console.log(`${viewport.viewport}: outer=${viewport.outerWidth}x${viewport.outerHeight}, inner=${viewport.width}x${viewport.height}, outerMinusInner=${viewport.outerMinusInner}, client=${viewport.clientWidth}, scroll=${viewport.scrollWidth}, overflowX=${viewport.overflowX}${visual}${content}${primaryImage}${typography}${media}, title="${viewport.title}", h1="${viewport.h1}", screenshot=${viewport.screenshot}`);
   if (sections) console.log(`  sectionAudit: ${sections}`);
   if (viewport.sectionScreenshots?.length) {
     const captured = viewport.sectionScreenshots.map((item) => item.screenshot).filter(Boolean);
@@ -448,10 +477,107 @@ async function waitForVisualReadiness(page, selector, delayMs) {
   }
   await page.evaluate(async () => {
     if (document.fonts?.ready) await document.fonts.ready;
+    await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
     const loadedImages = [...document.images].filter((image) => image.complete);
     await Promise.all(loadedImages.map((image) => image.decode?.().catch(() => {})));
   });
   if (delayMs > 0) await page.waitForTimeout(delayMs);
+}
+
+async function primeVisibleMedia(page, selector, delayMs) {
+  const plan = await page.evaluate(({ selector, maximumRows }) => {
+    function isRendered(element) {
+      const rect = element.getBoundingClientRect();
+      if (rect.width <= 0 || rect.height <= 0) return false;
+      if (typeof element.checkVisibility === "function") {
+        return element.checkVisibility({ checkOpacity: true, checkVisibilityCSS: true });
+      }
+      const style = getComputedStyle(element);
+      return style.display !== "none"
+        && style.visibility !== "hidden"
+        && Number.parseFloat(style.opacity || "1") > 0;
+    }
+
+    let selected;
+    try {
+      if (!selector) {
+        selected = [...document.images];
+      } else {
+        const roots = [...document.querySelectorAll(selector)];
+        selected = [...new Set(roots.flatMap((root) => (
+          root.tagName === "IMG" ? [root] : [...root.querySelectorAll("img")]
+        )))];
+      }
+    } catch (error) {
+      return {
+        renderedImages: 0,
+        notRenderedImages: 0,
+        renderedRows: 0,
+        visitedRows: 0,
+        truncated: false,
+        indices: [],
+        selectorError: error.message,
+      };
+    }
+
+    const allImages = [...document.images];
+    const rendered = selected
+      .filter(isRendered)
+      .map((image) => {
+        const rect = image.getBoundingClientRect();
+        return {
+          index: allImages.indexOf(image),
+          documentTop: Math.round(rect.top + window.scrollY),
+        };
+      })
+      .filter((item) => item.index >= 0)
+      .sort((a, b) => a.documentTop - b.documentTop);
+
+    const rows = [];
+    for (const item of rendered) {
+      const sameRow = rows.find((row) => Math.abs(row.documentTop - item.documentTop) <= 8);
+      if (!sameRow) rows.push(item);
+    }
+
+    return {
+      renderedImages: rendered.length,
+      notRenderedImages: selected.length - rendered.length,
+      renderedRows: rows.length,
+      visitedRows: Math.min(rows.length, maximumRows),
+      truncated: rows.length > maximumRows,
+      indices: rows.slice(0, maximumRows).map((item) => item.index),
+      selectorError: null,
+    };
+  }, { selector, maximumRows: 200 });
+
+  const failures = [];
+  for (const index of plan.indices) {
+    try {
+      await page.evaluate((imageIndex) => {
+        document.images[imageIndex]?.scrollIntoView({ block: "center", inline: "nearest" });
+      }, index);
+      await page.waitForTimeout(60);
+    } catch (error) {
+      failures.push({ index, message: error?.message || String(error) });
+    }
+  }
+
+  await page.evaluate(async () => {
+    window.scrollTo(0, 0);
+    const completeImages = [...document.images].filter((image) => image.complete && image.naturalWidth > 0);
+    await Promise.all(completeImages.map((image) => image.decode?.().catch(() => {})));
+  });
+  if (delayMs > 0) await page.waitForTimeout(Math.min(Math.max(delayMs, 100), 2_000));
+
+  return {
+    renderedImages: plan.renderedImages,
+    notRenderedImages: plan.notRenderedImages,
+    renderedRows: plan.renderedRows,
+    visitedRows: plan.visitedRows,
+    truncated: plan.truncated,
+    selectorError: plan.selectorError,
+    failures,
+  };
 }
 
 async function captureSectionScreenshots(page, viewport, outDir, sectionSelector, maxCount, includeFirstViewport = false) {
@@ -569,7 +695,7 @@ function collectScreenshotSections({ sectionSelector, maxCount, includeFirstView
   }
 }
 
-function auditPage({ viewportName, requestedWidth, isMobile, forbidPatterns, requirePatterns, pageType, expectedWindowWidth, contentSelector, mediaSelector, sectionSelector, screenshotSections }) {
+function auditPage({ viewportName, requestedWidth, isMobile, forbidPatterns, requirePatterns, pageType, expectedWindowWidth, contentSelector, mediaSelector, mediaWalkRequested, sectionSelector, screenshotSections }) {
   const issues = [];
   const forbiddenTerms = forbidPatterns.map((pattern) => new RegExp(pattern, "g"));
   const requiredTerms = requirePatterns.map((pattern) => new RegExp(pattern, "g"));
@@ -626,6 +752,9 @@ function auditPage({ viewportName, requestedWidth, isMobile, forbidPatterns, req
   meta.firstViewportContent = measureFirstViewportContent(contentSelector);
   meta.primaryImage = measurePrimaryImage(mediaSelector);
   meta.typography = measureTypography();
+  const mediaAudit = auditMedia({ viewportName, mediaSelector, mediaWalkRequested });
+  meta.media = mediaAudit.meta;
+  issues.push(...mediaAudit.issues);
   const sectionAudit = auditSections(sectionSelector);
   meta.sections = sectionAudit.meta;
   issues.push(...sectionAudit.issues);
@@ -842,37 +971,6 @@ function auditPage({ viewportName, requestedWidth, isMobile, forbidPatterns, req
   }
 
   auditSameRowFields();
-
-  for (const img of selectedImages(mediaSelector).filter(isVisible)) {
-    if (!img.complete || img.naturalWidth === 0) {
-      issues.push({ viewport: viewportName, selector: describe(img), type: "image-not-loaded", severity: "error", text: img.alt || img.src });
-      continue;
-    }
-
-    const imageMetrics = measureImage(img);
-    if (!imageMetrics || imageMetrics.area < 10_000) continue;
-
-    const ratioDelta = Math.abs(imageMetrics.displayedRatio / imageMetrics.naturalRatio - 1);
-    if (!["cover", "contain", "scale-down"].includes(imageMetrics.objectFit) && ratioDelta > 0.08) {
-      issues.push({
-        viewport: viewportName,
-        selector: describe(img),
-        type: "image-aspect-mismatch",
-        severity: "error",
-        text: img.alt || img.src,
-        detail: `Image displays at ratio ${imageMetrics.displayedRatio} but natural ratio is ${imageMetrics.naturalRatio}; object-fit is "${imageMetrics.objectFit}".`,
-      });
-    } else if (imageMetrics.objectFit === "cover" && ratioDelta > 0.25) {
-      issues.push({
-        viewport: viewportName,
-        selector: describe(img),
-        type: "image-heavy-crop",
-        severity: "warning",
-        text: img.alt || img.src,
-        detail: `Image container ratio ${imageMetrics.displayedRatio} differs from natural ratio ${imageMetrics.naturalRatio}. Inspect whether important content is cropped.`,
-      });
-    }
-  }
 
   issues.push(...auditImageOverlays({ viewportName, mediaSelector }));
 
@@ -1211,7 +1309,7 @@ function auditPage({ viewportName, requestedWidth, isMobile, forbidPatterns, req
   function selectedImages(selector) {
     if (!selector) return [...document.images];
     try {
-      const roots = [...document.querySelectorAll(selector)].filter(isVisible);
+      const roots = [...document.querySelectorAll(selector)];
       return [...new Set(roots.flatMap((root) => {
         if (root.tagName === "IMG") return [root];
         return [...root.querySelectorAll("img")];
@@ -1219,6 +1317,112 @@ function auditPage({ viewportName, requestedWidth, isMobile, forbidPatterns, req
     } catch {
       return [...document.images];
     }
+  }
+
+  function auditMedia({ viewportName, mediaSelector, mediaWalkRequested }) {
+    const found = [];
+    const selected = selectedImages(mediaSelector);
+    const rendered = selected.filter(isVisible);
+    const states = {
+      selected: selected.length,
+      rendered: rendered.length,
+      notRendered: selected.length - rendered.length,
+      loaded: 0,
+      broken: 0,
+      stillLoading: 0,
+      deferredLazy: 0,
+      missingSource: 0,
+    };
+
+    for (const img of rendered) {
+      const rect = img.getBoundingClientRect();
+      const inViewport = rect.bottom > 0
+        && rect.right > 0
+        && rect.top < window.innerHeight
+        && rect.left < window.innerWidth;
+      const source = img.currentSrc || img.getAttribute("src")?.trim() || "";
+      const hasDeferredSource = Boolean(
+        img.getAttribute("data-src")
+        || img.getAttribute("data-lazy-src")
+        || img.getAttribute("data-original"),
+      );
+      const isLazy = img.loading === "lazy" || hasDeferredSource;
+      const isDeferred = !mediaWalkRequested
+        && !inViewport
+        && isLazy
+        && (!img.complete || img.naturalWidth === 0 || !source);
+
+      if (isDeferred) {
+        states.deferredLazy += 1;
+        continue;
+      }
+
+      if (!source) {
+        states.missingSource += 1;
+        found.push({
+          viewport: viewportName,
+          selector: describe(img),
+          type: "image-source-missing",
+          severity: "error",
+          text: img.alt || "",
+          detail: "Rendered image has no requested source. If it is lazy-loaded, visit its visible row before judging the asset.",
+        });
+        continue;
+      }
+
+      if (img.complete && img.naturalWidth === 0) {
+        states.broken += 1;
+        found.push({
+          viewport: viewportName,
+          selector: describe(img),
+          type: "image-broken",
+          severity: "error",
+          text: img.alt || source,
+          detail: "The image request completed without decodable natural dimensions.",
+        });
+        continue;
+      }
+
+      if (!img.complete || img.naturalWidth === 0) {
+        states.stillLoading += 1;
+        found.push({
+          viewport: viewportName,
+          selector: describe(img),
+          type: "image-still-loading",
+          severity: "error",
+          text: img.alt || source,
+          detail: "The rendered image had not completed loading when evidence was captured; this is not yet proof of a broken asset.",
+        });
+        continue;
+      }
+
+      states.loaded += 1;
+      const imageMetrics = measureImage(img);
+      if (!imageMetrics || imageMetrics.area < 10_000) continue;
+
+      const ratioDelta = Math.abs(imageMetrics.displayedRatio / imageMetrics.naturalRatio - 1);
+      if (!["cover", "contain", "scale-down"].includes(imageMetrics.objectFit) && ratioDelta > 0.08) {
+        found.push({
+          viewport: viewportName,
+          selector: describe(img),
+          type: "image-aspect-mismatch",
+          severity: "error",
+          text: img.alt || source,
+          detail: `Image displays at ratio ${imageMetrics.displayedRatio} but natural ratio is ${imageMetrics.naturalRatio}; object-fit is "${imageMetrics.objectFit}".`,
+        });
+      } else if (imageMetrics.objectFit === "cover" && ratioDelta > 0.25) {
+        found.push({
+          viewport: viewportName,
+          selector: describe(img),
+          type: "image-heavy-crop",
+          severity: "warning",
+          text: img.alt || source,
+          detail: `Image container ratio ${imageMetrics.displayedRatio} differs from natural ratio ${imageMetrics.naturalRatio}. Inspect whether important content is cropped.`,
+        });
+      }
+    }
+
+    return { meta: states, issues: found };
   }
 
   function measureImage(img) {


### PR DESCRIPTION
## Summary
- distinguish deferred lazy media, active loading, missing sources, and confirmed broken images
- scope responsive media checks to the currently rendered branch
- add an explicit scroll-visible-media audit path
- harden post-login navigation evidence against stale remembered labels
- add focused behavior and trigger regressions

## Verification
- quick_validate passed
- old-vs-new regression audit passed against Git baseline 771f950
- security scan passed
- package_skill passed
- old script reproduced two false image-not-loaded findings; v1.5.0 reports deferred coverage and loads both visible-branch covers after media scrolling
- existing layout and evidence-edge fixtures retained their expected findings