### PR TITLE
ci: register five more test suites

### DIFF
--- a/scripts/ci/test-suites.txt
+++ b/scripts/ci/test-suites.txt
@@ -18,3 +18,8 @@
 #   node-test         node --test <path>
 
 python-unittest  git-safety-net/tests
+python-unittest  tests
+python-unittest  auto-repo-setup/tests
+python-unittest  llm-wiki-setup/tests
+python-unittest  daymade-claude-code/local-conversation-history/tests
+python-unittest  daymade-claude-code/claude-code-history-files-finder/tests


### PR DESCRIPTION
The registry shipped with **one** suite. Honest, but thin — a green `tests` job proved almost nothing about the repository.

Each addition was checked against the admission criteria already written in the file: standard library only, no network or credentials, deterministic, and **verified on Linux** rather than only on macOS.

| suite | tests |
|---|---|
| `tests` (root) | 29 |
| `auto-repo-setup/tests` | 13 |
| `llm-wiki-setup/tests` | 8 |
| `daymade-claude-code/local-conversation-history/tests` | 12 |
| `daymade-claude-code/claude-code-history-files-finder/tests` | 38 |

**100 tests** join the 5 already registered.

## One thing worth recording

The root suite *appeared* to fail on Linux. It turned out the verification harness had copied the suite without the skill directories its tests import from — the failure was in the copy, not the tests. With the dependencies present it passes: `Ran 29 tests ... OK`.

Checking the harness before believing its verdict is the same discipline these gates exist to enforce, and it nearly cost a healthy suite its place here.

## Not registered

Seven candidate directories still need dependencies or network access. They can earn a line individually once that is resolved — which is the point of an explicit registry rather than a glob: each one is a decision somebody made on purpose.

This PR's own CI run is the real verification: the expanded registry executes on the GitHub runner before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVNKjMSk2hnjnp4T7JEpUB