### PR TITLE
docs(contributing): align external-facing docs with curation policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -442,15 +442,13 @@ Decline all third-party marketplace promotion requests. For policy, response tem
 
 ## External Contributor PRs (Curation Policy)
 
-This is a **curated marketplace of our own skills**, not a community collection. Standing policy for external pull requests:
+**Policy SSOT: [CONTRIBUTING.md](./CONTRIBUTING.md)** — this is a curated marketplace of our own skills; bug fixes are welcome, new-skill PRs are not accepted.
 
-- **Bug fixes to existing skills: welcome.** Review the fix for correctness, then ensure the repo's own bookkeeping lands with it (version bump in `marketplace.json`, CHANGELOG entry, README sync where applicable) — contributor PRs usually lack these; add them in a maintainer follow-up commit.
-- **New skills or new features from external contributors: not accepted.** Close politely with the standing message below. If an outside skill is genuinely compelling, the path is re-authoring it ourselves under our conventions — never merging theirs.
-- **Agents never merge external PRs unilaterally.** Every external-PR merge decision goes to the user first, no matter how small or obviously-correct the fix looks. (2026-07-19: an agent batch-merged 4 external PRs under an ambiguous "merge what's left" instruction, including a whole new contributor skill that repo policy would never have accepted — it had to be reverted. Ambiguous instruction + other people's work = ask first, always.)
+Agent rules when an external PR appears:
 
-Standing close message for new-skill PRs:
-
-> Thanks for taking the time to build this! This repository is a curated marketplace of our own skills — we only accept bug fixes to existing skills, not new-skill PRs. You're very welcome to publish it as your own marketplace.
+- **Never merge external PRs unilaterally.** Every external-PR merge decision goes to the user first, no matter how small or obviously-correct the fix looks. (2026-07-19: an agent batch-merged 4 external PRs under an ambiguous "merge what's left" instruction, including a whole new contributor skill the policy would never have accepted — it had to be reverted. Ambiguous instruction + other people's work = ask first, always.)
+- **Bug-fix PRs** (after the user approves): land the repo bookkeeping as a maintainer follow-up — version bump in `marketplace.json`, CHANGELOG entry, README sync where applicable. Contributor PRs usually lack these.
+- **New-skill PRs**: close with the standing message in CONTRIBUTING.md.
 
 ## Best Practices Reference
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,118 +1,50 @@
 # Contributing to Claude Code Skills Marketplace
 
-Thank you for your interest in contributing! This marketplace aims to provide high-quality, production-ready skills for Claude Code users.
+Thank you for your interest in contributing! This is a **curated marketplace of our own skills**, not a community collection — please read "What We Don't Accept" before opening a pull request.
 
-## How to Contribute
+## What We Accept
 
-### Reporting Issues
+### 🐛 Bug Reports
+
+Always welcome:
 
 1. Check if the issue already exists
 2. Provide clear description and reproduction steps
 3. Include Claude Code version and environment details
 4. Add relevant error messages or screenshots
 
-### Suggesting New Skills
+### 🔧 Bug Fixes to Existing Skills
 
-1. Open an issue with the `skill-request` label
-2. Describe the skill's purpose and use cases
-3. Explain why it would benefit the community
-4. Provide examples of when it would activate
+Welcome. To submit a fix:
 
-### Submitting Skills
+1. **Open an issue describing the bug first**, so we can confirm it's a real defect rather than intended behavior
+2. Fork the repository and make your change on a branch
+3. Test thoroughly — if the skill has evals or a registered test suite, run them
+4. Submit a pull request referencing the issue
 
-To submit a new skill to this marketplace:
+Notes:
 
-#### 1. Skill Quality Requirements
+- **Keep the fix minimal and scoped to the bug.** Drive-by refactors, reformatting, or unrelated "improvements" will be asked to be split into separate PRs.
+- **Don't worry about version numbers, CHANGELOG, or README bookkeeping** — the maintainer handles those in a follow-up commit (repo rules require a `marketplace.json` version bump for every skill-file change, and contributor PRs almost never include it).
 
-All skills must meet these standards:
+## What We Don't Accept
 
-**Required Structure:**
-- ✅ `SKILL.md` with valid YAML frontmatter (`name` and `description`)
-- ✅ Imperative/infinitive writing style (verb-first instructions)
-- ✅ Clear "When to Use This Skill" section
-- ✅ Proper resource organization (`scripts/`, `references/`, `assets/`)
+### 🚫 New Skills (or major new features) via PR
 
-**Quality Standards:**
-- ✅ Comprehensive documentation
-- ✅ Working code examples
-- ✅ Tested functionality
-- ✅ No TODOs or placeholder text
-- ✅ Proper cross-referencing of bundled resources
+We do not accept new-skill submissions, even excellent ones. This marketplace is a curated collection of skills we build and maintain ourselves; merging outside skills would make us responsible for code we didn't write and can't stand behind at our quality bar.
 
-**Best Practices:**
-- ✅ Progressive disclosure pattern (metadata → SKILL.md → references)
-- ✅ No duplication between SKILL.md and references
-- ✅ Scripts have proper shebangs and are executable
-- ✅ Clear activation criteria in description
+If you've built a skill worth sharing:
 
-#### 2. Validation
+- **Publish it as your own marketplace.** The format is open — anyone can add your repo with `claude plugin marketplace add <your-repo>` exactly the way this one is added. Our [marketplace-dev](https://github.com/daymade/claude-code-skills/tree/main/daymade-claude-code/marketplace-dev) skill automates the marketplace.json generation, validation, and packaging if you want it.
+- **Think it belongs here specifically?** Open an issue describing what it does and why. If we're convinced, we'll **re-author it ourselves** under our conventions rather than merge your PR.
 
-Before submitting, validate your skill:
+New-skill PRs are closed with this standing message:
 
-```bash
-# Use skill-creator validation
-~/.claude/plugins/marketplaces/anthropics-skills/skill-creator/scripts/quick_validate.py /path/to/your-skill
+> Thanks for taking the time to build this! This repository is a curated marketplace of our own skills — we only accept bug fixes to existing skills, not new-skill PRs. You're very welcome to publish it as your own marketplace.
 
-# Test in Claude Code
-# 1. Copy skill to ~/.claude/skills/your-skill
-# 2. Restart Claude Code
-# 3. Verify skill activates correctly
-```
+## Guidelines That Apply to Bug Fixes
 
-#### 3. Submission Process
-
-1. **Fork this repository**
-
-2. **Add your skill:**
-   ```bash
-   # Create skill directory
-   mkdir your-skill-name
-
-   # Add SKILL.md and resources
-   # Follow the structure of existing skills
-   ```
-
-3. **Update marketplace.json:**
-   ```json
-   {
-     "skills": [
-       // ... existing skills
-       "./your-skill-name"
-     ]
-   }
-   ```
-
-4. **Update README.md:**
-   - Add skill description to "Included Skills" section
-   - Follow the existing format
-
-5. **Test locally:**
-   ```bash
-   # Add your fork as marketplace
-   claude plugin marketplace add https://github.com/your-username/claude-code-skills
-   # Marketplace name comes from .claude-plugin/marketplace.json
-
-   # Install and test
-   claude plugin install productivity-skills@your-marketplace-name
-   ```
-
-6. **Submit Pull Request:**
-   - Clear title describing the skill
-   - Description explaining the skill's purpose
-   - Link to any relevant documentation
-   - Screenshots or examples (if applicable)
-
-### Improving Existing Skills
-
-To improve an existing skill:
-
-1. Open an issue describing the improvement
-2. Fork the repository
-3. Make your changes
-4. Test thoroughly
-5. Submit a pull request referencing the issue
-
-## Skill Authoring Guidelines
+The standards below govern any change you make to an existing skill (they were originally written for skill authors, and a fix must not degrade them).
 
 ### Writing Style
 
@@ -128,31 +60,6 @@ Extract files from a repomix file using the bundled script.
 You should extract files from a repomix file by using the script.
 ```
 
-### Documentation Structure
-
-Follow this pattern:
-
-```markdown
----
-name: skill-name
-description: Clear description with activation triggers. Activates when...
----
-
-# Skill Name
-
-## Overview
-[1-2 sentence explanation]
-
-## When to Use This Skill
-[Bullet list of activation scenarios]
-
-## Core Workflow
-[Step-by-step instructions]
-
-## Resources
-[Reference bundled files]
-```
-
 ### Bundled Resources
 
 - **scripts/**: Executable code (Python/Bash) for automation
@@ -165,7 +72,7 @@ Keep SKILL.md lean (~100-500 lines). Move detailed content to `references/`.
 
 ### Python Scripts
 
-- Use Python 3.6+ compatible syntax
+- Use Python 3.10+ compatible syntax
 - Include proper shebang: `#!/usr/bin/env python3`
 - Add docstrings for functions
 - Follow PEP 8 style guidelines
@@ -180,26 +87,24 @@ Keep SKILL.md lean (~100-500 lines). Move detailed content to `references/`.
 
 ## Testing Checklist
 
-Before submitting, verify:
+Before submitting a fix, verify:
 
-- [ ] Skill has valid YAML frontmatter
-- [ ] Description includes activation triggers
+- [ ] The bug reproduces on current `main` without your change, and is gone with it
+- [ ] YAML frontmatter of any touched SKILL.md is still valid
 - [ ] All referenced files exist
 - [ ] Scripts are executable and working
-- [ ] No absolute paths (use relative or `~/.claude/skills/`)
-- [ ] Tested in actual Claude Code session
-- [ ] Documentation is clear and complete
+- [ ] No absolute paths or user-specific information
+- [ ] Tested in an actual Claude Code session
 - [ ] No sensitive information (API keys, passwords, etc.)
 
 ## Review Process
 
-Pull requests will be reviewed for:
+Bug-fix PRs are reviewed for:
 
-1. **Functionality**: Does the skill work as described?
-2. **Quality**: Does it meet our quality standards?
-3. **Documentation**: Is it well-documented?
-4. **Originality**: Is it distinct from existing skills?
-5. **Value**: Does it benefit the community?
+1. **Correctness**: does it fix the reported bug without regressions?
+2. **Scope**: is it minimal — only the fix?
+3. **Convention fit**: does it follow the existing style of that skill?
+4. **Evidence**: for behavior changes, before/after output or a test.
 
 ## Questions?
 

--- a/README.md
+++ b/README.md
@@ -3449,11 +3449,11 @@ We recommend using [CC-Switch](https://github.com/farion1231/cc-switch) to manag
 
 ## 🤝 Contributing
 
-Contributions are welcome! Please feel free to:
+This is a curated marketplace of our own skills — see [CONTRIBUTING.md](./CONTRIBUTING.md) for the full policy. In short:
 
-1. Open issues for bugs or feature requests
-2. Submit pull requests with improvements
-3. Share feedback on skill quality
+1. **Bug reports and bug-fix PRs are welcome** — open an issue first, then a scoped fix
+2. **New-skill PRs are not accepted** — publish your own marketplace instead (the format is open)
+3. Feedback on skill quality is always appreciated
 
 ### Skill Quality Standards
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -3465,11 +3465,11 @@ claude plugin install skill-name@daymade-skills
 
 ## 🤝 贡献
 
-欢迎贡献！请随时：
+本仓库是我们自己的精选 skill 合集——完整政策见 [CONTRIBUTING.md](./CONTRIBUTING.md)。简言之：
 
-1. 为错误或功能请求开启问题
-2. 提交带有改进的拉取请求
-3. 分享关于技能质量的反馈
+1. **欢迎 bug 报告和 bug 修复 PR**——先开 issue 确认，再提交最小化修复
+2. **不接受新 skill PR**——格式是开放的，欢迎发布你自己的 marketplace
+3. 随时欢迎对 skill 质量的反馈
 
 ### 技能质量标准
 


### PR DESCRIPTION
## 发现的不一致（文档治理盘点）

- **CONTRIBUTING.md（外部 SSOT）与策展政策正面冲突**：整章在教外部贡献者提交新 skill 的完整流程，还含两个过时示例（`anthropics-skills` 旧 quick_validate 路径、不符合现行 schema 的 marketplace.json 写法）
- README / README.zh-CN 的贡献节是泛化的「欢迎 PR」措辞
- CLAUDE.md 政策节（#179）把政策全文+关闭措辞又写了一遍 = 同一事实两处定义（5d 违规）

## 修改

- **CONTRIBUTING.md**：以真实政策重写——bug 报告 + 限定范围的 bug 修复欢迎（先开 issue，版本/CHANGELOG 由 maintainer 补）；新 skill PR 不收（提供 publish-your-own-marketplace 出路 + 标准关闭措辞作为 SSOT）
- **CLAUDE.md**：政策节瘦身为 agent 操作规则 + 指向 CONTRIBUTING.md（单一事实定义）
- **README ×2**：贡献节同步收窄

🤖 Generated with [Claude Code](https://claude.com/claude-code)