### PR TITLE
Improve history recovery and skill safety checks

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -103,7 +103,7 @@
       "description": "Claude Code operations suite that bundles archive-aware local conversation discovery across Claude Code and Codex, internal-timestamp full-event session search and recovery, interrupted-work continuation, plugin/skill troubleshooting, CLAUDE.md progressive disclosure optimization, statusline configuration, exported .txt repair, full claude.ai conversation extraction with tool-call rendering and file download, plugin marketplace development, multi-provider profile isolation for running Kimi/GLM/DeepSeek/StepFun/Anthropic in separate windows, local source sync for Claude/Codex skill installs, and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
       "source": "./daymade-claude-code",
       "strict": false,
-      "version": "1.17.0",
+      "version": "1.18.0",
       "category": "suite",
       "keywords": [
         "suite",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1023,7 +1023,7 @@
       "description": "Audits already-rendered web, landing-page, HTML deck/slide, browser tool/game, dashboard/admin, design-system, and desktop UIs with real-browser or native-app journeys, inspected screenshots, DOM geometry, responsive or projection viewports, and a Playwright sweep. Use after implementation to find typography, wrapping, overlap, overflow, responsive, route, authorization-state, overlay, map, transient-state, data-visualization, runtime-label, browser-output, file-dialog, PDF/print, or Electron-shell defects. Not for greenfield UI design, design-system extraction, general QA-program setup, or nonvisual debugging.",
       "source": "./frontend-visual-qa",
       "strict": false,
-      "version": "1.5.0",
+      "version": "1.8.0",
       "category": "design",
       "keywords": [
         "frontend",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -400,10 +400,10 @@
     },
     {
       "name": "git-safety-net",
-      "description": "Audits, preserves, recovers, and safely retires local Git state: unpushed or wrong-branch commits, dirty or detached worktrees, orphaned/dropped stashes, dangling commits, stale branches, and squash/rebase merge uncertainty. Use when the user fears work was lost; asks to recover a commit, branch, stash, or reflog state; asks whether a worktree can be deleted; wants all valuable state converged onto main; or needs proof that cleanup/rebase/branch deletion will not drop work. Triggers on \"did I lose work\", \"is everything merged\", \"safe to delete this worktree\", \"clean up old branches/stashes/worktrees\", \"git reflog\", \"dangling commits\", \"分支灾难\", \"误删分支/commit\", \"worktree 能删吗\", \"确认全部合并了\". Covers local-Git forensics, not GitHub PR/API operations or routine repository sync.",
+      "description": "Audits, preserves, recovers, and safely retires local Git state: unpushed or wrong-branch commits, dirty or detached worktrees, forgotten duplicate clones of the same repo, untracked work no bundle can back up, orphaned stashes, dangling commits, stale branches, and squash/rebase merge uncertainty. Use when the user fears work was lost; asks to recover a commit or branch; asks whether a worktree, clone, or scratch directory can be deleted; wants everything converged onto one main branch; or needs proof that cleanup will not drop work. Use it even after an audit reported clean — the usual gap is scope: every in-repo command is blind to a second clone elsewhere on disk. Triggers on \"did I lose work\", \"is everything merged\", \"is anything else lost\", \"safe to delete this clone\", \"clean up old branches/stashes\", \"only keep one main branch\", \"git reflog\", \"dangling commits\", \"分支灾难\", \"误删分支/commit\", \"worktree 能删吗\", \"还有没有丢的东西\", \"只保留一个主分支\". Covers local-Git forensics, not GitHub PR/API operations or routine sync.",
       "source": "./git-safety-net",
       "strict": false,
-      "version": "1.3.0",
+      "version": "1.4.0",
       "category": "developer-tools",
       "keywords": [
         "git",
@@ -415,7 +415,9 @@
         "squash-merge",
         "disaster-recovery",
         "worktree",
-        "claude-code"
+        "claude-code",
+        "clone-discovery",
+        "untracked-backup"
       ]
     },
     {

--- a/README.md
+++ b/README.md
@@ -888,8 +888,9 @@ config homes and the long-term archives registered in
 - **Cross-project sweep**: `--all-projects` searches every project when the project is unknown; `--codex` also covers Codex rollout history; `--exclude-session` skips self-matches
 - **Copy-safe union**: Search distinct records from every copy of a session ID without double-counting identical records
 - **Internal-time search**: Filter matching records by JSONL timestamps, never file mtime
-- **Structured search**: Cover messages, thinking, tools, results, queues, attachments, and summaries
-- **Content recovery**: Extract files from Write tool calls with deduplication
+- **Structured search**: Cover messages, thinking, tools, results, queues, attachments, summaries, and original file-history paths
+- **Exact checkpoint recovery**: Union same-session copies and companion roots, then restore captured bytes after Write/Edit/shell changes, including binaries and pre-deletion checkpoints
+- **Fail-visible fidelity**: Label Write-only checkpoints as lower fidelity and abort when exact metadata points to missing bytes instead of silently guessing
 - **Statistics analysis**: Message counts, tool usage breakdown, file operations
 - **Batch operations**: Process multiple sessions with keyword filtering
 - **Streaming processing**: Handle large session files (>100MB) efficiently
@@ -905,6 +906,11 @@ python3 scripts/analyze_sessions.py search /path/to/project \
 
 # Recover deleted files from the exact path printed by search
 python3 scripts/recover_content.py <printed-session-path> -k DeletedComponent -o ./recovered/
+
+# Search every project for multiple vanished job artifacts
+python3 scripts/analyze_sessions.py search --all-projects \
+  artifact-a.html artifact-b.html \
+  --exclude-session <current-session-id>
 
 # Get session statistics
 python3 scripts/analyze_sessions.py stats /path/to/session.jsonl --show-files

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -925,10 +925,12 @@ python3 scripts/calculate_metrics.py tests/TEST-EXECUTION-TRACKING.csv
 
 **主要功能：**
 - **完整来源集**：默认同时检索活跃目录与已登记备份
+- **跨项目扩搜**：项目未知时用 `--all-projects` 一次检索全部项目；可同时传多个关键词
 - **副本安全并集**：同一会话 ID 的所有副本都参与检索，相同记录不重复计数
 - **内部时间检索**：按 JSONL 记录时间过滤，不用文件 mtime
-- **结构化检索**：覆盖消息、thinking、工具输入/结果、队列、附件与摘要
-- **内容恢复**：从 Write 工具调用中提取文件并去重
+- **结构化检索**：覆盖消息、thinking、工具输入/结果、队列、附件、摘要与 file-history 原始路径
+- **精确检查点恢复**：联合同一会话的多个副本与配套备份根，恢复 Write/Edit/命令行修改后捕获的原始字节，包括二进制与删除前检查点
+- **保真度显式可见**：Write-only 结果标为低保真；元数据指向的精确字节缺失时直接报错，不静默猜测
 - **统计分析**：消息计数、工具使用明细、文件操作
 - **批量操作**：使用关键字过滤处理多个会话
 - **流式处理**：高效处理大型会话文件（>100MB）
@@ -944,6 +946,11 @@ python3 scripts/analyze_sessions.py search /path/to/project \
 
 # 从 search 输出的精确路径恢复已删除文件
 python3 scripts/recover_content.py <printed-session-path> -k DeletedComponent -o ./recovered/
+
+# 项目未知时一次查找多个已消失的临时任务产物
+python3 scripts/analyze_sessions.py search --all-projects \
+  artifact-a.html artifact-b.html \
+  --exclude-session <current-session-id>
 
 # 获取会话统计信息
 python3 scripts/analyze_sessions.py stats /path/to/session.jsonl --show-files

--- a/daymade-claude-code/claude-code-history-files-finder/.security-scan-passed
+++ b/daymade-claude-code/claude-code-history-files-finder/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-07-19T07:50:59.792323+00:00
+Scanned at: 2026-07-19T09:32:31.568599+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 564d22fa9b5bc86b70595aa5ed7417d1ca5e6d13e15192a6c1c2c59855316492
+Content hash: 762e929ebd20e399d87e9b4fffff41f9a805fc51397a105f227bfab573343c97

--- a/daymade-claude-code/claude-code-history-files-finder/.security-scan-passed
+++ b/daymade-claude-code/claude-code-history-files-finder/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-07-16T06:59:30.069326+00:00
+Scanned at: 2026-07-19T07:50:59.792323+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 3889a9d33024a7d1482649118441f7f97fff852224f0607296e5db23de767f49
+Content hash: 564d22fa9b5bc86b70595aa5ed7417d1ca5e6d13e15192a6c1c2c59855316492

--- a/daymade-claude-code/claude-code-history-files-finder/.security-scan-passed
+++ b/daymade-claude-code/claude-code-history-files-finder/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-07-19T09:32:31.568599+00:00
+Scanned at: 2026-07-19T09:44:10.323053+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 762e929ebd20e399d87e9b4fffff41f9a805fc51397a105f227bfab573343c97
+Content hash: 43de469681704c4796ee2f7b612513c68e51064e54cb1c04a3864e48e3000f1e

--- a/daymade-claude-code/claude-code-history-files-finder/SKILL.md
+++ b/daymade-claude-code/claude-code-history-files-finder/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: claude-code-history-files-finder
 description: >-
-  Searches and recovers content from Claude Code JSONL session history across
-  all active config homes and every long-term archive registered in
-  ~/.claude/history-sources.json — sweeping every project at once with
-  --all-projects when the project is unknown, and optionally covering Codex
-  rollout history with --codex. Uses internal record timestamps rather than
-  file mtime and searches message text, thinking, tool inputs/results,
-  queue-operation content, attachments, summaries, and titles. Use for keyword
-  or date-bounded history search, prior-conversation forensics, deleted-file
-  recovery, tool/file-operation analysis, or requests mentioning session
-  history, find in history, previous conversation, or .claude/projects. Do not
-  use for a simple recent Claude+Codex inventory; use local-conversation-history.
+  Searches and recovers Claude Code JSONL history across all active config homes
+  and archives registered in ~/.claude/history-sources.json. Use --all-projects
+  when the project is unknown and --codex to include Codex rollout search. Uses
+  internal timestamps and searches messages, thinking, tool inputs/results,
+  queues, attachments, summaries, titles, and file-history paths. Recovers exact
+  captured bytes from Claude file-history snapshots, including post-Write edits
+  and binary files; otherwise labels Write checkpoints as lower fidelity. Use
+  for keyword/date-bounded history search, prior-conversation forensics,
+  deleted-file recovery, vanished ~/.claude/jobs artifacts, tool/file-operation
+  analysis, or requests mentioning session history, find in history, previous
+  conversation, or .claude/projects. For a recent Claude+Codex inventory, use
+  local-conversation-history instead.
 ---
 
 # Claude Code History Files Finder
@@ -21,7 +22,8 @@ homes and explicitly registered long-term archives.
 
 ## Capabilities
 
-- Recover deleted or lost files from previous sessions
+- Recover exact captured bytes for deleted or lost files from file-history
+  snapshots, including files changed after their original Write call
 - Search for specific code or content across conversation history
 - Analyze file modifications across past sessions
 - Track tool usage and file operations over time
@@ -65,6 +67,16 @@ Each Claude history root stores sessions at
 `<history-root>/projects/<encoded-project-path>/<session-id>.jsonl`. Active roots
 are discovered automatically. Durable archive roots are configured once in
 `~/.claude/history-sources.json` and then included by default.
+
+Claude may also keep checkpoint payloads at
+`<history-root>/file-history/<session-id>/<opaque-backup-name>`. The JSONL's
+`file-history-snapshot.snapshot.trackedFileBackups` map connects each original
+path to its opaque backup name and version. This companion store is separate
+from `projects/`: copying only a JSONL into a long-term archive does not prove
+its checkpoint bytes were copied too. The format is an observed Claude Code
+runtime detail rather than a documented stable API, so the bundled recovery
+parser validates the selected mapping, version/name agreement, path containment,
+and byte identity, then fails visibly when those facts disagree.
 
 **The directory name is the project's ABSOLUTE working-directory path with every `/` replaced by `-` — never the basename.** For example `/Users/<name>/Desktop/my-app` becomes `-Users-<name>-Desktop-my-app`, so a bare `my-app` cannot match a directory directly.
 
@@ -160,8 +172,9 @@ Returns sessions ranked by keyword frequency with:
 - Primary matching path plus any other matching copies
 
 Search covers messages, thinking text (not signatures), tool inputs/results,
-queue-operation content, attachments, last prompts, system/summary content, and
-custom titles. Optional: `--case-sensitive` for exact casing; `--from-date` and
+queue-operation content, attachments, last prompts, system/summary content,
+custom titles, and original paths in file-history snapshots. Optional:
+`--case-sensitive` for exact casing; `--from-date` and
 `--to-date` constrain matching records by their own internal timestamps, not by
 session mtime. `--exclude-session <id>` (repeatable) drops sessions — pass the
 current session's id whenever you search for a phrase you just typed, because
@@ -181,6 +194,10 @@ sweep every project instead (`list` accepts the same flag):
 ```bash
 python3 scripts/analyze_sessions.py search --all-projects 'some phrase'
 ```
+
+With `--all-projects`, every positional term is a keyword, so multi-keyword
+search is valid: `search --all-projects keyword1 keyword2`. Without that flag,
+the first positional is the project path and the remaining terms are keywords.
 
 Expected output: one pass over every project's sessions across all sources,
 with a `Project:` line naming the encoded project dir on each hit. This is a
@@ -205,19 +222,32 @@ every rollout is searched. `event_msg` message mirrors are strict duplicates
 of `response_item` message text and are counted once. Rollout record shapes
 are documented in `references/session_file_format.md`.
 
+`--codex` widens **search only**. Codex rollouts do not carry Claude's
+file-history mapping, so `recover_content.py` rejects a Codex rollout with a
+clear boundary error instead of returning an empty, apparently successful
+recovery.
+
 The zero-match hint printed by the script already suggests whichever of
 `--all-projects` / `--codex` / shorter substrings was not yet applied — read
 stderr before concluding anything is absent.
 
 ### 3. Recover Deleted Content
 
-Extract files from session history:
+Recover files from the selected session:
 
 ```bash
 python3 scripts/recover_content.py <session-path-from-search>
 ```
 
-Extracts all Write tool calls and saves files to `./recovered_content/`, preserving the original directory structure.
+For each path, the default mode unions every known copy of the same session ID,
+selects the newest valid file-history checkpoint, and restores its exact bytes
+from active or registered-archive companion stores. That captures later Edit or
+shell-driven changes and can recover binary files or files without a Write tool
+call. A later `backupFileName: null` is a deletion tombstone: the last available
+checkpoint is recovered with the later deletion stated in the report. If a path
+has no usable snapshot checkpoint, the script recovers the latest Write call and
+labels it as lower fidelity in `recovery_report.txt`. Original directory
+structure is preserved under `./recovered_content/`.
 
 **Filtering by keywords**:
 
@@ -233,6 +263,21 @@ Recovers only files matching any keyword in their path.
 ```bash
 python3 scripts/recover_content.py <session-path-from-search> -o ./my_recovery/
 ```
+
+Registered archive roots and same-ID JSONL copies are included automatically.
+If an unregistered companion checkpoint store lives elsewhere, add the root
+that directly contains `<session-id>/` directories:
+
+```bash
+python3 scripts/recover_content.py <session-path-from-search> \
+  --file-history-root /path/to/file-history \
+  -o ./my_recovery/
+```
+
+Snapshot metadata without its referenced backup is a fidelity error: recovery
+aborts before writing any selected files instead of silently substituting stale
+Write content. Use `--write-only` only when the user explicitly accepts that
+later Edit or shell changes may be absent.
 
 ### 4. Analyze Session Statistics
 
@@ -257,7 +302,12 @@ For detailed workflow examples including file recovery, tracking file evolution,
 
 ### Deduplication
 
-`recover_content.py` automatically keeps only the latest version of each file. If a file was written multiple times in a session, only the final version is saved.
+`recover_content.py` unions same-ID session copies, keeps the highest
+file-history version for each original path, and uses checkpoint timestamps for
+ties. A later deletion tombstone does not erase an earlier recoverable backup;
+it changes the reported state. For paths with no usable checkpoint, recovery
+keeps the latest internally timestamped Write call. Physical JSONL line order
+across copies is not treated as sufficient time evidence.
 
 ### Keyword Selection
 
@@ -291,30 +341,42 @@ find ./recovered_content/ -type f
 # Read recovery report (shows full output paths)
 cat ./recovered_content/recovery_report.txt
 
-# Spot-check content (use actual path from report)
+# Spot-check content and compare the report's SHA-256 with the source backup
 head -20 ./recovered_content/src/components/ImportantFile.jsx
 ```
+
+Treat `Source: file-history` plus its SHA-256 as exact captured-checkpoint
+evidence. Treat `Source: Write` as a recoverable checkpoint, not proof of the
+file's final state.
 
 ## Limitations
 
 ### What Can Be Recovered
 
-✅ Files written using Write tool
-✅ Code shown in markdown blocks (partial extraction)
-✅ File paths from Edit/Read operations
+✅ Exact bytes referenced by available file-history snapshots
+✅ Binary files present in the companion file-history store
+✅ Files changed by Edit or shell commands once a later checkpoint captured them
+✅ Files written using Write when no snapshot metadata exists (lower fidelity)
+✅ Text explicitly present in messages or tool results (manual extraction)
 
 ### What Cannot Be Recovered
 
 ❌ Files never written to disk (only discussed)
 ❌ Files deleted before session start
-❌ Binary files (images, PDFs) - only paths available
+❌ Snapshot payloads that were deleted or not copied with an archived JSONL
 ❌ External tool outputs not captured in session
+
+Edit/Read records can reveal a path and Edit delta, but they are not themselves
+a full-file recovery source.
 
 ### File Versions
 
-- Only captures state when Write tool was called
-- Intermediate edits between Write calls are lost
-- Edit operations show deltas, not full content
+- A file-history backup is an exact captured checkpoint, not a guarantee that
+  no uncheckpointed filesystem change happened afterward.
+- Without a file-history entry, Write recovery cannot reconstruct later Edit or
+  shell changes; Edit records contain deltas rather than the full resulting file.
+- The file-history JSONL/store contract is runtime-observed and may evolve;
+  malformed or conflicting metadata must fail visibly rather than be guessed.
 
 ## Troubleshooting
 
@@ -341,21 +403,26 @@ widening ladder from the Completeness invariant section: `--all-projects` →
 ### Empty Recovery
 
 Possible causes:
-- Files were edited (Edit tool) but never written (Write tool)
 - Keywords don't match file paths in session
 - Session predates file creation
+- The path was never captured by either file-history or Write
 
 Solutions:
 - Try `--show-edits` flag to see Edit operations
 - Broaden keyword search
 - Search adjacent sessions
+- If an exact-backup error names a missing companion store, locate it and pass
+  `--file-history-root`; do not claim the stale Write checkpoint is final
 
 ### Large Session Files
 
 For sessions >100MB:
-- Scripts use streaming (line-by-line processing)
-- Memory usage remains constant
-- Processing may take 1-2 minutes
+- Search streams JSONL line by line instead of loading whole sessions.
+- Recovery copies exact backup bytes in chunks and retains only five lightweight
+  Edit summaries, never full Edit old/new payloads.
+- Recovery still retains valid Write payloads and record fingerprints needed for
+  copy union, so memory is not constant. Use `-k` to limit recovery scope and
+  expect runtime to scale with every discovered physical copy.
 
 ## Security & Privacy
 
@@ -369,12 +436,15 @@ Session files may contain:
 Always sanitize before sharing:
 
 ```bash
-# Remove absolute paths
-sed -i '' 's|~/|<home>/|g' file.js
-
-# Verify no credentials
-grep -i "api_key\|password\|token" recovered_content/*
+# Read-only audit; review every hit before creating a separate redacted copy.
+rg -n --hidden -S \
+  '(api[_-]?key|password|token|secret|/Users/[^/]+/|/home/[^/]+/)' \
+  recovered_content/
 ```
+
+`recovery_report.txt` is sensitive too: it records requested session copies,
+original absolute paths, checkpoint locations, and output paths. Audit and
+redact the report together with the recovered files; do not share it by default.
 
 ### Safe Storage
 

--- a/daymade-claude-code/claude-code-history-files-finder/SKILL.md
+++ b/daymade-claude-code/claude-code-history-files-finder/SKILL.md
@@ -246,8 +246,10 @@ shell-driven changes and can recover binary files or files without a Write tool
 call. A later `backupFileName: null` is a deletion tombstone: the last available
 checkpoint is recovered with the later deletion stated in the report. If a path
 has no usable snapshot checkpoint, the script recovers the latest Write call and
-labels it as lower fidelity in `recovery_report.txt`. Original directory
-structure is preserved under `./recovered_content/`.
+labels it as lower fidelity in `recovery_report.txt`. A Write whose matching
+`tool_result` explicitly has `is_error: true` is skipped; an attempted write is
+not a checkpoint. Original directory structure is preserved under
+`./recovered_content/`.
 
 **Filtering by keywords**:
 
@@ -307,7 +309,8 @@ file-history version for each original path, and uses checkpoint timestamps for
 ties. A later deletion tombstone does not erase an earlier recoverable backup;
 it changes the reported state. For paths with no usable checkpoint, recovery
 keeps the latest internally timestamped Write call. Physical JSONL line order
-across copies is not treated as sufficient time evidence.
+across copies is not treated as sufficient time evidence, and an explicitly
+failed Write tool result excludes that attempted Write from recovery.
 
 ### Keyword Selection
 

--- a/daymade-claude-code/claude-code-history-files-finder/evals/evals.json
+++ b/daymade-claude-code/claude-code-history-files-finder/evals/evals.json
@@ -16,7 +16,7 @@
     {
       "id": 3,
       "prompt": "Recover the deleted implementation of WidgetPanel from whichever previous Claude Code session wrote it, including sessions that are no longer in the active directory.",
-      "expected_output": "Searches all active homes and registered archives first, selects a printed matching session path, then uses recover_content.py while preserving the existing recovery and verification workflow.",
+      "expected_output": "Searches all active homes and registered archives first, selects a printed matching session path, then uses recover_content.py. It prefers the latest valid file-history checkpoint for exact bytes, labels Write-only recovery as lower fidelity, and verifies source provenance plus SHA-256 from the report.",
       "files": []
     },
     {
@@ -35,6 +35,24 @@
       "id": 6,
       "prompt": "找一下我们说「在测试机上配一条内容流水线」这句话的那次会话，大概昨天或今天说的，我忘了在哪个项目目录里开的，也可能是用 Codex 跑的。",
       "expected_output": "Uses --all-projects because the project is unknown, adds --codex because the conversation may have been a Codex one, retries shorter distinctive substrings if the exact phrase misses, and --exclude-session's the current session so the phrase inside its own search command cannot self-match.",
+      "files": []
+    },
+    {
+      "id": 7,
+      "prompt": "这几个 file:///.../.claude/jobs/<job>/tmp/*.html 链接昨天还能打开，今天临时目录没了。请把最终版本恢复出来；文件创建后又被 Edit 和命令行改过，不要只给我最初 Write 的版本。",
+      "expected_output": "Searches all projects with the filenames as multiple keywords, excludes the current self-match, selects the original session, and runs recover_content.py. It maps file-history-snapshot trackedFileBackups entries to the companion file-history store, restores the newest captured bytes including post-Write changes, reports version and SHA-256, and aborts visibly if referenced backup bytes are unavailable instead of silently substituting stale Write content.",
+      "files": []
+    },
+    {
+      "id": 8,
+      "prompt": "The active JSONL only has an old Write, but a registered archive may contain a richer copy of the same session and its file-history bytes. Recover the best checkpoint, including a file that was later deleted.",
+      "expected_output": "Unions same-ID JSONL copies and file-history roots from active homes and registered archives. It restores the highest available exact checkpoint; if a later null backupFileName records deletion, the report labels the recovered bytes as the last pre-deletion checkpoint and states the later deletion.",
+      "files": []
+    },
+    {
+      "id": 9,
+      "prompt": "I found the phrase with --codex. Pass that Codex rollout to the recovery command and restore its files.",
+      "expected_output": "Explains that --codex is a search-only widening. recover_content.py fails fast because Codex rollouts do not use Claude Write/file-history recovery records; it does not return an empty success or imply that files were restored.",
       "files": []
     }
   ]

--- a/daymade-claude-code/claude-code-history-files-finder/references/session_file_format.md
+++ b/daymade-claude-code/claude-code-history-files-finder/references/session_file_format.md
@@ -67,22 +67,72 @@ Conversation messages are the lines you usually want. In current Claude Code (>=
 }
 ```
 
-- **Role lives in `message.role`**; the top-level `type` only labels the line. Older sessions stored `role`/`content` at the top level, so a robust extractor reads both locations, e.g. `role = data.get("role") or data.get("message", {}).get("role")` (the bundled scripts do this).
+- **Role lives in `message.role`**; the top-level `type` only labels the line. Older sessions stored `role`/`content` at the top level, and some records carry `message: null`, so first type-check the nested object: `message = data.get("message"); role = data.get("role") or (message.get("role") if isinstance(message, dict) else None)` (the bundled scripts do this).
 - `message.content` is either a string or an array of content blocks (`text`, `tool_use`, `tool_result`, ...).
 
 ### Non-message event lines
 
 Recent sessions also interleave non-message event lines. Their `type` can be
 `attachment`, `system`, `summary`, `last-prompt`, `queue-operation`,
-`custom-title`, `mode`, and others. They carry no `message.role`, but several do
-carry search-relevant or recoverable text. A conversation-message counter may
-skip them; a history search must inspect their known payload fields.
+`custom-title`, `mode`, `file-history-snapshot`, and others. They carry no
+`message.role`, but several carry search-relevant text or recovery metadata. A
+conversation-message counter may skip them; a history search or recovery tool
+must inspect its relevant known payload fields.
 
 The bundled search extracts semantic text segments instead of searching raw JSON
 serialization. It covers message text, thinking text, tool inputs/results,
 queue-operation content, attachment payloads, last prompts, system/summary
 content, and custom titles. Structural keys, UUIDs, tool-use IDs, and thinking
 signatures are excluded to avoid false positives.
+
+### File-history snapshot
+
+Current Claude Code sessions can record a path-to-backup map separate from tool
+calls:
+
+```json
+{
+  "type": "file-history-snapshot",
+  "snapshot": {
+    "timestamp": "2026-07-01T10:05:00.000Z",
+    "trackedFileBackups": {
+      "/absolute/path/to/artifact.html": {
+        "backupFileName": "opaque-hash@v3",
+        "version": 3,
+        "backupTime": "2026-07-01T10:04:59.000Z"
+      }
+    }
+  }
+}
+```
+
+The referenced bytes normally live at
+`<claude-home>/file-history/<session-id>/<backupFileName>`. This is a companion
+store: a copied JSONL can outlive or move independently from its backup files.
+The schema is runtime-observed, not a documented stability contract. Parse
+unknown record types tolerantly, but validate every selected snapshot entry.
+
+`backupFileName: null` with a valid version is not malformed metadata. It is a
+no-payload deletion tombstone: the path existed at an earlier checkpoint but
+was recorded as deleted at that version. Recovery should preserve the latest
+earlier backup when available and state the later deletion explicitly.
+
+For each original path:
+
+1. Compare all valid entries, preferring the highest numeric `version`.
+2. Use `backupTime`, then the enclosing snapshot timestamp, as tie-breakers.
+3. Resolve the opaque name strictly inside `<file-history-root>/<session-id>/`.
+4. If duplicate roots contain that name, require byte-identical content.
+5. If metadata exists but its backup is missing, report a fidelity error. Do not
+   silently replace it with an older Write call.
+6. Union same-ID JSONL copies and their companion roots across active homes and
+   registered archives before selecting a checkpoint.
+7. Treat a later tombstone as state evidence, not as a malformed entry that
+   poisons a valid earlier checkpoint.
+
+Because the backup is byte-oriented, it can preserve binary files and the
+result of Edit or shell-driven changes that a Write-only extractor cannot
+reconstruct.
 
 ### Content Types
 
@@ -199,13 +249,19 @@ Due to schema variations, some fields may appear in different locations:
 ### Role Field
 
 ```python
-role = data.get("role") or data.get("message", {}).get("role")
+message = data.get("message")
+role = data.get("role") or (
+    message.get("role") if isinstance(message, dict) else None
+)
 ```
 
 ### Content Field
 
 ```python
-content = data.get("content") or data.get("message", {}).get("content", [])
+message = data.get("message")
+content = data.get("content")
+if content is None and isinstance(message, dict):
+    content = message.get("content", [])
 ```
 
 ### Timestamp Field
@@ -225,9 +281,15 @@ file or the session's overall range.
 
 ### Recover Deleted Files
 
-1. Search for `Write` tool calls with matching file path
-2. Extract `input.content` from latest occurrence
-3. Save to disk with original filename
+1. Search semantic content and original paths in `file-history-snapshot` maps.
+2. Union all known physical copies of the session and their companion roots.
+3. Recover the highest available snapshot version as exact bytes.
+4. If a later deletion tombstone exists, recover the prior checkpoint and
+   record the deletion as the later state.
+5. Only when no usable snapshot checkpoint exists, recover the latest
+   internally timestamped Write call and label it as lower fidelity.
+6. Save under a preflighted output root with original path provenance and
+   SHA-256.
 
 ### Track File Changes
 
@@ -295,12 +357,19 @@ with open(session_file, 'r') as f:
         process_line(line)
 ```
 
+Streaming does not make all memory use constant. Cross-copy de-duplication keeps
+record fingerprints, and Write recovery retains valid Write payloads. Exact
+file-history payloads should be hashed and copied in chunks; Edit old/new text
+is not needed for recovery and should not be retained.
+
 ## Performance Tips
 
 ### Memory Efficiency
 
 - Process files line-by-line (streaming)
-- Don't load entire file into memory
+- Do not load the entire JSONL or exact backup blob into memory
+- Retain only lightweight summaries for Edit calls
+- Expect record fingerprints and Write payloads to scale with the session
 - Use generators for large result sets
 
 ### Search Optimization
@@ -312,13 +381,19 @@ with open(session_file, 'r') as f:
 
 ### Deduplication
 
-When recovering files, keep latest version only:
+When recovering Write-only checkpoints, parse the ISO timestamps and keep the
+latest call rather than assuming physical line order is chronological:
 
 ```python
 files_by_path = {}
 for call in write_calls:
-    files_by_path[file_path] = call  # Overwrites earlier versions
+    previous = files_by_path.get(call["file_path"])
+    if previous is None or parse_timestamp(call["timestamp"]) > parse_timestamp(previous["timestamp"]):
+        files_by_path[call["file_path"]] = call
 ```
+
+For file-history entries, compare numeric versions first. Never de-duplicate
+different bytes merely because their opaque backup filenames match.
 
 ## Security Considerations
 
@@ -373,3 +448,6 @@ Notes:
   that cwd.
 - `analyze_sessions.py search --codex` implements exactly this table; prefer
   it over hand-rolled grep so mirrors and duplicates stay handled.
+- Codex support is search-only. `recover_content.py` requires Claude's Write or
+  file-history records and fails fast on a Codex rollout instead of returning
+  an empty success.

--- a/daymade-claude-code/claude-code-history-files-finder/references/workflow_examples.md
+++ b/daymade-claude-code/claude-code-history-files-finder/references/workflow_examples.md
@@ -22,7 +22,8 @@ cat ./recovered/recovery_report.txt
 
 `Source: file-history` means exact bytes from the named captured checkpoint.
 `Source: Write` means a lower-fidelity Write checkpoint whose later Edit or
-shell changes may be absent.
+shell changes may be absent. Write calls with an explicit failed `tool_result`
+are excluded because their requested content was not confirmed written.
 
 ## Recover Vanished Temporary Job Artifacts
 

--- a/daymade-claude-code/claude-code-history-files-finder/references/workflow_examples.md
+++ b/daymade-claude-code/claude-code-history-files-finder/references/workflow_examples.md
@@ -16,9 +16,45 @@ python3 scripts/recover_content.py <printed-session-path> \
     -k DeletedComponent ModelScreen \
     -o ./recovered/
 
-# 3. Review recovered files
-ls -lh ./recovered/
+# 3. Review provenance before treating a file as final
+cat ./recovered/recovery_report.txt
 ```
+
+`Source: file-history` means exact bytes from the named captured checkpoint.
+`Source: Write` means a lower-fidelity Write checkpoint whose later Edit or
+shell changes may be absent.
+
+## Recover Vanished Temporary Job Artifacts
+
+**Scenario**: Browser URLs point into an expired Claude job directory, and the
+original files are gone.
+
+```bash
+# 1. The project is uncertain, so every positional after --all-projects is a keyword
+python3 scripts/analyze_sessions.py search --all-projects \
+    artifact-a.html artifact-b.html \
+    --exclude-session <current-session-id>
+
+# 2. Recover exact captured checkpoints from the best matching session
+python3 scripts/recover_content.py <printed-session-path> \
+    -k artifact-a.html artifact-b.html \
+    -o ./restored-artifacts/
+
+# 3. Confirm source, checkpoint version, byte count, and SHA-256
+cat ./restored-artifacts/recovery_report.txt
+```
+
+Recovery automatically unions same-ID JSONL copies and companion roots from all
+active homes and registered archives. If exact-backup lookup still reports that
+bytes are missing, locate an unregistered checkpoint root and add
+`--file-history-root /path/to/file-history`. Do not silently call a stale Write
+checkpoint the final file. `--write-only` is an explicit lower-fidelity choice,
+not an automatic fallback. If the report says `Later state: recorded deleted`,
+the bytes are the last available pre-deletion checkpoint, not the current state.
+
+Codex rollout hits can be found with `--codex`, but they cannot be passed to
+`recover_content.py`: Codex search and Claude file recovery are separate
+capabilities.
 
 ## Track File Evolution Across Sessions
 
@@ -35,7 +71,7 @@ for session in session1.jsonl session2.jsonl session3.jsonl; do
         grep "componentName.jsx"
 done
 
-# 3. Recover all versions
+# 3. Recover the best captured version from each session
 python3 scripts/recover_content.py session1.jsonl -k componentName -o ./v1/
 python3 scripts/recover_content.py session2.jsonl -k componentName -o ./v2/
 python3 scripts/recover_content.py session3.jsonl -k componentName -o ./v3/

--- a/daymade-claude-code/claude-code-history-files-finder/scripts/analyze_sessions.py
+++ b/daymade-claude-code/claude-code-history-files-finder/scripts/analyze_sessions.py
@@ -590,6 +590,7 @@ class SessionAnalyzer:
             excluded_untimed_count = 0
             excluded_untimed_from_prior_copies: set[str] = set()
             matched_records_from_prior_copies: set[str] = set()
+            matched_file_history_paths: set[str] = set()
             matching_copies: List[Dict[str, Any]] = []
 
             copies = ref.get("copies") or [
@@ -612,6 +613,15 @@ class SessionAnalyzer:
                     for data in records:
                         record_identity = _record_identity(data)
                         record_timestamp = parse_timestamp(data.get("timestamp"))
+                        if (
+                            record_timestamp is None
+                            and data.get("type") == "file-history-snapshot"
+                        ):
+                            snapshot = data.get("snapshot")
+                            if isinstance(snapshot, dict):
+                                record_timestamp = parse_timestamp(
+                                    snapshot.get("timestamp")
+                                )
                         if from_timestamp is not None or to_timestamp is not None:
                             if record_timestamp is None:
                                 if record_identity not in excluded_untimed_from_prior_copies:
@@ -622,6 +632,44 @@ class SessionAnalyzer:
                                 record_timestamp, from_timestamp, to_timestamp
                             ):
                                 continue
+
+                        if data.get("type") == "file-history-snapshot":
+                            snapshot = data.get("snapshot")
+                            tracked = (
+                                snapshot.get("trackedFileBackups")
+                                if isinstance(snapshot, dict)
+                                else None
+                            )
+                            if isinstance(tracked, dict):
+                                for original_path in tracked:
+                                    if not isinstance(original_path, str):
+                                        continue
+                                    path_text = (
+                                        original_path
+                                        if case_sensitive
+                                        else original_path.casefold()
+                                    )
+                                    path_counts = {
+                                        keyword: 1
+                                        for keyword, search_keyword in search_keywords
+                                        if search_keyword in path_text
+                                    }
+                                    if not path_counts:
+                                        continue
+                                    copy_had_match = True
+                                    matching_source_labels.add(source.display_label)
+                                    match_sources.add("file_history_path")
+                                    if record_timestamp is not None:
+                                        match_timestamps.observe(record_timestamp)
+                                    if original_path in matched_file_history_paths:
+                                        continue
+                                    matched_file_history_paths.add(original_path)
+                                    path_mentions = sum(path_counts.values())
+                                    for keyword, count in path_counts.items():
+                                        keyword_counts[keyword] += count
+                                    total_mentions += path_mentions
+                                    copy_new_mentions += path_mentions
+
                         record_counts = defaultdict(int)
                         record_sources: set[str] = set()
                         for segment in searchable_segments(data):
@@ -923,6 +971,28 @@ def _validate_project_scope(args, parser) -> None:
         )
 
 
+def _normalize_search_scope(args, parser) -> None:
+    """Resolve the search positional grammar without argparse ambiguity.
+
+    ``project_path?`` followed by ``keywords+`` is ambiguous when
+    ``--all-projects`` is active: argparse consumes the first of two keywords as
+    the optional project. Parse one term list instead, then apply the scope the
+    caller selected.
+    """
+    terms = list(args.search_terms)
+    if args.all_projects:
+        args.project_path = None
+        args.keywords = terms
+        return
+    if len(terms) < 2:
+        parser.error(
+            "search requires a project path followed by at least one keyword; "
+            "use --all-projects when the project is unknown"
+        )
+    args.project_path = terms[0]
+    args.keywords = terms[1:]
+
+
 def _collect_sessions(analyzer: "SessionAnalyzer", args) -> List[Dict[str, Any]]:
     """Collect session refs for the requested scope, applying exclusions."""
     if args.all_projects:
@@ -1015,12 +1085,13 @@ def main():
     # Search command
     search_parser = subparsers.add_parser("search", help="Search sessions for keywords")
     search_parser.add_argument(
-        "project_path",
-        nargs="?",
-        help="Project path (omit when using --all-projects)",
-    )
-    search_parser.add_argument(
-        "keywords", nargs="+", help="Keywords to search for"
+        "search_terms",
+        nargs="+",
+        metavar="PROJECT_OR_KEYWORD",
+        help=(
+            "Project path followed by keywords, or only keywords with "
+            "--all-projects"
+        ),
     )
     search_parser.add_argument(
         "--all-projects",
@@ -1065,6 +1136,9 @@ def main():
     if not args.command:
         parser.print_help()
         sys.exit(1)
+
+    if args.command == "search":
+        _normalize_search_scope(args, parser)
 
     if args.command == "list":
         _validate_project_scope(args, parser)

--- a/daymade-claude-code/claude-code-history-files-finder/scripts/recover_content.py
+++ b/daymade-claude-code/claude-code-history-files-finder/scripts/recover_content.py
@@ -213,6 +213,7 @@ class SessionContentRecovery:
             "duplicate_records_skipped": 0,
             "session_copies": 0,
             "write_calls": 0,
+            "failed_write_calls_skipped": 0,
             "edit_calls": 0,
             "snapshot_records": 0,
             "snapshot_paths": 0,
@@ -425,6 +426,7 @@ class SessionContentRecovery:
             return self._scan_result
 
         writes: List[Dict[str, Any]] = []
+        failed_tool_use_ids: set[str] = set()
         edit_summaries: deque[Dict[str, Any]] = deque(maxlen=5)
         snapshots: Dict[str, Dict[str, Any]] = {}
         tombstones: Dict[str, Dict[str, Any]] = {}
@@ -499,12 +501,23 @@ class SessionContentRecovery:
                         message.get("role") if isinstance(message, dict) else None
                     )
                     role = data.get("role") or nested_role
-                    if role != "assistant":
-                        continue
                     content = data.get("content")
                     if content is None and isinstance(message, dict):
                         content = message.get("content", [])
                     if not isinstance(content, list):
+                        continue
+
+                    for item in content:
+                        if (
+                            isinstance(item, dict)
+                            and item.get("type") == "tool_result"
+                            and item.get("is_error") is True
+                        ):
+                            tool_use_id = item.get("tool_use_id")
+                            if isinstance(tool_use_id, str) and tool_use_id:
+                                failed_tool_use_ids.add(tool_use_id)
+
+                    if role != "assistant":
                         continue
 
                     for item in content:
@@ -526,6 +539,11 @@ class SessionContentRecovery:
                                         "file_path": file_path,
                                         "content": file_content,
                                         "timestamp": data.get("timestamp", ""),
+                                        "tool_use_id": (
+                                            item.get("id")
+                                            if isinstance(item.get("id"), str)
+                                            else None
+                                        ),
                                     }
                                 )
                                 self.stats["write_calls"] += 1
@@ -541,6 +559,19 @@ class SessionContentRecovery:
                             self.stats["edit_calls"] += 1
 
             record_hashes_from_prior_copies.update(copy_record_hashes)
+
+        usable_writes: List[Dict[str, Any]] = []
+        for write in writes:
+            tool_use_id = write.get("tool_use_id")
+            if tool_use_id and tool_use_id in failed_tool_use_ids:
+                self.stats["failed_write_calls_skipped"] += 1
+                self.warnings.append(
+                    "Skipped Write checkpoint with an explicit failed tool result: "
+                    f"{write['file_path']} ({write['source_file']}:{write['line']})"
+                )
+                continue
+            usable_writes.append(write)
+        writes = usable_writes
 
         if saw_codex_signature and not saw_claude_signature:
             raise RecoveryError(
@@ -1100,6 +1131,8 @@ class SessionContentRecovery:
             f"  Total lines processed: {self.stats['total_lines']:,}",
             f"  Duplicate records skipped: {self.stats['duplicate_records_skipped']}",
             f"  Write tool calls found: {self.stats['write_calls']}",
+            "  Failed Write tool calls skipped: "
+            f"{self.stats['failed_write_calls_skipped']}",
             f"  Edit tool calls found: {self.stats['edit_calls']}",
             f"  File-history snapshot records: {self.stats['snapshot_records']}",
             f"  Paths with snapshot metadata: {self.stats['snapshot_paths']}",

--- a/daymade-claude-code/claude-code-history-files-finder/scripts/recover_content.py
+++ b/daymade-claude-code/claude-code-history-files-finder/scripts/recover_content.py
@@ -1,266 +1,1095 @@
 #!/usr/bin/env python3
-"""
-Recover content from Claude Code history session files.
+"""Recover files from Claude Code session history.
 
-This script extracts Write tool calls, Edit operations, and text content
-from Claude Code's JSONL session history files.
+The highest-fidelity source is a ``file-history-snapshot`` record paired with
+``<claude-home>/file-history/<session-id>/``. Those backups preserve exact
+bytes captured after Write, Edit, and shell-driven changes. When no snapshot
+metadata exists for a path, the script retains the older Write-tool recovery
+mode and labels it as a lower-fidelity checkpoint.
 """
 
+from __future__ import annotations
+
+import argparse
+import hashlib
 import json
+import os
+import re
 import sys
-from pathlib import Path
-from typing import Dict, List, Any, Optional
+import tempfile
+from collections import deque
+from datetime import datetime
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import Any, Dict, Iterable, List, Optional
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _core.sources import (  # noqa: E402
+    HistorySource,
+    HistorySourceConfigError,
+    discover_claude_sources,
+)
+
+
+BACKUP_VERSION_RE = re.compile(r"@v(\d+)$")
+
+
+class RecoveryError(RuntimeError):
+    """Raised when exact recovery cannot be completed safely."""
+
+
+def _timestamp_rank(value: object) -> float:
+    if not isinstance(value, str) or not value:
+        return float("-inf")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return float("-inf")
+    if parsed.tzinfo is None:
+        return float("-inf")
+    return parsed.timestamp()
+
+
+def _backup_version(metadata: Dict[str, Any]) -> int:
+    value = metadata.get("version")
+    metadata_version: Optional[int] = None
+    if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+        metadata_version = value
+    elif isinstance(value, str) and value.isdigit():
+        metadata_version = int(value)
+    backup_name = metadata.get("backupFileName")
+    name_version: Optional[int] = None
+    if isinstance(backup_name, str):
+        match = BACKUP_VERSION_RE.search(backup_name)
+        if match:
+            name_version = int(match.group(1))
+    if (
+        metadata_version is not None
+        and name_version is not None
+        and metadata_version != name_version
+    ):
+        raise ValueError(
+            f"version {metadata_version} conflicts with backup name {backup_name!r}"
+        )
+    version = metadata_version if metadata_version is not None else name_version
+    if version is None:
+        raise ValueError("snapshot entry has no valid non-negative version")
+    return version
+
+
+def _entry_rank(entry: Dict[str, Any]) -> tuple[int, float, float]:
+    return (
+        entry["version"],
+        _timestamp_rank(entry.get("backup_time")),
+        _timestamp_rank(entry.get("snapshot_time")),
+    )
+
+
+def _metadata_version_hint(metadata: Dict[str, Any]) -> Optional[int]:
+    """Return a conservative version hint for malformed snapshot metadata."""
+    values: List[int] = []
+    raw_version = metadata.get("version")
+    if (
+        isinstance(raw_version, int)
+        and not isinstance(raw_version, bool)
+        and raw_version >= 0
+    ):
+        values.append(raw_version)
+    elif isinstance(raw_version, str) and raw_version.isdigit():
+        values.append(int(raw_version))
+    backup_name = metadata.get("backupFileName")
+    if isinstance(backup_name, str):
+        match = BACKUP_VERSION_RE.search(backup_name)
+        if match:
+            values.append(int(match.group(1)))
+    return max(values) if values else None
+
+
+def _inspect_file(path: Path) -> tuple[str, int, int]:
+    digest = hashlib.sha256()
+    size = 0
+    newlines = 0
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+            size += len(chunk)
+            newlines += chunk.count(b"\n")
+    lines = newlines + (1 if size else 0)
+    return digest.hexdigest(), size, lines
+
+
+def _atomic_write(path: Path, content: bytes) -> None:
+    """Atomically replace ``path`` with ``content``."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, path)
+    finally:
+        if temporary_path.exists():
+            temporary_path.unlink()
+
+
+def _atomic_copy(path: Path, source: Path, expected_sha256: str) -> None:
+    """Copy one checkpoint in chunks and verify it before publishing it."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    temporary_path = Path(temporary_name)
+    digest = hashlib.sha256()
+    try:
+        with (
+            source.open("rb") as input_handle,
+            os.fdopen(descriptor, "wb") as output_handle,
+        ):
+            while chunk := input_handle.read(1024 * 1024):
+                digest.update(chunk)
+                output_handle.write(chunk)
+            output_handle.flush()
+            os.fsync(output_handle.fileno())
+        if digest.hexdigest() != expected_sha256:
+            raise RecoveryError(
+                f"Checkpoint changed while it was being copied: {source}"
+            )
+        os.replace(temporary_path, path)
+    finally:
+        if temporary_path.exists():
+            temporary_path.unlink()
 
 
 class SessionContentRecovery:
-    """Extract and recover content from Claude Code session files."""
+    """Extract and recover files from all known copies of one Claude session."""
 
-    def __init__(self, session_file: Path, output_dir: Optional[Path] = None):
-        self.session_file = Path(session_file)
-        self.output_dir = output_dir or Path.cwd() / "recovered_content"
-        self.output_dir.mkdir(exist_ok=True)
+    CODEX_RECORD_TYPES = {
+        "session_meta",
+        "response_item",
+        "event_msg",
+        "turn_context",
+        "world_state",
+    }
+    CLAUDE_RECORD_TYPES = {
+        "assistant",
+        "user",
+        "queue-operation",
+        "attachment",
+        "file-history-snapshot",
+    }
 
-        # Statistics
+    def __init__(
+        self,
+        session_file: Path,
+        output_dir: Optional[Path] = None,
+        file_history_roots: Optional[Iterable[Path]] = None,
+        write_only: bool = False,
+    ) -> None:
+        self.session_file = Path(session_file).expanduser()
+        self.output_dir = (
+            Path(output_dir).expanduser()
+            if output_dir
+            else Path.cwd() / "recovered_content"
+        )
+        self.explicit_file_history_roots = [
+            Path(root).expanduser() for root in (file_history_roots or [])
+        ]
+        self.write_only = write_only
+        self.warnings: List[str] = []
+        self._scan_result: Optional[Dict[str, Any]] = None
+        self._source_cache: Optional[List[HistorySource]] = None
+        self._session_file_cache: Optional[List[Path]] = None
+
         self.stats = {
             "total_lines": 0,
+            "duplicate_records_skipped": 0,
+            "session_copies": 0,
             "write_calls": 0,
             "edit_calls": 0,
-            "text_mentions": 0,
+            "snapshot_records": 0,
+            "snapshot_paths": 0,
+            "tombstone_paths": 0,
             "files_recovered": 0,
+            "exact_recoveries": 0,
+            "write_recoveries": 0,
         }
 
-    def extract_write_calls(self) -> List[Dict[str, Any]]:
-        """Extract all Write tool calls from session."""
-        write_calls = []
+    def _history_sources(self) -> List[HistorySource]:
+        if self._source_cache is not None:
+            return self._source_cache
+        try:
+            sources, warnings = discover_claude_sources()
+        except HistorySourceConfigError as error:
+            raise RecoveryError(str(error)) from error
+        self.warnings.extend(warnings)
+        self._source_cache = sources
+        return sources
 
-        with open(self.session_file, "r") as f:
-            for line_num, line in enumerate(f, 1):
-                self.stats["total_lines"] += 1
+    def _discover_session_files(self) -> List[Path]:
+        """Find same-id JSONL copies in active homes and registered archives."""
+        if self._session_file_cache is not None:
+            return self._session_file_cache
 
-                try:
-                    data = json.loads(line.strip())
+        files: List[Path] = []
+        seen: set[str] = set()
 
-                    # Check both direct role and nested message.role
-                    role = data.get("role") or data.get("message", {}).get("role")
-                    if role != "assistant":
+        def add(candidate: Path) -> None:
+            if not candidate.is_file():
+                return
+            try:
+                key = str(candidate.resolve())
+            except OSError:
+                key = str(candidate.absolute())
+            if key not in seen:
+                seen.add(key)
+                files.append(candidate)
+
+        add(self.session_file)
+        filename = self.session_file.name
+        for source in self._history_sources():
+            projects_dir = source.home / "projects"
+            if not projects_dir.is_dir():
+                continue
+            for project_dir in sorted(projects_dir.iterdir()):
+                if project_dir.is_dir():
+                    add(project_dir / filename)
+
+        if not files:
+            raise RecoveryError(f"Session file not found: {self.session_file}")
+        self._session_file_cache = files
+        self.stats["session_copies"] = len(files)
+        return files
+
+    @staticmethod
+    def _record_error(
+        errors: Dict[str, List[Dict[str, Any]]],
+        original_path: str,
+        message: str,
+        metadata: Optional[Dict[str, Any]],
+        snapshot_time: object,
+        source_file: Path,
+        line_num: int,
+    ) -> None:
+        version = _metadata_version_hint(metadata or {})
+        rank = (
+            (
+                version,
+                _timestamp_rank((metadata or {}).get("backupTime")),
+                _timestamp_rank(snapshot_time),
+            )
+            if version is not None
+            else None
+        )
+        errors.setdefault(original_path, []).append(
+            {
+                "message": f"{source_file}:{line_num}: {message}",
+                "rank": rank,
+            }
+        )
+
+    def _consider_snapshot_entry(
+        self,
+        mapping: Dict[str, Dict[str, Any]],
+        candidate: Dict[str, Any],
+        errors: Dict[str, List[Dict[str, Any]]],
+    ) -> None:
+        original_path = candidate["file_path"]
+        previous = mapping.get(original_path)
+        if previous is None or _entry_rank(candidate) > _entry_rank(previous):
+            mapping[original_path] = candidate
+            return
+        if _entry_rank(candidate) != _entry_rank(previous):
+            return
+        previous_name = previous.get("backup_file_name")
+        candidate_name = candidate.get("backup_file_name")
+        if previous_name != candidate_name:
+            self._record_error(
+                errors,
+                original_path,
+                "conflicting snapshot states have the same version and timestamp",
+                {
+                    "version": candidate["version"],
+                    "backupFileName": candidate_name,
+                    "backupTime": candidate.get("backup_time"),
+                },
+                candidate.get("snapshot_time"),
+                candidate["source_file"],
+                candidate["line"],
+            )
+
+    def _consume_snapshot(
+        self,
+        data: Dict[str, Any],
+        source_file: Path,
+        line_num: int,
+        snapshots: Dict[str, Dict[str, Any]],
+        tombstones: Dict[str, Dict[str, Any]],
+        errors: Dict[str, List[Dict[str, Any]]],
+    ) -> None:
+        self.stats["snapshot_records"] += 1
+        snapshot = data.get("snapshot")
+        if not isinstance(snapshot, dict):
+            self.warnings.append(
+                f"{source_file}:{line_num}: snapshot payload is not an object"
+            )
+            return
+        tracked = snapshot.get("trackedFileBackups")
+        if tracked is None:
+            return
+        if not isinstance(tracked, dict):
+            self.warnings.append(
+                f"{source_file}:{line_num}: trackedFileBackups is not an object"
+            )
+            return
+
+        snapshot_time = snapshot.get("timestamp", "")
+        for original_path, metadata in tracked.items():
+            if not isinstance(original_path, str) or not original_path:
+                self.warnings.append(
+                    f"{source_file}:{line_num}: ignored snapshot entry with an invalid path"
+                )
+                continue
+            if not isinstance(metadata, dict):
+                self._record_error(
+                    errors,
+                    original_path,
+                    "snapshot metadata is not an object",
+                    None,
+                    snapshot_time,
+                    source_file,
+                    line_num,
+                )
+                continue
+            if "backupFileName" not in metadata:
+                self._record_error(
+                    errors,
+                    original_path,
+                    "snapshot metadata is missing backupFileName",
+                    metadata,
+                    snapshot_time,
+                    source_file,
+                    line_num,
+                )
+                continue
+
+            backup_name = metadata.get("backupFileName")
+            if backup_name is not None and (
+                not isinstance(backup_name, str) or not backup_name
+            ):
+                self._record_error(
+                    errors,
+                    original_path,
+                    "snapshot backupFileName must be a non-empty string or null",
+                    metadata,
+                    snapshot_time,
+                    source_file,
+                    line_num,
+                )
+                continue
+            try:
+                version = _backup_version(metadata)
+            except ValueError as error:
+                self._record_error(
+                    errors,
+                    original_path,
+                    str(error),
+                    metadata,
+                    snapshot_time,
+                    source_file,
+                    line_num,
+                )
+                continue
+
+            candidate = {
+                "line": line_num,
+                "source_file": source_file,
+                "file_path": original_path,
+                "backup_file_name": backup_name,
+                "version": version,
+                "backup_time": metadata.get("backupTime", ""),
+                "snapshot_time": snapshot_time,
+            }
+            destination = tombstones if backup_name is None else snapshots
+            self._consider_snapshot_entry(destination, candidate, errors)
+
+    def _scan_session(self) -> Dict[str, Any]:
+        if self._scan_result is not None:
+            return self._scan_result
+
+        writes: List[Dict[str, Any]] = []
+        edit_summaries: deque[Dict[str, Any]] = deque(maxlen=5)
+        snapshots: Dict[str, Dict[str, Any]] = {}
+        tombstones: Dict[str, Dict[str, Any]] = {}
+        snapshot_error_candidates: Dict[str, List[Dict[str, Any]]] = {}
+        session_ids: List[str] = []
+        record_hashes_from_prior_copies: set[str] = set()
+        saw_claude_signature = False
+        saw_codex_signature = False
+        session_files = self._discover_session_files()
+
+        for session_file in session_files:
+            copy_record_hashes: set[str] = set()
+            stem = session_file.stem
+            if stem and stem not in session_ids:
+                session_ids.append(stem)
+            try:
+                handle = session_file.open("r", encoding="utf-8", errors="replace")
+            except OSError as error:
+                raise RecoveryError(
+                    f"Cannot read session copy {session_file}: {error}"
+                ) from error
+            with handle:
+                for line_num, line in enumerate(handle, 1):
+                    self.stats["total_lines"] += 1
+                    try:
+                        data = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if not isinstance(data, dict):
                         continue
 
-                    # Get content from either location
-                    content = data.get("content") or data.get("message", {}).get(
-                        "content", []
+                    canonical = json.dumps(
+                        data,
+                        ensure_ascii=False,
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ).encode("utf-8")
+                    record_hash = hashlib.sha256(canonical).hexdigest()
+                    if record_hash in record_hashes_from_prior_copies:
+                        self.stats["duplicate_records_skipped"] += 1
+                        continue
+                    copy_record_hashes.add(record_hash)
+
+                    record_type = data.get("type")
+                    if record_type in self.CODEX_RECORD_TYPES:
+                        saw_codex_signature = True
+                    if record_type in self.CLAUDE_RECORD_TYPES or isinstance(
+                        data.get("sessionId"), str
+                    ):
+                        saw_claude_signature = True
+
+                    session_id = data.get("sessionId")
+                    if (
+                        isinstance(session_id, str)
+                        and session_id
+                        and session_id not in session_ids
+                    ):
+                        session_ids.append(session_id)
+
+                    if record_type == "file-history-snapshot":
+                        self._consume_snapshot(
+                            data,
+                            session_file,
+                            line_num,
+                            snapshots,
+                            tombstones,
+                            snapshot_error_candidates,
+                        )
+
+                    message = data.get("message")
+                    nested_role = (
+                        message.get("role") if isinstance(message, dict) else None
                     )
-
-                    for item in content:
-                        if not isinstance(item, dict):
-                            continue
-
-                        # Look for Write tool calls
-                        if item.get("type") == "tool_use" and item.get("name") == "Write":
-                            write_input = item.get("input", {})
-                            write_calls.append(
-                                {
-                                    "line": line_num,
-                                    "file_path": write_input.get("file_path", ""),
-                                    "content": write_input.get("content", ""),
-                                    "timestamp": data.get("timestamp", ""),
-                                }
-                            )
-                            self.stats["write_calls"] += 1
-
-                except json.JSONDecodeError:
-                    continue
-                except Exception as e:
-                    print(f"Warning: Error processing line {line_num}: {e}", file=sys.stderr)
-                    continue
-
-        return write_calls
-
-    def extract_edit_calls(self) -> List[Dict[str, Any]]:
-        """Extract all Edit tool calls from session."""
-        edit_calls = []
-
-        with open(self.session_file, "r") as f:
-            for line_num, line in enumerate(f, 1):
-                try:
-                    data = json.loads(line.strip())
-
-                    role = data.get("role") or data.get("message", {}).get("role")
+                    role = data.get("role") or nested_role
                     if role != "assistant":
                         continue
-
-                    content = data.get("content") or data.get("message", {}).get(
-                        "content", []
-                    )
+                    content = data.get("content")
+                    if content is None and isinstance(message, dict):
+                        content = message.get("content", [])
+                    if not isinstance(content, list):
+                        continue
 
                     for item in content:
-                        if not isinstance(item, dict):
+                        if not isinstance(item, dict) or item.get("type") != "tool_use":
                             continue
-
-                        if item.get("type") == "tool_use" and item.get("name") == "Edit":
-                            edit_input = item.get("input", {})
-                            edit_calls.append(
+                        tool_input = item.get("input")
+                        if not isinstance(tool_input, dict):
+                            continue
+                        if item.get("name") == "Write":
+                            file_path = tool_input.get("file_path", "")
+                            file_content = tool_input.get("content", "")
+                            if isinstance(file_path, str) and isinstance(
+                                file_content, str
+                            ):
+                                writes.append(
+                                    {
+                                        "line": line_num,
+                                        "source_file": session_file,
+                                        "file_path": file_path,
+                                        "content": file_content,
+                                        "timestamp": data.get("timestamp", ""),
+                                    }
+                                )
+                                self.stats["write_calls"] += 1
+                        elif item.get("name") == "Edit":
+                            edit_summaries.append(
                                 {
                                     "line": line_num,
-                                    "file_path": edit_input.get("file_path", ""),
-                                    "old_string": edit_input.get("old_string", ""),
-                                    "new_string": edit_input.get("new_string", ""),
+                                    "source_file": session_file,
+                                    "file_path": tool_input.get("file_path", ""),
                                     "timestamp": data.get("timestamp", ""),
                                 }
                             )
                             self.stats["edit_calls"] += 1
 
-                except Exception:
-                    continue
+            record_hashes_from_prior_copies.update(copy_record_hashes)
 
-        return edit_calls
+        if saw_codex_signature and not saw_claude_signature:
+            raise RecoveryError(
+                "This is a Codex rollout. Keyword search supports Codex with "
+                "analyze_sessions.py --codex, but file recovery currently supports "
+                "Claude Code JSONL sessions only."
+            )
+
+        all_snapshot_paths = set(snapshots) | set(tombstones)
+        blocking_errors: Dict[str, str] = {}
+        for original_path, error_entries in snapshot_error_candidates.items():
+            valid_ranks = [
+                _entry_rank(entry)
+                for entry in (
+                    snapshots.get(original_path),
+                    tombstones.get(original_path),
+                )
+                if entry is not None
+            ]
+            best_valid_rank = max(valid_ranks) if valid_ranks else None
+            for error_entry in error_entries:
+                error_rank = error_entry["rank"]
+                if (
+                    error_rank is None
+                    or best_valid_rank is None
+                    or error_rank >= best_valid_rank
+                ):
+                    blocking_errors[original_path] = error_entry["message"]
+                else:
+                    self.warnings.append(
+                        "Ignored older malformed snapshot metadata for "
+                        f"{original_path}: {error_entry['message']}"
+                    )
+
+        for original_path in set(snapshots) & set(tombstones):
+            if _entry_rank(snapshots[original_path]) == _entry_rank(
+                tombstones[original_path]
+            ):
+                blocking_errors[original_path] = (
+                    "the same file-history version is recorded as both a backup "
+                    "and a deletion tombstone"
+                )
+
+        self.stats["snapshot_paths"] = len(all_snapshot_paths)
+        self.stats["tombstone_paths"] = len(tombstones)
+        self._scan_result = {
+            "writes": writes,
+            "edit_summaries": list(edit_summaries),
+            "snapshots": snapshots,
+            "tombstones": tombstones,
+            "snapshot_errors": blocking_errors,
+            "session_ids": session_ids,
+            "session_files": session_files,
+        }
+        return self._scan_result
+
+    def extract_write_calls(self) -> List[Dict[str, Any]]:
+        """Return every valid Write tool call found in the session union."""
+        return list(self._scan_session()["writes"])
+
+    def extract_edit_calls(self) -> List[Dict[str, Any]]:
+        """Return lightweight summaries for at most the five latest Edit calls."""
+        return list(self._scan_session()["edit_summaries"])
+
+    def extract_file_history_snapshots(self) -> Dict[str, Dict[str, Any]]:
+        """Return the latest usable backup checkpoint for every path."""
+        return dict(self._scan_session()["snapshots"])
+
+    def _file_history_roots(self) -> List[Path]:
+        roots: List[Path] = []
+        seen: set[str] = set()
+
+        def add(root: Path) -> None:
+            expanded = root.expanduser()
+            try:
+                key = str(expanded.resolve())
+            except OSError:
+                key = str(expanded.absolute())
+            if key not in seen:
+                seen.add(key)
+                roots.append(expanded)
+
+        for session_file in self._discover_session_files():
+            for parent in session_file.resolve().parents:
+                if parent.name == "projects":
+                    add(parent.parent / "file-history")
+                    break
+        for source in self._history_sources():
+            add(source.home / "file-history")
+        for root in self.explicit_file_history_roots:
+            add(root)
+        return roots
+
+    @staticmethod
+    def _safe_identifier(value: str, label: str) -> str:
+        if not value or value in {".", ".."} or "/" in value or "\\" in value:
+            raise RecoveryError(f"Unsafe {label}: {value!r}")
+        return value
+
+    def _read_snapshot_backup(
+        self, entry: Dict[str, Any], roots: List[Path], session_ids: List[str]
+    ) -> tuple[Path, str, int, int]:
+        backup_name = self._safe_identifier(
+            entry["backup_file_name"], "file-history backup name"
+        )
+        safe_session_ids = [
+            self._safe_identifier(session_id, "session id")
+            for session_id in session_ids
+        ]
+        matches: List[tuple[Path, str, int, int]] = []
+        searched: List[Path] = []
+
+        for root in roots:
+            try:
+                resolved_root = root.resolve()
+            except OSError:
+                resolved_root = root.absolute()
+            for session_id in safe_session_ids:
+                session_dir = root / session_id
+                candidate = session_dir / backup_name
+                searched.append(candidate)
+                if session_dir.is_symlink():
+                    raise RecoveryError(
+                        f"Unsafe file-history session directory symlink: {session_dir}"
+                    )
+                if not session_dir.exists():
+                    continue
+                if not session_dir.is_dir():
+                    raise RecoveryError(
+                        "Unsafe file-history session object (expected a directory): "
+                        f"{session_dir}"
+                    )
+                try:
+                    resolved_dir = session_dir.resolve()
+                    resolved_dir.relative_to(resolved_root)
+                except (OSError, ValueError) as error:
+                    raise RecoveryError(
+                        f"file-history session directory escapes its root: {session_dir}"
+                    ) from error
+                if candidate.is_symlink():
+                    raise RecoveryError(
+                        f"Unsafe file-history backup symlink: {candidate}"
+                    )
+                if not candidate.exists():
+                    continue
+                if not candidate.is_file():
+                    raise RecoveryError(
+                        "Unsafe file-history backup object (expected a regular file): "
+                        f"{candidate}"
+                    )
+                try:
+                    resolved_candidate = candidate.resolve()
+                    resolved_candidate.relative_to(resolved_dir)
+                    resolved_candidate.relative_to(resolved_root)
+                except (OSError, ValueError) as error:
+                    raise RecoveryError(
+                        f"file-history backup escapes its session directory: {candidate}"
+                    ) from error
+                try:
+                    digest, size, lines = _inspect_file(candidate)
+                except OSError as error:
+                    raise RecoveryError(
+                        f"Cannot read file-history backup {candidate}: {error}"
+                    ) from error
+                matches.append((candidate, digest, size, lines))
+
+        if not matches:
+            searched_dirs = sorted({str(path.parent) for path in searched})
+            detail = (
+                ", ".join(searched_dirs) if searched_dirs else "no roots discovered"
+            )
+            raise RecoveryError(
+                "Snapshot metadata exists but its exact backup is unavailable for "
+                f"{entry['file_path']}. Expected {backup_name} under: {detail}. "
+                "Provide the companion root with --file-history-root, or use "
+                "--write-only only if a lower-fidelity Write checkpoint is acceptable."
+            )
+
+        digests = {digest for _, digest, _, _ in matches}
+        if len(digests) != 1:
+            locations = ", ".join(str(path) for path, _, _, _ in matches)
+            raise RecoveryError(
+                "Conflicting file-history backups have the same metadata name but "
+                f"different bytes: {locations}"
+            )
+        return matches[0]
+
+    def _output_path(self, original_path: str) -> Path:
+        if re.match(r"^[A-Za-z]:[\\/]", original_path):
+            pure_path = PureWindowsPath(original_path)
+            parts = list(pure_path.parts)
+            start = 1
+            if len(parts) > 2 and parts[1].lower() == "users":
+                start = 3
+        else:
+            pure_path = PurePosixPath(original_path)
+            parts = list(pure_path.parts)
+            start = 0
+            if pure_path.is_absolute():
+                start = 1
+                if len(parts) > 2 and parts[1].lower() in {"users", "home"}:
+                    start = 3
+
+        relative_parts = parts[start:]
+        if not relative_parts and pure_path.name:
+            relative_parts = [pure_path.name]
+        if not relative_parts or any(
+            part in {"", ".", ".."} for part in relative_parts
+        ):
+            raise RecoveryError(f"Unsafe recovered file path: {original_path!r}")
+
+        output_path = self.output_dir.joinpath(*relative_parts)
+        try:
+            output_path.resolve().relative_to(self.output_dir.resolve())
+        except (OSError, ValueError) as error:
+            raise RecoveryError(
+                f"Recovered file path escapes the output directory: {original_path!r}"
+            ) from error
+        return output_path
+
+    def _preflight_destinations(self, planned: List[Dict[str, Any]]) -> None:
+        """Reject deterministic collisions before writing any recovered bytes."""
+        if self.output_dir.exists() and not self.output_dir.is_dir():
+            raise RecoveryError(
+                f"Recovery output path is not a directory: {self.output_dir}"
+            )
+
+        report_path = self.output_dir / "recovery_report.txt"
+        report_key = report_path.resolve()
+        destinations: Dict[Path, str] = {}
+        for item in planned:
+            output_path = self._output_path(item["original_path"])
+            key = output_path.resolve()
+            if key == report_key:
+                raise RecoveryError(
+                    "A recovered artifact would overwrite the reserved recovery "
+                    f"report: {item['original_path']!r} -> {report_path}"
+                )
+            collision = destinations.get(key)
+            if collision and collision != item["original_path"]:
+                raise RecoveryError(
+                    "Two original paths map to the same recovery destination: "
+                    f"{collision!r} and {item['original_path']!r} -> {output_path}"
+                )
+            destinations[key] = item["original_path"]
+            item["output_path"] = output_path
+
+        destination_keys = list(destinations)
+        for index, first in enumerate(destination_keys):
+            for second in destination_keys[index + 1 :]:
+                if first in second.parents or second in first.parents:
+                    raise RecoveryError(
+                        "Recovered destinations have a file/directory ancestor "
+                        f"collision: {first} and {second}"
+                    )
+
+        for destination in [
+            *(item["output_path"] for item in planned),
+            report_path,
+        ]:
+            if destination.is_symlink():
+                raise RecoveryError(
+                    f"Recovery destination is an existing symlink: {destination}"
+                )
+            if destination.exists() and destination.is_dir():
+                raise RecoveryError(
+                    f"Recovery destination is an existing directory: {destination}"
+                )
+            parent = destination.parent
+            while parent != self.output_dir and self.output_dir in parent.parents:
+                if parent.is_symlink():
+                    raise RecoveryError(
+                        f"Recovery destination parent is a symlink: {parent}"
+                    )
+                if parent.exists() and not parent.is_dir():
+                    raise RecoveryError(
+                        f"Recovery destination parent is not a directory: {parent}"
+                    )
+                parent = parent.parent
+
+    @staticmethod
+    def _tombstone_note(tombstone: Dict[str, Any]) -> str:
+        timestamp = tombstone.get("backup_time") or tombstone.get("snapshot_time")
+        when = timestamp if isinstance(timestamp, str) and timestamp else "unknown time"
+        return f"recorded deleted at file-history v{tombstone['version']} ({when})"
+
+    @staticmethod
+    def _tombstone_follows_write(
+        tombstone: Dict[str, Any], write: Dict[str, Any]
+    ) -> bool:
+        tombstone_time = _timestamp_rank(
+            tombstone.get("backup_time") or tombstone.get("snapshot_time")
+        )
+        write_time = _timestamp_rank(write.get("timestamp"))
+        return tombstone_time > write_time
+
+    def _select_writes(
+        self, writes: List[Dict[str, Any]]
+    ) -> tuple[Dict[str, Dict[str, Any]], List[str]]:
+        selected: Dict[str, Dict[str, Any]] = {}
+        failures: List[str] = []
+        for call in writes:
+            file_path = call["file_path"]
+            if not file_path:
+                continue
+            previous = selected.get(file_path)
+            if previous is None:
+                selected[file_path] = call
+                continue
+            rank = _timestamp_rank(call.get("timestamp"))
+            previous_rank = _timestamp_rank(previous.get("timestamp"))
+            if rank > previous_rank:
+                selected[file_path] = call
+            elif rank == previous_rank and call["content"] != previous["content"]:
+                failures.append(
+                    "Conflicting Write checkpoints have the same timestamp for "
+                    f"{file_path}: {previous['source_file']}:{previous['line']} and "
+                    f"{call['source_file']}:{call['line']}"
+                )
+        return selected, failures
+
+    def recover_files(
+        self, keywords: Optional[List[str]] = None
+    ) -> List[Dict[str, Any]]:
+        """Plan and preflight the whole recovery before writing selected files."""
+        scan = self._scan_session()
+        snapshots: Dict[str, Dict[str, Any]] = scan["snapshots"]
+        tombstones: Dict[str, Dict[str, Any]] = scan["tombstones"]
+        snapshot_errors: Dict[str, str] = scan["snapshot_errors"]
+        writes_by_path, failures = self._select_writes(scan["writes"])
+
+        all_paths = (
+            set(writes_by_path)
+            | set(snapshots)
+            | set(tombstones)
+            | set(snapshot_errors)
+        )
+        if keywords:
+            lowered = [keyword.casefold() for keyword in keywords]
+            all_paths = {
+                path
+                for path in all_paths
+                if any(keyword in path.casefold() for keyword in lowered)
+            }
+
+        roots = self._file_history_roots()
+        planned: List[Dict[str, Any]] = []
+
+        for original_path in sorted(all_paths):
+            if not self.write_only and original_path in snapshot_errors:
+                failures.append(f"{original_path}: {snapshot_errors[original_path]}")
+                continue
+
+            snapshot = snapshots.get(original_path)
+            tombstone = tombstones.get(original_path)
+            later_state: Optional[str] = None
+            if (
+                snapshot
+                and tombstone
+                and _entry_rank(tombstone) > _entry_rank(snapshot)
+            ):
+                later_state = self._tombstone_note(tombstone)
+
+            if not self.write_only and snapshot is not None:
+                try:
+                    backup_path, digest, size, lines = self._read_snapshot_backup(
+                        snapshot, roots, scan["session_ids"]
+                    )
+                except RecoveryError as error:
+                    failures.append(str(error))
+                    continue
+                fidelity = "exact bytes from captured checkpoint"
+                if later_state:
+                    fidelity += " before a later recorded deletion"
+                planned.append(
+                    {
+                        "original_path": original_path,
+                        "content": None,
+                        "source_file": backup_path,
+                        "sha256": digest,
+                        "size": size,
+                        "lines": lines,
+                        "source": "file-history",
+                        "source_path": str(backup_path),
+                        "version": snapshot["version"],
+                        "timestamp": snapshot["backup_time"]
+                        or snapshot["snapshot_time"],
+                        "fidelity": fidelity,
+                        "later_state": later_state,
+                    }
+                )
+                continue
+
+            write = writes_by_path.get(original_path)
+            if write is None:
+                if self.write_only and (snapshot is not None or tombstone is not None):
+                    self.warnings.append(
+                        "Skipped snapshot-only path in --write-only mode: "
+                        f"{original_path}"
+                    )
+                elif tombstone is not None:
+                    self.warnings.append(
+                        "Skipped deleted path with no recoverable prior checkpoint: "
+                        f"{original_path} ({self._tombstone_note(tombstone)})"
+                    )
+                continue
+
+            content = write["content"].encode("utf-8")
+            if tombstone is not None and self._tombstone_follows_write(
+                tombstone, write
+            ):
+                later_state = self._tombstone_note(tombstone)
+            planned.append(
+                {
+                    "original_path": original_path,
+                    "content": content,
+                    "source_file": None,
+                    "sha256": hashlib.sha256(content).hexdigest(),
+                    "size": len(content),
+                    "lines": content.count(b"\n") + (1 if content else 0),
+                    "source": "Write",
+                    "source_path": f"{write['source_file']}:{write['line']}",
+                    "version": None,
+                    "timestamp": write.get("timestamp", ""),
+                    "fidelity": (
+                        "Write checkpoint; later Edit or shell changes may be absent"
+                    ),
+                    "later_state": later_state,
+                }
+            )
+
+        if failures:
+            raise RecoveryError(
+                "Recovery aborted before writing files:\n- " + "\n- ".join(failures)
+            )
+
+        self._preflight_destinations(planned)
+        saved: List[Dict[str, Any]] = []
+        for item in planned:
+            output_path = item["output_path"]
+            if item["source"] == "file-history":
+                _atomic_copy(output_path, item["source_file"], item["sha256"])
+            else:
+                _atomic_write(output_path, item["content"])
+            saved.append(
+                {
+                    "file": output_path.name,
+                    "original_path": item["original_path"],
+                    "size": item["size"],
+                    "lines": item["lines"],
+                    "timestamp": item["timestamp"] or "unknown",
+                    "output_path": str(output_path),
+                    "source": item["source"],
+                    "source_path": item["source_path"],
+                    "version": item["version"],
+                    "fidelity": item["fidelity"],
+                    "later_state": item["later_state"],
+                    "sha256": item["sha256"],
+                }
+            )
+            self.stats["files_recovered"] += 1
+            if item["source"] == "file-history":
+                self.stats["exact_recoveries"] += 1
+            else:
+                self.stats["write_recoveries"] += 1
+        return saved
 
     def save_recovered_files(
         self, write_calls: List[Dict[str, Any]], keywords: Optional[List[str]] = None
     ) -> List[Dict[str, Any]]:
-        """
-        Save recovered files to disk, preserving original directory structure.
-
-        Args:
-            write_calls: List of Write tool calls
-            keywords: Optional keywords to filter files (matches any keyword in file path)
-
-        Returns:
-            List of saved file metadata
-        """
-        saved = []
-
-        # Filter by keywords if provided
-        if keywords:
-            write_calls = [
-                call
-                for call in write_calls
-                if any(kw.lower() in call["file_path"].lower() for kw in keywords)
-            ]
-
-        # Deduplicate: keep latest version of each file
-        files_by_path = {}
-        for call in write_calls:
-            file_path = call["file_path"]
-            if not file_path:
-                continue
-
-            # Keep latest version (assuming chronological order in session)
-            files_by_path[file_path] = call
-
-        # Save files
-        for file_path, call in files_by_path.items():
-            try:
-                if not file_path:
-                    continue
-
-                # Preserve original directory structure
-                # Convert absolute path to relative path within output directory
-                original_path = Path(file_path)
-
-                # Handle absolute paths: extract meaningful relative path
-                # e.g., <home>/project/src/file.py -> src/file.py
-                # e.g., <home>/workspace/project/lib/module.py -> lib/module.py
-                path_parts = original_path.parts
-                if len(path_parts) > 1 and path_parts[0] == "/":
-                    # For absolute paths, try to find a project-like directory
-                    # Skip leading /, Users/username, home/username patterns
-                    start_idx = 1  # Skip leading "/"
-                    if len(path_parts) > 2 and path_parts[1].lower() in ("users", "home", "user"):
-                        start_idx = 3  # Skip /Users/username or /home/user
-                    relative_parts = path_parts[start_idx:]
-                else:
-                    relative_parts = path_parts
-
-                # Construct output path preserving structure
-                if relative_parts:
-                    output_file = self.output_dir.joinpath(*relative_parts)
-                else:
-                    # Fallback to filename only if path is too shallow
-                    output_file = self.output_dir / original_path.name
-
-                # Create parent directories
-                output_file.parent.mkdir(parents=True, exist_ok=True)
-
-                with open(output_file, "w") as f:
-                    f.write(call["content"])
-
-                saved.append(
-                    {
-                        "file": output_file.name,
-                        "original_path": file_path,
-                        "size": len(call["content"]),
-                        "lines": call["content"].count("\n") + 1,
-                        "timestamp": call.get("timestamp", "unknown"),
-                        "output_path": str(output_file),
-                    }
-                )
-
-                self.stats["files_recovered"] += 1
-
-            except Exception as e:
-                print(f"Warning: Failed to save {file_path}: {e}", file=sys.stderr)
-                continue
-
-        return saved
+        """Compatibility wrapper; recovery now selects the best source itself."""
+        del write_calls
+        return self.recover_files(keywords)
 
     def generate_report(self, saved_files: List[Dict[str, Any]]) -> str:
-        """Generate recovery report."""
+        """Generate a provenance-rich recovery report."""
+        scan = self._scan_session()
         report_lines = [
             "=" * 60,
             "Claude Code Session Content Recovery Report",
             "=" * 60,
             "",
-            f"Session file: {self.session_file}",
+            f"Requested session file: {self.session_file}",
             f"Output directory: {self.output_dir}",
             "",
+            "Session copies scanned:",
+            *(f"  - {path}" for path in scan["session_files"]),
+            "",
             "Statistics:",
+            f"  Session copies: {self.stats['session_copies']}",
             f"  Total lines processed: {self.stats['total_lines']:,}",
+            f"  Duplicate records skipped: {self.stats['duplicate_records_skipped']}",
             f"  Write tool calls found: {self.stats['write_calls']}",
             f"  Edit tool calls found: {self.stats['edit_calls']}",
+            f"  File-history snapshot records: {self.stats['snapshot_records']}",
+            f"  Paths with snapshot metadata: {self.stats['snapshot_paths']}",
+            f"  Paths with deletion tombstones: {self.stats['tombstone_paths']}",
             f"  Files recovered: {self.stats['files_recovered']}",
+            f"  Exact checkpoint recoveries: {self.stats['exact_recoveries']}",
+            f"  Write checkpoint recoveries: {self.stats['write_recoveries']}",
             "",
         ]
 
-        if saved_files:
-            report_lines.extend(
-                [
-                    "Recovered Files:",
-                    "",
-                ]
-            )
+        if self.warnings:
+            report_lines.append("Warnings:")
+            report_lines.extend(f"  - {warning}" for warning in self.warnings)
+            report_lines.append("")
 
+        if saved_files:
+            report_lines.extend(["Recovered Files:", ""])
             for item in saved_files:
+                version = (
+                    f" v{item['version']}" if isinstance(item["version"], int) else ""
+                )
                 report_lines.extend(
                     [
-                        f"✅ {item['file']}",
+                        f"OK {item['file']}",
                         f"   Original: {item['original_path']}",
-                        f"   Size: {item['size']:,} characters",
+                        f"   Source: {item['source']}{version} ({item['source_path']})",
+                        f"   Fidelity: {item['fidelity']}",
+                    ]
+                )
+                if item["later_state"]:
+                    report_lines.append(f"   Later state: {item['later_state']}")
+                report_lines.extend(
+                    [
+                        f"   Captured: {item['timestamp']}",
+                        f"   Size: {item['size']:,} bytes",
                         f"   Lines: {item['lines']:,}",
+                        f"   SHA-256: {item['sha256']}",
                         f"   Saved to: {item['output_path']}",
                         "",
                     ]
                 )
         else:
-            report_lines.append("No files recovered (no matches or no Write calls found)")
-            report_lines.append("")
+            report_lines.extend(["No files matched the requested recovery scope.", ""])
 
         report_lines.extend(["=" * 60, ""])
-
         return "\n".join(report_lines)
 
 
-def main():
-    """Main entry point."""
-    import argparse
-
+def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Recover content from Claude Code session history files"
+        description=(
+            "Recover exact file-history checkpoints when available, otherwise "
+            "recover explicitly labeled Write-tool checkpoints"
+        )
     )
-    parser.add_argument(
-        "session_file",
-        type=Path,
-        help="Path to Claude Code session JSONL file",
-    )
+    parser.add_argument("session_file", type=Path, help="Claude Code session JSONL")
     parser.add_argument(
         "-o",
         "--output",
@@ -271,60 +1100,78 @@ def main():
         "-k",
         "--keywords",
         nargs="+",
-        help="Filter files by keywords (matches any keyword in file path)",
+        help="Recover paths matching any keyword",
+    )
+    parser.add_argument(
+        "--file-history-root",
+        action="append",
+        type=Path,
+        default=[],
+        metavar="DIR",
+        help=(
+            "Additional file-history root containing <session-id>/ directories "
+            "(repeatable)"
+        ),
+    )
+    parser.add_argument(
+        "--write-only",
+        action="store_true",
+        help=(
+            "Ignore file-history metadata and explicitly recover lower-fidelity "
+            "Write checkpoints"
+        ),
     )
     parser.add_argument(
         "--show-edits",
         action="store_true",
-        help="Also show Edit operations (not saved, just listed)",
+        help="List the five latest Edit operations",
     )
-
     args = parser.parse_args()
 
-    # Validate session file exists
-    if not args.session_file.exists():
+    if not args.session_file.is_file():
         print(f"Error: Session file not found: {args.session_file}", file=sys.stderr)
-        sys.exit(1)
+        return 1
 
-    # Create recovery instance
-    recovery = SessionContentRecovery(args.session_file, args.output)
+    recovery = SessionContentRecovery(
+        args.session_file,
+        args.output,
+        args.file_history_root,
+        args.write_only,
+    )
+    print(f"Analyzing session: {args.session_file}")
+    print(f"Output directory: {recovery.output_dir}\n")
 
-    print(f"🔍 Analyzing session: {args.session_file}")
-    print(f"📂 Output directory: {recovery.output_dir}\n")
-
-    # Extract Write calls
-    print("1️⃣ Extracting Write tool calls...")
-    write_calls = recovery.extract_write_calls()
-    print(f"   Found {len(write_calls)} Write calls\n")
-
-    # Save files
-    print("2️⃣ Saving recovered files...")
-    if args.keywords:
-        print(f"   Filtering by keywords: {', '.join(args.keywords)}")
-    saved = recovery.save_recovered_files(write_calls, args.keywords)
-    print(f"   Saved {len(saved)} files\n")
-
-    # Optionally show edits
-    if args.show_edits:
-        print("3️⃣ Extracting Edit tool calls...")
-        edit_calls = recovery.extract_edit_calls()
-        print(f"   Found {len(edit_calls)} Edit calls")
-        if edit_calls:
-            print("\n   Recent edits:")
-            for edit in edit_calls[-5:]:  # Show last 5
-                print(f"   - {Path(edit['file_path']).name} (line {edit['line']})")
+    try:
+        write_calls = recovery.extract_write_calls()
+        print(f"Write calls: {len(write_calls)}")
+        print(f"Paths with file-history metadata: {recovery.stats['snapshot_paths']}")
+        if args.write_only:
+            print("Recovery mode: explicit Write-only checkpoint mode")
+        else:
+            print("Recovery mode: exact file-history checkpoint preferred")
+        if args.keywords:
+            print(f"Path filters: {', '.join(args.keywords)}")
         print()
 
-    # Generate and print report
-    report = recovery.generate_report(saved)
-    print(report)
+        saved = recovery.recover_files(args.keywords)
+        if args.show_edits:
+            edits = recovery.extract_edit_calls()
+            print(f"Edit calls: {recovery.stats['edit_calls']}")
+            for edit in edits:
+                print(f"  - {Path(str(edit['file_path'])).name} (line {edit['line']})")
+            print()
 
-    # Save report
-    report_file = recovery.output_dir / "recovery_report.txt"
-    with open(report_file, "w") as f:
-        f.write(report)
-    print(f"📄 Report saved to: {report_file}\n")
+        report = recovery.generate_report(saved)
+        print(report)
+        report_file = recovery.output_dir / "recovery_report.txt"
+        _atomic_write(report_file, report.encode("utf-8"))
+    except (RecoveryError, OSError) as error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 2
+
+    print(f"Report saved to: {report_file}")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/daymade-claude-code/claude-code-history-files-finder/scripts/recover_content.py
+++ b/daymade-claude-code/claude-code-history-files-finder/scripts/recover_content.py
@@ -837,30 +837,66 @@ class SessionContentRecovery:
         write_time = _timestamp_rank(write.get("timestamp"))
         return tombstone_time > write_time
 
+    @staticmethod
+    def _write_follows_tombstone(
+        write: Dict[str, Any], tombstone: Dict[str, Any]
+    ) -> bool:
+        write_time = _timestamp_rank(write.get("timestamp"))
+        tombstone_time = _timestamp_rank(
+            tombstone.get("backup_time") or tombstone.get("snapshot_time")
+        )
+        return write_time > tombstone_time
+
+    @staticmethod
+    def _write_follows_snapshot(
+        write: Dict[str, Any], snapshot: Dict[str, Any]
+    ) -> bool:
+        write_time = _timestamp_rank(write.get("timestamp"))
+        snapshot_time = max(
+            _timestamp_rank(snapshot.get("backup_time")),
+            _timestamp_rank(snapshot.get("snapshot_time")),
+        )
+        return (
+            write_time != float("-inf")
+            and snapshot_time != float("-inf")
+            and write_time > snapshot_time
+        )
+
     def _select_writes(
         self, writes: List[Dict[str, Any]]
-    ) -> tuple[Dict[str, Dict[str, Any]], List[str]]:
-        selected: Dict[str, Dict[str, Any]] = {}
-        failures: List[str] = []
+    ) -> tuple[Dict[str, Dict[str, Any]], Dict[str, str]]:
+        calls_by_path: Dict[str, List[Dict[str, Any]]] = {}
         for call in writes:
             file_path = call["file_path"]
-            if not file_path:
-                continue
-            previous = selected.get(file_path)
-            if previous is None:
-                selected[file_path] = call
-                continue
-            rank = _timestamp_rank(call.get("timestamp"))
-            previous_rank = _timestamp_rank(previous.get("timestamp"))
-            if rank > previous_rank:
-                selected[file_path] = call
-            elif rank == previous_rank and call["content"] != previous["content"]:
-                failures.append(
+            if file_path:
+                calls_by_path.setdefault(file_path, []).append(call)
+
+        selected: Dict[str, Dict[str, Any]] = {}
+        conflicts: Dict[str, str] = {}
+        for file_path, calls in calls_by_path.items():
+            latest_rank = max(_timestamp_rank(call.get("timestamp")) for call in calls)
+            latest = [
+                call
+                for call in calls
+                if _timestamp_rank(call.get("timestamp")) == latest_rank
+            ]
+            latest.sort(key=lambda call: (str(call["source_file"]), call["line"]))
+            selected[file_path] = latest[0]
+            conflict = next(
+                (
+                    call
+                    for call in latest[1:]
+                    if call["content"] != latest[0]["content"]
+                ),
+                None,
+            )
+            if conflict is not None:
+                conflicts[file_path] = (
                     "Conflicting Write checkpoints have the same timestamp for "
-                    f"{file_path}: {previous['source_file']}:{previous['line']} and "
-                    f"{call['source_file']}:{call['line']}"
+                    f"{file_path}: {latest[0]['source_file']}:{latest[0]['line']} and "
+                    f"{conflict['source_file']}:{conflict['line']}"
                 )
-        return selected, failures
+        return selected, conflicts
 
     def recover_files(
         self, keywords: Optional[List[str]] = None
@@ -870,10 +906,12 @@ class SessionContentRecovery:
         snapshots: Dict[str, Dict[str, Any]] = scan["snapshots"]
         tombstones: Dict[str, Dict[str, Any]] = scan["tombstones"]
         snapshot_errors: Dict[str, str] = scan["snapshot_errors"]
-        writes_by_path, failures = self._select_writes(scan["writes"])
+        writes_by_path, write_conflicts = self._select_writes(scan["writes"])
+        failures: List[str] = []
 
         all_paths = (
             set(writes_by_path)
+            | set(write_conflicts)
             | set(snapshots)
             | set(tombstones)
             | set(snapshot_errors)
@@ -896,15 +934,40 @@ class SessionContentRecovery:
 
             snapshot = snapshots.get(original_path)
             tombstone = tombstones.get(original_path)
+            write = writes_by_path.get(original_path)
             later_state: Optional[str] = None
+            latest_tombstone = (
+                tombstone
+                if tombstone is not None
+                and (
+                    snapshot is None
+                    or _entry_rank(tombstone) > _entry_rank(snapshot)
+                )
+                else None
+            )
+            write_supersedes_snapshot = bool(
+                write is not None
+                and snapshot is not None
+                and (
+                    self._write_follows_snapshot(write, snapshot)
+                    or (
+                        latest_tombstone is not None
+                        and self._write_follows_tombstone(write, latest_tombstone)
+                    )
+                )
+            )
             if (
                 snapshot
-                and tombstone
-                and _entry_rank(tombstone) > _entry_rank(snapshot)
+                and latest_tombstone
+                and not write_supersedes_snapshot
             ):
-                later_state = self._tombstone_note(tombstone)
+                later_state = self._tombstone_note(latest_tombstone)
 
-            if not self.write_only and snapshot is not None:
+            if (
+                not self.write_only
+                and snapshot is not None
+                and not write_supersedes_snapshot
+            ):
                 try:
                     backup_path, digest, size, lines = self._read_snapshot_backup(
                         snapshot, roots, scan["session_ids"]
@@ -934,7 +997,6 @@ class SessionContentRecovery:
                 )
                 continue
 
-            write = writes_by_path.get(original_path)
             if write is None:
                 if self.write_only and (snapshot is not None or tombstone is not None):
                     self.warnings.append(
@@ -948,11 +1010,15 @@ class SessionContentRecovery:
                     )
                 continue
 
+            if original_path in write_conflicts:
+                failures.append(write_conflicts[original_path])
+                continue
+
             content = write["content"].encode("utf-8")
-            if tombstone is not None and self._tombstone_follows_write(
-                tombstone, write
+            if latest_tombstone is not None and self._tombstone_follows_write(
+                latest_tombstone, write
             ):
-                later_state = self._tombstone_note(tombstone)
+                later_state = self._tombstone_note(latest_tombstone)
             planned.append(
                 {
                     "original_path": original_path,

--- a/daymade-claude-code/claude-code-history-files-finder/tests/test_analyze_sessions.py
+++ b/daymade-claude-code/claude-code-history-files-finder/tests/test_analyze_sessions.py
@@ -335,7 +335,7 @@ class SessionAnalyzerTests(unittest.TestCase):
                 user_record(
                     first_id,
                     self.workspace,
-                    "cross-project-marker",
+                    "cross-project-marker second-marker",
                     "2026-04-20T10:00:00Z",
                 )
             ],
@@ -346,7 +346,7 @@ class SessionAnalyzerTests(unittest.TestCase):
                 user_record(
                     second_id,
                     other_workspace,
-                    "cross-project-marker",
+                    "cross-project-marker second-marker",
                     "2026-04-21T10:00:00Z",
                 )
             ],
@@ -355,6 +355,7 @@ class SessionAnalyzerTests(unittest.TestCase):
             "search",
             "--all-projects",
             "cross-project-marker",
+            "second-marker",
             "--home",
             str(self.active_home),
             "--home",
@@ -364,6 +365,7 @@ class SessionAnalyzerTests(unittest.TestCase):
         self.assertIn(second_id, completed.stdout)
         self.assertIn("Project:", completed.stdout)
         self.assertIn("2 project(s)", completed.stdout)
+        self.assertIn("cross-project-marker(1), second-marker(1)", completed.stdout)
 
         listed = self.run_cli(
             "list",
@@ -376,13 +378,12 @@ class SessionAnalyzerTests(unittest.TestCase):
         self.assertIn("across 2 project(s)", listed.stdout)
         self.assertIn("== ", listed.stdout)
 
-    def test_project_scope_is_required_and_exclusive(self) -> None:
+    def test_project_scope_is_required_and_list_scope_is_exclusive(self) -> None:
         neither = self.run_cli("search", "anything", check=False)
         self.assertEqual(neither.returncode, 2)
         both = self.run_cli(
-            "search",
+            "list",
             str(self.workspace),
-            "anything",
             "--all-projects",
             check=False,
         )
@@ -456,6 +457,48 @@ class SessionAnalyzerTests(unittest.TestCase):
         self.assertNotIn("--all-projects", widened.stderr)
         self.assertNotIn("--codex (", widened.stderr)
         self.assertIn("substrings", widened.stderr)
+
+    def test_search_finds_snapshot_only_original_path_once_across_copies(self) -> None:
+        session_id = "abababab-abab-4bab-8bab-abababababab"
+        original_path = "/tmp/generated/snapshot-only.bin"
+        record = {
+            "type": "file-history-snapshot",
+            "snapshot": {
+                "timestamp": "2026-04-22T10:00:00Z",
+                "trackedFileBackups": {
+                    original_path: {
+                        "backupFileName": "snapshot@v2",
+                        "version": 2,
+                        "backupTime": "2026-04-22T10:00:00Z",
+                    }
+                },
+            },
+        }
+        write_jsonl(
+            project_dir(self.active_home, self.workspace) / f"{session_id}.jsonl",
+            [record, record],
+        )
+        write_jsonl(
+            project_dir(self.archive_home, self.workspace) / f"{session_id}.jsonl",
+            [record],
+        )
+
+        completed = self.run_cli(
+            "search",
+            str(self.workspace),
+            "snapshot-only.bin",
+            "--from-date",
+            "2026-04-22",
+            "--to-date",
+            "2026-04-22",
+            "--history-sources",
+            str(self.manifest),
+        )
+
+        self.assertIn(session_id, completed.stdout)
+        self.assertIn("snapshot-only.bin(1)", completed.stdout)
+        self.assertIn("file_history_path", completed.stdout)
+        self.assertIn("active:main, archive:full-backup", completed.stdout)
 
     def seed_codex_rollout(
         self,

--- a/daymade-claude-code/claude-code-history-files-finder/tests/test_recover_content.py
+++ b/daymade-claude-code/claude-code-history-files-finder/tests/test_recover_content.py
@@ -371,6 +371,91 @@ class SessionRecoveryTests(unittest.TestCase):
         )
         self.assertNotIn("Later state:", completed.stdout)
 
+    def test_write_after_snapshot_and_tombstone_recovers_recreated_bytes(self) -> None:
+        backup_name = "before-recreate@v2"
+        write_jsonl(
+            self.session_file,
+            [
+                snapshot_record(
+                    str(self.original), backup_name, 2, "2026-07-01T19:20:00Z"
+                ),
+                snapshot_record(str(self.original), None, 3, "2026-07-01T19:25:00Z"),
+                write_record(
+                    str(self.original), "recreated-new", "2026-07-01T19:30:00Z"
+                ),
+            ],
+        )
+        self.backup_path(backup_name).write_bytes(b"pre-delete-old")
+
+        completed = self.run_cli(str(self.session_file), "-o", str(self.output_dir))
+
+        self.assertEqual(
+            self.expected_output().read_text(encoding="utf-8"), "recreated-new"
+        )
+        self.assertIn("Source: Write", completed.stdout)
+        self.assertNotIn("Later state:", completed.stdout)
+
+    def test_unrelated_write_conflict_does_not_abort_keyword_recovery(self) -> None:
+        unrelated = self.root / "jobs" / "task" / "unrelated.txt"
+        write_jsonl(
+            self.session_file,
+            [
+                write_record(
+                    str(self.original), "wanted-content", "2026-07-01T19:31:00Z"
+                ),
+                write_record(str(unrelated), "noise-a", "2026-07-01T19:32:00Z"),
+                write_record(str(unrelated), "noise-b", "2026-07-01T19:32:00Z"),
+            ],
+        )
+
+        self.run_cli(
+            str(self.session_file),
+            "-k",
+            "artifact.bin",
+            "-o",
+            str(self.output_dir),
+        )
+
+        self.assertEqual(
+            self.expected_output().read_text(encoding="utf-8"), "wanted-content"
+        )
+
+    def test_newer_snapshot_makes_older_write_conflict_irrelevant(self) -> None:
+        backup_name = "after-conflict@v2"
+        write_jsonl(
+            self.session_file,
+            [
+                write_record(str(self.original), "draft-a", "2026-07-01T19:33:00Z"),
+                write_record(str(self.original), "draft-b", "2026-07-01T19:33:00Z"),
+                snapshot_record(
+                    str(self.original), backup_name, 2, "2026-07-01T19:34:00Z"
+                ),
+            ],
+        )
+        self.backup_path(backup_name).write_bytes(b"exact-after-conflict")
+
+        self.run_cli(str(self.session_file), "-o", str(self.output_dir))
+
+        self.assertEqual(self.expected_output().read_bytes(), b"exact-after-conflict")
+
+    def test_older_write_conflict_is_superseded_by_unique_later_write(self) -> None:
+        write_jsonl(
+            self.session_file,
+            [
+                write_record(str(self.original), "draft-a", "2026-07-01T19:35:00Z"),
+                write_record(str(self.original), "draft-b", "2026-07-01T19:35:00Z"),
+                write_record(
+                    str(self.original), "final-write", "2026-07-01T19:36:00Z"
+                ),
+            ],
+        )
+
+        self.run_cli(str(self.session_file), "-o", str(self.output_dir))
+
+        self.assertEqual(
+            self.expected_output().read_text(encoding="utf-8"), "final-write"
+        )
+
     def test_write_before_tombstone_reports_the_later_deletion(self) -> None:
         write_jsonl(
             self.session_file,

--- a/daymade-claude-code/claude-code-history-files-finder/tests/test_recover_content.py
+++ b/daymade-claude-code/claude-code-history-files-finder/tests/test_recover_content.py
@@ -1,0 +1,605 @@
+#!/usr/bin/env python3
+"""Regression tests for exact Claude file-history recovery."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path, PurePosixPath
+from unittest import mock
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+from recover_content import SessionContentRecovery  # noqa: E402
+
+
+SKILL_DIR = Path(__file__).resolve().parents[1]
+SCRIPT = SKILL_DIR / "scripts" / "recover_content.py"
+SESSION_ID = "11111111-1111-4111-8111-111111111111"
+
+
+def write_jsonl(path: Path, records: list[object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def write_record(path: str, content: str, timestamp: str) -> dict:
+    return {
+        "type": "assistant",
+        "sessionId": SESSION_ID,
+        "timestamp": timestamp,
+        "message": {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "name": "Write",
+                    "input": {"file_path": path, "content": content},
+                }
+            ],
+        },
+    }
+
+
+def snapshot_record(
+    path: str, backup_name: str | None, version: int, timestamp: str
+) -> dict:
+    return {
+        "type": "file-history-snapshot",
+        "messageId": "22222222-2222-4222-8222-222222222222",
+        "snapshot": {
+            "messageId": "22222222-2222-4222-8222-222222222222",
+            "timestamp": timestamp,
+            "trackedFileBackups": {
+                path: {
+                    "backupFileName": backup_name,
+                    "version": version,
+                    "backupTime": timestamp,
+                }
+            },
+        },
+        "isSnapshotUpdate": True,
+    }
+
+
+def edit_record(path: str, marker: str, timestamp: str) -> dict:
+    return {
+        "type": "assistant",
+        "sessionId": SESSION_ID,
+        "timestamp": timestamp,
+        "message": {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "name": "Edit",
+                    "input": {
+                        "file_path": path,
+                        "old_string": f"old-{marker}" * 1000,
+                        "new_string": f"new-{marker}" * 1000,
+                    },
+                }
+            ],
+        },
+    }
+
+
+class SessionRecoveryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        self.user_home = self.root / "user-home"
+        self.claude_home = self.user_home / ".claude"
+        self.project_dir = self.claude_home / "projects" / "-tmp-demo"
+        self.project_dir.mkdir(parents=True)
+        self.session_file = self.project_dir / f"{SESSION_ID}.jsonl"
+        self.original = self.root / "jobs" / "task" / "artifact.bin"
+        self.output_dir = self.root / "recovered"
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def run_cli(
+        self, *arguments: str, check: bool = True
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), *arguments],
+            text=True,
+            encoding="utf-8",
+            capture_output=True,
+            check=check,
+            env={
+                **os.environ,
+                "HOME": str(self.user_home),
+                "CLAUDE_CONFIG_DIR": str(self.claude_home),
+            },
+        )
+
+    def expected_output(self, original: Path | None = None) -> Path:
+        source = original or self.original
+        return self.output_dir.joinpath(*PurePosixPath(str(source)).parts[1:])
+
+    def backup_path(self, name: str, root: Path | None = None) -> Path:
+        history_root = root or (self.claude_home / "file-history")
+        path = history_root / SESSION_ID / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def test_file_history_snapshot_wins_over_stale_write(self) -> None:
+        backup_name = "abc123@v2"
+        final_bytes = b"final after edit\n"
+        write_jsonl(
+            self.session_file,
+            [
+                write_record(
+                    str(self.original), "initial write\n", "2026-07-01T10:00:00Z"
+                ),
+                snapshot_record(
+                    str(self.original), backup_name, 2, "2026-07-01T10:05:00Z"
+                ),
+            ],
+        )
+        self.backup_path(backup_name).write_bytes(final_bytes)
+
+        completed = self.run_cli(
+            str(self.session_file), "-k", "artifact.bin", "-o", str(self.output_dir)
+        )
+
+        self.assertEqual(self.expected_output().read_bytes(), final_bytes)
+        self.assertIn("Source: file-history v2", completed.stdout)
+        self.assertIn("exact bytes from captured checkpoint", completed.stdout)
+
+    def test_snapshot_recovers_binary_file_without_write_call(self) -> None:
+        backup_name = "binary123@v1"
+        binary = b"\x00\xff\x10binary\x00"
+        write_jsonl(
+            self.session_file,
+            [
+                snapshot_record(
+                    str(self.original), backup_name, 1, "2026-07-01T11:00:00Z"
+                )
+            ],
+        )
+        self.backup_path(backup_name).write_bytes(binary)
+
+        self.run_cli(str(self.session_file), "-o", str(self.output_dir))
+
+        self.assertEqual(self.expected_output().read_bytes(), binary)
+
+    def test_latest_snapshot_version_is_selected(self) -> None:
+        write_jsonl(
+            self.session_file,
+            [
+                snapshot_record(
+                    str(self.original), "versioned@v1", 1, "2026-07-01T12:00:00Z"
+                ),
+                snapshot_record(
+                    str(self.original), "versioned@v2", 2, "2026-07-01T12:05:00Z"
+                ),
+            ],
+        )
+        self.backup_path("versioned@v1").write_bytes(b"old")
+        self.backup_path("versioned@v2").write_bytes(b"new")
+
+        self.run_cli(str(self.session_file), "-o", str(self.output_dir))
+
+        self.assertEqual(self.expected_output().read_bytes(), b"new")
+
+    def test_missing_exact_backup_aborts_without_stale_write_fallback(self) -> None:
+        write_jsonl(
+            self.session_file,
+            [
+                write_record(str(self.original), "stale", "2026-07-01T13:00:00Z"),
+                snapshot_record(
+                    str(self.original), "missing@v2", 2, "2026-07-01T13:05:00Z"
+                ),
+            ],
+        )
+
+        completed = self.run_cli(
+            str(self.session_file), "-o", str(self.output_dir), check=False
+        )
+
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn("exact backup is unavailable", completed.stderr)
+        self.assertFalse(self.expected_output().exists())
+
+    def test_write_only_is_an_explicit_lower_fidelity_mode(self) -> None:
+        write_jsonl(
+            self.session_file,
+            [
+                write_record(str(self.original), "stale", "2026-07-01T14:00:00Z"),
+                snapshot_record(
+                    str(self.original), "missing@v2", 2, "2026-07-01T14:05:00Z"
+                ),
+            ],
+        )
+
+        completed = self.run_cli(
+            str(self.session_file),
+            "--write-only",
+            "-o",
+            str(self.output_dir),
+        )
+
+        self.assertEqual(self.expected_output().read_text(encoding="utf-8"), "stale")
+        self.assertIn(
+            "Write checkpoint; later Edit or shell changes may be absent",
+            completed.stdout,
+        )
+
+    def test_explicit_file_history_root_recovers_archive_copy(self) -> None:
+        archive = self.root / "archive"
+        self.session_file = archive / "projects" / "-tmp-demo" / f"{SESSION_ID}.jsonl"
+        backup_name = "archive123@v3"
+        write_jsonl(
+            self.session_file,
+            [
+                snapshot_record(
+                    str(self.original), backup_name, 3, "2026-07-01T15:00:00Z"
+                )
+            ],
+        )
+        companion_root = self.root / "companion-file-history"
+        self.backup_path(backup_name, companion_root).write_bytes(b"archive-final")
+
+        self.run_cli(
+            str(self.session_file),
+            "--file-history-root",
+            str(companion_root),
+            "-o",
+            str(self.output_dir),
+        )
+
+        self.assertEqual(self.expected_output().read_bytes(), b"archive-final")
+
+    def test_unsafe_backup_name_is_rejected(self) -> None:
+        write_jsonl(
+            self.session_file,
+            [
+                snapshot_record(
+                    str(self.original), "../outside", 1, "2026-07-01T16:00:00Z"
+                )
+            ],
+        )
+
+        completed = self.run_cli(
+            str(self.session_file), "-o", str(self.output_dir), check=False
+        )
+
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn("Unsafe file-history backup name", completed.stderr)
+        self.assertFalse(self.expected_output().exists())
+
+    def test_snapshot_version_and_backup_name_must_agree(self) -> None:
+        write_jsonl(
+            self.session_file,
+            [
+                snapshot_record(
+                    str(self.original), "mismatch@v1", 2, "2026-07-01T16:30:00Z"
+                )
+            ],
+        )
+
+        completed = self.run_cli(
+            str(self.session_file), "-o", str(self.output_dir), check=False
+        )
+
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn("conflicts with backup name", completed.stderr)
+        self.assertFalse(self.output_dir.exists())
+
+    def test_later_tombstone_recovers_last_available_checkpoint(self) -> None:
+        backup_name = "before-delete@v2"
+        write_jsonl(
+            self.session_file,
+            [
+                snapshot_record(
+                    str(self.original), backup_name, 2, "2026-07-01T17:00:00Z"
+                ),
+                snapshot_record(str(self.original), None, 3, "2026-07-01T17:05:00Z"),
+            ],
+        )
+        self.backup_path(backup_name).write_bytes(b"last existing bytes")
+
+        completed = self.run_cli(str(self.session_file), "-o", str(self.output_dir))
+
+        self.assertEqual(self.expected_output().read_bytes(), b"last existing bytes")
+        self.assertIn("before a later recorded deletion", completed.stdout)
+        self.assertIn(
+            "Later state: recorded deleted at file-history v3", completed.stdout
+        )
+
+    def test_lower_version_tombstone_does_not_poison_newer_backup(self) -> None:
+        backup_name = "newer@v2"
+        write_jsonl(
+            self.session_file,
+            [
+                snapshot_record(
+                    str(self.original), backup_name, 2, "2026-07-01T18:00:00Z"
+                ),
+                snapshot_record(str(self.original), None, 1, "2026-07-01T18:05:00Z"),
+            ],
+        )
+        self.backup_path(backup_name).write_bytes(b"newer")
+
+        completed = self.run_cli(str(self.session_file), "-o", str(self.output_dir))
+
+        self.assertEqual(self.expected_output().read_bytes(), b"newer")
+        self.assertNotIn("Later state:", completed.stdout)
+
+    def test_unrelated_tombstone_does_not_abort_write_recovery(self) -> None:
+        deleted = self.root / "jobs" / "task" / "deleted.txt"
+        write_jsonl(
+            self.session_file,
+            [
+                write_record(
+                    str(self.original), "write survives", "2026-07-01T19:00:00Z"
+                ),
+                snapshot_record(str(deleted), None, 4, "2026-07-01T19:05:00Z"),
+            ],
+        )
+
+        completed = self.run_cli(str(self.session_file), "-o", str(self.output_dir))
+
+        self.assertEqual(
+            self.expected_output().read_text(encoding="utf-8"), "write survives"
+        )
+        self.assertIn("Skipped deleted path", completed.stdout)
+
+    def test_write_after_tombstone_is_reported_as_recreated_not_later_deleted(
+        self,
+    ) -> None:
+        write_jsonl(
+            self.session_file,
+            [
+                snapshot_record(str(self.original), None, 2, "2026-07-01T19:30:00Z"),
+                write_record(str(self.original), "recreated", "2026-07-01T19:35:00Z"),
+            ],
+        )
+
+        completed = self.run_cli(str(self.session_file), "-o", str(self.output_dir))
+
+        self.assertEqual(
+            self.expected_output().read_text(encoding="utf-8"), "recreated"
+        )
+        self.assertNotIn("Later state:", completed.stdout)
+
+    def test_write_before_tombstone_reports_the_later_deletion(self) -> None:
+        write_jsonl(
+            self.session_file,
+            [
+                write_record(str(self.original), "pre-delete", "2026-07-01T19:40:00Z"),
+                snapshot_record(str(self.original), None, 3, "2026-07-01T19:45:00Z"),
+            ],
+        )
+
+        completed = self.run_cli(str(self.session_file), "-o", str(self.output_dir))
+
+        self.assertEqual(
+            self.expected_output().read_text(encoding="utf-8"), "pre-delete"
+        )
+        self.assertIn("Later state: recorded deleted", completed.stdout)
+
+    def test_registered_archive_file_history_root_is_used_automatically(self) -> None:
+        archive_home = self.root / "registered-archive"
+        (archive_home / "projects" / "-tmp-demo").mkdir(parents=True)
+        self.claude_home.joinpath("history-sources.json").write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "sources": [
+                        {
+                            "provider": "claude",
+                            "kind": "archive",
+                            "label": "backup",
+                            "home": str(archive_home),
+                            "required": True,
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        backup_name = "archive-root@v4"
+        write_jsonl(
+            self.session_file,
+            [
+                snapshot_record(
+                    str(self.original), backup_name, 4, "2026-07-01T20:00:00Z"
+                )
+            ],
+        )
+        self.backup_path(backup_name, archive_home / "file-history").write_bytes(
+            b"registered exact"
+        )
+
+        self.run_cli(str(self.session_file), "-o", str(self.output_dir))
+
+        self.assertEqual(self.expected_output().read_bytes(), b"registered exact")
+
+    def test_registered_archive_session_copy_supersedes_stale_active_write(
+        self,
+    ) -> None:
+        archive_home = self.root / "registered-archive"
+        archive_session = (
+            archive_home / "projects" / "-moved-project" / self.session_file.name
+        )
+        self.claude_home.joinpath("history-sources.json").write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "sources": [
+                        {
+                            "provider": "claude",
+                            "kind": "archive",
+                            "label": "backup",
+                            "home": str(archive_home),
+                            "required": True,
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        backup_name = "archive-copy@v5"
+        write_jsonl(
+            self.session_file,
+            [write_record(str(self.original), "stale", "2026-07-01T21:00:00Z")],
+        )
+        write_jsonl(
+            archive_session,
+            [
+                snapshot_record(
+                    str(self.original), backup_name, 5, "2026-07-01T21:05:00Z"
+                )
+            ],
+        )
+        self.backup_path(backup_name, archive_home / "file-history").write_bytes(
+            b"archive final"
+        )
+
+        completed = self.run_cli(str(self.session_file), "-o", str(self.output_dir))
+
+        self.assertEqual(self.expected_output().read_bytes(), b"archive final")
+        self.assertIn("Session copies: 2", completed.stdout)
+
+    def test_report_destination_collision_aborts_before_writing(self) -> None:
+        write_jsonl(
+            self.session_file,
+            [write_record("recovery_report.txt", "artifact", "2026-07-01T22:00:00Z")],
+        )
+
+        completed = self.run_cli(
+            str(self.session_file), "-o", str(self.output_dir), check=False
+        )
+
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn("reserved recovery report", completed.stderr)
+        self.assertFalse(self.output_dir.exists())
+
+    def test_parent_child_destination_collision_aborts_without_partial_output(
+        self,
+    ) -> None:
+        write_jsonl(
+            self.session_file,
+            [
+                write_record("a", "parent", "2026-07-01T23:00:00Z"),
+                write_record("a/b", "child", "2026-07-01T23:01:00Z"),
+            ],
+        )
+
+        completed = self.run_cli(
+            str(self.session_file), "-o", str(self.output_dir), check=False
+        )
+
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn("ancestor collision", completed.stderr)
+        self.assertFalse(self.output_dir.exists())
+
+    def test_symlinked_session_directory_cannot_escape_file_history_root(self) -> None:
+        explicit_root = self.root / "declared-root"
+        outside = self.root / "outside" / SESSION_ID
+        outside.mkdir(parents=True)
+        explicit_root.mkdir()
+        backup_name = "escape@v1"
+        (outside / backup_name).write_bytes(b"outside")
+        (explicit_root / SESSION_ID).symlink_to(outside, target_is_directory=True)
+        write_jsonl(
+            self.session_file,
+            [
+                snapshot_record(
+                    str(self.original), backup_name, 1, "2026-07-02T00:00:00Z"
+                )
+            ],
+        )
+
+        completed = self.run_cli(
+            str(self.session_file),
+            "--file-history-root",
+            str(explicit_root),
+            "-o",
+            str(self.output_dir),
+            check=False,
+        )
+
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn("session directory symlink", completed.stderr)
+        self.assertFalse(self.expected_output().exists())
+
+    def test_null_message_is_ignored_without_traceback(self) -> None:
+        write_jsonl(
+            self.session_file,
+            [
+                {"type": "assistant", "sessionId": SESSION_ID, "message": None},
+                write_record(str(self.original), "valid", "2026-07-02T01:00:00Z"),
+            ],
+        )
+
+        completed = self.run_cli(str(self.session_file), "-o", str(self.output_dir))
+
+        self.assertEqual(self.expected_output().read_text(encoding="utf-8"), "valid")
+        self.assertNotIn("Traceback", completed.stderr)
+
+    def test_codex_rollout_fails_fast_with_supported_boundary(self) -> None:
+        write_jsonl(
+            self.session_file,
+            [
+                {
+                    "type": "session_meta",
+                    "timestamp": "2026-07-02T02:00:00Z",
+                    "payload": {"id": SESSION_ID},
+                },
+                {
+                    "type": "response_item",
+                    "timestamp": "2026-07-02T02:00:01Z",
+                    "payload": {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "hello"}],
+                    },
+                },
+            ],
+        )
+
+        completed = self.run_cli(
+            str(self.session_file), "-o", str(self.output_dir), check=False
+        )
+
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn("Codex rollout", completed.stderr)
+        self.assertIn("Claude Code JSONL sessions only", completed.stderr)
+        self.assertFalse(self.output_dir.exists())
+
+    def test_edit_summaries_drop_large_old_and_new_payloads(self) -> None:
+        records = [
+            edit_record(str(self.original), str(index), f"2026-07-02T03:00:0{index}Z")
+            for index in range(6)
+        ]
+        write_jsonl(self.session_file, records)
+
+        with mock.patch.dict(
+            os.environ,
+            {
+                "HOME": str(self.user_home),
+                "CLAUDE_CONFIG_DIR": str(self.claude_home),
+            },
+            clear=False,
+        ):
+            recovery = SessionContentRecovery(self.session_file, self.output_dir)
+            summaries = recovery.extract_edit_calls()
+
+        self.assertEqual(recovery.stats["edit_calls"], 6)
+        self.assertEqual(len(summaries), 5)
+        self.assertNotIn("old_string", summaries[0])
+        self.assertNotIn("new_string", summaries[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/daymade-claude-code/claude-code-history-files-finder/tests/test_recover_content.py
+++ b/daymade-claude-code/claude-code-history-files-finder/tests/test_recover_content.py
@@ -29,18 +29,43 @@ def write_jsonl(path: Path, records: list[object]) -> None:
             handle.write(json.dumps(record, ensure_ascii=False) + "\n")
 
 
-def write_record(path: str, content: str, timestamp: str) -> dict:
+def write_record(
+    path: str,
+    content: str,
+    timestamp: str,
+    tool_use_id: str | None = None,
+) -> dict:
+    tool_use = {
+        "type": "tool_use",
+        "name": "Write",
+        "input": {"file_path": path, "content": content},
+    }
+    if tool_use_id is not None:
+        tool_use["id"] = tool_use_id
     return {
         "type": "assistant",
         "sessionId": SESSION_ID,
         "timestamp": timestamp,
         "message": {
             "role": "assistant",
+            "content": [tool_use],
+        },
+    }
+
+
+def tool_result_record(tool_use_id: str, is_error: bool, timestamp: str) -> dict:
+    return {
+        "type": "user",
+        "sessionId": SESSION_ID,
+        "timestamp": timestamp,
+        "message": {
+            "role": "user",
             "content": [
                 {
-                    "type": "tool_use",
-                    "name": "Write",
-                    "input": {"file_path": path, "content": content},
+                    "type": "tool_result",
+                    "tool_use_id": tool_use_id,
+                    "is_error": is_error,
+                    "content": "permission denied" if is_error else "write complete",
                 }
             ],
         },
@@ -394,6 +419,33 @@ class SessionRecoveryTests(unittest.TestCase):
         )
         self.assertIn("Source: Write", completed.stdout)
         self.assertNotIn("Later state:", completed.stdout)
+
+    def test_failed_later_write_does_not_override_exact_snapshot(self) -> None:
+        backup_name = "confirmed-before-failure@v2"
+        write_jsonl(
+            self.session_file,
+            [
+                snapshot_record(
+                    str(self.original), backup_name, 2, "2026-07-01T19:30:00Z"
+                ),
+                write_record(
+                    str(self.original),
+                    "never-written",
+                    "2026-07-01T19:35:00Z",
+                    "toolu_failed_write",
+                ),
+                tool_result_record(
+                    "toolu_failed_write", True, "2026-07-01T19:35:01Z"
+                ),
+            ],
+        )
+        self.backup_path(backup_name).write_bytes(b"confirmed-exact")
+
+        completed = self.run_cli(str(self.session_file), "-o", str(self.output_dir))
+
+        self.assertEqual(self.expected_output().read_bytes(), b"confirmed-exact")
+        self.assertIn("Source: file-history v2", completed.stdout)
+        self.assertNotIn("never-written", completed.stdout)
 
     def test_unrelated_write_conflict_does_not_abort_keyword_recovery(self) -> None:
         unrelated = self.root / "jobs" / "task" / "unrelated.txt"

--- a/frontend-visual-qa/.security-scan-passed
+++ b/frontend-visual-qa/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-07-17T07:55:45.526583+00:00
+Scanned at: 2026-07-19T06:30:02.049701+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: a9b296a0abf4819389ff83db7043ebadf0756a03673dedc0df4d5bb5e9f4cdb1
+Content hash: 02782baaa28fe2806fdb239b030cc6718047832739831a7d9242834766f2cc68

--- a/frontend-visual-qa/.security-scan-passed
+++ b/frontend-visual-qa/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-07-19T06:30:02.049701+00:00
+Scanned at: 2026-07-19T09:30:44.944247+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 02782baaa28fe2806fdb239b030cc6718047832739831a7d9242834766f2cc68
+Content hash: 5ca2a12454e98acf7446335936da1e226aa000e158a29fbdc66bcb768e85300b

--- a/frontend-visual-qa/SKILL.md
+++ b/frontend-visual-qa/SKILL.md
@@ -231,11 +231,14 @@ mechanically:
       --css path/to/bridge.css --library-css node_modules/<lib>/dist/<lib>.css
 
 Pass every family in the stack and the weight the page really uses. The probe
-answers with four verdicts — healthy / host-provided-only / broken asset /
-absent here — and only the middle two are defects. Do not compress that into
-"working or dead": a bundled fallback and a never-shipped family look identical
-until the fonts are loaded, and reporting the first as the second sends the
-reader to delete the thing that was protecting them.
+answers with five verdicts — platform generic / healthy / host-provided-only /
+broken asset / absent here — and only host-provided-only and broken asset are
+defects. CSS generic families such as `system-ui` are intentionally supplied by
+the platform; never tell users to bundle or remove them. Do not compress the
+remaining outcomes into "working or dead": a bundled fallback and a
+never-shipped family look identical until the fonts are loaded, and reporting
+the first as the second sends the reader to delete the thing that was protecting
+them.
 
 A declared font that never loads is the single highest-yield check, because it
 degrades every screen simultaneously and both obvious tests give false
@@ -291,6 +294,18 @@ Do not mutate the audited project merely to run the sweep. Reuse its package
 manager and canonical browser harness. If Playwright is absent, continue with
 available Level A/B evidence and report the omitted Level C sweep; install a
 dependency only when dependency changes are authorized.
+
+For an authenticated page, pass repeated `--header "Name: value"` flags only
+when needed. The probe applies them exclusively to the `--url` origin and strips
+them from cross-origin redirects and requests. TLS verification stays enabled;
+use `--ignore-https-errors` only for an explicitly trusted self-signed test
+origin.
+
+Run the probe regressions from a project that already provides Playwright:
+
+```bash
+node --test <skill-root>/tests/test_silent_degradation_probe.mjs
+```
 
 ### 5. Exercise Journeys And Outputs
 

--- a/frontend-visual-qa/SKILL.md
+++ b/frontend-visual-qa/SKILL.md
@@ -209,6 +209,44 @@ Check at minimum:
 Load [references/history-derived-checklist.md](references/history-derived-checklist.md)
 for the core visual/responsive defect catalog and standards-backed checks.
 
+Some defects produce no diagnostic anywhere: a global reset outranking a
+component's own styles, a library renaming its internal DOM classes so whole
+rule groups match nothing, a font family declared but never shipped, geometry
+written into theme config where source scans cannot see it, a new design token
+reusing a name the file already spent, a property that cannot apply because the
+rule never set the layout mode it presupposes, and per-element compliance that
+still reads as "no design system" in aggregate. Source review, type checks and
+geometry assertions are structurally blind to these — the artifacts are valid
+and simply do nothing. When a page looks cheap while every gate is green, that
+combination is the signature. Load
+[references/silent-degradation-and-evidence.md](references/silent-degradation-and-evidence.md)
+for the detection method per class, and probe the two highest-yield ones
+mechanically:
+
+    node <skill-root>/scripts/silent_degradation_probe.mjs font \
+      --url http://127.0.0.1:5173/ --weight 700 \
+      --family "Brand Sans" --family "Fallback Sans"
+
+    node <skill-root>/scripts/silent_degradation_probe.mjs class \
+      --css path/to/bridge.css --library-css node_modules/<lib>/dist/<lib>.css
+
+Pass every family in the stack and the weight the page really uses. The probe
+answers with four verdicts — healthy / host-provided-only / broken asset /
+absent here — and only the middle two are defects. Do not compress that into
+"working or dead": a bundled fallback and a never-shipped family look identical
+until the fonts are loaded, and reporting the first as the second sends the
+reader to delete the thing that was protecting them.
+
+A declared font that never loads is the single highest-yield check, because it
+degrades every screen simultaneously and both obvious tests give false
+positives: computed `fontFamily` returns the declared name, and
+`document.fonts.check()` returns true even with no `@font-face` at all. Only
+comparing rendered width against a deliberately nonexistent family is decisive,
+and the probe string must contain Latin characters — CJK is full-width in every
+font and cannot reveal a substitution. Width comparison has its own trap: fonts
+load lazily, so measure only after awaiting `document.fonts.load()` for each
+candidate, or a perfectly good bundled fallback reads as dead.
+
 Run the bundled sweep from the audited project so it can resolve the project's
 existing Playwright dependency:
 
@@ -294,6 +332,24 @@ excuse to expand a local visual-only audit into every profile.
 
 ### 6. Report, Fix, And Re-run
 
+**Every appearance claim ships with the pixels that show it.** A reader who
+cannot see the defect cannot decide anything about it, and cannot check whether
+the finding is even real. Crop to the affected element with just enough
+surrounding context to locate it — a full-page screenshot proves nothing about a
+14px misalignment, and prose alone ("the buttons look cheap") is unactionable no
+matter how accurate. `scripts/silent_degradation_probe.mjs shot` crops one
+element plus padding for exactly this.
+
+Four rules that decide whether the evidence survives contact with a reader:
+comparisons must be **scale-matched** (two full-width regions placed side by side
+shrink until the 3px difference under discussion vanishes — crop both to the same
+component at the same width instead); dimensions are reported in **CSS px, never
+device px** (a DPR-2 capture has twice the pixel count, and quoting that as page
+height has produced a false "20 screens long" finding); a capture taken before a
+fix is **labeled with the commit it shows** rather than presented as current; and
+findings resting on a **code count** rather than a photograph are **marked as
+such**, so the reader knows which parts of the list are equally evidenced.
+
 Separate **impact** from **category**. Follow the project's severity taxonomy
 when one exists. Otherwise use:
 
@@ -334,6 +390,21 @@ In **audit-only** mode, stop after the evidence-backed report. In
 3. Re-run the same route, state, viewport, journey, and recipient output.
 4. Add or update the smallest regression guard that would catch the confirmed
    failure class.
+
+Three habits keep the fix pass from manufacturing its own defects — each has
+produced one:
+
+- **Shoot the "before" while the defect still exists.** After the rebuild it is
+  unreproducible, and a closure report can then only assert the improvement.
+  Reuse the identical crop window for the after-shot so the pair differs by one
+  variable.
+- **Grep a new shared name before introducing it.** A token named after a word
+  the file already spent (`rail`, `bar`, `card`) silently overrides or gets
+  overridden depending on definition order, changing two subsystems at once
+  (silent-degradation class 1f).
+- **Prove the repaired assertion can fail.** Reintroduce the defect, watch it go
+  red with the expected magnitude, then remove it. An assertion that stayed
+  green through the whole bug does not become a guard by being rewritten.
 
 ## Completion Gate
 

--- a/frontend-visual-qa/references/silent-degradation-and-evidence.md
+++ b/frontend-visual-qa/references/silent-degradation-and-evidence.md
@@ -1,0 +1,316 @@
+# Silent degradation, and the evidence a visual finding must carry
+
+Two things this file covers, both learned from audits where the product looked
+cheap while every automated gate stayed green:
+
+1. **Silent degradation** — defect classes where nothing errors. The source is
+   correct, the build passes, the assertions pass, and the pixels are still
+   wrong. Static analysis is structurally unable to see these.
+2. **Evidence discipline** — what a visual finding must carry to be actionable.
+   A reader who cannot see the defect cannot decide anything about it.
+
+## Part 1 — Why static checks miss a whole category
+
+A lint rule reads what the author wrote. A geometry assertion reads a box. The
+defects below live in between: in the cascade's verdict, in a library's DOM, in
+whether a declared asset was ever shipped. In every one of them **the failing
+artifact is syntactically valid and produces no diagnostic** — a CSS rule that
+matches no element is not an error in CSS; it simply does nothing.
+
+The practical consequence: *the only detector is rendered output*. Not the
+source, not the type system, not the build log.
+
+### 1a. Cascade override — the component's own styles lose
+
+A global reset can outrank a component's styles and strip them, while every
+component call site remains correct.
+
+Real instance: `.app-surface button:not([class*="ant-"])` has specificity
+`0-2-1`; the button primitive's `.btn--primary.btn--info` has `0-2-0`. The
+`:not()` contributes its argument's weight, and the extra element selector
+(`button`) decides it. The reset won on every hand-authored button in the
+workspace: background and border removed, leaving primary buttons as bare text
+with a 2px `::after` underline. Users reported "the clickable things don't look
+clickable"; the source review found nothing, because nothing was wrong there.
+
+**Detect:** screenshot the surface, then read `getComputedStyle` on a control
+that should have an affordance. `backgroundColor: rgba(0,0,0,0)` plus
+`borderStyle: none` on something that is semantically a button is the signature.
+
+**Do not** fix by adding `!important` at the call site — that inverts the
+cascade for everyone downstream.
+
+**Prefer zeroing the reset's specificity over narrowing its match.** Wrapping
+the whole selector in `:where(...)` keeps it matching exactly the same elements
+at specificity `0-0-0`, so any authored class wins while bare elements still get
+the reset:
+
+    :where(.app-surface button:not([class*="ant-"])) { border: none; background: none; }
+
+Narrowing the match instead (`button:not([class])`) looks equivalent and is not.
+In React, `className={cond ? 'is-active' : ''}` renders `class=""` — the
+attribute is *present*, so `:not([class])` skips those buttons and they fall
+back to the browser's default chrome. The narrowing fix trades one silent defect
+for another; the `:where()` fix changes only who wins, never who matches.
+
+### 1b. Library rename — a whole rule group stops matching
+
+Component libraries rename internal DOM classes across major versions. Every
+stylesheet rule targeting the old names quietly matches nothing, and the
+components revert to the library's stock appearance — which is precisely the
+"looks like an unstyled framework app" complaint.
+
+Real instance: antd 5 → 6 moved the Select frame from an inner
+`.ant-select-selector` to the outer `.ant-select` (v6 renders
+`.ant-select > .ant-select-content + .ant-select-suffix`), renamed the Modal
+body container `-content` → `-container`, the Drawer panel `-content` →
+`-section`, and Popconfirm's `-message-title` → `-title`. Nine rules across the
+bridge stylesheet were dead. The design system's tone vocabulary — the colored
+rail that marks a control's semantic state — had not rendered for an unknown
+number of releases.
+
+**Detect:** enumerate every library-internal class the stylesheet references
+and count each one in the *installed* library's compiled CSS.
+`scripts/silent_degradation_probe.mjs class` does this:
+
+    node <skill-root>/scripts/silent_degradation_probe.mjs class \
+      --css path/to/library-bridge.css \
+      --library-css node_modules/<library>/dist/<library>.css \
+      --prefix ant
+
+Two refinements that prevent false alarms and false clears:
+
+- A dead name inside a **selector group** whose sibling branch still matches
+  costs nothing (`.ant-input:focus, .ant-input-focused` — the first still
+  works). Confirm the group before editing.
+- A rename can also change **which element** carries the class. Drawer's
+  `-section` sits on the same element as the caller's own className, so
+  `.my-drawer .ant-drawer-section` still matches nothing — the rule must target
+  `.my-drawer` itself. Check the level, not just the name.
+
+### 1c. Declared font that was never shipped
+
+The most invisible of the three, because the two obvious checks both return
+success:
+
+| Check | Reports | Truth |
+|---|---|---|
+| `getComputedStyle(el).fontFamily` | the declared stack | says nothing about availability |
+| `document.fonts.check('16px "X"')` | `true` | returns true when **no** `@font-face` exists at all |
+| **width vs. a nonexistent family** | differs / identical | **the only reliable signal** |
+
+Real instance: `--font-sans` listed a brand family first; the app shipped zero
+`@font-face` rules and zero font files. Every glyph in the product rendered in a
+system fallback. Neither the author's machine nor the reviewer's could see it,
+because the fallback is what both had always seen — there was no control group.
+
+**Detect:**
+
+    node <skill-root>/scripts/silent_degradation_probe.mjs font \
+      --url http://127.0.0.1:5173/ --weight 700 \
+      --family "Brand Sans" --family "Brand Mono" --family "Fallback Sans"
+
+List **every entry in the stack**, not just the first — the whole point is to
+learn which one customers actually land on.
+
+**The probe string must contain Latin characters.** CJK glyphs are full-width in
+essentially every font, so an all-CJK probe measures the same width whatever
+font actually renders, and reports a false pass. This exact mistake produced a
+false "font not working" reading on an app where it *was* working.
+
+Also check the whole stack, not just the first family: a `--font-mono` whose
+first entry is a platform-only face (`DIN Alternate` on macOS) renders one way
+for the team and another for everyone else.
+
+**Measure only after `document.fonts.load()` — otherwise the probe condemns
+healthy fallbacks.** A webfont is fetched when something *uses* it, not when the
+`@font-face` is parsed. A bundled fallback that the audited page happens not to
+use is therefore still unloaded at probe time, measures identical to the
+sentinel, and looks exactly like a font that was never shipped. Ask for each
+candidate explicitly (`await document.fonts.load('700 16px "X"', probeString)`,
+then `await document.fonts.ready`) before measuring. Pass the **weight the page
+actually uses**: faces are declared per weight, and a stack whose 700 is missing
+while 400 loads fine is a real defect that a 400-only probe cannot see.
+
+The first version of this probe skipped that wait and reported a correctly
+bundled, correctly working Latin fallback as "never renders; every glyph falls
+back." The reading went into a report as "this is a dead stack entry, delete
+it" — advice that would have removed the one face standing between the product
+and a 25%-wider fallback on every non-macOS machine. **A checker that condemns
+healthy input is worse than no checker**: it teaches the reader to stop
+believing the output, and this one pointed at the wrong repair.
+
+So report four outcomes, never pass/fail:
+
+| shipped | renders | verdict |
+|---|---|---|
+| yes | yes | healthy — leave it alone |
+| no | yes | **host-provided only** — works for the team, falls back for customers |
+| yes | no | **broken asset** — 404, bad path, rejected format, or an unbuilt weight |
+| no | no | absent on this host — may still be an intentional face for an OS you did not test |
+
+Only the middle two are defects. The fourth needs the OS you ran on stated
+alongside it, or the next reader deletes a deliberate Windows or Android entry.
+
+### 1d. Geometry values that live in theme config
+
+Design-token discipline is usually enforced by scanning source for raw values.
+Values written into a component library's theme provider are invisible to that
+scan: the page's own source contains no spacing value at all, so the scan is
+clean while the rendered rhythm comes from, e.g., `itemMarginBottom: 14` — a
+number on no scale.
+
+**Detect:** read the theme configuration as part of the audit surface, and
+check its geometry values against the token scale. A clean source scan on a page
+that visibly has off-scale rhythm is the tell.
+
+### 1e. Per-element compliance, aggregate incoherence
+
+Every element can satisfy every rule while the composition still reads as
+"no design system," because the rules constrain each element in isolation and
+say nothing about **how many different ways the same concept is expressed**.
+
+Real instance, one toolbar, one row: a native `<input type=date>`, a library
+Select, a tinted info pill, two plain-text buttons, and one plain-text button
+with an underline — five clickable/input syntaxes side by side. Elsewhere: the
+same decorative rail implemented seven times at different sizes and colors; a
+count rendered in four different size/family pairings.
+
+**Detect:** it is a counting task, not a per-element check. For each recurring
+semantic object (clickable, count, status marker, filter control), enumerate the
+distinct implementations across the app. More than one is the finding; the
+target is one primitive per concept.
+
+Count *distinct shapes*, not raw declarations. Deduplicate by geometry signature
+(width × height × radius): 33 declarations that collapse to 18 shapes is the real
+finding, and the largest group is often a single component's tone variants —
+legitimate reuse, not drift. Reporting the raw count inflates the problem and
+invites a reader to dismiss the whole finding once they spot the variants.
+
+### 1f. Token namespace collision — the new name was already taken
+
+Adding a design token whose name already exists elsewhere in the same scope is
+not an error. The later definition simply wins, and every consumer of *both*
+names silently changes.
+
+Real instance: a rail primitive was introduced as `--rail-w: 4px`. A layout
+section further down the same `:root` already defined `--rail-w: 188px` (a
+sidebar column width, consumed by four grid rules). Later definition wins, so
+all 33 migrated rails would have rendered 188px wide *and* the four grids would
+have kept working by accident — one edit, two subsystems, no diagnostic.
+
+**Detect:** grep the token name across the whole scope *before* introducing it,
+not after. A build-time token generator makes this nearly free: it emits one
+entry per name, so a collision shows up as the wrong value next to your new
+name. Without a generator, `rg -n '\-\-your-token-name\s*:'` is the whole check.
+
+**Name defensively.** Generic geometry words (`rail`, `bar`, `line`, `gap`,
+`card`) are exactly the ones a mature token file has already spent. Pick the
+narrower noun for the narrower concept (`marker` for a 4px state stripe, leaving
+`rail` to the 188px layout column), and say in a comment which neighbour you
+were avoiding — the next author reaching for the obvious name needs that.
+
+### 1g. A property that cannot apply — valid, inert, silent
+
+CSS accepts a declaration whose formatting context makes it meaningless. It
+produces no warning and no effect, and the source reads as if the intent were
+implemented.
+
+Real instance: a container carried `min-height` and `align-content: center` but
+never `display: grid`. `align-content` only applies to grid/flex containers, so
+it did nothing; the two children stayed inline-level and butted together — a
+32px number and its 12px caption sharing a baseline with no gap, on the most
+prominent element of the page. Every reviewer read `align-content` and assumed
+a grid.
+
+The tell is a declaration that *presupposes* a layout mode the rule never sets.
+`align-content` / `justify-items` / `place-items` / `gap` / `order` /
+`flex-basis` all imply grid or flex; `vertical-align` implies inline or
+table-cell.
+
+**Detect:** these cannot be caught by reading intent — the intent is right there
+in the property name. Screenshot the element and compare against what the
+declaration claims. Or check computed layout directly:
+`getComputedStyle(el).display` on a container whose rule sets `align-content`.
+
+## Part 2 — Evidence a visual finding must carry
+
+A finding the reader cannot see is a finding they cannot act on. The rule:
+**a claim about appearance ships with the pixels that show it.**
+
+- **Crop to the defect, keep enough context to locate it.** A full-page
+  screenshot proves nothing about a 14px misalignment. `shot` mode crops one
+  element plus padding.
+- **Comparisons must be scale-matched.** Two 1200px-wide toolbars placed
+  side by side in a report shrink to ~460px each and the difference under
+  discussion — a 3px colored rail, an arrow shape — disappears. Crop both to the
+  *same component* at the *same width* instead. (A report making this mistake
+  committed the very sin it was reporting.)
+- **Report CSS px, never device px.** A DPR-2 capture has twice the pixel
+  count; quoting that as page height once produced a false "the page is 20
+  screens long" finding when it was 10. State the viewport and DPR alongside.
+- **Date the capture against the code.** A screenshot from before a fix is
+  still valid evidence *of the old state* — label which commit it shows, and say
+  so, rather than quietly presenting it as current.
+- **Separate "photographed" from "counted."** Findings resting on a code count
+  (seven rails, four count styles) are weaker than photographed ones until they
+  too are captured. Mark which is which rather than letting the reader assume
+  the whole list is equally evidenced.
+- **Capture the "before" before you fix — it is unreproducible afterwards.**
+  Once the build is rebuilt on the fixed code, the defect no longer exists
+  anywhere you can point a browser at, and a before/after pair becomes
+  impossible to assemble honestly. Shoot every finding at audit time even when
+  no one has asked for a fix report yet; the cost is one script run, and the
+  alternative is a closure report that can only assert the improvement.
+  Reuse the *identical* crop window for the after-shot (same selector, same
+  width/height, same DPR) so the pair differs by exactly one variable: the code.
+- **Watch for confounders inside a matched crop.** Two runs of the same selector
+  can land on different data — a table's first row, a rotating metric — so a
+  font-weight or colour difference in the pair may come from content, not from
+  the change. Say so in the caption and point the reader at the part that is
+  actually comparable.
+
+## Part 3 — Assertions have blind spots too; state what yours cannot see
+
+A geometry assertion measures a chosen box, and the choice is a hypothesis.
+
+Real instance: a suite asserted the form label's left edge aligns with the
+input's. It measured the **label element box** — but a decorative `::before`
+inside that box pushed the *text* 14px right. The visible misalignment was
+exactly what the assertion existed to catch, and it passed. Measuring the first
+text node (`Range.getBoundingClientRect()`) sees what the eye sees.
+
+When adding an assertion, write down what it would *not* catch. That sentence is
+usually where the next defect lives.
+
+**A repaired assertion is unproven until it fails on the defect it missed.**
+Rewriting the measurement and watching the suite stay green proves nothing — it
+was green before, with the bug shipping. Reintroduce the old behaviour
+temporarily (paste the removed rule back at the end of the stylesheet), run the
+assertion, and confirm it goes red with the expected magnitude; then remove the
+temporary rule and confirm green again. In the alignment case above the repaired
+assertion reported `479.0 vs 465.0` across three viewports — the exact 14px the
+decoration was contributing, which is also how you know it is measuring the
+right thing and not merely something.
+
+Budget one minute for this. It is the only step that distinguishes "I changed
+the assertion" from "the assertion now guards the line."
+
+## Fast triage
+
+When a page "looks cheap" but every gate is green, check in this order — cheapest
+and highest-yield first:
+
+1. **Fonts** — `probe font`. Wrong typeface degrades every screen at once.
+2. **Library class names** — `probe class`. One rename can kill a whole
+   component family's styling.
+3. **Affordance** — do controls that should be clickable have background or
+   border? Cascade override is the usual cause.
+4. **Syntax count** — how many ways is the same concept expressed on one screen?
+5. **Theme config geometry** — off-scale values invisible to source scans.
+6. **Inert declarations** — any `align-content` / `gap` / `justify-items` on a
+   container that never sets `display`.
+
+And when *fixing* rather than auditing, two more that only bite on the way out:
+grep the token name before you add it (1f), and prove the repaired assertion can
+fail (Part 3).

--- a/frontend-visual-qa/references/silent-degradation-and-evidence.md
+++ b/frontend-visual-qa/references/silent-degradation-and-evidence.md
@@ -140,17 +140,19 @@ and a 25%-wider fallback on every non-macOS machine. **A checker that condemns
 healthy input is worse than no checker**: it teaches the reader to stop
 believing the output, and this one pointed at the wrong repair.
 
-So report four outcomes, never pass/fail:
+So report five outcomes, never pass/fail:
 
-| shipped | renders | verdict |
-|---|---|---|
-| yes | yes | healthy — leave it alone |
-| no | yes | **host-provided only** — works for the team, falls back for customers |
-| yes | no | **broken asset** — 404, bad path, rejected format, or an unbuilt weight |
-| no | no | absent on this host — may still be an intentional face for an OS you did not test |
+| family kind | shipped | renders | verdict |
+|---|---|---|---|
+| CSS generic (`system-ui`, `serif`, etc.) | no | platform-dependent | platform generic — healthy by design |
+| custom | yes | yes | healthy — leave it alone |
+| custom | no | yes | **host-provided only** — works for the team, falls back for customers |
+| custom | yes | no | **broken asset** — 404, bad path, rejected format, or an unbuilt weight |
+| custom | no | no | absent on this host — may still be an intentional face for an OS you did not test |
 
-Only the middle two are defects. The fourth needs the OS you ran on stated
-alongside it, or the next reader deletes a deliberate Windows or Android entry.
+Only host-provided-only and broken asset are defects. An absent custom family
+needs the OS you ran on stated alongside it, or the next reader deletes a
+deliberate Windows or Android entry.
 
 ### 1d. Geometry values that live in theme config
 

--- a/frontend-visual-qa/scripts/silent_degradation_probe.mjs
+++ b/frontend-visual-qa/scripts/silent_degradation_probe.mjs
@@ -15,7 +15,7 @@
  *           Measuring also has to happen AFTER document.fonts.load(): a webfont
  *           is fetched only when used, so a healthy bundled fallback that this
  *           page happens not to use measures exactly like one that was never
- *           shipped. Reports four outcomes rather than pass/fail, because
+ *           shipped. Reports five outcomes rather than pass/fail, because
  *           "bundled and working" and "never shipped" must not be conflated —
  *           acting on that confusion means deleting a fallback that works.
  *
@@ -35,7 +35,8 @@
  *   node silent_degradation_probe.mjs shot  --url <url> --select "<css>" --out <dir> [--name x] [--pad 12] [--dpr 3]
  *
  * Common flags: --browser <chrome-executable>  --viewport WxH  --wait <ms>
- *   --header "k: v" (repeatable)  --storage <playwright-storage-state.json>
+ *   --header "k: v" (repeatable, target origin only)
+ *   --storage <playwright-storage-state.json>  --ignore-https-errors
  *
  * Exit: 0 clean · 1 degradation found · 2 invalid input / runtime failure.
  */
@@ -48,6 +49,50 @@ const mode = argv[0];
 const flag = (n, d = null) => { const i = argv.indexOf(`--${n}`); return i > -1 ? argv[i + 1] : d; };
 const flags = (n) => argv.reduce((a, v, i) => (v === `--${n}` ? [...a, argv[i + 1]] : a), []);
 const has = (n) => argv.includes(`--${n}`);
+
+const CSS_GENERIC_FAMILIES = new Set([
+  'serif', 'sans-serif', 'monospace', 'cursive', 'fantasy', 'system-ui',
+  'ui-serif', 'ui-sans-serif', 'ui-monospace', 'ui-rounded', 'math', 'emoji',
+  'fangsong',
+]);
+
+function normalizedFamily(family) {
+  return family.trim().replace(/^['"]|['"]$/g, '').toLowerCase();
+}
+
+function stripCssComments(css) {
+  let output = '';
+  let quote = null;
+  for (let index = 0; index < css.length; index += 1) {
+    const char = css[index];
+    const next = css[index + 1];
+    if (quote) {
+      output += char;
+      if (char === '\\' && index + 1 < css.length) {
+        output += css[index + 1];
+        index += 1;
+      } else if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      output += char;
+      continue;
+    }
+    if (char === '/' && next === '*') {
+      index += 2;
+      while (index < css.length && !(css[index] === '*' && css[index + 1] === '/')) {
+        if (css[index] === '\n' || css[index] === '\r') output += css[index];
+        index += 1;
+      }
+      continue;
+    }
+    output += char;
+  }
+  return output;
+}
 
 if (!mode || has('help') || !['font', 'class', 'shot'].includes(mode)) {
   process.stdout.write(readFileSync(new URL(import.meta.url)).toString().split('*/')[0].replace(/^\/\*\*?/, '') + '\n');
@@ -71,21 +116,55 @@ async function loadPlaywright() {
 }
 
 async function openPage() {
-  const pw = await loadPlaywright();
-  const [w, h] = (flag('viewport', '1440x900')).split('x').map(Number);
-  const browser = await pw.chromium.launch({ executablePath: flag('browser') || undefined });
-  const ctx = await browser.newContext({
-    ignoreHTTPSErrors: true,
-    viewport: { width: w, height: h },
-    deviceScaleFactor: Number(flag('dpr', '2')),
-    storageState: flag('storage') || undefined,
-    extraHTTPHeaders: Object.fromEntries(flags('header').map((s) => {
-      const i = s.indexOf(':'); return [s.slice(0, i).trim(), s.slice(i + 1).trim()];
-    })),
-  });
-  const page = await ctx.newPage();
   const url = flag('url');
   if (!url) { process.stderr.write('--url is required\n'); process.exit(2); }
+  let targetOrigin;
+  try { targetOrigin = new URL(url).origin; }
+  catch { process.stderr.write(`invalid --url: ${url}\n`); process.exit(2); }
+  const extraHeaders = {};
+  for (const spec of flags('header')) {
+    const separator = typeof spec === 'string' ? spec.indexOf(':') : -1;
+    const name = separator > 0 ? spec.slice(0, separator).trim().toLowerCase() : '';
+    if (!name) {
+      process.stderr.write(`invalid --header (expected "name: value"): ${spec ?? '<missing>'}\n`);
+      process.exit(2);
+    }
+    extraHeaders[name] = spec.slice(separator + 1).trim();
+  }
+  const [w, h] = (flag('viewport', '1440x900')).split('x').map(Number);
+  const dpr = Number(flag('dpr', '2'));
+  if (![w, h, dpr].every(Number.isFinite) || w <= 0 || h <= 0 || dpr <= 0) {
+    process.stderr.write('--viewport must be positive WxH and --dpr must be positive\n');
+    process.exit(2);
+  }
+  const pw = await loadPlaywright();
+  const browser = await pw.chromium.launch({ executablePath: flag('browser') || undefined });
+  const ctx = await browser.newContext({
+    ignoreHTTPSErrors: has('ignore-https-errors'),
+    viewport: { width: w, height: h },
+    deviceScaleFactor: dpr,
+    storageState: flag('storage') || undefined,
+  });
+  if (Object.keys(extraHeaders).length) {
+    await ctx.route('**/*', async (route) => {
+      const requestHeaders = { ...route.request().headers() };
+      for (const name of Object.keys(extraHeaders)) delete requestHeaders[name];
+      let requestOrigin = null;
+      try { requestOrigin = new URL(route.request().url()).origin; } catch {}
+      if (requestOrigin === targetOrigin) {
+        Object.assign(requestHeaders, extraHeaders);
+        // route.continue() applies header overrides to automatic redirects too,
+        // which can forward a target-origin credential to another origin before
+        // interception runs again. Fetch exactly one hop, then fulfill it so the
+        // browser issues any redirect as a fresh, independently filtered request.
+        const response = await route.fetch({ headers: requestHeaders, maxRedirects: 0 });
+        await route.fulfill({ response });
+      } else {
+        await route.continue({ headers: requestHeaders });
+      }
+    });
+  }
+  const page = await ctx.newPage();
   await page.goto(url, { waitUntil: 'networkidle' });
   await page.waitForTimeout(Number(flag('wait', '1200')));
   return { browser, page };
@@ -149,14 +228,17 @@ if (mode === 'font') {
     };
   }, { fams: families, weight });
   await browser.close();
-  // Four distinct outcomes. Only two of them are defects, and conflating the
+  // Five distinct outcomes. Only two of them are defects, and conflating the
   // healthy-bundled case with the never-shipped case is worse than not checking
   // at all: it tells the reader to delete a fallback that works.
-  const healthy = result.families.filter((f) => f.actuallyRenders && f.shippedByPage);
-  const hostOnly = result.families.filter((f) => f.actuallyRenders && !f.shippedByPage);
-  const brokenAsset = result.families.filter((f) => !f.actuallyRenders && f.shippedByPage);
-  const absent = result.families.filter((f) => !f.actuallyRenders && !f.shippedByPage);
+  const platformGeneric = result.families.filter((f) => CSS_GENERIC_FAMILIES.has(normalizedFamily(f.family)));
+  const custom = result.families.filter((f) => !CSS_GENERIC_FAMILIES.has(normalizedFamily(f.family)));
+  const healthy = custom.filter((f) => f.actuallyRenders && f.shippedByPage);
+  const hostOnly = custom.filter((f) => f.actuallyRenders && !f.shippedByPage);
+  const brokenAsset = custom.filter((f) => !f.actuallyRenders && f.shippedByPage);
+  const absent = custom.filter((f) => !f.actuallyRenders && !f.shippedByPage);
   process.stdout.write(JSON.stringify({ mode: 'font', ...result,
+    platformGeneric: platformGeneric.map((f) => f.family),
     healthy: healthy.map((f) => f.family),
     hostProvidedOnly: hostOnly.map((f) => f.family),
     declaredButUnusable: brokenAsset.map((f) => f.family),
@@ -189,8 +271,8 @@ if (mode === 'font') {
 if (mode === 'class') {
   const cssPath = flag('css'), libPath = flag('library-css');
   if (!cssPath || !libPath) { process.stderr.write('--css and --library-css are required\n'); process.exit(2); }
-  const own = readFileSync(resolve(cssPath), 'utf8');
-  const lib = readFileSync(resolve(libPath), 'utf8');
+  const own = stripCssComments(readFileSync(resolve(cssPath), 'utf8'));
+  const lib = stripCssComments(readFileSync(resolve(libPath), 'utf8'));
   const prefix = flag('prefix', 'ant');
   const referenced = [...new Set([...own.matchAll(new RegExp(`\\.(${prefix}-[a-z0-9-]+)`, 'g'))].map((m) => m[1]))].sort();
   const rows = referenced.map((name) => {

--- a/frontend-visual-qa/scripts/silent_degradation_probe.mjs
+++ b/frontend-visual-qa/scripts/silent_degradation_probe.mjs
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+/**
+ * Silent-degradation probe.
+ *
+ * Static checks (lint, typecheck, geometry assertions) cannot see three whole
+ * classes of visual defect, because in each of them **nothing errors**:
+ *
+ *   font    A font family is declared but never shipped. computed fontFamily
+ *           returns the declared name and document.fonts.check() returns true
+ *           even when no @font-face exists, so both report success while every
+ *           glyph renders in a fallback. Only measuring text width against a
+ *           deliberately nonexistent family tells the truth — and the probe
+ *           string must contain Latin characters, since CJK glyphs are
+ *           full-width in every font and cannot reveal a substitution.
+ *           Measuring also has to happen AFTER document.fonts.load(): a webfont
+ *           is fetched only when used, so a healthy bundled fallback that this
+ *           page happens not to use measures exactly like one that was never
+ *           shipped. Reports four outcomes rather than pass/fail, because
+ *           "bundled and working" and "never shipped" must not be conflated —
+ *           acting on that confusion means deleting a fallback that works.
+ *
+ *   class   A component library renames its internal DOM classes on a major
+ *           version. Every stylesheet rule targeting the old names silently
+ *           matches nothing; components fall back to the library's stock look
+ *           while the design system's own vocabulary disappears. A CSS rule
+ *           that matches no element is not an error in CSS.
+ *
+ *   shot    A claim that something "looks wrong" is unverifiable without the
+ *           pixels. This mode crops the exact element (with a little context)
+ *           so a report can carry its own evidence.
+ *
+ * Usage:
+ *   node silent_degradation_probe.mjs font  --url <url> --family "Brand Sans" [--family ...]
+ *   node silent_degradation_probe.mjs class --css <file.css> --library-css <node_modules/lib/dist/lib.css>
+ *   node silent_degradation_probe.mjs shot  --url <url> --select "<css>" --out <dir> [--name x] [--pad 12] [--dpr 3]
+ *
+ * Common flags: --browser <chrome-executable>  --viewport WxH  --wait <ms>
+ *   --header "k: v" (repeatable)  --storage <playwright-storage-state.json>
+ *
+ * Exit: 0 clean · 1 degradation found · 2 invalid input / runtime failure.
+ */
+import { readFileSync, mkdirSync, existsSync } from 'node:fs';
+import { resolve, dirname, join } from 'node:path';
+import process from 'node:process';
+
+const argv = process.argv.slice(2);
+const mode = argv[0];
+const flag = (n, d = null) => { const i = argv.indexOf(`--${n}`); return i > -1 ? argv[i + 1] : d; };
+const flags = (n) => argv.reduce((a, v, i) => (v === `--${n}` ? [...a, argv[i + 1]] : a), []);
+const has = (n) => argv.includes(`--${n}`);
+
+if (!mode || has('help') || !['font', 'class', 'shot'].includes(mode)) {
+  process.stdout.write(readFileSync(new URL(import.meta.url)).toString().split('*/')[0].replace(/^\/\*\*?/, '') + '\n');
+  process.exit(mode ? 2 : 0);
+}
+
+/** Resolve playwright from the audited project, never from this skill. */
+async function loadPlaywright() {
+  for (const base of [process.cwd(), join(process.cwd(), '..'), join(process.cwd(), '../..')]) {
+    for (const p of ['node_modules/playwright/index.js', '.ds-sync/node_modules/playwright/index.js']) {
+      const full = join(base, p);
+      if (existsSync(full)) {
+        const mod = await import(`file://${full}`);
+        return mod.default ?? mod;
+      }
+    }
+  }
+  try { return (await import('playwright')).default ?? (await import('playwright')); } catch {}
+  process.stderr.write('playwright not resolvable from the audited project. Run from the project root, or skip this probe and report it as omitted.\n');
+  process.exit(2);
+}
+
+async function openPage() {
+  const pw = await loadPlaywright();
+  const [w, h] = (flag('viewport', '1440x900')).split('x').map(Number);
+  const browser = await pw.chromium.launch({ executablePath: flag('browser') || undefined });
+  const ctx = await browser.newContext({
+    ignoreHTTPSErrors: true,
+    viewport: { width: w, height: h },
+    deviceScaleFactor: Number(flag('dpr', '2')),
+    storageState: flag('storage') || undefined,
+    extraHTTPHeaders: Object.fromEntries(flags('header').map((s) => {
+      const i = s.indexOf(':'); return [s.slice(0, i).trim(), s.slice(i + 1).trim()];
+    })),
+  });
+  const page = await ctx.newPage();
+  const url = flag('url');
+  if (!url) { process.stderr.write('--url is required\n'); process.exit(2); }
+  await page.goto(url, { waitUntil: 'networkidle' });
+  await page.waitForTimeout(Number(flag('wait', '1200')));
+  return { browser, page };
+}
+
+// ---------------------------------------------------------------- font
+if (mode === 'font') {
+  const families = flags('family');
+  if (!families.length) { process.stderr.write('at least one --family is required\n'); process.exit(2); }
+  const weight = flag('weight', '400');
+  const { browser, page } = await openPage();
+  const result = await page.evaluate(async ({ fams, weight: wt }) => {
+    // Latin characters are mandatory: CJK is full-width in every font, so an
+    // all-CJK probe measures identical widths whatever font actually renders.
+    const PROBE = 'Handgloves 0123456789 幅';
+    const measure = (family) => {
+      const c = document.createElement('canvas').getContext('2d');
+      c.font = `${wt} 16px ${family}`;
+      return c.measureText(PROBE).width;
+    };
+
+    // A webfont is fetched only when something on the page uses it. Measuring a
+    // bundled-but-not-yet-used @font-face therefore returns the fallback width
+    // and looks exactly like a font that was never shipped. Ask for each family
+    // explicitly and wait, or this probe condemns healthy fallbacks.
+    const loadErrors = {};
+    await Promise.all(fams.map(async (f) => {
+      try { await document.fonts.load(`${wt} 16px "${f}"`, PROBE); }
+      catch (e) { loadErrors[f] = String(e).slice(0, 120); }
+    }));
+    await document.fonts.ready;
+
+    const sentinel = measure('"NoSuchFamily__PROBE__"');
+    return {
+      fontFaceRules: Array.from(document.styleSheets).flatMap((s) => {
+        try { return Array.from(s.cssRules || []); } catch { return []; }
+      }).filter((r) => r.constructor.name === 'CSSFontFaceRule').length,
+      documentFonts: document.fonts.size,
+      sentinelWidth: sentinel,
+      weightProbed: wt,
+      families: fams.map((f) => {
+        const w = measure(`"${f}"`);
+        // Does the page itself ship this family, or is it merely present on
+        // this machine? A face that renders only because the auditor's OS has
+        // it will fall back on every machine that does not — the classic
+        // "works for the team, broken for the customer" case.
+        const faces = Array.from(document.fonts)
+          .filter((ff) => ff.family.replace(/^["']|["']$/g, '') === f);
+        return {
+          family: f,
+          width: w,
+          // check() is reported for contrast only — it returns true with no
+          // @font-face at all, which is exactly the false positive to expose.
+          checkSaysAvailable: document.fonts.check(`${wt} 16px "${f}"`),
+          actuallyRenders: Math.abs(w - sentinel) > 0.5,
+          shippedByPage: faces.length > 0,
+          faceStatus: faces.map((ff) => `${ff.weight}:${ff.status}`).join(' ') || null,
+          loadError: loadErrors[f] || null,
+        };
+      }),
+    };
+  }, { fams: families, weight });
+  await browser.close();
+  // Four distinct outcomes. Only two of them are defects, and conflating the
+  // healthy-bundled case with the never-shipped case is worse than not checking
+  // at all: it tells the reader to delete a fallback that works.
+  const healthy = result.families.filter((f) => f.actuallyRenders && f.shippedByPage);
+  const hostOnly = result.families.filter((f) => f.actuallyRenders && !f.shippedByPage);
+  const brokenAsset = result.families.filter((f) => !f.actuallyRenders && f.shippedByPage);
+  const absent = result.families.filter((f) => !f.actuallyRenders && !f.shippedByPage);
+  process.stdout.write(JSON.stringify({ mode: 'font', ...result,
+    healthy: healthy.map((f) => f.family),
+    hostProvidedOnly: hostOnly.map((f) => f.family),
+    declaredButUnusable: brokenAsset.map((f) => f.family),
+    absentStackEntries: absent.map((f) => f.family) }, null, 2) + '\n');
+  if (hostOnly.length) {
+    process.stderr.write(`\n${hostOnly.length} family/families render here but are NOT shipped by the page:\n`
+      + hostOnly.map((f) => `  - ${f.family}`).join('\n')
+      + `\nThey resolve only because this machine happens to have them installed. Any user without\n`
+      + `them gets a fallback, and no probe run on a developer machine will ever reveal it.\n`
+      + `Ship the face with the app, or drop it from the stack.\n`);
+  }
+  if (brokenAsset.length) {
+    process.stderr.write(`\n${brokenAsset.length} family/families are declared by the page but still do not render:\n`
+      + brokenAsset.map((f) => `  - ${f.family} (faces ${f.faceStatus}`
+        + `${f.loadError ? `; load error ${f.loadError}` : ''})`).join('\n')
+      + `\nThe @font-face exists, so this is a broken asset — a 404, a bad path, a format the\n`
+      + `browser rejected, or a weight that was never built. Check the network panel.\n`);
+  }
+  if (absent.length) {
+    process.stderr.write(`\n${absent.length} stack entry/entries neither ship nor resolve on this host:\n`
+      + absent.map((f) => `  - ${f.family} (width ${f.width} === sentinel ${result.sentinelWidth}`
+        + `${f.checkSaysAvailable ? '; document.fonts.check() reported true — a false positive' : ''})`).join('\n')
+      + `\nThese contribute nothing on this machine. They may still be intentional (a platform face\n`
+      + `for an OS you are not testing on) — confirm before deleting, and note which OS you ran on.\n`);
+  }
+  process.exit(hostOnly.length || brokenAsset.length ? 1 : 0);
+}
+
+// --------------------------------------------------------------- class
+if (mode === 'class') {
+  const cssPath = flag('css'), libPath = flag('library-css');
+  if (!cssPath || !libPath) { process.stderr.write('--css and --library-css are required\n'); process.exit(2); }
+  const own = readFileSync(resolve(cssPath), 'utf8');
+  const lib = readFileSync(resolve(libPath), 'utf8');
+  const prefix = flag('prefix', 'ant');
+  const referenced = [...new Set([...own.matchAll(new RegExp(`\\.(${prefix}-[a-z0-9-]+)`, 'g'))].map((m) => m[1]))].sort();
+  const rows = referenced.map((name) => {
+    const inLib = (lib.match(new RegExp(`\\.${name}(?![a-z0-9-])`, 'g')) || []).length;
+    return { name, occurrencesInLibrary: inLib, dead: inLib === 0 };
+  });
+  const dead = rows.filter((r) => r.dead);
+  process.stdout.write(JSON.stringify({ mode: 'class', referenced: rows.length, dead: dead.map((d) => d.name), rows }, null, 2) + '\n');
+  if (dead.length) {
+    process.stderr.write(`\n${dead.length} of ${rows.length} referenced class name(s) do not exist in the installed library:\n`
+      + dead.map((d) => `  - .${d.name}`).join('\n')
+      + `\nRules targeting them match nothing and fail silently — the component keeps the library's stock look.\n`
+      + `Check the library's changelog for renames, then re-anchor each rule.\n`
+      + `Note: a dead name inside a selector GROUP whose other branch still matches costs nothing; confirm before editing.\n`);
+    process.exit(1);
+  }
+  process.exit(0);
+}
+
+// ---------------------------------------------------------------- shot
+if (mode === 'shot') {
+  const sel = flag('select'), outDir = flag('out');
+  if (!sel || !outDir) { process.stderr.write('--select and --out are required\n'); process.exit(2); }
+  mkdirSync(resolve(outDir), { recursive: true });
+  const pad = Number(flag('pad', '12'));
+  const name = flag('name', 'evidence');
+  const { browser, page } = await openPage();
+  const box = await page.locator(sel).first().boundingBox({ timeout: 5000 }).catch(() => null);
+  if (!box) { await browser.close(); process.stderr.write(`selector matched nothing: ${sel}\n`); process.exit(2); }
+  const vp = page.viewportSize();
+  const clip = {
+    x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+    width: Math.min(vp.width - Math.max(0, box.x - pad), box.width + pad * 2),
+    height: box.height + pad * 2,
+  };
+  const file = join(resolve(outDir), `${name}.png`);
+  await page.screenshot({ path: file, clip });
+  await browser.close();
+  // Report CSS px, not device px: a DPR-2 capture is twice the pixel count and
+  // reporting that number as page height has produced false "20 screens long"
+  // findings. The image file is larger; the layout is not.
+  process.stdout.write(JSON.stringify({
+    mode: 'shot', file, cssPx: { w: Math.round(clip.width), h: Math.round(clip.height) },
+    note: 'dimensions are CSS px; the PNG is deviceScaleFactor times larger',
+  }, null, 2) + '\n');
+  process.exit(0);
+}

--- a/frontend-visual-qa/tests/test_silent_degradation_probe.mjs
+++ b/frontend-visual-qa/tests/test_silent_degradation_probe.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+"use strict";
+
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = resolve(TEST_DIR, '../scripts/silent_degradation_probe.mjs');
+
+function runProbe(args) {
+  return new Promise((resolveRun) => {
+    const child = spawn(process.execPath, [SCRIPT, ...args], { cwd: process.cwd() });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.on('close', (code) => resolveRun({ code, stdout, stderr }));
+  });
+}
+
+function projectHasPlaywright() {
+  return [
+    join(process.cwd(), 'node_modules/playwright/index.js'),
+    join(process.cwd(), '.ds-sync/node_modules/playwright/index.js'),
+    join(process.cwd(), '../node_modules/playwright/index.js'),
+  ].some(existsSync);
+}
+
+function listen(server) {
+  return new Promise((resolveListen) => {
+    server.listen(0, '127.0.0.1', resolveListen);
+  });
+}
+
+test('class mode ignores project and library CSS comments', async () => {
+  const root = await mkdtemp(join(os.tmpdir(), 'silent-degradation-css-'));
+  try {
+    const projectComment = join(root, 'project-comment.css');
+    const liveProject = join(root, 'live-project.css');
+    const library = join(root, 'library.css');
+    const libraryComment = join(root, 'library-comment.css');
+    await writeFile(projectComment, '/* old .ant-removed selector */\n.bridge { color: red; }\n');
+    await writeFile(liveProject, '.ant-removed { color: red; }\n');
+    await writeFile(library, '.ant-current { color: blue; }\n');
+    await writeFile(libraryComment, '/* .ant-removed no longer exists */\n');
+
+    const falseFailure = await runProbe([
+      'class', '--css', projectComment, '--library-css', library,
+    ]);
+    assert.equal(falseFailure.code, 0, falseFailure.stdout + falseFailure.stderr);
+    assert.equal(JSON.parse(falseFailure.stdout).referenced, 0);
+
+    const falseClear = await runProbe([
+      'class', '--css', liveProject, '--library-css', libraryComment,
+    ]);
+    assert.equal(falseClear.code, 1, falseClear.stdout + falseClear.stderr);
+    assert.deepEqual(JSON.parse(falseClear.stdout).dead, ['ant-removed']);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('font mode treats system-ui as a platform generic', async (t) => {
+  if (!projectHasPlaywright()) return t.skip('Playwright is not available in the audited project');
+  const result = await runProbe([
+    'font',
+    '--url', 'data:text/html,<p>probe</p>',
+    '--family', 'system-ui',
+    '--wait', '0',
+  ]);
+  assert.equal(result.code, 0, result.stdout + result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout).platformGeneric, ['system-ui']);
+});
+
+test('invalid header syntax is rejected as input before browser startup', async () => {
+  const result = await runProbe([
+    'font',
+    '--url', 'http://127.0.0.1/',
+    '--family', 'system-ui',
+    '--header',
+  ]);
+  assert.equal(result.code, 2, result.stdout + result.stderr);
+  assert.match(result.stderr, /invalid --header/);
+  assert.doesNotMatch(result.stderr, /playwright not resolvable/);
+});
+
+test('headers stay on the requested origin across redirects', async (t) => {
+  if (!projectHasPlaywright()) return t.skip('Playwright is not available in the audited project');
+  let initialAuthorization = '';
+  let redirectedAuthorization = '';
+  const destination = http.createServer((request, response) => {
+    redirectedAuthorization = request.headers.authorization || '';
+    response.end('<p>destination</p>');
+  });
+  await listen(destination);
+  const redirector = http.createServer((request, response) => {
+    initialAuthorization = request.headers.authorization || '';
+    response.writeHead(302, {
+      Location: `http://127.0.0.1:${destination.address().port}/destination`,
+    });
+    response.end();
+  });
+  await listen(redirector);
+
+  try {
+    const result = await runProbe([
+      'font',
+      '--url', `http://127.0.0.1:${redirector.address().port}/start`,
+      '--family', 'system-ui',
+      '--header', 'Authorization: Bearer PROBE_SECRET',
+      '--wait', '0',
+    ]);
+    assert.equal(result.code, 0, result.stdout + result.stderr);
+    assert.equal(initialAuthorization, 'Bearer PROBE_SECRET');
+    assert.equal(redirectedAuthorization, '');
+  } finally {
+    redirector.close();
+    destination.close();
+  }
+});

--- a/git-safety-net/.security-scan-passed
+++ b/git-safety-net/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-07-18T09:16:45.993030+00:00
+Scanned at: 2026-07-18T11:09:05.423380+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: bfc8b77388a375fa0ae086dd2bc12e81b1959900a66fd445ba2abfd6449eac35
+Content hash: 8d2d3915c49d043977ec2f73e0c2baf7507413ec2a7f2bd9105d8617274aac85

--- a/git-safety-net/.security-scan-passed
+++ b/git-safety-net/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-07-18T11:09:05.423380+00:00
+Scanned at: 2026-07-19T09:30:44.909355+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 8d2d3915c49d043977ec2f73e0c2baf7507413ec2a7f2bd9105d8617274aac85
+Content hash: d4e1d34972db8ec80c27d073baa6734d143ac47e0b004e4ac6dc1c193dbf1f43

--- a/git-safety-net/.security-scan-passed
+++ b/git-safety-net/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-07-19T09:30:44.909355+00:00
+Scanned at: 2026-07-19T09:44:10.306155+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: d4e1d34972db8ec80c27d073baa6734d143ac47e0b004e4ac6dc1c193dbf1f43
+Content hash: da5138ae00144cc592e72af0960917a41e43a70d6ddf7cba3527d73d0794b4fa

--- a/git-safety-net/SKILL.md
+++ b/git-safety-net/SKILL.md
@@ -96,15 +96,27 @@ including the independent clones no in-repo command can see:
 
 ```bash
 scripts/git_find_all_checkouts.sh              # defaults to this repo's parent + grandparent
-scripts/git_find_all_checkouts.sh ~ DEPTH=6    # widen when clones live far from each other
+DEPTH=6 scripts/git_find_all_checkouts.sh ~    # widen when clones live far from each other
 ```
 
 It matches sibling checkouts by normalized remote URL (so the SSH and HTTPS forms of one
-repository compare equal), falling back to **shared root commit** when there's no `origin` —
-never by directory name, because an independent clone is usually named differently from the
-original (`repo` vs `repo-hotfix`), which is exactly when name matching fails. Exit is 1 when any
-*other* checkout holds uncommitted, untracked, or unpushed work. Run Steps 1–2 in **each** of the
-checkouts it reports, then treat "nothing at risk" as a claim about all of them, not just this one.
+repository compare equal), falling back to **shared root commit** whenever either the current or a
+candidate checkout has no `origin` — never by directory name, because an independent clone is
+usually named differently from the original (`repo` vs `repo-hotfix`), which is exactly when name
+matching fails. It canonicalizes path aliases before identifying the current checkout, disables
+repository-provided fsmonitor commands while inspecting candidates, and treats commits reachable
+from any locally known remote-tracking ref as pushed even when a branch has no upstream. Exit is 1
+when any *other* checkout holds uncommitted, untracked, unpushed, or uninspectable work. Run Steps
+1–2 in **each** checkout it reports, then treat "nothing at risk" as a claim about all of them, not
+just this one.
+
+### Maintainer verification
+
+Run the isolated regression suite after changing checkout discovery:
+
+```bash
+uv run python -m unittest discover -s tests -p 'test_*.py'
+```
 
 **Step 1 — audit (non-destructive).** What, if anything, is at risk of loss right now:
 

--- a/git-safety-net/SKILL.md
+++ b/git-safety-net/SKILL.md
@@ -100,15 +100,16 @@ DEPTH=6 scripts/git_find_all_checkouts.sh ~    # widen when clones live far from
 ```
 
 It matches sibling checkouts by normalized remote URL (so the SSH and HTTPS forms of one
-repository compare equal), falling back to **shared root commit** whenever either the current or a
-candidate checkout has no `origin` — never by directory name, because an independent clone is
-usually named differently from the original (`repo` vs `repo-hotfix`), which is exactly when name
-matching fails. It canonicalizes path aliases before identifying the current checkout, disables
-repository-provided fsmonitor commands while inspecting candidates, and treats commits reachable
-from any locally known remote-tracking ref as pushed even when a branch has no upstream. Exit is 1
-when any *other* checkout holds uncommitted, untracked, unpushed, or uninspectable work. Run Steps
-1–2 in **each** checkout it reports, then treat "nothing at risk" as a claim about all of them, not
-just this one.
+repository compare equal), falling back to **any shared commit history** whenever either the current
+or a candidate checkout has no `origin`. That history check works for shallow clones that cannot
+see the repository's true root. It never matches by directory name, because an independent clone
+is usually named differently from the original (`repo` vs `repo-hotfix`), which is exactly when
+name matching fails. It canonicalizes path aliases before identifying the current checkout,
+disables repository-provided fsmonitor commands while inspecting candidates, and treats commits
+reachable from any locally known remote-tracking ref as pushed even when a branch has no upstream.
+Exit is 1 when any *other* checkout holds uncommitted, untracked, unpushed, or uninspectable work.
+Run Steps 1–2 in **each** checkout it reports, then treat "nothing at risk" as a claim about all of
+them, not just this one.
 
 ### Maintainer verification
 

--- a/git-safety-net/SKILL.md
+++ b/git-safety-net/SKILL.md
@@ -2,15 +2,18 @@
 name: git-safety-net
 description: >-
   Audits, preserves, recovers, and safely retires local Git state: unpushed or
-  wrong-branch commits, dirty or detached worktrees, orphaned/dropped stashes,
-  dangling commits, stale branches, and squash/rebase merge uncertainty. Use when
-  the user fears work was lost; asks to recover a commit, branch, stash, or reflog
-  state; asks whether a worktree can be deleted; wants all valuable state converged
-  onto main; or needs proof that cleanup/rebase/branch deletion will not drop work.
-  Triggers on "did I lose work", "is everything merged", "safe to delete this
-  worktree", "clean up old branches/stashes/worktrees", "git reflog", "dangling
-  commits", "分支灾难", "误删分支/commit", "worktree 能删吗", "确认全部合并了".
-  Covers local-Git forensics, not GitHub PR/API operations or routine repository sync.
+  wrong-branch commits, dirty or detached worktrees, forgotten duplicate clones of the
+  same repo, untracked work no bundle can back up, orphaned stashes, dangling commits,
+  stale branches, and squash/rebase merge uncertainty. Use when the user fears work was
+  lost; asks to recover a commit or branch; asks whether a worktree, clone, or scratch
+  directory can be deleted; wants everything converged onto one main branch; or
+  needs proof that cleanup will not drop work. Use it even after an audit reported clean
+  — the usual gap is scope: every in-repo command is blind to a second clone elsewhere
+  on disk. Triggers on "did I lose work", "is everything merged", "is anything else
+  lost", "safe to delete this clone", "clean up old branches/stashes", "only keep one
+  main branch", "git reflog", "dangling commits", "分支灾难", "误删分支/commit",
+  "worktree 能删吗", "还有没有丢的东西", "只保留一个主分支".
+  Covers local-Git forensics, not GitHub PR/API operations or routine sync.
 ---
 
 # Git Safety Net
@@ -27,30 +30,49 @@ until a step is explicitly labeled destructive — recovery must never make the 
 | "did I lose anything?", "what worktrees/stashes/branches remain?", after a messy session | **Mode B — Audit & preserve** |
 | "is everything merged?", "what's still not on main?", before deleting old branches | **Mode C — Verify merged** |
 | "so this never happens again", starting parallel/multi-branch work | **Mode D — Prevent** |
-| "clean up worktrees/stashes/branches", "converge everything onto main" | **Mode E — Retire safely** |
+| "clean up worktrees/stashes/branches", "converge everything onto main", "only keep one main branch" | **Mode E — Retire safely** |
+| "an audit already said it's clean, but is anything *else* lost?", "check again" | **Mode B, starting at Step 0** — a repeat request usually means the first pass had the wrong scope, not that it looked carelessly |
 
-When in doubt, **run Mode B first** (`git_loss_audit.sh`) — it is cheap, non-destructive, and tells
-you whether anything is actually at risk before you decide what to do.
+When in doubt, **run Mode B first**, beginning with `git_find_all_checkouts.sh` (Step 0) and then
+`git_loss_audit.sh` in each checkout it finds. Both are cheap and non-destructive, and they answer
+"is anything at risk" for the whole machine rather than for whichever directory you started in.
 
-## The five load-bearing rules (internalize these; the modes apply them)
+## The six load-bearing rules (internalize these; the modes apply them)
 
-1. **Run `git_loss_audit.sh` for the authoritative "what would be lost" check.** It compares the
-   current HEAD, every linked-worktree HEAD, local branches, and tags against every remote, then
-   inspects each worktree for tracked/untracked changes plus stashes and dangling commits. The
-   shorter `git log HEAD --branches --tags --not --remotes` misses a detached HEAD in a different
-   worktree and all uncommitted files. Ahead/behind counts do **not** answer this.
-2. **`git reflog` is the first move for "I lost a commit," not `fsck`.** Reflog records every
+1. **Get the SCOPE right before you trust any verdict: every instrument here only sees the
+   repository it runs in.** `git worktree list`, `git branch -a`, `git fsck`, `git stash list`,
+   `git log --not --remotes` — all of them are structurally blind to an **independent clone** of
+   the same repository elsewhere on the machine. A linked worktree (`git worktree add`) has a
+   gitlink *file* pointing home, so it shows up; a second `git clone` has its own complete `.git`
+   and no back-reference, so it shows up in **nothing**. Run `git_find_all_checkouts.sh` first —
+   otherwise a clean audit means "clean in this one directory," which is not the question the
+   user asked. Real incident: a repository audited clean, every branch pushed, while 440 lines of
+   a working feature sat as untracked files in a sibling clone one `rm -rf` from gone.
+2. **Run `git_loss_audit.sh` for the authoritative "what would be lost" check *within a
+   checkout*.** It compares the current HEAD, every linked-worktree HEAD, local branches, and tags
+   against every remote, then inspects each worktree for tracked/untracked changes plus stashes and
+   dangling commits. The shorter `git log HEAD --branches --tags --not --remotes` misses a detached
+   HEAD in a different worktree and all uncommitted files. Ahead/behind counts do **not** answer
+   this. Run it once per checkout that rule 1 turned up, not just in the one you happen to be in.
+3. **`git reflog` is the first move for "I lost a commit," not `fsck`.** Reflog records every
    HEAD position (commits, checkouts, resets, rebases) for ~90 days and the lost commit is
    usually in its top few lines. `git fsck` is the deeper net for commits reflog can't reach.
-3. **Preserve before you clean up.** Pin at-risk/dangling commits somewhere garbage collection
-   can't reach them *before* deleting a branch, running `gc`, or force-pushing. Cleanup is
-   reversible only while a ref (or the reflog window) still points at the work.
-4. **Verify "merged" by CONTENT, never by commit count.** After a squash-merge, `main..branch`
+4. **Preserve before you clean up — and know which backup tool can actually reach the work.**
+   Pin at-risk/dangling commits somewhere garbage collection can't reach them *before* deleting a
+   branch, running `gc`, or force-pushing. Cleanup is reversible only while a ref (or the reflog
+   window) still points at the work. **Critical asymmetry: `bundle`, `archive`, and `format-patch`
+   can only reach objects git already knows about.** An untracked file that was never `git add`ed
+   and never `stash -u`ed is invisible to all three — the copy on disk is the only copy, so
+   preserving it means literally copying the file out. Backing up "the repository" and believing
+   untracked work came along is how a clean-looking backup silently omits the only thing at risk.
+5. **Verify "merged" by CONTENT, never by commit count.** After a squash-merge, `main..branch`
    shows the branch's original commits as "unmerged" even though their content is on main —
    often 100+ phantom commits. Judge with file/blob comparison, not counts (Mode C).
-5. **For a high-stakes "is everything merged?" call, verify adversarially — ideally with a
+6. **For a high-stakes "is everything merged?" call, verify adversarially — ideally with a
    fan-out of independent agents each trying to *disprove* it.** One reviewer (human or model)
-   scanning many branches reliably misses a real gap; independent cross-checks catch it.
+   scanning many branches reliably misses a real gap; independent cross-checks catch it. Give at
+   least one agent the explicit job of widening the *scope* (rule 1) rather than re-checking the
+   branches already on the table — scope gaps hide from reviewers who accept the given frame.
 
 ## Mode A — Recover lost work
 
@@ -68,6 +90,21 @@ If reflog doesn't show it (e.g. a dropped stash, an orphan from a rebase), fall 
 `git fsck --dangling` — see the playbook.
 
 ## Mode B — Audit what's at risk, then preserve it
+
+**Step 0 — establish the scope (rule 1).** Find every checkout of this repository on the machine,
+including the independent clones no in-repo command can see:
+
+```bash
+scripts/git_find_all_checkouts.sh              # defaults to this repo's parent + grandparent
+scripts/git_find_all_checkouts.sh ~ DEPTH=6    # widen when clones live far from each other
+```
+
+It matches sibling checkouts by normalized remote URL (so the SSH and HTTPS forms of one
+repository compare equal), falling back to **shared root commit** when there's no `origin` —
+never by directory name, because an independent clone is usually named differently from the
+original (`repo` vs `repo-hotfix`), which is exactly when name matching fails. Exit is 1 when any
+*other* checkout holds uncommitted, untracked, or unpushed work. Run Steps 1–2 in **each** of the
+checkouts it reports, then treat "nothing at risk" as a claim about all of them, not just this one.
 
 **Step 1 — audit (non-destructive).** What, if anything, is at risk of loss right now:
 
@@ -94,6 +131,22 @@ reach a referenced commit) without cluttering `git branch`, and optionally write
 non-stash commit. For a *specific* important commit, also give it the full treatment — local
 branch **and** a pushed remote branch **and** a `git format-patch` file — so a single disk or a
 single `git gc` can't take it. Details + why triple-backup: **[references/recovery_playbook.md](references/recovery_playbook.md)**.
+
+**Untracked files need a different tool — plain copying (rule 4).** Everything above moves *git
+objects*; a file git was never told about is not one. Preserve those explicitly, and keep the
+three channels separate so a later reader knows what each restores:
+
+```bash
+git -C <checkout> status --porcelain | grep '^??'                     # what is untracked
+cp <each-untracked-path> <backup>/                                    # the ONLY copy — plain cp
+git -C <checkout> diff > <backup>/uncommitted.diff                    # tracked-but-uncommitted
+git -C <checkout> bundle create <backup>/history.bundle origin/main..HEAD   # unpushed commits
+git bundle verify <backup>/history.bundle                             # prove it restores
+```
+
+Write a one-paragraph `README` beside them saying where they came from, which branch, and when the
+session stopped. A backup nobody can interpret six weeks later is only slightly better than none —
+and the person reading it will not be the person who made it.
 
 ## Mode C — Verify everything is merged (without being fooled by counts)
 
@@ -127,6 +180,14 @@ The habits that keep a branch tangle from ever stranding work:
   bring it where you need it *live* by merging — not by stashing, and not by spinning up a second
   `git worktree` checkout (which is one more place to forget work and won't even have your
   gitignored deps). A shared working tree with commit-then-switch discipline is the safe default.
+- **If you truly need a second checkout, make it a worktree — never a second `git clone`.** Both
+  are extra places to forget work, which is why commit-then-switch above is still the default. But
+  the failure modes are not equal: a linked worktree announces itself in `git worktree list`, so
+  every audit finds it, while an independent clone is invisible to every command run from the
+  original repository. Choosing `clone` for a few days of parallel work quietly opts out of all
+  the safety tooling. When a clone already exists (a colleague made it, a script made it, you
+  inherited it), register it somewhere the team actually reads and retire it the day it's done —
+  and until then, treat it as an audit target in its own right, not as a scratch directory.
 - **Push a work-in-progress branch to a remote early.** The one commit only on a local branch is
   the only commit that a dead laptop actually loses.
 - **Confirm the current branch before committing** (`git branch --show-current`) — a fix committed
@@ -145,8 +206,10 @@ The habits that keep a branch tangle from ever stranding work:
 
 The opposite worry from Mode A: not "I lost something" but "these leftovers are piling up —
 which can I destroy?" Deleting is trivial; **proving each item is superseded is the work**.
-Start with `git_loss_audit.sh` and `git worktree list --porcelain`; treat every checkout as an
-independent place where uncommitted or detached work can hide. Then triage, backup, and retire:
+Start with `git_find_all_checkouts.sh` — `git worktree list --porcelain` alone will not show an
+independent clone, and those are the leftovers most likely to be forgotten — then `git_loss_audit.sh`
+inside each checkout it reports. Treat every checkout as an independent place where uncommitted or
+detached work can hide. Then triage, backup, and retire:
 
 **Step 1 — classify each leftover: live WIP, or superseded draft?** Evidence ladder, strongest first:
 
@@ -194,6 +257,21 @@ use repeated `--branch` instead. The exporter never drops or deletes anything.
 - Local branches: prefer `git branch -d` (refuses unmerged); use `-D` only for items Step 1
   proved superseded, backed up, and the user authorized deleting. Delete remote branches only
   after re-verifying the exact remote and repository visibility/ownership.
+- **Independent clones: there is no safe git-level command — only `rm -rf`, which git cannot
+  undo.** `git worktree remove` does not apply (it isn't a worktree) and refuses to help, so the
+  usual "the tool will stop me if it's unsafe" backstop is absent here. Make the check explicit
+  instead: gate the deletion on the backup actually existing, so a missing file aborts rather
+  than being noticed afterwards.
+
+  ```bash
+  for f in <backup>/<untracked-file> <backup>/uncommitted.diff <backup>/history.bundle; do
+    [ -s "$f" ] || { echo "MISSING: $f — refusing to delete"; exit 1; }
+  done
+  rm -rf <clone-path>
+  ```
+
+  Prefer deleting one clone at a time with its own verification over a loop across several — a
+  glob that deletes five directories has five chances to be wrong and reports none of them.
 
 **Recovery, if you regret it:** patches re-apply with `git apply`; the untracked tar extracts
 in place; the bundle restores full history via `git fetch <file>.bundle <branch>:restored/<branch>`.
@@ -202,18 +280,33 @@ in place; the bundle restores full history via `git fetch <file>.bundle <branch>
 
 | Script | Does | Mutates? |
 |---|---|---|
+| `scripts/git_find_all_checkouts.sh [root ...]` | Find every checkout of this repo on the machine — including independent clones invisible to `git worktree list` — and flag those holding uncommitted/untracked/unpushed work | Nothing (read-only, no fetch) |
 | `scripts/git_loss_audit.sh [remote]` | Refresh one remote, then report every worktree, local-only commit, stash, and dangler | Remote-tracking refs only |
 | `scripts/git_preserve_danglers.sh [--patch-dir DIR]` | Pin danglers to `refs/dangling-backup/`, optional patches | Adds refs only (never deletes/gc) |
 | `scripts/git_verify_branch_merged.sh <branch> [base]` | Refresh remotes, then give a content-level MERGED/UNMERGED verdict | Remote-tracking refs only |
 | `scripts/git_export_before_drop.sh [--all-stashes] [--stash N] [--branch B] [--all-refs] [--out DIR]` | Export stashes plus selected branches or every current ref into verified bundles | Writes backup files only (never drops/deletes) |
 
-All four run from the repository root. They only ever `fetch`, `log`, `diff`, `show`,
-`cat-file`, `rev-list`, `fsck`, `for-each-ref`, `stash show`, `archive`, `bundle create/verify`,
-and (preserve only) `update-ref` — never `checkout`, `reset`, `push`, `stash drop`, `branch -d`,
-or `gc`, so they are safe to run in a dirty tree or alongside other agents.
+All five run from the repository root. They only ever `find`, `fetch`, `log`, `diff`, `show`,
+`status`, `cat-file`, `rev-list`, `rev-parse`, `fsck`, `for-each-ref`, `remote get-url`,
+`stash show`, `archive`, `bundle create/verify`, and (preserve only) `update-ref` — never
+`checkout`, `reset`, `push`, `stash drop`, `branch -d`, or `gc`, so they are safe to run in a
+dirty tree or alongside other agents. `git_find_all_checkouts.sh` additionally never fetches, so
+it works offline and behind a proxy.
 
 ## Troubleshooting
 
+- **An audit came back clean but the user still thinks something is missing** — believe them and
+  suspect **scope, not thoroughness**. The in-repo instruments were probably all correct about the
+  one directory they could see. Run Step 0 (`git_find_all_checkouts.sh`) before re-running anything
+  you already ran; repeating a correctly-executed check in the wrong scope returns the same clean
+  answer with more confidence behind it, which is worse than the first pass.
+- **`git_find_all_checkouts.sh` finds nothing, but you're fairly sure another copy exists** — three
+  likely causes, in order: (1) the copy lives outside the default roots (pass an explicit root such
+  as `~`, and raise `DEPTH`); (2) it sits under a pruned path — the sweep skips `node_modules`,
+  `.venv`, `vendor`, `.terraform`; (3) its `origin` points somewhere else entirely (a fork, or a
+  path remote), so remote matching rejects it — check with `git -C <suspect> remote -v` and compare
+  root commits by hand: `git rev-list --max-parents=0 HEAD`. A copy made by `cp -r` before the repo
+  had any remote will only match on root commit.
 - **`git_loss_audit.sh` reports dangling commits that look like old stashes** — expected after
   stash-heavy work. They're reflog-reachable now; pin them with `git_preserve_danglers.sh` if you
   want them past the gc window, then inspect with `git show <sha>` at leisure.

--- a/git-safety-net/scripts/git_find_all_checkouts.sh
+++ b/git-safety-net/scripts/git_find_all_checkouts.sh
@@ -72,19 +72,32 @@ normalize_remote() {
 SELF_REMOTE_RAW="$(safe_git remote get-url origin 2>/dev/null | head -1 || true)"
 SELF_REMOTE="$(normalize_remote "$SELF_REMOTE_RAW")"
 
-# Identity fallback: the ROOT COMMIT, never the directory name. Independent clones are
-# usually named differently from the original (`repo` vs `repo-hotfix`) — exactly the case
-# this script exists to catch — so name matching fails precisely when it matters most.
-# Every clone of a repository shares its root commit, whatever the directory is called.
-SELF_ROOTCOMMIT="$(safe_git rev-list --max-parents=0 HEAD 2>/dev/null | tail -1 || true)"
+# Identity fallback: any shared commit, never the directory name. A shallow clone
+# cannot see the repository's true root, but it still carries at least its shallow
+# boundary and HEAD. Checking the candidate's reachable commits against this
+# repository therefore works for full, shallow, detached, and differently named
+# copies without trusting a mutable path label.
+shares_commit_with_self() {
+  local checkout="$1"
+  local oid
+  while IFS= read -r oid; do
+    [ -n "$oid" ] || continue
+    if safe_git -C "$SELF_ROOT" cat-file -e "${oid}^{commit}" 2>/dev/null; then
+      return 0
+    fi
+  done < <(safe_git -C "$checkout" rev-list --all HEAD 2>/dev/null)
+  return 1
+}
+
+SELF_HEAD="$(safe_git rev-parse --verify HEAD 2>/dev/null | head -1 || true)"
 
 if [ -n "$SELF_REMOTE" ]; then
   MATCH_MODE="remote"
   IDENTITY="$SELF_REMOTE"
-elif [ -n "$SELF_ROOTCOMMIT" ]; then
-  MATCH_MODE="rootcommit"
-  IDENTITY="root commit ${SELF_ROOTCOMMIT}"
-  echo "note: no 'origin' remote here — identifying sibling checkouts by shared root commit instead."
+elif [ -n "$SELF_HEAD" ]; then
+  MATCH_MODE="history"
+  IDENTITY="history shared with ${SELF_HEAD}"
+  echo "note: no 'origin' remote here — identifying sibling checkouts by shared commit history instead."
 else
   echo "cannot identify this repository: it has no 'origin' remote and no commits yet." >&2
   exit 2
@@ -134,14 +147,12 @@ for gitpath in "${CANDIDATES[@]}"; do
       [ "$other_remote" = "$SELF_REMOTE" ] || continue
     else
       # A copied checkout may deliberately or accidentally lose its origin. It is
-      # still the same repository when its root commit matches, and is exactly the
-      # kind of hidden work this scanner exists to find.
-      other_root="$(safe_git -C "$checkout" rev-list --max-parents=0 HEAD 2>/dev/null | tail -1 || true)"
-      [ -n "$other_root" ] && [ "$other_root" = "$SELF_ROOTCOMMIT" ] || continue
+      # still related when it shares any commit, even if it is shallow and cannot
+      # see the true root. That is exactly the hidden work this scanner targets.
+      shares_commit_with_self "$checkout" || continue
     fi
   else
-    other_root="$(safe_git -C "$checkout" rev-list --max-parents=0 HEAD 2>/dev/null | tail -1 || true)"
-    [ -n "$other_root" ] && [ "$other_root" = "$SELF_ROOTCOMMIT" ] || continue
+    shares_commit_with_self "$checkout" || continue
   fi
 
   FOUND=$((FOUND + 1))

--- a/git-safety-net/scripts/git_find_all_checkouts.sh
+++ b/git-safety-net/scripts/git_find_all_checkouts.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# git_find_all_checkouts.sh — enumerate EVERY checkout of this repository on this machine,
+# including the ones `git worktree list` is structurally blind to.
+#
+# WHY THIS EXISTS (the blind spot that makes every other audit incomplete):
+#   `git worktree list` only knows LINKED worktrees — checkouts made with `git worktree add`,
+#   whose `.git` is a gitlink *file* pointing back to this repository. An INDEPENDENT CLONE
+#   (a second `git clone` of the same remote, or a copied directory) has its own complete
+#   `.git` directory and no back-reference, so it appears in NONE of the usual instruments:
+#   not `git worktree list`, not `git branch -a`, not `git fsck`, not `git stash list`,
+#   not `git log --not --remotes` — all of those only ever see the repository they run in.
+#
+#   So an audit that enumerates checkouts via `git worktree list` will confidently report
+#   "nothing at risk" while unpushed commits and uncommitted files sit in a sibling clone.
+#   Untracked files are the worst case: no bundle, no `git archive`, and no `format-patch`
+#   can reach a file git was never told about, so the only copy is the one on disk.
+#
+#   Real incident: a session stopped mid-flight and left 440 lines of a working feature as
+#   untracked files in a sibling clone. The repository's own audit was clean, every branch
+#   was pushed, and the work was still one `rm -rf` away from being gone for good.
+#
+# NON-DESTRUCTIVE: runs only `find`, `git rev-parse`, `git remote`, `git status`,
+# `git rev-list`, `git config`. It never fetches, writes refs, stages, or touches a file.
+# Safe to run in a dirty tree and alongside other agents.
+#
+# USAGE:
+#   scripts/git_find_all_checkouts.sh [search-root ...]
+#
+#   With no arguments it searches the parent and grandparent of this repository — where
+#   sibling clones actually accumulate (`~/workspace/js/repo` plus `~/workspace/repo-hotfix`).
+#   Pass explicit roots to widen (`~`) or narrow the sweep. Set DEPTH=<n> to change how deep
+#   each root is scanned (default 4; raise it for deeply nested layouts).
+#
+# EXIT: 0 when no OTHER checkout holds at-risk work; 1 when any other checkout has
+# uncommitted changes, untracked files, or unpushed commits; 2 if not run inside a Git repo.
+
+set -uo pipefail
+
+DEPTH="${DEPTH:-4}"
+
+git rev-parse --git-dir >/dev/null 2>&1 || {
+  echo "not inside a Git repository" >&2
+  exit 2
+}
+
+SELF_ROOT="$(git rev-parse --show-toplevel)"
+
+# Normalize a remote URL so the SSH and HTTPS forms of the same repository compare equal:
+#   git@github.com:owner/repo.git  ->  github.com/owner/repo
+#   https://github.com/owner/repo  ->  github.com/owner/repo
+normalize_remote() {
+  printf '%s' "${1:-}" | sed -E 's#^[a-z+]+://##; s#^[^@/]+@##; s#:#/#; s#\.git/?$##; s#/+$##'
+}
+
+SELF_REMOTE_RAW="$(git remote get-url origin 2>/dev/null | head -1 || true)"
+SELF_REMOTE="$(normalize_remote "$SELF_REMOTE_RAW")"
+
+# Identity fallback: the ROOT COMMIT, never the directory name. Independent clones are
+# usually named differently from the original (`repo` vs `repo-hotfix`) — exactly the case
+# this script exists to catch — so name matching fails precisely when it matters most.
+# Every clone of a repository shares its root commit, whatever the directory is called.
+SELF_ROOTCOMMIT="$(git rev-list --max-parents=0 HEAD 2>/dev/null | tail -1 || true)"
+
+if [ -n "$SELF_REMOTE" ]; then
+  MATCH_MODE="remote"
+  IDENTITY="$SELF_REMOTE"
+elif [ -n "$SELF_ROOTCOMMIT" ]; then
+  MATCH_MODE="rootcommit"
+  IDENTITY="root commit ${SELF_ROOTCOMMIT}"
+  echo "note: no 'origin' remote here — identifying sibling checkouts by shared root commit instead."
+else
+  echo "cannot identify this repository: it has no 'origin' remote and no commits yet." >&2
+  exit 2
+fi
+
+if [ "$#" -gt 0 ]; then
+  ROOTS=("$@")
+else
+  ROOTS=("$(dirname "$SELF_ROOT")" "$(dirname "$(dirname "$SELF_ROOT")")")
+fi
+
+echo "Searching for every checkout of: ${IDENTITY}"
+echo "Search roots (depth ${DEPTH}): ${ROOTS[*]}"
+echo
+
+# Collect candidate .git entries. A .git DIRECTORY is a full repository (clone); a .git FILE
+# is a gitlink — either a linked worktree or a submodule. Both are real checkouts that can
+# hold uncommitted work, so both are reported.
+CANDIDATES=()
+for root in "${ROOTS[@]}"; do
+  [ -d "$root" ] || continue
+  while IFS= read -r gitpath; do
+    [ -n "$gitpath" ] && CANDIDATES+=("$gitpath")
+  done < <(
+    find "$root" -maxdepth "$DEPTH" -name '.git' \( -type d -o -type f \) \
+      -not -path '*/node_modules/*' -not -path '*/.venv/*' \
+      -not -path '*/vendor/*' -not -path '*/.terraform/*' 2>/dev/null
+  )
+done
+
+AT_RISK=0
+FOUND=0
+SEEN=""
+
+for gitpath in "${CANDIDATES[@]}"; do
+  checkout="$(dirname "$gitpath")"
+
+  # De-duplicate: two search roots commonly overlap.
+  case "$SEEN" in *"|$checkout|"*) continue ;; esac
+  SEEN="$SEEN|$checkout|"
+
+  if [ "$MATCH_MODE" = "remote" ]; then
+    other_remote="$(normalize_remote "$(git -C "$checkout" remote get-url origin 2>/dev/null | head -1 || true)")"
+    [ "$other_remote" = "$SELF_REMOTE" ] || continue
+  else
+    other_root="$(git -C "$checkout" rev-list --max-parents=0 HEAD 2>/dev/null | tail -1 || true)"
+    [ -n "$other_root" ] && [ "$other_root" = "$SELF_ROOTCOMMIT" ] || continue
+  fi
+
+  FOUND=$((FOUND + 1))
+
+  if [ -d "$gitpath" ]; then
+    kind="independent clone"
+  elif grep -q 'worktrees/' "$gitpath" 2>/dev/null; then
+    kind="linked worktree"
+  else
+    kind="gitlink (submodule?)"
+  fi
+
+  branch="$(git -C "$checkout" rev-parse --abbrev-ref HEAD 2>/dev/null | head -1)"
+  head_sha="$(git -C "$checkout" rev-parse --short HEAD 2>/dev/null | head -1)"
+  modified="$(git -C "$checkout" status --porcelain 2>/dev/null | grep -cv '^??' || true)"
+  untracked="$(git -C "$checkout" status --porcelain 2>/dev/null | grep -c '^??' || true)"
+  unpushed="$(git -C "$checkout" rev-list --count '@{u}..HEAD' 2>/dev/null | head -1)"
+  [ -n "$branch" ] || branch='?'
+  [ -n "$head_sha" ] || head_sha='?'
+  [ -n "$unpushed" ] || unpushed='no-upstream'
+
+  if [ "$checkout" = "$SELF_ROOT" ]; then
+    marker="  (this repository)"
+  else
+    marker=""
+    if [ "${modified:-0}" -gt 0 ] || [ "${untracked:-0}" -gt 0 ] \
+       || { [ "$unpushed" != "no-upstream" ] && [ "${unpushed:-0}" -gt 0 ]; } \
+       || [ "$unpushed" = "no-upstream" ]; then
+      AT_RISK=$((AT_RISK + 1))
+      marker="  <-- AT RISK"
+    fi
+  fi
+
+  echo "${checkout}${marker}"
+  echo "    kind:      ${kind}"
+  echo "    branch:    ${branch} @ ${head_sha}"
+  echo "    modified:  ${modified}   untracked: ${untracked}   unpushed: ${unpushed}"
+  if [ "${untracked:-0}" -gt 0 ] && [ "$checkout" != "$SELF_ROOT" ]; then
+    echo "    NOTE: untracked files are unreachable by bundle/archive/format-patch."
+    echo "          Copy them out directly — that disk copy is the only copy."
+  fi
+  echo
+done
+
+echo "------------------------------------------------------------"
+echo "Checkouts found: ${FOUND}    At-risk (excluding this one): ${AT_RISK}"
+
+if [ "$AT_RISK" -gt 0 ]; then
+  cat <<'GUIDANCE'
+
+Each AT-RISK checkout holds work that exists nowhere else. Before deleting any of them:
+  1. Untracked files      -> copy them out of the tree (nothing in git can reach them).
+  2. Uncommitted changes  -> `git -C <checkout> diff > <backup>/uncommitted.diff`.
+  3. Unpushed commits     -> `git -C <checkout> bundle create <backup>/history.bundle origin/main..HEAD`
+                             (verify it: `git bundle verify <backup>/history.bundle`).
+Then judge each item by CONTENT against the surviving repository — a branch name, a commit
+message, or "it looks old" is not evidence that the work already landed.
+GUIDANCE
+  exit 1
+fi
+
+if [ "$FOUND" -le 1 ]; then
+  echo "Only this checkout exists — no hidden clone is holding work."
+fi
+exit 0

--- a/git-safety-net/scripts/git_find_all_checkouts.sh
+++ b/git-safety-net/scripts/git_find_all_checkouts.sh
@@ -19,9 +19,10 @@
 #   untracked files in a sibling clone. The repository's own audit was clean, every branch
 #   was pushed, and the work was still one `rm -rf` away from being gone for good.
 #
-# NON-DESTRUCTIVE: runs only `find`, `git rev-parse`, `git remote`, `git status`,
-# `git rev-list`, `git config`. It never fetches, writes refs, stages, or touches a file.
-# Safe to run in a dirty tree and alongside other agents.
+# NON-DESTRUCTIVE: runs only `find` plus read-only Git queries. Repository-provided
+# fsmonitor commands are disabled and optional index refreshes are suppressed before
+# inspecting discovered checkouts. It never fetches, writes refs, stages, or touches a
+# file. Safe to run in a dirty tree and alongside other agents.
 #
 # USAGE:
 #   scripts/git_find_all_checkouts.sh [search-root ...]
@@ -38,12 +39,28 @@ set -uo pipefail
 
 DEPTH="${DEPTH:-4}"
 
-git rev-parse --git-dir >/dev/null 2>&1 || {
+safe_git() {
+  GIT_OPTIONAL_LOCKS=0 git --no-pager \
+    -c core.fsmonitor=false \
+    -c core.untrackedCache=false \
+    -c status.submoduleSummary=false \
+    "$@"
+}
+
+canonical_dir() {
+  (cd "$1" 2>/dev/null && pwd -P)
+}
+
+safe_git rev-parse --git-dir >/dev/null 2>&1 || {
   echo "not inside a Git repository" >&2
   exit 2
 }
 
-SELF_ROOT="$(git rev-parse --show-toplevel)"
+SELF_ROOT_RAW="$(safe_git rev-parse --show-toplevel)"
+SELF_ROOT="$(canonical_dir "$SELF_ROOT_RAW")" || {
+  echo "cannot resolve this repository's working tree" >&2
+  exit 2
+}
 
 # Normalize a remote URL so the SSH and HTTPS forms of the same repository compare equal:
 #   git@github.com:owner/repo.git  ->  github.com/owner/repo
@@ -52,14 +69,14 @@ normalize_remote() {
   printf '%s' "${1:-}" | sed -E 's#^[a-z+]+://##; s#^[^@/]+@##; s#:#/#; s#\.git/?$##; s#/+$##'
 }
 
-SELF_REMOTE_RAW="$(git remote get-url origin 2>/dev/null | head -1 || true)"
+SELF_REMOTE_RAW="$(safe_git remote get-url origin 2>/dev/null | head -1 || true)"
 SELF_REMOTE="$(normalize_remote "$SELF_REMOTE_RAW")"
 
 # Identity fallback: the ROOT COMMIT, never the directory name. Independent clones are
 # usually named differently from the original (`repo` vs `repo-hotfix`) — exactly the case
 # this script exists to catch — so name matching fails precisely when it matters most.
 # Every clone of a repository shares its root commit, whatever the directory is called.
-SELF_ROOTCOMMIT="$(git rev-list --max-parents=0 HEAD 2>/dev/null | tail -1 || true)"
+SELF_ROOTCOMMIT="$(safe_git rev-list --max-parents=0 HEAD 2>/dev/null | tail -1 || true)"
 
 if [ -n "$SELF_REMOTE" ]; then
   MATCH_MODE="remote"
@@ -100,49 +117,69 @@ done
 
 AT_RISK=0
 FOUND=0
+FOUND_SELF=0
 SEEN=""
 
 for gitpath in "${CANDIDATES[@]}"; do
-  checkout="$(dirname "$gitpath")"
+  checkout_raw="$(dirname "$gitpath")"
+  checkout="$(canonical_dir "$checkout_raw")" || continue
 
   # De-duplicate: two search roots commonly overlap.
   case "$SEEN" in *"|$checkout|"*) continue ;; esac
   SEEN="$SEEN|$checkout|"
 
   if [ "$MATCH_MODE" = "remote" ]; then
-    other_remote="$(normalize_remote "$(git -C "$checkout" remote get-url origin 2>/dev/null | head -1 || true)")"
-    [ "$other_remote" = "$SELF_REMOTE" ] || continue
+    other_remote="$(normalize_remote "$(safe_git -C "$checkout" remote get-url origin 2>/dev/null | head -1 || true)")"
+    if [ -n "$other_remote" ]; then
+      [ "$other_remote" = "$SELF_REMOTE" ] || continue
+    else
+      # A copied checkout may deliberately or accidentally lose its origin. It is
+      # still the same repository when its root commit matches, and is exactly the
+      # kind of hidden work this scanner exists to find.
+      other_root="$(safe_git -C "$checkout" rev-list --max-parents=0 HEAD 2>/dev/null | tail -1 || true)"
+      [ -n "$other_root" ] && [ "$other_root" = "$SELF_ROOTCOMMIT" ] || continue
+    fi
   else
-    other_root="$(git -C "$checkout" rev-list --max-parents=0 HEAD 2>/dev/null | tail -1 || true)"
+    other_root="$(safe_git -C "$checkout" rev-list --max-parents=0 HEAD 2>/dev/null | tail -1 || true)"
     [ -n "$other_root" ] && [ "$other_root" = "$SELF_ROOTCOMMIT" ] || continue
   fi
 
   FOUND=$((FOUND + 1))
 
-  if [ -d "$gitpath" ]; then
+  if [ -d "$checkout/.git" ]; then
     kind="independent clone"
-  elif grep -q 'worktrees/' "$gitpath" 2>/dev/null; then
+  elif grep -q 'worktrees/' "$checkout/.git" 2>/dev/null; then
     kind="linked worktree"
   else
     kind="gitlink (submodule?)"
   fi
 
-  branch="$(git -C "$checkout" rev-parse --abbrev-ref HEAD 2>/dev/null | head -1)"
-  head_sha="$(git -C "$checkout" rev-parse --short HEAD 2>/dev/null | head -1)"
-  modified="$(git -C "$checkout" status --porcelain 2>/dev/null | grep -cv '^??' || true)"
-  untracked="$(git -C "$checkout" status --porcelain 2>/dev/null | grep -c '^??' || true)"
-  unpushed="$(git -C "$checkout" rev-list --count '@{u}..HEAD' 2>/dev/null | head -1)"
+  branch="$(safe_git -C "$checkout" rev-parse --abbrev-ref HEAD 2>/dev/null | head -1)"
+  head_sha="$(safe_git -C "$checkout" rev-parse --short HEAD 2>/dev/null | head -1)"
+  if status_output="$(safe_git -C "$checkout" status --porcelain=v1 --untracked-files=all --ignore-submodules=all 2>/dev/null)"; then
+    modified="$(printf '%s' "$status_output" | grep -cv '^??' || true)"
+    untracked="$(printf '%s' "$status_output" | grep -c '^??' || true)"
+  else
+    modified='unknown'
+    untracked='unknown'
+  fi
+  # Upstream configuration is not a preservation boundary. A detached or
+  # no-upstream HEAD is safe when every commit is already reachable from some
+  # locally known remote-tracking ref.
+  unpushed="$(safe_git -C "$checkout" rev-list --count HEAD --not --remotes 2>/dev/null | head -1)"
   [ -n "$branch" ] || branch='?'
   [ -n "$head_sha" ] || head_sha='?'
-  [ -n "$unpushed" ] || unpushed='no-upstream'
+  [ -n "$unpushed" ] || unpushed='unknown'
 
   if [ "$checkout" = "$SELF_ROOT" ]; then
+    FOUND_SELF=1
     marker="  (this repository)"
   else
     marker=""
-    if [ "${modified:-0}" -gt 0 ] || [ "${untracked:-0}" -gt 0 ] \
-       || { [ "$unpushed" != "no-upstream" ] && [ "${unpushed:-0}" -gt 0 ]; } \
-       || [ "$unpushed" = "no-upstream" ]; then
+    if [ "$modified" = 'unknown' ] || [ "$untracked" = 'unknown' ] \
+       || [ "$unpushed" = 'unknown' ] \
+       || [ "${modified:-0}" -gt 0 ] || [ "${untracked:-0}" -gt 0 ] \
+       || [ "${unpushed:-0}" -gt 0 ]; then
       AT_RISK=$((AT_RISK + 1))
       marker="  <-- AT RISK"
     fi
@@ -165,10 +202,10 @@ echo "Checkouts found: ${FOUND}    At-risk (excluding this one): ${AT_RISK}"
 if [ "$AT_RISK" -gt 0 ]; then
   cat <<'GUIDANCE'
 
-Each AT-RISK checkout holds work that exists nowhere else. Before deleting any of them:
+Each AT-RISK checkout may hold work that is not proven preserved elsewhere. Before deleting it:
   1. Untracked files      -> copy them out of the tree (nothing in git can reach them).
   2. Uncommitted changes  -> `git -C <checkout> diff > <backup>/uncommitted.diff`.
-  3. Unpushed commits     -> `git -C <checkout> bundle create <backup>/history.bundle origin/main..HEAD`
+  3. Unpushed commits     -> `git -C <checkout> bundle create <backup>/history.bundle HEAD --not --remotes`
                              (verify it: `git bundle verify <backup>/history.bundle`).
 Then judge each item by CONTENT against the surviving repository — a branch name, a commit
 message, or "it looks old" is not evidence that the work already landed.
@@ -176,7 +213,11 @@ GUIDANCE
   exit 1
 fi
 
-if [ "$FOUND" -le 1 ]; then
+if [ "$FOUND" -eq 0 ]; then
+  echo "No matching checkout was found under the requested search roots."
+elif [ "$FOUND" -eq 1 ] && [ "$FOUND_SELF" -eq 1 ]; then
   echo "Only this checkout exists — no hidden clone is holding work."
+elif [ "$FOUND_SELF" -eq 0 ]; then
+  echo "Note: the current repository was outside the requested search roots."
 fi
 exit 0

--- a/git-safety-net/tests/test_git_find_all_checkouts.py
+++ b/git-safety-net/tests/test_git_find_all_checkouts.py
@@ -40,7 +40,20 @@ class CheckoutDiscoveryTests(unittest.TestCase):
             tree,
             input_text="fixture\n",
         ).stdout.strip()
-        self.git("-C", str(self.seed), "update-ref", "refs/heads/main", commit)
+        head = self.git(
+            "-C",
+            str(self.seed),
+            "-c",
+            "user.name=Fixture",
+            "-c",
+            "user.email=fixture@example.invalid",
+            "commit-tree",
+            tree,
+            "-p",
+            commit,
+            input_text="second fixture\n",
+        ).stdout.strip()
+        self.git("-C", str(self.seed), "update-ref", "refs/heads/main", head)
         self.git("clone", "-q", str(self.seed), str(self.current))
         self.git("clone", "-q", str(self.seed), str(self.candidate))
 
@@ -70,7 +83,7 @@ class CheckoutDiscoveryTests(unittest.TestCase):
             env={**os.environ, "DEPTH": "3"},
         )
 
-    def test_clone_without_origin_is_still_found_by_root_commit(self) -> None:
+    def test_clone_without_origin_is_still_found_by_shared_history(self) -> None:
         self.git("-C", str(self.candidate), "remote", "remove", "origin")
         (self.candidate / "untracked-proof.txt").write_text(
             "only copy", encoding="utf-8"
@@ -80,6 +93,26 @@ class CheckoutDiscoveryTests(unittest.TestCase):
 
         self.assertEqual(completed.returncode, 1, completed.stdout + completed.stderr)
         self.assertIn(str(self.candidate.resolve()), completed.stdout)
+        self.assertIn("untracked: 1", completed.stdout)
+        self.assertIn("AT RISK", completed.stdout)
+
+    def test_shallow_clone_without_origin_is_found_by_shared_history(self) -> None:
+        shallow = self.checkouts / "shallow"
+        self.git(
+            "clone",
+            "-q",
+            "--depth",
+            "1",
+            self.seed.resolve().as_uri(),
+            str(shallow),
+        )
+        self.git("-C", str(shallow), "remote", "remove", "origin")
+        (shallow / "untracked-proof.txt").write_text("only copy", encoding="utf-8")
+
+        completed = self.run_scanner(self.checkouts)
+
+        self.assertEqual(completed.returncode, 1, completed.stdout + completed.stderr)
+        self.assertIn(str(shallow.resolve()), completed.stdout)
         self.assertIn("untracked: 1", completed.stdout)
         self.assertIn("AT RISK", completed.stdout)
 

--- a/git-safety-net/tests/test_git_find_all_checkouts.py
+++ b/git-safety-net/tests/test_git_find_all_checkouts.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Regression tests for cross-checkout Git discovery."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SKILL_DIR = Path(__file__).resolve().parents[1]
+SCRIPT = SKILL_DIR / "scripts" / "git_find_all_checkouts.sh"
+
+
+class CheckoutDiscoveryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        temp_parent = "/tmp" if Path("/tmp").is_dir() else None
+        self.temp_dir = tempfile.TemporaryDirectory(
+            prefix="git-safety-net-", dir=temp_parent
+        )
+        self.root = Path(self.temp_dir.name)
+        self.seed = self.root / "seed"
+        self.checkouts = self.root / "checkouts"
+        self.checkouts.mkdir()
+        self.current = self.checkouts / "current"
+        self.candidate = self.checkouts / "candidate"
+
+        self.git("init", "-q", "-b", "main", str(self.seed))
+        tree = self.git("-C", str(self.seed), "mktree", input_text="").stdout.strip()
+        commit = self.git(
+            "-C",
+            str(self.seed),
+            "-c",
+            "user.name=Fixture",
+            "-c",
+            "user.email=fixture@example.invalid",
+            "commit-tree",
+            tree,
+            input_text="fixture\n",
+        ).stdout.strip()
+        self.git("-C", str(self.seed), "update-ref", "refs/heads/main", commit)
+        self.git("clone", "-q", str(self.seed), str(self.current))
+        self.git("clone", "-q", str(self.seed), str(self.candidate))
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    @staticmethod
+    def git(
+        *arguments: str, input_text: str | None = None
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", *arguments],
+            input=input_text,
+            text=True,
+            encoding="utf-8",
+            capture_output=True,
+            check=True,
+        )
+
+    def run_scanner(self, search_root: Path | str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(SCRIPT), str(search_root)],
+            cwd=self.current,
+            text=True,
+            encoding="utf-8",
+            capture_output=True,
+            env={**os.environ, "DEPTH": "3"},
+        )
+
+    def test_clone_without_origin_is_still_found_by_root_commit(self) -> None:
+        self.git("-C", str(self.candidate), "remote", "remove", "origin")
+        (self.candidate / "untracked-proof.txt").write_text(
+            "only copy", encoding="utf-8"
+        )
+
+        completed = self.run_scanner(self.checkouts)
+
+        self.assertEqual(completed.returncode, 1, completed.stdout + completed.stderr)
+        self.assertIn(str(self.candidate.resolve()), completed.stdout)
+        self.assertIn("untracked: 1", completed.stdout)
+        self.assertIn("AT RISK", completed.stdout)
+
+    def test_clean_detached_remote_reachable_clone_is_not_at_risk(self) -> None:
+        self.git("-C", str(self.candidate), "switch", "--detach", "origin/main")
+
+        completed = self.run_scanner(self.checkouts)
+
+        self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+        candidate_line = next(
+            line
+            for line in completed.stdout.splitlines()
+            if line.startswith(str(self.candidate.resolve()))
+        )
+        self.assertNotIn("AT RISK", candidate_line)
+        self.assertIn("unpushed: 0", completed.stdout)
+
+    def test_path_alias_is_recognized_as_the_current_checkout(self) -> None:
+        raw_root = str(self.checkouts)
+        if raw_root == str(self.checkouts.resolve()):
+            self.skipTest("temporary root has no path alias on this platform")
+
+        completed = self.run_scanner(raw_root)
+
+        self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+        current_line = next(
+            line
+            for line in completed.stdout.splitlines()
+            if line.startswith(str(self.current.resolve()))
+        )
+        self.assertIn("(this repository)", current_line)
+        self.assertNotIn("AT RISK", current_line)
+
+    def test_repository_fsmonitor_command_is_not_executed(self) -> None:
+        marker = self.root / "FS_MONITOR_EXECUTED"
+        monitor = self.root / "fsmonitor.sh"
+        monitor.write_text(
+            "#!/bin/sh\n: > \"$1\"\nexit 0\n", encoding="utf-8"
+        )
+        monitor.chmod(0o755)
+        self.git(
+            "-C",
+            str(self.candidate),
+            "config",
+            "core.fsmonitor",
+            f"{monitor} {marker}",
+        )
+
+        completed = self.run_scanner(self.checkouts)
+
+        self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+        self.assertFalse(marker.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add machine-wide duplicate-checkout discovery and safer untracked-work preservation guidance
- add rendered-output probes for silent selector and font degradation, with stronger evidence rules
- upgrade Claude history recovery to restore exact file-history checkpoints across active and archived session copies
- update marketplace metadata and user-facing documentation

## Validation

- history finder: 33 automated tests passed; Ruff passed
- Skill Creator quick validation, regression audit, security scan, and packaging passed
- marketplace structure and documentation lists passed
- gitleaks scanned the complete three-commit push range with no findings
- pre-commit and pre-push PII Guard checks passed
- publish history uses GitHub noreply metadata and contains no private session links
