### PR TITLE
fix(skills): resolve the two validation failures the new CI reports as known

### DIFF
--- a/daymade-financial/gangtise-copilot/.security-scan-passed
+++ b/daymade-financial/gangtise-copilot/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-05-17T16:03:14.139633
+Scanned at: 2026-07-19T18:05:23.499558+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: ee0d8a18a6deb2e6d64cbfadfd7e0e35caa72152829abf7fd222a62b571ad4ab
+Content hash: 5cee5f870458e2e49a5ef0e8868da3e4ba68a67e85ec730d6ed86d0560794dc3

--- a/daymade-financial/gangtise-copilot/SKILL.md
+++ b/daymade-financial/gangtise-copilot/SKILL.md
@@ -65,7 +65,8 @@ ln -sf <gangtise-copilot-source-dir> <openclaw-skills-dir>/gangtise-copilot
 
 # Enable in OpenClaw gateway config (if the agent supports skill entries in config)
 # Run: openclaw config set 'skills.entries.gangtise-copilot' '{}'
-# Then restart the gateway: sh scripts/restart.sh
+# Then restart the gateway using OpenClaw's own script, not this skill's:
+# sh <openclaw-install-dir>/scripts/restart.sh
 ```
 
 ### Step 3 — Install all 19 Gangtise official skills
@@ -98,7 +99,7 @@ bash <gangtise-copilot-dir>/scripts/configure_auth.sh \
 1. Writes `~/.config/gangtise/authorization.json` (mode 600)
 2. Performs live auth call to verify credentials work
 3. Writes `~/.GTS_AUTHORIZATION` runtime token
-4. **Creates symlinks** from every installed skill's `scripts/.authorization` to the shared credential file
+4. **Creates symlinks** from each installed skill's own `<gangtise-skill-dir>/scripts/.authorization` to the shared credential file
 
 > ⚠️ **Critical**: After Step 3, `diagnose.sh` may report "19 skill(s) missing .authorization" even if credentials exist. Run Step 4 even when `~/.config/gangtise/authorization.json` already exists — `configure_auth.sh` creates the missing symlinks.
 

--- a/daymade-financial/gangtise-copilot/references/best_practices.md
+++ b/daymade-financial/gangtise-copilot/references/best_practices.md
@@ -63,15 +63,15 @@ If your account is missing a scope, the affected scripts will return an error at
 ```bash
 # Tier: rag (should work)
 cd ~/.local/share/gangtise-copilot/skills/gangtise-kb-client
-python3 scripts/kb.py -q "test" -l 1
+python3 <gangtise-skill-dir>/scripts/kb.py -q "test" -l 1
 
 # Tier: data (fails if no data scope)
 cd ../gangtise-data-client
-python3 scripts/quote.py --securities 宁德时代 -sd 2026-04-01 -ed 2026-04-10
+python3 <gangtise-skill-dir>/scripts/quote.py --securities 宁德时代 -sd 2026-04-01 -ed 2026-04-10
 
 # Tier: file (fails if no file scope)
 cd ../gangtise-file-client
-python3 scripts/report.py -k 宁德时代 -l 3
+python3 <gangtise-skill-dir>/scripts/report.py -k 宁德时代 -l 3
 ```
 
 ## Working around the OBS LIST block

--- a/daymade-financial/gangtise-copilot/references/credentials_setup.md
+++ b/daymade-financial/gangtise-copilot/references/credentials_setup.md
@@ -4,7 +4,7 @@ Deep-dive documentation for `scripts/configure_auth.sh`. Read this to understand
 
 ## Credential shapes
 
-Every Gangtise skill's `scripts/utils.py` looks for `scripts/.authorization` and accepts one of two shapes:
+Every Gangtise skill's own `<gangtise-skill-dir>/scripts/utils.py` looks for `<gangtise-skill-dir>/scripts/.authorization` and accepts one of two shapes:
 
 ### Shape A — accessKey + secretAccessKey (recommended)
 
@@ -49,7 +49,7 @@ Each Gangtise skill (19 of them) has its own `scripts/` subdirectory, and each o
 2. **Drift is easy.** If even one file gets out of sync during rotation, one skill will fail while the others work, and debugging it is miserable.
 3. **Security surface is larger.** 19 files means 19 places a leak can happen.
 
-The wrapper solves this by writing a single file to the XDG location and then creating **symlinks** from each skill's `scripts/.authorization` to the shared file:
+The wrapper solves this by writing a single file to the XDG location and then creating **symlinks** from each skill's own `<gangtise-skill-dir>/scripts/.authorization` to the shared file:
 
 ```
 ~/.local/share/gangtise-copilot/skills/

--- a/daymade-financial/gangtise-copilot/references/installation_flow.md
+++ b/daymade-financial/gangtise-copilot/references/installation_flow.md
@@ -81,7 +81,7 @@ The wrapper uses a **single canonical install + one symlink per agent** layout:
 Benefits:
 
 - **One update, every agent gets it.** When you upgrade a skill (re-run the installer), the canonical location changes and every symlink instantly points at the new version. No per-agent re-install.
-- **Credentials propagate automatically.** The shared `.authorization` file (`~/.config/gangtise/authorization.json`) is symlinked from each skill's `scripts/.authorization`. Rotating the credential means editing one file; every skill in every agent picks up the new value on next use.
+- **Credentials propagate automatically.** The shared `.authorization` file (`~/.config/gangtise/authorization.json`) is symlinked from each installed skill's own `<gangtise-skill-dir>/scripts/.authorization`. Rotating the credential means editing one file; every skill in every agent picks up the new value on next use.
 - **Safer than `cp -r`.** If you re-run the installer with a different `--preset`, the canonical location is rewritten and all symlinks continue to work. A `cp -r`-based install would leave stale copies in each agent's directory.
 
 The canonical root can be overridden with `GANGTISE_COPILOT_HOME` for test isolation:

--- a/daymade-financial/gangtise-copilot/references/skill_registry.md
+++ b/daymade-financial/gangtise-copilot/references/skill_registry.md
@@ -104,7 +104,7 @@ Same file-type coverage as `gangtise-file-client` for the 6 core types (reports,
 | Operation | Use for |
 |---|---|
 | List pools | See what watchlists your account has |
-| Create pool | `scripts/create_stockpool.py --name "新能源车" --stocks "比亚迪,宁德时代"` |
+| Create pool | `<gangtise-skill-dir>/scripts/create_stockpool.py --name "新能源车" --stocks "比亚迪,宁德时代"` |
 | Add to pool | Append stocks to an existing pool |
 | Remove from pool | Remove by code |
 | Delete pool | Delete entirely |

--- a/daymade-financial/gangtise-copilot/scripts/configure_auth.sh
+++ b/daymade-financial/gangtise-copilot/scripts/configure_auth.sh
@@ -2,7 +2,7 @@
 #
 # configure_auth.sh — Set up Gangtise OpenAPI credentials + verify against
 # the live authentication server + symlink each installed skill's
-# scripts/.authorization to the shared XDG config file.
+# <gangtise-skill-dir>/scripts/.authorization to the shared XDG config file.
 #
 # Flow:
 #   1. Read accessKey + secretAccessKey (from env vars, from flag, or
@@ -12,7 +12,7 @@
 #   4. Perform a live auth call against open.gangtise.com to verify
 #      the credentials actually work (body-shape check, not just HTTP code)
 #   5. Scan the canonical install location for installed skills
-#   6. Create or refresh each skill's scripts/.authorization as a symlink to
+#   6. Create or refresh each skill's <gangtise-skill-dir>/scripts/.authorization as a symlink to
 #      the shared XDG file
 #
 # Re-run safely — every step is idempotent.
@@ -292,7 +292,7 @@ EOF
 fi
 
 # ============================================================================
-# Symlink every installed Gangtise skill's scripts/.authorization
+# Symlink every installed Gangtise skill's <gangtise-skill-dir>/scripts/.authorization
 # ============================================================================
 
 if [ ! -d "$CANONICAL_SKILLS_DIR" ]; then

--- a/qa-expert/.security-scan-passed
+++ b/qa-expert/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2025-11-10T01:04:27.457659
+Scanned at: 2026-07-19T18:05:23.666253+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 285963ff8755c043176531839cd549a80bebebaf1d9bcdd21628234d0c5d6246
+Content hash: 94e7833f2bf45208f037af2857e63d88055ec826396cfb05837e52ec0d036770

--- a/qa-expert/SKILL.md
+++ b/qa-expert/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: qa-expert
 description: This skill should be used when establishing comprehensive QA testing processes for any software project. Use when creating test strategies, writing test cases following Google Testing Standards, executing test plans, tracking bugs with P0-P4 classification, calculating quality metrics, or generating progress reports. Includes autonomous execution capability via master prompts and complete documentation templates for third-party QA team handoffs. Implements OWASP security testing and achieves 90% coverage targets.
-keywords: [qa, testing, test-cases, bug-tracking, google-standards, owasp, security, automation, quality-gates, metrics]
 ---
 
 # QA Expert

--- a/qa-expert/references/ground_truth_principle.md
+++ b/qa-expert/references/ground_truth_principle.md
@@ -149,7 +149,7 @@ if __name__ == "__main__":
 
 **Usage**:
 ```bash
-python scripts/validate_test_ids.py \
+python <your-project>/scripts/validate_test_ids.py \
   tests/docs/02-CLI-TEST-CASES.md \
   tests/docs/templates/TEST-EXECUTION-TRACKING.csv
 
@@ -222,7 +222,7 @@ When you discover a sync issue:
 ### Step 1: Assess Severity
 ```bash
 # Run ID validation script
-python scripts/validate_test_ids.py <doc> <csv>
+python <your-project>/scripts/validate_test_ids.py <doc> <csv>
 
 # Consistency Rate:
 #   100%:   ✅ No action needed


### PR DESCRIPTION
Both skills fail `quick_validate` on `main`. Neither is actually broken — both describe files that belong to **somebody else's directory**, using a path that reads as their own. The new `skills` CI job classifies them as pre-existing and carries them; this clears them.

## qa-expert

`keywords` was declared in SKILL.md frontmatter, which is not an allowed property. The identical list already lives in `marketplace.json`, which is the schema that *has* a keywords field — so the line is removed rather than relocated. Nothing is lost; the two lists were verified byte-identical first.

## gangtise-copilot

This skill is a **wrapper** that installs and configures 19 separate Gangtise skills. It referred to *those* skills' files as `scripts/...` — and since it has its own `scripts/` directory, every such reference reads as a promise about this bundle:

| reference | what it actually is |
|---|---|
| `sh scripts/restart.sh` | OpenClaw's restart script, inside OpenClaw's install dir |
| `scripts/utils.py`, `scripts/kb.py`, `scripts/quote.py`, `scripts/report.py`, `scripts/create_stockpool.py` | scripts belonging to the installed Gangtise data skills |
| `scripts/.authorization` | a credential symlink created **at install time** inside each of those skills — correctly absent here, and always will be |

Each is now written as `<gangtise-skill-dir>/scripts/...`, which is what the surrounding prose already said in words ("every Gangtise skill's", "each installed skill's").

**The validator was right to complain.** A reader following `sh scripts/restart.sh` inside this skill finds nothing — and that same ambiguity is what made a documentation defect present itself as missing files.

## Verification

- Both skills report `Skill is valid!` with **zero warnings** (the fix covers the reference files too, not just SKILL.md — 11 ambiguous paths in total)
- **All 88 skills in the repository now validate**, so the CI `skills` job will carry no known failures
- `configure_auth.sh` changed **only in comments**: stripping comments from both versions leaves them line-for-line identical, so no executable logic moved
- Security scan re-run on both skills; marker hashes refreshed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVNKjMSk2hnjnp4T7JEpUB