### PR TITLE
feat(git-safety-net): report how stale each checkout's cached remote refs are

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -403,7 +403,7 @@
       "description": "Audits, preserves, recovers, and safely retires local Git state: unpushed or wrong-branch commits, dirty or detached worktrees, forgotten duplicate clones of the same repo, untracked work no bundle can back up, orphaned stashes, dangling commits, stale branches, and squash/rebase merge uncertainty. Use when the user fears work was lost; asks to recover a commit or branch; asks whether a worktree, clone, or scratch directory can be deleted; wants everything converged onto one main branch; or needs proof that cleanup will not drop work. Use it even after an audit reported clean — the usual gap is scope: every in-repo command is blind to a second clone elsewhere on disk. Triggers on \"did I lose work\", \"is everything merged\", \"is anything else lost\", \"safe to delete this clone\", \"clean up old branches/stashes\", \"only keep one main branch\", \"git reflog\", \"dangling commits\", \"分支灾难\", \"误删分支/commit\", \"worktree 能删吗\", \"还有没有丢的东西\", \"只保留一个主分支\". Covers local-Git forensics, not GitHub PR/API operations or routine sync.",
       "source": "./git-safety-net",
       "strict": false,
-      "version": "1.4.0",
+      "version": "1.5.0",
       "category": "developer-tools",
       "keywords": [
         "git",

--- a/git-safety-net/.security-scan-passed
+++ b/git-safety-net/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-07-19T09:44:10.306155+00:00
+Scanned at: 2026-07-19T17:05:59.110364+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: da5138ae00144cc592e72af0960917a41e43a70d6ddf7cba3527d73d0794b4fa
+Content hash: 4a321ef11a0c56c55282363e11ffec0085c7ab2d0ec65073d82d092ddc321ddd

--- a/git-safety-net/SKILL.md
+++ b/git-safety-net/SKILL.md
@@ -48,6 +48,15 @@ When in doubt, **run Mode B first**, beginning with `git_find_all_checkouts.sh` 
    otherwise a clean audit means "clean in this one directory," which is not the question the
    user asked. Real incident: a repository audited clean, every branch pushed, while 440 lines of
    a working feature sat as untracked files in a sibling clone one `rm -rf` from gone.
+   **Scope has a second axis: TIME.** Every `origin/*` ref is a cached snapshot from your last
+   fetch, not the remote — so `git fetch --all --prune` before you trust any verdict that depends
+   on one. Read a stale cache in the right direction: for *"what would be lost"* it errs safe
+   (it can over-report unpushed work, never hide it), which is why the scripts here still run
+   offline. For *"is this already upstream?"* it fails the other way — work the remote already
+   has reads as unique, so you re-ship it, and if the remote improved it meanwhile your "restore"
+   silently **reverts** those improvements while looking like a rescue. Real incident: a
+   comparison base one day old made an already-merged change look unshipped; the rescue PR would
+   have reverted three fixes a later review added on top, one of them a security fix.
 2. **Run `git_loss_audit.sh` for the authoritative "what would be lost" check *within a
    checkout*.** It compares the current HEAD, every linked-worktree HEAD, local branches, and tags
    against every remote, then inspects each worktree for tracked/untracked changes plus stashes and
@@ -169,6 +178,14 @@ The trap: a stale branch shows "173 commits ahead of main" yet every line is alr
 ```bash
 scripts/git_verify_branch_merged.sh <branch> [<base>]   # base defaults to origin/main
 ```
+
+This mode is the one direction where a stale base is *unsafe* (rule 1): judged against yesterday's
+`origin/main`, a branch whose content landed hours ago still reads UNMERGED, and "rescuing" it
+re-applies an older version over whatever was built on top. The script fetches first for exactly
+that reason — but if the fetch fails it falls back to cached refs and says so **on stderr only**.
+Treat that line as a blocker, not a footnote: rerun once the network is back before acting on the
+verdict. Comparing by hand (`git diff origin/main <branch>`, `git log origin/main..<branch>`) has
+no such safety net at all — fetch yourself first, every time.
 
 It reports **MERGED (ancestor)** or **MERGED (content contained)** — safe to delete — versus
 **UNMERGED / NEEDS REVIEW**, listing the files the branch would still change. The verdict is sound,
@@ -293,7 +310,7 @@ in place; the bundle restores full history via `git fetch <file>.bundle <branch>
 
 | Script | Does | Mutates? |
 |---|---|---|
-| `scripts/git_find_all_checkouts.sh [root ...]` | Find every checkout of this repo on the machine — including independent clones invisible to `git worktree list` — and flag those holding uncommitted/untracked/unpushed work | Nothing (read-only, no fetch) |
+| `scripts/git_find_all_checkouts.sh [root ...]` | Find every checkout of this repo on the machine — including independent clones invisible to `git worktree list` — and flag those holding uncommitted/untracked/unpushed work, plus how stale each one's cached remote refs are (`STALE_AFTER=<s>`, default 3600) | Nothing (read-only, no fetch) |
 | `scripts/git_loss_audit.sh [remote]` | Refresh one remote, then report every worktree, local-only commit, stash, and dangler | Remote-tracking refs only |
 | `scripts/git_preserve_danglers.sh [--patch-dir DIR]` | Pin danglers to `refs/dangling-backup/`, optional patches | Adds refs only (never deletes/gc) |
 | `scripts/git_verify_branch_merged.sh <branch> [base]` | Refresh remotes, then give a content-level MERGED/UNMERGED verdict | Remote-tracking refs only |
@@ -325,8 +342,17 @@ it works offline and behind a proxy.
   want them past the gc window, then inspect with `git show <sha>` at leisure.
 - **A branch shows huge "commits ahead" but you suspect it's merged** — trust
   `git_verify_branch_merged.sh` (content), not the count. See Mode C.
-- **`git fetch` in a script hangs behind a proxy / offline** — the audit still works on cached
-  remote refs; pass an already-fetched state or skip the fetch. Loss detection uses local refs.
+- **`git fetch` in a script hangs behind a proxy / offline** — loss detection still works on
+  cached remote refs, because a stale cache can only over-report unpushed work. Merge and
+  supersession verdicts (Mode C, Mode E) are the exception and genuinely need a fetch; without
+  one, say so in the report rather than presenting the verdict as settled.
+- **Your work looks unmerged, but the repository moved while you were working** — check the clock
+  before you rescue anything: `git_find_all_checkouts.sh` prints when each checkout last fetched,
+  and `git log --oneline <cached-base>..origin/main` after a fresh fetch shows what arrived
+  meanwhile. A long session is the risk window — the base you compared against at the start can be
+  many hours old by the end. Symptom to recognise: a change you know you committed appears absent
+  upstream, so you prepare to re-ship it. Fetch first, then compare by content; if it did land,
+  check whether anyone improved it before re-applying your version over theirs.
 - **You're on a detached HEAD after checking out a commit** — that commit is safe as long as you
   `git switch -c <branch> HEAD` (or the reflog remembers it for ~90 days). Don't leave important
   new work on a detached HEAD across a `gc`.

--- a/git-safety-net/scripts/git_find_all_checkouts.sh
+++ b/git-safety-net/scripts/git_find_all_checkouts.sh
@@ -19,6 +19,16 @@
 #   untracked files in a sibling clone. The repository's own audit was clean, every branch
 #   was pushed, and the work was still one `rm -rf` away from being gone for good.
 #
+# THE SECOND AXIS — FRESHNESS:
+#   `unpushed` below is measured against this checkout's `origin/*` refs, which are a CACHED
+#   SNAPSHOT from its last fetch, not the remote. So every checkout also reports how long ago
+#   it last heard from its remote, and a stale one is called out explicitly.
+#
+#   Read the number in the right direction. For "what would be lost" a stale cache is safe:
+#   it can only over-report unpushed work, never hide it. For "is this already upstream?" it
+#   fails the other way — work the remote already has reads as unique, and re-shipping it can
+#   revert whatever was built on top of it in the meantime. Fetch before that second question.
+#
 # NON-DESTRUCTIVE: runs only `find` plus read-only Git queries. Repository-provided
 # fsmonitor commands are disabled and optional index refreshes are suppressed before
 # inspecting discovered checkouts. It never fetches, writes refs, stages, or touches a
@@ -30,7 +40,8 @@
 #   With no arguments it searches the parent and grandparent of this repository — where
 #   sibling clones actually accumulate (`~/workspace/js/repo` plus `~/workspace/repo-hotfix`).
 #   Pass explicit roots to widen (`~`) or narrow the sweep. Set DEPTH=<n> to change how deep
-#   each root is scanned (default 4; raise it for deeply nested layouts).
+#   each root is scanned (default 4; raise it for deeply nested layouts). Set STALE_AFTER=<s>
+#   to change when a checkout's cached remote refs are called stale (default 3600 seconds).
 #
 # EXIT: 0 when no OTHER checkout holds at-risk work; 1 when any other checkout has
 # uncommitted changes, untracked files, or unpushed commits; 2 if not run inside a Git repo.
@@ -38,6 +49,7 @@
 set -uo pipefail
 
 DEPTH="${DEPTH:-4}"
+STALE_AFTER="${STALE_AFTER:-3600}"
 
 safe_git() {
   GIT_OPTIONAL_LOCKS=0 git --no-pager \
@@ -49,6 +61,42 @@ safe_git() {
 
 canonical_dir() {
   (cd "$1" 2>/dev/null && pwd -P)
+}
+
+# BSD (macOS) and GNU stat disagree on the mtime flag, and they disagree destructively:
+# to GNU, `-f` means --file-system, so `stat -f %m` does not simply fail there. It dumps
+# filesystem info to stdout *and then* exits nonzero, so a plain `A || B` fallback returns
+# that dump concatenated with B's answer — a multi-line string that blows up the arithmetic
+# downstream. Validate that what came back is actually an integer, on every branch.
+file_mtime() {
+  local mtime
+  mtime="$(stat -f %m "$1" 2>/dev/null)"
+  case "$mtime" in ''|*[!0-9]*) mtime="$(stat -c %Y "$1" 2>/dev/null)" ;; esac
+  case "$mtime" in ''|*[!0-9]*) return 1 ;; esac
+  printf '%s\n' "$mtime"
+}
+
+# How long ago a checkout last heard from its remote. FETCH_HEAD's mtime is the right
+# signal: git rewrites it on every fetch even when nothing changed, whereas a
+# remote-tracking reflog only gains an entry when the remote actually moved — so a
+# reflog-based age reads "old" after a fetch that found no news, which is the opposite
+# of what we need. Prints seconds; returns 1 when this checkout has never fetched.
+fetch_age_seconds() {
+  local gitdir fetch_head mtime
+  gitdir="$(safe_git -C "$1" rev-parse --git-dir 2>/dev/null)" || return 1
+  case "$gitdir" in /*) ;; *) gitdir="$1/$gitdir" ;; esac
+  fetch_head="$gitdir/FETCH_HEAD"
+  [ -f "$fetch_head" ] || return 1
+  mtime="$(file_mtime "$fetch_head")" || return 1
+  [ -n "$mtime" ] || return 1
+  echo $(( $(date +%s) - mtime ))
+}
+
+human_age() {
+  if   [ "$1" -lt 3600 ]  ; then echo "$(( $1 / 60 ))m ago"
+  elif [ "$1" -lt 86400 ] ; then echo "$(( $1 / 3600 ))h ago"
+  else                           echo "$(( $1 / 86400 ))d ago"
+  fi
 }
 
 safe_git rev-parse --git-dir >/dev/null 2>&1 || {
@@ -131,6 +179,7 @@ done
 AT_RISK=0
 FOUND=0
 FOUND_SELF=0
+STALE_SEEN=0
 SEEN=""
 
 for gitpath in "${CANDIDATES[@]}"; do
@@ -182,6 +231,20 @@ for gitpath in "${CANDIDATES[@]}"; do
   [ -n "$head_sha" ] || head_sha='?'
   [ -n "$unpushed" ] || unpushed='unknown'
 
+  # Staleness is reported, never escalated to AT RISK: a cached ref can only over-report
+  # unpushed work, so flagging it as danger would cry wolf on healthy checkouts and teach
+  # people to ignore the marker that does mean something.
+  if fetch_age="$(fetch_age_seconds "$checkout")"; then
+    freshness="last fetched $(human_age "$fetch_age")"
+    if [ "$fetch_age" -gt "$STALE_AFTER" ]; then
+      freshness="${freshness}   <-- STALE, fetch before judging 'already merged'"
+      STALE_SEEN=$((STALE_SEEN + 1))
+    fi
+  else
+    freshness="never fetched in this checkout"
+    STALE_SEEN=$((STALE_SEEN + 1))
+  fi
+
   if [ "$checkout" = "$SELF_ROOT" ]; then
     FOUND_SELF=1
     marker="  (this repository)"
@@ -199,7 +262,8 @@ for gitpath in "${CANDIDATES[@]}"; do
   echo "${checkout}${marker}"
   echo "    kind:      ${kind}"
   echo "    branch:    ${branch} @ ${head_sha}"
-  echo "    modified:  ${modified}   untracked: ${untracked}   unpushed: ${unpushed}"
+  echo "    modified:  ${modified}   untracked: ${untracked}   unpushed: ${unpushed} (vs cached refs)"
+  echo "    remote:    ${freshness}"
   if [ "${untracked:-0}" -gt 0 ] && [ "$checkout" != "$SELF_ROOT" ]; then
     echo "    NOTE: untracked files are unreachable by bundle/archive/format-patch."
     echo "          Copy them out directly — that disk copy is the only copy."
@@ -209,6 +273,22 @@ done
 
 echo "------------------------------------------------------------"
 echo "Checkouts found: ${FOUND}    At-risk (excluding this one): ${AT_RISK}"
+
+if [ "$STALE_SEEN" -gt 0 ]; then
+  cat <<'FRESHNESS'
+
+FRESHNESS: some checkout above has not fetched recently, so its `unpushed` count was measured
+against a cached snapshot of the remote. That direction is safe for "what would be lost" — a
+stale cache over-reports unpushed work, it cannot hide it. It is NOT safe for the opposite
+question. Before concluding a branch is unmerged, or that local work still needs shipping:
+
+  git fetch --all --prune
+
+Skipping that has a specific failure shape: work the remote already has reads as unique, so it
+gets re-shipped — and if the remote improved it in the meantime, the "restore" reverts those
+improvements while looking like a rescue.
+FRESHNESS
+fi
 
 if [ "$AT_RISK" -gt 0 ]; then
   cat <<'GUIDANCE'


### PR DESCRIPTION
## The gap

Rule 1 covered scope in **space** — which checkouts an audit can actually see. It said nothing about scope in **time**, and every `origin/*` ref is a cached snapshot from the last fetch, not the remote.

The two directions are not symmetric, and the skill never said which was which:

| Question | Stale cache does what |
|---|---|
| "What would be lost?" | **Errs safe** — over-reports unpushed work, can never hide it. This is why these scripts still run offline. |
| "Is this already upstream?" | **Fails the other way** — work the remote already has reads as unique, so it gets re-shipped. If the remote improved it meanwhile, the "restore" reverts those improvements while looking like a rescue. |

Earned the hard way: a comparison base one day old made an already-merged change look unshipped. The rescue PR would have reverted three fixes a later review had added on top of it, one of them a security fix. Every individual check along the way was executed correctly — they were just run against the wrong baseline, which is the same shape as the scope bug rule 1 already describes, one axis over.

## What changed

**`git_find_all_checkouts.sh`** now reports each checkout's last fetch and prints a targeted note when any is stale (`STALE_AFTER`, default 3600s).

Freshness comes from `FETCH_HEAD`'s mtime, deliberately: git rewrites it on every fetch *even when the fetch finds no news*, whereas a remote-tracking reflog only gains an entry when the remote actually moved — so a reflog-based age reads "stale" right after a successful fetch, which is exactly backwards.

Staleness is reported but **never escalated to AT RISK**. A cached ref can only over-report, so flagging it as danger would cry wolf on healthy checkouts and train people to ignore the marker that does mean something.

**SKILL.md**
- Rule 1 gains the time axis, stating both directions explicitly rather than just "fetch first"
- Mode C notes that `git_verify_branch_merged.sh` already fetches — and that its fetch-failed fallback is announced **on stderr only**, so that line is a blocker rather than a footnote. Comparing by hand has no such safety net.
- Troubleshooting entry for recognising the symptom mid-session, when the base you compared against at the start has aged out by the end

## Verification

| case | expected | got |
|---|---|---|
| freshly fetched | no warning | no warning |
| `STALE_AFTER=1` | stale + guidance block | stale + guidance block |
| never-fetched repo | "never fetched in this checkout" + block | as expected |

`bash -n` clean; run from the commit itself, not the working copy. `quick_validate` reports valid; gitleaks scan passes and the marker hash is refreshed; the added lines were also read line-by-line rather than trusting the keyword scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVNKjMSk2hnjnp4T7JEpUB