### PR TITLE
feat(frontend-visual-qa): auditor-side traps reference + focus/motion checks (1.9.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1023,7 +1023,7 @@
       "description": "Audits already-rendered web, landing-page, HTML deck/slide, browser tool/game, dashboard/admin, design-system, and desktop UIs with real-browser or native-app journeys, inspected screenshots, DOM geometry, responsive or projection viewports, and a Playwright sweep. Use after implementation to find typography, wrapping, overlap, overflow, responsive, route, authorization-state, overlay, map, transient-state, data-visualization, runtime-label, browser-output, file-dialog, PDF/print, or Electron-shell defects. Not for greenfield UI design, design-system extraction, general QA-program setup, or nonvisual debugging.",
       "source": "./frontend-visual-qa",
       "strict": false,
-      "version": "1.8.0",
+      "version": "1.9.0",
       "category": "design",
       "keywords": [
         "frontend",

--- a/frontend-visual-qa/SKILL.md
+++ b/frontend-visual-qa/SKILL.md
@@ -133,6 +133,17 @@ exact missing evidence and mark the affected claim **partial** or **blocked**.
 Use the project's canonical launcher and existing fixture/auth path. Do not
 invent a new server command or silently seed a different state.
 
+Two driving constraints decide what evidence is even obtainable, so settle them
+before capturing anything. **Extension-based browser control generally cannot
+open `file://`** — a local artifact needs a local HTTP server before it can be
+driven interactively, and the two schemes differ in CORS behavior, so name which
+one produced the evidence. And **after any edit, assume the browser is showing
+you the previous build**: cache-bust the URL and verify a visible freshness
+anchor (version stamp / build time) before judging content, or you will chase a
+defect you already fixed. Both traps, plus the click/screenshot/emulation ones,
+are in
+[references/browser-driving-and-observation-traps.md](references/browser-driving-and-observation-traps.md).
+
 Record this state from the rendered page:
 
     () => ({
@@ -202,7 +213,22 @@ Check at minimum:
   rows, one global fact re-rendered per row, and unlabeled numeric/graphic cells
   (contract details in the journey/page-contract reference);
 - keyboard focus visibility, focus obstruction, and target size/spacing when
-  accessibility is in scope;
+  accessibility is in scope. A default screenshot cannot show this: an element
+  can pass "is it focusable" and still leave the user lost, because a global
+  `outline:none` suppressed the ring and nothing replaced it. The sweep reports
+  `focus-indicator-suppressed` (error) and `focus-indicator-default-only`
+  (warning); confirm visually that the focus state is also distinguishable from
+  the *selected* and *hover* states, which a stylesheet audit cannot judge;
+- motion that ignores user preference — the sweep reports
+  `motion-without-reduced-motion-fallback` when the page animates but declares no
+  `@media (prefers-reduced-motion: reduce)`. Degrading means keeping the end
+  state and dropping the travel (keep the highlight, drop the flash), not
+  removing the feedback;
+- states that only exist off the default path: a wrapped narrow-viewport row
+  screenshotted *with a selection active*, a scroll container at a height that
+  actually scrolls, an expanded/error/empty variant. Default-state evidence is
+  partial evidence — say which states the report covers
+  ([references/browser-driving-and-observation-traps.md](references/browser-driving-and-observation-traps.md) §6);
 - parity with the named reference and the project's tokens/assets before
   applying generic taste rules.
 
@@ -450,5 +476,10 @@ check the available agent tools can perform.
   (proxy, CSP entry point, server-log triangulation).
 - references/data_viz_tier_and_token_audit.md — conditional data-viz,
   reference-tier, token, and palette audit.
+- references/browser-driving-and-observation-traps.md — the auditor's own failure
+  modes: misread clicks, stale caches, `file://` limits, viewport-vs-page
+  screenshots, width-resize vs device emulation, and states a default screenshot
+  cannot show. Read it before driving a real browser, and whenever an observation
+  surprises you.
 - evals/evals.json and evals/trigger-evals.json — behavior and routing
   regression cases; excluded from packaged runtime content.

--- a/frontend-visual-qa/evals/evals.json
+++ b/frontend-visual-qa/evals/evals.json
@@ -26,7 +26,9 @@
         "Requires real Chrome print preview with nonblank pages for a print/PDF pass; when that evidence is available, identifies the about:blank print target as defective",
         "Marks unavailable GUI-owned evidence partial or blocked instead of claiming it was clicked or verified"
       ],
-      "files": ["evals/files/browser-output-fixture.html"]
+      "files": [
+        "evals/files/browser-output-fixture.html"
+      ]
     },
     {
       "id": 3,
@@ -52,7 +54,9 @@
         "Flags the brief lifetime, raw English/backend wording, missing alert semantics, and unchanged recovery state",
         "Reports actual tool evidence and does not rely only on source reading"
       ],
-      "files": ["evals/files/transient-fixture.html"]
+      "files": [
+        "evals/files/transient-fixture.html"
+      ]
     },
     {
       "id": 5,
@@ -82,7 +86,9 @@
         "Measures or directly inspects dense marker target size/spacing and obstruction by labels or the drawer",
         "Captures the open mobile drawer state and reports width, close-path, overflow, and scroll ownership evidence"
       ],
-      "files": ["evals/files/gis-fixture.html"]
+      "files": [
+        "evals/files/gis-fixture.html"
+      ]
     },
     {
       "id": 7,
@@ -95,7 +101,9 @@
         "Tests refresh, a direct deep link, and back/forward rather than inferring addressability",
         "Reports route-state drift with exact state and evidence"
       ],
-      "files": ["evals/files/route-state-fixture.html"]
+      "files": [
+        "evals/files/route-state-fixture.html"
+      ]
     },
     {
       "id": 8,
@@ -108,7 +116,9 @@
         "When screenshots are generated, opens and inspects the desktop and mobile screenshots and identifies the deliberately overlapping schedule events even if the mechanical report does not flag arbitrary element collisions",
         "Keeps the result audit-only, does not install a driver, and distinguishes mechanical findings or a blocked sweep from a full GUI verdict"
       ],
-      "files": ["evals/files/layout-defects.html"]
+      "files": [
+        "evals/files/layout-defects.html"
+      ]
     },
     {
       "id": 9,
@@ -121,7 +131,9 @@
         "Ties each finding to visible image evidence and user impact",
         "Explicitly marks DOM geometry, responsive behavior, routes, focus, and interaction as unverified"
       ],
-      "files": ["evals/files/static-review.png"]
+      "files": [
+        "evals/files/static-review.png"
+      ]
     },
     {
       "id": 10,
@@ -135,7 +147,9 @@
         "When section evidence is generated, records viewport-slice capture mode and verifies every screenshot is bounded to the configured viewport rather than a tens-of-thousands-pixel element image",
         "When no driver exists, marks the Level C check blocked with the exact prerequisite error instead of claiming a visual pass"
       ],
-      "files": ["evals/files/script-evidence-edge-cases.html"]
+      "files": [
+        "evals/files/script-evidence-edge-cases.html"
+      ]
     },
     {
       "id": 11,
@@ -149,7 +163,9 @@
         "Records body and key-heading font family, size, weight, line height, letter spacing, smallest important text, and relevant text-column width",
         "Does not invent values or force an unrelated mobile audit for this projection-only contract"
       ],
-      "files": ["evals/files/deck-fixture.html"]
+      "files": [
+        "evals/files/deck-fixture.html"
+      ]
     },
     {
       "id": 12,
@@ -201,7 +217,25 @@
         "Counts the inactive responsive branch as not rendered and never waits for, scrolls to, or requires its images to load",
         "Records commands, exit codes, report paths, and screenshot inspection; uses no dependency installation or project mutation"
       ],
-      "files": ["evals/files/lazy-responsive-media-fixture.html"]
+      "files": [
+        "evals/files/lazy-responsive-media-fixture.html"
+      ]
+    },
+    {
+      "id": 16,
+      "name": "interaction-state-defects-invisible-in-default-screenshot",
+      "prompt": "Audit evals/files/focus-and-motion-fixture.html with the bundled visual_layout_audit.mjs and report what a plain screenshot of this page would miss. Say explicitly whether a keyboard user can tell where focus is, and whether the page respects a reduced-motion preference.",
+      "expected_output": "An audit that reports focus-indicator-suppressed as an error (the stylesheet kills the outline with no :focus/:focus-visible replacement, so the page is keyboard-unusable despite every control being focusable) and motion-without-reduced-motion-fallback as a warning, explains that neither defect is visible in a default screenshot, and does not claim the page passed on the basis of screenshots alone.",
+      "files": [
+        "evals/files/focus-and-motion-fixture.html"
+      ],
+      "expectations": [
+        "Reports focus-indicator-suppressed at error severity and attributes it to outline suppression without a :focus/:focus-visible replacement",
+        "Reports motion-without-reduced-motion-fallback and recommends degrading motion while keeping the end state, not deleting the feedback",
+        "Distinguishes 'element is focusable' from 'focus is visible' rather than treating the existing non-focusable-* checks as covering this",
+        "States that these defects cannot be seen in a default screenshot, so a screenshot-only pass would have reported the page as clean",
+        "Records the exact command, exit code, and report path; installs no dependencies into the audited project"
+      ]
     }
   ]
 }

--- a/frontend-visual-qa/evals/files/focus-and-motion-fixture.html
+++ b/frontend-visual-qa/evals/files/focus-and-motion-fixture.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Focus + motion state fixture</title>
+<style>
+  /* Defect 1: the focus ring is suppressed and never replaced.
+     Every control below is focusable, so a "can it be focused" audit passes —
+     but a keyboard user cannot see where focus is. */
+  * { outline: none; }
+  button, a { outline: 0; }
+
+  /* Defect 2: the page animates but declares no reduced-motion fallback. */
+  .card { transition: transform .28s ease, box-shadow .28s ease; }
+  .card:hover { transform: translateY(-3px); }
+  .pulse { animation: pulse 1.6s ease-in-out infinite; }
+  @keyframes pulse { 0%,100% { opacity: 1 } 50% { opacity: .55 } }
+
+  body { font-family: Georgia, serif; background: #FBF9F4; color: #211D17; margin: 0; padding: 40px; }
+  .card { background: #fff; border: 1px solid #E7DFCF; border-radius: 8px; padding: 18px; margin-bottom: 14px; }
+  button { font: inherit; padding: 8px 16px; border: 1px solid #D8CDB6; border-radius: 5px; background: #fff; cursor: pointer; }
+  h1 { font-size: 22px; margin: 0 0 18px; }
+</style>
+</head>
+<body>
+  <h1>Interactive states that a screenshot cannot show</h1>
+
+  <div class="card">
+    <p class="pulse">This element animates continuously.</p>
+    <button type="button">Primary action</button>
+    <button type="button">Secondary action</button>
+    <a href="#somewhere">A linked anchor</a>
+  </div>
+
+  <div class="card">
+    <label for="q">Search</label>
+    <input id="q" type="text" placeholder="type here">
+    <select><option>One</option><option>Two</option></select>
+    <textarea rows="2"></textarea>
+  </div>
+
+  <div class="card">
+    <button type="button">Third</button>
+    <button type="button">Fourth</button>
+    <button type="button">Fifth</button>
+  </div>
+</body>
+</html>

--- a/frontend-visual-qa/references/browser-driving-and-observation-traps.md
+++ b/frontend-visual-qa/references/browser-driving-and-observation-traps.md
@@ -1,0 +1,166 @@
+# Browser-Driving And Observation Traps
+
+Failure modes that belong to *the auditor*, not to the page. Each one makes a
+healthy page look broken or a broken page look healthy, and every one of them has
+produced a wrong verdict: at best a wasted round, at worst an "fix" applied to
+code that was already correct.
+
+Read this before driving a real browser, and again whenever an observation
+surprises you.
+
+## Contents
+
+- [1. "Clicked, nothing happened" is not evidence of a broken feature](#1-clicked-nothing-happened-is-not-evidence-of-a-broken-feature)
+- [2. The page you are looking at may not be the page you just changed](#2-the-page-you-are-looking-at-may-not-be-the-page-you-just-changed)
+- [3. `file://` is not drivable by browser-extension tooling](#3-file-is-not-drivable-by-browser-extension-tooling)
+- [4. A headless screenshot is a viewport, not the page](#4-a-headless-screenshot-is-a-viewport-not-the-page)
+- [5. Resizing a headless window is not device emulation](#5-resizing-a-headless-window-is-not-device-emulation)
+- [6. Default state hides whole categories of defect](#6-default-state-hides-whole-categories-of-defect)
+- [7. Mid-run state is not final state](#7-mid-run-state-is-not-final-state)
+
+---
+
+## 1. "Clicked, nothing happened" is not evidence of a broken feature
+
+The most expensive mistake in this list. A click that produces no visible change
+has at least four causes, and only one of them is "the feature is broken":
+
+1. **The click missed.** Inline targets (a `<span>` inside a paragraph, an icon,
+   a short link) are a few pixels tall. A coordinate derived from a screenshot is
+   often just outside them, and the click silently lands on the parent.
+2. **The handler threw.** Visible only in the console.
+3. **The element was replaced** between the screenshot and the click (re-render,
+   HMR reload, async data arrival), so the coordinate now points at nothing.
+4. The feature really is broken.
+
+**Order of investigation — cheapest and most-likely first:**
+
+```
+1. Read the console for errors      → rules out cause 2
+2. Re-target by element reference   → rules out causes 1 and 3
+   (resolve the element by role/text/accessible name, click that reference,
+    not an x/y pair)
+3. Only now suspect the code
+```
+
+Skipping to step 3 leads to editing code that was already correct. Prefer
+reference-based clicking over coordinates for anything smaller than a large
+button — coordinates are for canvas, maps, and drag paths, where no element
+reference exists.
+
+## 2. The page you are looking at may not be the page you just changed
+
+Browsers cache aggressively, and **`file://` is cached too** — reloading the tab
+after editing the file frequently re-renders the *old* build. This produces the
+worst class of QA error: "I fixed it, but the screenshot still shows the bug",
+which sends you chasing a phantom.
+
+Two habits remove it:
+
+- **Cache-bust the URL** when re-opening after an edit: append a changing query
+  (`?v=<timestamp>`) so the browser treats it as a new resource.
+- **Give the artifact a visible freshness anchor** and check it *before*
+  judging any content: a version stamp, a build time, a generation timestamp
+  rendered on the page. Then "is this stale?" is answerable in one glance rather
+  than by inference.
+
+The anchor has to be one you actually keep current. A stamp that is updated in
+one place (say, an on-page badge) but not another (the `<title>`) creates a
+second-order trap: the reader checks the *stale* one, concludes "this is the old
+version", and dismisses a change that did ship. If an artifact carries a version
+in more than one place, they must be written together.
+
+## 3. `file://` is not drivable by browser-extension tooling
+
+Extension-based browser automation generally cannot navigate to `file://` URLs
+(the extension has no host permission for the scheme). Headless CLI browsers
+*can* open `file://`, so a local artifact is inspectable but not necessarily
+*interactive* through the same channel.
+
+When an audit needs real interaction on a local file, serve it:
+
+```bash
+# from the artifact's directory
+python3 -m http.server <port> --bind 127.0.0.1
+# then drive http://127.0.0.1:<port>/<artifact>.html
+```
+
+Serving over HTTP also removes a second class of confusion: `file://` has
+distinct CORS behavior, so a page that fetches anything at runtime behaves
+differently under the two schemes. State which scheme the evidence came from.
+
+## 4. A headless screenshot is a viewport, not the page
+
+`--window-size=W,H` sets the **viewport**; the screenshot is that rectangle.
+Content below `H` is not captured — it is not "the full page scaled down". A tall
+page screenshotted at a normal height silently drops everything past the fold,
+and a section audited that way was never audited at all.
+
+Three ways out, in order of preference:
+
+1. **Isolate the region** — render a copy of the artifact with the other
+   sections hidden, then screenshot at a normal viewport. This preserves
+   realistic `vh` units and scroll containers, so what you see matches what a
+   user sees.
+2. **Segment** — screenshot at a normal height, scroll, repeat, and inspect the
+   segments.
+3. **One tall viewport** — simplest, but distorts anything sized in `vh` or any
+   internal `max-height` scroll container: a panel that scrolls in reality will
+   appear fully expanded, so scroll-dependent defects become invisible.
+
+Also note anchors: navigating to `#section` does not scroll a headless capture
+into view the way it does interactively. Don't assume the anchor took.
+
+## 5. Resizing a headless window is not device emulation
+
+A narrow `--window-size` triggers width-based media queries, which is enough to
+check that a breakpoint's layout rules fire. It is **not** mobile emulation: no
+device pixel ratio, no touch flags, and — critically — no check of whether the
+document declares a viewport meta tag at all.
+
+Consequence: a page can look perfect at a 390px-wide headless window and still be
+unusable on a real phone, because without `<meta name="viewport">` the device
+renders it at desktop width and scales it down. Width-resize testing cannot
+detect that class of defect; a real emulation profile (or the bundled sweep,
+which asserts the meta tag and effective-viewport agreement) can.
+
+State which one produced your evidence. "Checked at 560px" and "checked on a
+mobile profile" are different claims.
+
+## 6. Default state hides whole categories of defect
+
+A screenshot captures one state: loaded, idle, mouse-driven, default user
+preferences. Defects living in the *other* states survive every visual pass:
+
+| State | Defect it hides | How to surface it |
+|---|---|---|
+| Keyboard focus | Focus ring suppressed (`outline:none`) with no replacement — element is focusable but the user cannot see where they are | Tab through and screenshot; or audit stylesheets for `outline:none` with zero `:focus`/`:focus-visible` rules |
+| Reduced-motion preference | Animation with no degraded path | Check for an `@media (prefers-reduced-motion: reduce)` block; emulate the preference |
+| Narrow viewport, selected item | Only the *selected* item carries a border/background, so in a wrapped horizontal layout it becomes a raised outlier and rows stop aligning | Screenshot the narrow breakpoint *with a selection active* — the default screenshot has selection on the first item, which often hides the misalignment |
+| Long-content scroll containers | Scrollbar styling that clashes with the surface; scroll affordance invisible | View at a height that forces the container to scroll |
+| Hover | Hover-only affordances unreachable by keyboard/touch | Inspect the rule, not just the rendering |
+
+The bundled sweep automates the first two (`focus-indicator-suppressed`,
+`focus-indicator-default-only`, `motion-without-reduced-motion-fallback`). The
+rest still need a deliberately constructed state — the point is to *know that
+default-state evidence is partial* and say so, rather than reporting "audited"
+after one screenshot.
+
+**A note on what should not become an automated check:** a custom scrollbar, a
+missing hover style, an unusual focus color — these are design choices, and
+flagging them mechanically produces false positives on healthy pages. A check
+earns automation only when its failure state is unambiguous (suppressed focus
+with no replacement is; "uses the default scrollbar" is not). Misfiring on healthy
+input trains people to ignore the whole gate, which is worse than not having it.
+
+## 7. Mid-run state is not final state
+
+When a multi-step process is running (a batch sweep, a sync, a queued render),
+reading its state file or its output directory *while it runs* shows whichever
+items it has reached so far. Items not yet processed look identical to items that
+were processed and found empty.
+
+Before concluding "these were skipped / found nothing", wait for the process to
+exit and check its exit status. "Not reached yet" and "no result" are
+indistinguishable from the outside, and reporting the former as the latter is a
+fabricated negative.

--- a/frontend-visual-qa/references/browser-driving-and-observation-traps.md
+++ b/frontend-visual-qa/references/browser-driving-and-observation-traps.md
@@ -2,7 +2,7 @@
 
 Failure modes that belong to *the auditor*, not to the page. Each one makes a
 healthy page look broken or a broken page look healthy, and every one of them has
-produced a wrong verdict: at best a wasted round, at worst an "fix" applied to
+produced a wrong verdict: at best a wasted round, at worst a "fix" applied to
 code that was already correct.
 
 Read this before driving a real browser, and again whenever an observation

--- a/frontend-visual-qa/scripts/visual_layout_audit.mjs
+++ b/frontend-visual-qa/scripts/visual_layout_audit.mjs
@@ -898,6 +898,82 @@ function auditPage({ viewportName, requestedWidth, isMobile, forbidPatterns, req
     });
   }
 
+  // Focus indicator + motion fallback: both are invisible in a default screenshot,
+  // so they survive every visual pass unless something inspects the stylesheets.
+  // A page can pass "is it focusable" (above) and still be unusable by keyboard
+  // because the focus ring was suppressed and never replaced.
+  {
+    let focusRuleCount = 0;
+    let outlineSuppressed = 0;
+    let reducedMotionQuery = 0;
+    let styleSheetsReadable = 0;
+    // Do NOT branch on `rule.cssRules` to mean "this is a grouping rule": since CSS
+    // Nesting shipped, a plain CSSStyleRule also exposes an (empty) cssRules list,
+    // and an empty CSSRuleList is still truthy — that branch silently skips every
+    // ordinary rule, so the audit below can never fire. Handle both facets instead.
+    const walkRules = (rules) => {
+      for (const rule of rules) {
+        const sel = rule.selectorText || "";
+        if (sel) {
+          const text = rule.cssText || "";
+          if (/:focus(-visible|-within)?\b/.test(sel)) focusRuleCount += 1;
+          if (/outline\s*:\s*(none|0(px)?)\s*[;}]/i.test(text)) outlineSuppressed += 1;
+        }
+        const cond = rule.conditionText || rule.media?.mediaText || "";
+        if (/prefers-reduced-motion/i.test(cond)) reducedMotionQuery += 1;
+        if (rule.cssRules && rule.cssRules.length) walkRules(rule.cssRules);
+      }
+    };
+    for (const sheet of document.styleSheets) {
+      try {
+        if (!sheet.cssRules) continue;
+        styleSheetsReadable += 1;
+        walkRules(sheet.cssRules);
+      } catch { /* cross-origin sheet: unreadable, not a defect */ }
+    }
+
+    const focusables = [...document.querySelectorAll(
+      'a[href],button,input,select,textarea,summary,[tabindex]:not([tabindex^="-"])'
+    )].filter(isVisible);
+
+    if (styleSheetsReadable > 0 && focusables.length >= 3 && outlineSuppressed > 0 && focusRuleCount === 0) {
+      issues.push({
+        viewport: viewportName,
+        selector: ":root",
+        type: "focus-indicator-suppressed",
+        severity: "error",
+        text: `${focusables.length} focusable elements`,
+        detail: `Stylesheets suppress the outline (${outlineSuppressed} rule(s)) without defining any :focus/:focus-visible replacement. Keyboard users cannot see where focus is. Add a visible focus style distinct from the selected/hover state.`,
+      });
+    } else if (styleSheetsReadable > 0 && focusables.length >= 8 && focusRuleCount === 0) {
+      issues.push({
+        viewport: viewportName,
+        selector: ":root",
+        type: "focus-indicator-default-only",
+        severity: "warning",
+        text: `${focusables.length} focusable elements`,
+        detail: "No :focus/:focus-visible rule exists, so focus relies entirely on the UA default ring, which is often invisible against custom backgrounds. Verify the ring is actually visible on this palette.",
+      });
+    }
+
+    const animated = [...document.querySelectorAll("*")].filter(isVisible).some((el) => {
+      const st = getComputedStyle(el);
+      const dur = parseFloat(st.transitionDuration) || 0;
+      const anim = st.animationName && st.animationName !== "none";
+      return dur > 0.15 || anim;
+    });
+    if (styleSheetsReadable > 0 && animated && reducedMotionQuery === 0) {
+      issues.push({
+        viewport: viewportName,
+        selector: ":root",
+        type: "motion-without-reduced-motion-fallback",
+        severity: "warning",
+        text: "transitions/animations present",
+        detail: "The page animates but defines no @media (prefers-reduced-motion: reduce) block. Degrade transforms/keyframes for users who request reduced motion; keep the end state (e.g. keep the highlight, drop the flash).",
+      });
+    }
+  }
+
   for (const el of [...document.querySelectorAll(textSelector)].filter(isVisible)) {
     const text = clean(el.textContent || "");
     if (!text || text.length < 2) continue;


### PR DESCRIPTION
## What

- **New reference** `references/browser-driving-and-observation-traps.md` — 7 failure modes that belong to the *auditor*, not the page: misread clicks, stale `file://` cache, viewport-vs-page screenshots, width-resize vs device emulation, default-state blindness, mid-run state reads. Each produced a wrong verdict in real audits.
- **Sweep checks** in `visual_layout_audit.mjs`: `focus-indicator-suppressed` (error), `focus-indicator-default-only` (warning), `motion-without-reduced-motion-fallback` (warning).
- **Bug fix** in `walkRules`: since CSS Nesting shipped, a plain `CSSStyleRule` also exposes a (truthy, empty) `cssRules` list — branching on it to mean "grouping rule" silently skipped every ordinary rule, so the new audits could never fire. Found only by running the fixture; syntax check and code reading both passed.
- **Eval case #16** + defect fixture (`focus-and-motion-fixture.html`) covering the three new checks.
- **SKILL.md**: driving constraints (serve `file://` over HTTP for interaction, cache-bust + freshness anchor after edits) and default-state-evidence-is-partial guidance; resource registration for the new reference.
- marketplace: frontend-visual-qa 1.8.0 → 1.9.0.

## Why

Distilled from a real audit session where each trap cost a round: a coordinate click missed a small span (looked like a broken feature), an edited `file://` page re-rendered stale, a `<title>` left at the old version while the on-page seal was bumped, and the CSS Nesting branch bug made the new focus/motion audit pass on defective fixtures.

## Notes

- Based on fresh `origin/main`; SKILL.md three-way merged so the silent-degradation content on main is preserved intact.
- `.security-scan-passed` intentionally untouched (left for the repo's scan tooling to refresh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKHNN3XS2xmZTs7tEhdYQ7