### PR TITLE
ci: add pull-request gates for manifest, skills, shell behaviour and secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,131 @@
+name: CI
+
+# Every job here was measured against main before being turned on, so a red result means
+# "this pull request broke something", never "this repo has always been like that". A gate
+# that fails for reasons the author did not cause is worse than no gate: people learn to
+# ignore it, and then it also stops catching the real thing.
+#
+# The logic lives in scripts/ci/, not inline here, so contributors can run exactly what CI
+# runs before pushing — and so the checks themselves are reviewable.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Read-only, and no secrets are used. Pull requests from forks therefore run safely: the
+# trigger is `pull_request` (fork code checked out WITHOUT repo credentials), never
+# `pull_request_target`.
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  structure:
+    name: Marketplace manifest and shell syntax
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      # The manifest every `/plugin marketplace add` reads. A source that no longer
+      # resolves breaks installation for everyone, and no skill imports this file, so
+      # nothing else in the repo would notice.
+      - name: Marketplace manifest resolves
+        run: python3 scripts/ci/check_marketplace.py
+
+      # Skills ship scripts users execute directly, usually mid-incident.
+      - name: Shell scripts parse
+        run: scripts/ci/check_shell_syntax.sh
+
+  skills:
+    name: Touched skills still validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The check compares against the merge base; a shallow clone has no such base,
+          # and comparing against a base you do not actually have is how you get a
+          # confident wrong answer.
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install validator dependency
+        run: python3 -m pip install --quiet pyyaml
+
+      - name: Validate skills touched by this change
+        env:
+          # Every value crosses into the shell through the environment, never through
+          # ${{ }} interpolation inside run:, so a ref name can never become part of the
+          # command line. github.head_ref — the one a fork actually controls — is not used
+          # anywhere in this workflow.
+          BASE_REF: ${{ github.base_ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          target="${BASE_REF:-${DEFAULT_BRANCH:-main}}"
+          # checkout gives full history but not necessarily a remote-tracking ref for the
+          # base branch, and the comparison is worthless without one.
+          git fetch --no-tags origin "+refs/heads/${target}:refs/remotes/origin/${target}"
+          scripts/ci/validate_changed_skills.sh "origin/${target}"
+
+  tests:
+    name: Registered test suites (Linux)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      # Suites shell out to git; without an identity, commit-creating fixtures fail with an
+      # error that looks like a product bug.
+      - name: Configure git identity for fixtures
+        run: |
+          git config --global user.email ci@example.invalid
+          git config --global user.name "CI"
+          git config --global init.defaultBranch main
+
+      # Running on Linux is the point of this job, not a detail. A shell script can parse
+      # identically on both platforms and still only work on one: `stat -f %m` reads an
+      # mtime on BSD/macOS and means --file-system to GNU, where it prints filesystem
+      # output and exits nonzero. That bug shipped green from a macOS-only test run.
+      - name: Run registered suites
+        run: scripts/ci/run_registered_tests.sh
+
+  secrets:
+    name: Secret scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      # Pinned to the same version .pre-commit-config.yaml uses, so local and CI agree.
+      # A pinned binary rather than a third-party action: one less thing in the supply
+      # chain of a public repository, and the version cannot move underneath us.
+      - name: Install gitleaks
+        env:
+          GITLEAKS_VERSION: 8.30.0
+        run: |
+          set -euo pipefail
+          curl -sSfL -o /tmp/gitleaks.tar.gz \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
+          sudo install -m 0755 /tmp/gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      # --no-git scans the tree as it stands. Scanning history instead would re-litigate
+      # every commit ever made on every pull request, and would fail on things no author
+      # of a current pull request can fix.
+      - name: Scan working tree
+        run: gitleaks detect --no-git --config .gitleaks.toml --redact --verbose

--- a/scripts/ci/check_marketplace.py
+++ b/scripts/ci/check_marketplace.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Check .claude-plugin/marketplace.json against the repository on disk.
+
+This is the manifest every user's `/plugin marketplace add` reads. A plugin whose
+`source` no longer resolves, or a duplicated name, breaks installation for everyone
+pulling the marketplace — and nothing else in the repo notices, because no skill
+imports this file.
+
+Only assertions that hold on `main` today are enforced, so a red result always means
+"this pull request broke something", never "this repo has always been like that".
+Deliberately NOT enforced: a length cap on marketplace descriptions. The 1024-character
+limit belongs to SKILL.md frontmatter (quick_validate checks it there); no such limit is
+documented for this file, and one entry already exceeds it. Guessing a constraint and
+gating on it would fail honest pull requests for a rule nobody agreed to.
+
+Run locally: python3 scripts/ci/check_marketplace.py
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST = REPO_ROOT / ".claude-plugin" / "marketplace.json"
+SEMVER = re.compile(r"\d+\.\d+\.\d+")
+REQUIRED_FIELDS = ("name", "source", "description", "version")
+
+
+def plugin_dir(source: str) -> Path:
+    return REPO_ROOT / source.lstrip("./")
+
+
+def looks_like_a_plugin(directory: Path) -> bool:
+    """A source directory must expose a skill, either directly or one level down.
+
+    Both layouts are in active use: a single-skill plugin keeps SKILL.md at its root,
+    while a suite (daymade-claude-code, minimax-skills) holds one subdirectory per skill.
+    """
+    if (directory / "SKILL.md").exists():
+        return True
+    if (directory / ".claude-plugin" / "plugin.json").exists():
+        return True
+    return any(child.joinpath("SKILL.md").exists() for child in directory.iterdir() if child.is_dir())
+
+
+def main() -> int:
+    if not MANIFEST.exists():
+        print(f"FAIL: {MANIFEST.relative_to(REPO_ROOT)} is missing")
+        return 1
+
+    try:
+        manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        print(f"FAIL: marketplace.json is not valid JSON — {exc}")
+        return 1
+
+    plugins = manifest.get("plugins")
+    if not isinstance(plugins, list) or not plugins:
+        print("FAIL: marketplace.json has no 'plugins' array")
+        return 1
+
+    failures: list[str] = []
+    seen: dict[str, int] = {}
+
+    for index, plugin in enumerate(plugins):
+        label = plugin.get("name") or f"plugins[{index}]"
+
+        missing = [field for field in REQUIRED_FIELDS if not plugin.get(field)]
+        if missing:
+            failures.append(f"{label}: missing required field(s): {', '.join(missing)}")
+            continue
+
+        seen[plugin["name"]] = seen.get(plugin["name"], 0) + 1
+
+        if not SEMVER.fullmatch(str(plugin["version"])):
+            failures.append(f"{label}: version {plugin['version']!r} is not MAJOR.MINOR.PATCH")
+
+        directory = plugin_dir(plugin["source"])
+        if not directory.is_dir():
+            failures.append(f"{label}: source {plugin['source']!r} does not exist")
+        elif not looks_like_a_plugin(directory):
+            failures.append(
+                f"{label}: source {plugin['source']!r} has no SKILL.md, no nested skill, "
+                "and no .claude-plugin/plugin.json"
+            )
+
+    for name, count in seen.items():
+        if count > 1:
+            failures.append(f"{name}: declared {count} times — plugin names must be unique")
+
+    if failures:
+        print(f"FAIL: {len(failures)} problem(s) in marketplace.json\n")
+        for failure in failures:
+            print(f"  - {failure}")
+        return 1
+
+    print(f"OK: {len(plugins)} plugins declared; every source resolves and every name is unique")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/check_shell_syntax.sh
+++ b/scripts/ci/check_shell_syntax.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# check_shell_syntax.sh — parse every shell script in the repository.
+#
+# Skills ship shell scripts that users execute directly. A syntax error reaches them at
+# run time, in their repository, usually while they are already trying to recover from
+# something. `bash -n` parses without executing, so this is safe to run anywhere.
+#
+# Scope note: this catches syntax, not behaviour. Behaviour is covered by the suites in
+# scripts/ci/test-suites.txt, which run on Linux precisely because a script can parse
+# fine on both platforms and still only work on one.
+#
+# Run locally: scripts/ci/check_shell_syntax.sh
+
+set -uo pipefail
+
+cd "$(dirname "$0")/../.." || exit 1
+
+total=0
+failed=0
+
+while IFS= read -r script; do
+  total=$((total + 1))
+  if ! output="$(bash -n "$script" 2>&1)"; then
+    failed=$((failed + 1))
+    echo "FAIL: $script"
+    printf '%s\n' "$output" | sed 's/^/    /'
+  fi
+done < <(
+  find . -name '*.sh' -type f \
+    -not -path './.git/*' \
+    -not -path '*/node_modules/*' \
+    -not -path '*/.venv/*' \
+    -not -path '*/vendor/*' \
+    | sort
+)
+
+if [ "$failed" -gt 0 ]; then
+  echo
+  echo "FAIL: $failed of $total shell script(s) do not parse"
+  exit 1
+fi
+
+echo "OK: $total shell scripts parse cleanly"

--- a/scripts/ci/run_registered_tests.sh
+++ b/scripts/ci/run_registered_tests.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# run_registered_tests.sh — run the suites declared in scripts/ci/test-suites.txt.
+#
+# Nothing is discovered; the registry is the whole list. See that file for why, and for
+# the criteria a suite has to meet before it earns a line.
+#
+# Run locally: scripts/ci/run_registered_tests.sh
+
+set -uo pipefail
+
+cd "$(dirname "$0")/../.." || exit 1
+
+REGISTRY="scripts/ci/test-suites.txt"
+
+if [ ! -f "$REGISTRY" ]; then
+  echo "FAIL: $REGISTRY is missing"
+  exit 1
+fi
+
+total=0
+failed=0
+
+while read -r runner target _rest; do
+  case "${runner:-}" in ''|'#'*) continue ;; esac
+
+  total=$((total + 1))
+  echo "──── $runner  $target"
+
+  if [ ! -d "$target" ]; then
+    echo "FAIL: registered suite '$target' does not exist"
+    failed=$((failed + 1))
+    continue
+  fi
+
+  case "$runner" in
+    python-unittest) command=(python3 -m unittest discover -s "$target" -v) ;;
+    node-test)       command=(node --test "$target") ;;
+    *)
+      echo "FAIL: unknown runner '$runner' — add it to this script and document it in $REGISTRY"
+      failed=$((failed + 1))
+      continue
+      ;;
+  esac
+
+  if "${command[@]}"; then
+    echo "PASS: $target"
+  else
+    echo "FAIL: $target"
+    failed=$((failed + 1))
+  fi
+  echo
+done < "$REGISTRY"
+
+if [ "$total" -eq 0 ]; then
+  echo "FAIL: the registry declares no suites — CI would report success without testing anything"
+  exit 1
+fi
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAIL: $failed of $total registered suite(s) failed"
+  exit 1
+fi
+
+echo "OK: $total registered suite(s) passed"

--- a/scripts/ci/test-suites.txt
+++ b/scripts/ci/test-suites.txt
@@ -1,0 +1,20 @@
+# Test suites CI runs, declared explicitly — one per line: <runner> <path>
+#
+# WHY A REGISTRY AND NOT AUTO-DISCOVERY:
+#   Globbing for `tests/` and running whatever turns up is the "put the file there and it
+#   executes" pattern: unreviewable, and it silently conscripts suites that need network
+#   access, API keys, or heavy dependencies, which then fail for reasons that have nothing
+#   to do with the pull request. A gate that fails for unrelated reasons gets ignored, and
+#   an ignored gate is worse than no gate. Adding a line here is a reviewable decision.
+#
+# ADMISSION CRITERIA — a suite belongs here only if all four hold:
+#   1. standard library only (no pip/npm install beyond the runner itself)
+#   2. no network, no credentials, no paths outside its own temp directory
+#   3. deterministic — same result on a rerun
+#   4. verified green on Linux before being added, not just on the author's machine
+#
+# RUNNERS:
+#   python-unittest   python3 -m unittest discover -s <path>
+#   node-test         node --test <path>
+
+python-unittest  git-safety-net/tests

--- a/scripts/ci/validate_changed_skills.sh
+++ b/scripts/ci/validate_changed_skills.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# validate_changed_skills.sh — run quick_validate on the skills this change touches.
+#
+# WHY ONLY THE TOUCHED ONES, AND WHY A RATCHET:
+#   Two skills on main do not pass quick_validate today (one references files that are
+#   deliberately gitignored, one has a stray frontmatter key). Gating the whole repo would
+#   therefore fail every pull request for reasons its author did not cause — the fastest
+#   way to teach people that a red check means nothing.
+#
+#   So this compares against the base: a skill is only reported as broken when it passed
+#   BEFORE the change and fails after. Pre-existing breakage is printed as a known issue
+#   and does not fail the run. That makes the check self-maintaining — no allow-list to go
+#   stale — and it still blocks any newly introduced breakage.
+#
+# Run locally: scripts/ci/validate_changed_skills.sh [base-ref]     # base defaults to origin/main
+
+set -uo pipefail
+
+cd "$(dirname "$0")/../.." || exit 1
+
+BASE_REF="${1:-origin/main}"
+VALIDATOR="daymade-skill/skill-creator/scripts/quick_validate.py"
+
+[ -f "$VALIDATOR" ] || { echo "FAIL: validator missing at $VALIDATOR"; exit 1; }
+
+if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
+  echo "FAIL: base ref '$BASE_REF' is unknown here — fetch it first (a stale or missing base"
+  echo "      makes every verdict below meaningless)"
+  exit 1
+fi
+
+MERGE_BASE="$(git merge-base "$BASE_REF" HEAD)" || { echo "FAIL: no merge base with $BASE_REF"; exit 1; }
+
+# PREFLIGHT — prove the validator can actually run before trusting a single verdict.
+#
+# quick_validate exits 0 (valid), 1 (invalid), or 2 (it could not run at all, e.g. PyYAML
+# missing). Without this check a missing dependency makes every skill fail identically, so
+# the ratchet below sees "fails now, failed at base too", files every genuine regression as
+# pre-existing, and exits 0. That is a gate reporting success exactly when it is broken —
+# worse than no gate, because the green tick is now evidence of nothing. Caught by a test
+# where a deliberately broken skill sailed through.
+if ! python3 -c 'import yaml' >/dev/null 2>&1; then
+  echo "FAIL: quick_validate needs PyYAML and it is not importable here."
+  echo "      Install it (pip install pyyaml) — refusing to report a verdict the validator"
+  echo "      cannot actually produce."
+  exit 1
+fi
+
+# Walk up from each changed file to the directory that owns a SKILL.md.
+skills="$(
+  git diff --name-only "$MERGE_BASE"...HEAD | while IFS= read -r path; do
+    dir="$(dirname "$path")"
+    while [ "$dir" != "." ] && [ "$dir" != "/" ]; do
+      [ -f "$dir/SKILL.md" ] && { echo "$dir"; break; }
+      dir="$(dirname "$dir")"
+    done
+  done | sort -u
+)"
+
+if [ -z "$skills" ]; then
+  echo "OK: this change touches no skill directory"
+  exit 0
+fi
+
+# Returns 0 = valid, 1 = invalid. Any other code means the validator itself failed, which
+# must never be silently read as "invalid" — that is what turns a broken instrument into a
+# confident verdict.
+validate() {
+  python3 "$VALIDATOR" "$1" >/dev/null 2>&1
+  local code=$?
+  case "$code" in
+    0|1) return "$code" ;;
+    *)
+      echo "FAIL: validator exited $code on '$1' — it could not run, so no verdict is possible."
+      exit 1
+      ;;
+  esac
+}
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+regressions=0
+preexisting=0
+checked=0
+
+while IFS= read -r skill; do
+  [ -n "$skill" ] || continue
+  checked=$((checked + 1))
+
+  if validate "$skill"; then
+    echo "  ok        $skill"
+    continue
+  fi
+
+  # It fails now. Did it also fail at the base? Then it is not this change's doing.
+  base_copy="$workdir/$(echo "$skill" | tr '/' '_')"
+  mkdir -p "$base_copy"
+  if git archive "$MERGE_BASE" "$skill" 2>/dev/null | tar -x -C "$base_copy" 2>/dev/null \
+     && [ -f "$base_copy/$skill/SKILL.md" ] \
+     && ! validate "$base_copy/$skill"; then
+    echo "  known     $skill (already failing on $BASE_REF — not caused by this change)"
+    preexisting=$((preexisting + 1))
+    continue
+  fi
+
+  echo "  BROKEN    $skill"
+  python3 "$VALIDATOR" "$skill" 2>&1 | sed 's/^/              /'
+  regressions=$((regressions + 1))
+done <<EOF
+$skills
+EOF
+
+echo
+if [ "$regressions" -gt 0 ]; then
+  echo "FAIL: $regressions of $checked touched skill(s) newly fail validation"
+  exit 1
+fi
+
+echo "OK: $checked touched skill(s) validated ($preexisting pre-existing issue(s) carried, not introduced here)"


### PR DESCRIPTION
## Why

There was no pull-request gate. `benchmark.yml` runs weekly against one subproject, and `.pre-commit-config.yaml` only ever runs on the machine of someone who installed it — which is nobody submitting from a fork.

**Every check was measured against `main` before being switched on.** A red result therefore means *this pull request broke something*, never *this repo has always been like that*. A gate that fails for reasons its author did not cause teaches people to ignore it — and an ignored gate stops catching the real thing too.

| job | checks | state on `main` when added |
|---|---|---|
| `structure` | `marketplace.json` resolves — 57 plugins, every `source`, unique names — and every shell script parses | clean |
| `skills` | `quick_validate` on the skills a change touches | 2 skills already fail → built as a ratchet |
| `tests` | the suites registered in `scripts/ci/test-suites.txt`, on Linux | passing |
| `secrets` | gitleaks, pinned to the version pre-commit already uses, against the repo's own `.gitleaks.toml` | clean |

## Three deliberate choices

**The `skills` job is a ratchet, not an allow-list.** Two skills fail validation on `main` today (one references deliberately gitignored files, one has a stray frontmatter key). Gating the whole repo would fail every unrelated pull request. Instead a skill is only reported when it **passed at the merge base and fails now**. Pre-existing breakage is printed and ignored. Nothing to keep up to date as those get fixed.

**Tests run on Linux because that is the point, not a detail.** `stat -f %m` reads an mtime on BSD/macOS; to GNU `-f` means `--file-system`, where it prints filesystem output and exits nonzero. A script can parse identically on both platforms and only work on one. That exact bug reached review having passed a macOS-only run.

**The test registry is explicit, not a glob over `tests/`.** Auto-discovery would conscript suites needing network access or credentials, which then fail for reasons unrelated to the change. Adding a line is a reviewable decision; the admission criteria are in the file.

## A bug found while building it, kept as a test

`validate_changed_skills.sh` was **fail-open**. `quick_validate` exits `2` when it cannot run at all (PyYAML missing) — neither valid nor invalid. Treating that as "invalid" made every skill fail identically, so the ratchet saw *fails now, failed at base too*, filed genuine regressions as pre-existing, and exited 0.

A gate that reports success precisely when it is broken is worse than no gate, because the green tick is now evidence of nothing. It now preflights the dependency and refuses any verdict on an exit code outside `{0,1}`. Found because a deliberately broken skill sailed through the test case written to catch it.

## Verification

Run in a throwaway clone against real repository content:

| case | expected | got |
|---|---|---|
| touches no skill | pass | pass |
| newly broken skill | **fail** | fail, names the skill and the reason |
| touches an already-broken skill | pass, reported as known | pass |
| validator cannot run | **fail loudly** | fail, explains no verdict is possible |

All four jobs re-measured against the current `main` after #173 landed. Logic lives in `scripts/ci/` rather than inline YAML so contributors can run exactly what CI runs.

Security: `permissions: contents: read`, no secrets, `pull_request` (never `pull_request_target`), and no `${{ }}` interpolation inside any `run:` block — the two context values reach the shell through `env:`, and `github.head_ref` (the fork-controlled one) is not used at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVNKjMSk2hnjnp4T7JEpUB