### PR TITLE
feat(git-safety-net): plumbing-commit escape hatch, squash -d, post-delete content re-check

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -403,7 +403,7 @@
       "description": "Audits, preserves, recovers, and safely retires local Git state: unpushed or wrong-branch commits, dirty or detached worktrees, forgotten duplicate clones of the same repo, untracked work no bundle can back up, orphaned stashes, dangling commits, stale branches, and squash/rebase merge uncertainty. Use when the user fears work was lost; asks to recover a commit or branch; asks whether a worktree, clone, or scratch directory can be deleted; wants everything converged onto one main branch; or needs proof that cleanup will not drop work. Use it even after an audit reported clean — the usual gap is scope: every in-repo command is blind to a second clone elsewhere on disk. Triggers on \"did I lose work\", \"is everything merged\", \"is anything else lost\", \"safe to delete this clone\", \"clean up old branches/stashes\", \"only keep one main branch\", \"git reflog\", \"dangling commits\", \"分支灾难\", \"误删分支/commit\", \"worktree 能删吗\", \"还有没有丢的东西\", \"只保留一个主分支\". Covers local-Git forensics, not GitHub PR/API operations or routine sync.",
       "source": "./git-safety-net",
       "strict": false,
-      "version": "1.5.0",
+      "version": "1.6.0",
       "category": "developer-tools",
       "keywords": [
         "git",

--- a/git-safety-net/.security-scan-passed
+++ b/git-safety-net/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-07-19T17:05:59.110364+00:00
+Scanned at: 2026-07-20T03:02:35.697705+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 4a321ef11a0c56c55282363e11ffec0085c7ab2d0ec65073d82d092ddc321ddd
+Content hash: 48a69286c37e3be6f20fe3dba07f25f22adbb860e190ebdefb7c127360449a2a

--- a/git-safety-net/SKILL.md
+++ b/git-safety-net/SKILL.md
@@ -226,6 +226,23 @@ The habits that keep a branch tangle from ever stranding work:
   work there, don't commit onto their branch — carry your edits to a branch off the base
   (`git checkout origin/main -b …`, after `git diff --quiet` proves your files match across bases),
   commit only your explicit paths, then switch the tree back to their branch to restore their state.
+- **If a parallel session is *actively* writing the shared tree** — files keep appearing while you
+  work — don't `switch`, `add`, or `reset` at all: each would either strand their uncommitted work
+  or trip a worktree guard. When your own change is self-contained (new files, or edits that belong
+  on `origin/main` rather than on their in-progress tree), build the commit with plumbing that never
+  touches the working tree, then push it to a branch and open a PR:
+  ```bash
+  export GIT_INDEX_FILE=$(mktemp)     # a scratch index — the tree's real index is untouched
+  git read-tree origin/main           # start from the pushed base, not the dirty tree
+  git update-index --add --cacheinfo 100644,"$(git hash-object -w path/to/file)",path/to/file
+  tree=$(git write-tree)
+  commit=$(git commit-tree "$tree" -p origin/main -m "…")   # HEAD does not move
+  unset GIT_INDEX_FILE
+  git push origin "$commit":refs/heads/<branch>             # open the PR from here
+  ```
+  The sequence reads and writes only the object store and a throwaway index, so `git status` in the
+  shared tree is byte-for-byte unchanged and the other session never sees a ripple. This is the
+  escape hatch for when commit-then-switch is off the table because someone else holds the tree.
 - **Before any rebase or branch-delete, run the Mode B audit.** Ten seconds; it's the difference
   between "nothing to lose" and finding out after gc.
 - **Before bumping a shared version/lockfile, check the base's current value** so two parallel
@@ -285,8 +302,13 @@ use repeated `--branch` instead. The exporter never drops or deletes anything.
   `--force`** and re-run `git worktree list`. Never remove the primary/current checkout. Follow
   **[references/merge_verification.md](references/merge_verification.md)** § Worktree retirement.
 - Local branches: prefer `git branch -d` (refuses unmerged); use `-D` only for items Step 1
-  proved superseded, backed up, and the user authorized deleting. Delete remote branches only
-  after re-verifying the exact remote and repository visibility/ownership.
+  proved superseded, backed up, and the user authorized deleting. **A squash-merge is the usual
+  reason `-d` refuses a branch whose content is fully merged**: `-d` judges by commit ancestry, and
+  the squash replaced the branch's commits with one new-SHA commit, so ancestry is broken even
+  though every line landed. That is not license to reach for `-D` reflexively — it means fall back
+  to Step 1's *content* check (`git cherry`, superset diff) and only `-D` once that proves
+  containment. Delete remote branches only after re-verifying the exact remote and repository
+  visibility/ownership.
 - **Independent clones: there is no safe git-level command — only `rm -rf`, which git cannot
   undo.** `git worktree remove` does not apply (it isn't a worktree) and refuses to help, so the
   usual "the tool will stop me if it's unsafe" backstop is absent here. Make the check explicit
@@ -302,6 +324,25 @@ use repeated `--branch` instead. The exporter never drops or deletes anything.
 
   Prefer deleting one clone at a time with its own verification over a loop across several — a
   glob that deletes five directories has five chances to be wrong and reports none of them.
+
+**Step 4 — after the delete, re-check by content, not by filename.** When a cleanup (or a batch of
+squash-merges) is already done and the question becomes "did any of it drop work?", the naming-based
+check that felt sufficient — `comm` over `git ls-tree` filenames, "every file is still on main" — is
+not enough: identical filenames say nothing about identical *content*. A file the deleted branch and
+the survivor both have can still differ line-for-line. Re-verify at blob level, and read the diff in
+the right direction:
+
+```bash
+git diff <survivor-ref> <deleted-or-merged-tip>    # survivor first, the gone thing second
+```
+
+Lines marked `-` are on the survivor but not the tip → the survivor is a **superset** (safe: it has
+everything the tip had, and more). Lines marked `+` are on the tip but not the survivor → **candidate
+loss** — run each through Step 1's ladder: is that symbol on the survivor under a different shape (a
+rename or refactor, not a deletion)? A diff that is mostly `-` with a few `+` is the fingerprint of
+"the survivor moved on and the deleted branch was an older version" — a merge that succeeded, not
+work lost. Apply the same test to any preserved backup: byte-identical or survivor-superset is safe;
+a line the survivor genuinely lacks anywhere is the one to escalate.
 
 **Recovery, if you regret it:** patches re-apply with `git apply`; the untracked tar extracts
 in place; the bundle restores full history via `git fetch <file>.bundle <branch>:restored/<branch>`.


### PR DESCRIPTION
Three gaps this session hit **live** that the skill did not yet cover. All additive — the regression audit reports **509 exact preservations** and one moved-but-verbatim sentence, no behavior removed.

## The three additions

**Mode D — plumbing escape hatch when a parallel session is *actively* writing the shared tree.** The skill already covered "a parallel session switched the tree onto its branch" (carry your edits to a base branch). But when the other session is *still writing* — files keep appearing while you work — `switch`/`add`/`reset` are all off the table: each strands their uncommitted work or trips a worktree guard. Added the plumbing sequence — a scratch `GIT_INDEX_FILE` + `read-tree origin/main` + `commit-tree` — that builds a commit touching only the object store, so `git status` in the shared tree is byte-for-byte unchanged. **This very PR was committed that way**, over an unrelated linter edit sitting uncommitted in the tree.

**Mode E — why a squash-merge makes `git branch -d` refuse a fully-merged branch.** A real confusion point: the content landed, yet `-d` won't delete. Because `-d` judges by commit *ancestry*, and the squash replaced the branch's commits with one new-SHA commit — ancestry broken, every line merged. The fix is not a reflexive `-D`; it's falling back to Step 1's content check (`git cherry`, superset diff) and `-D` only once that proves containment.

**Mode E Step 4 — after the delete, re-check by content, not filename.** When a cleanup or batch of squash-merges is done and the question is "did any of it drop work?", a filename-level `comm` over `git ls-tree` ("every file is still on main") is not enough — identical filenames say nothing about identical content. Re-verify at blob level with the direction spelled out:

```
git diff <survivor-ref> <deleted-or-merged-tip>
```

`-` lines = survivor-superset (safe); `+` lines = candidate loss, run each through Step 1's ladder (is that symbol on the survivor under a rename/refactor?). A mostly-`-`-few-`+` diff is the fingerprint of a merge that succeeded, not work lost. Earned from a two-round "did we drop anything?" audit this session where a filename-only check would have missed content-level loss.

## Process

Followed the skill-creator migration gate: snapshot from `git-ref:19ebf2d` before the first edit → `compare` (1 candidate, 509 preserved) → `classify` the one moved sentence as `preserved_or_moved` → `verify` passed. `quick_validate` valid, `security_scan` clean + Layer-4 semantic read of the new prose (only placeholders — `path/to/file`, `<branch>`, `<survivor-ref>`), `package_skill` gate green. Version 1.5.0 → 1.6.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVNKjMSk2hnjnp4T7JEpUB