### PR TITLE
docs(claude-md): declare local main a read-only mirror + post-merge ff-only ritual

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,25 @@ git commit -m "message"
 git push
 ```
 
+### Local `main` Is a Read-Only Mirror
+
+Squash-merged PRs rewrite commits under new SHAs, so every direct commit to
+local `main` guarantees divergence the moment its PR merges. Two rules keep
+`main` clean:
+
+1. **Never commit directly to local `main`.** All work starts on a feature
+   branch (`git checkout -b <topic>`), ships via PR, and lands by squash merge.
+2. **After every merge, run the 30-second ritual:** `git checkout main && git pull --ff-only`.
+   A successful ff-only pull proves nobody broke rule 1. If it fails, someone
+   committed to local `main` — inspect `git log origin/main..main` and rebase
+   the stray commits onto a feature branch; do not merge or force-push `main`.
+
+If local `main` has already diverged: do not `reset --hard` until every stray
+commit is proven superseded — mechanical test: cherry-pick them onto
+`origin/main` resolving conflicts toward the upstream version; an empty net
+result means the content already shipped. Back up first
+(`git bundle create /tmp/main-backup.bundle main` and verify it restores).
+
 ## Skill Writing Requirements
 
 ### Writing Style


### PR DESCRIPTION
## 背景

Squash 合并会改写 SHA，**本地 main 上每个直接 commit 在它的 PR 合并那一刻就注定分叉**——这个 repo 反复中招，本次实测攒了 4 个 stranded commit（经 cherry-pick-to-empty 机械验证全部已被上游进化版取代后才安全对齐）。

## 变更（仅 CLAUDE.md，Git Operations 新增一节）

1. **永不直接 commit 到本地 main**——所有工作从 feature branch 起、走 PR、squash 合并
2. **merge 后 30 秒仪式**：`git checkout main && git pull --ff-only`——ff-only 失败本身就是「有人违规」的警报
3. 附恢复 SOP：已分叉时先用 cherry-pick-to-empty 机械验证取代性、bundle 备份后才允许 `reset --hard`

规则写在这里是因为 CLAUDE.md 是所有并行 session 的必读 SSOT——口头约定在多 session 格局下等于没有。

🤖 Generated with [Claude Code](https://claude.com/claude-code)