### PR TITLE
claude-switch-models-setup: doctor stops false-positive drift on profile-local dirs

### DIFF
--- a/daymade-claude-code/claude-switch-models-setup/.security-scan-passed
+++ b/daymade-claude-code/claude-switch-models-setup/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-07-21T14:02:57.278672+00:00
+Scanned at: 2026-07-21T15:16:01.825525+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: a568a89dee2eb72ae10e043fadb1e06dba1673e1cacefd11f10308959a169242
+Content hash: c40d1bc1379e9762e29df099e906e2ecd0dfb68fad25327ade820f4ba3667066

--- a/daymade-claude-code/claude-switch-models-setup/scripts/claude-profiles.sh
+++ b/daymade-claude-code/claude-switch-models-setup/scripts/claude-profiles.sh
@@ -406,6 +406,11 @@ claude-profiles-doctor() {
                     continue
                     ;;
             esac
+            # Only flag as drift when the main ~/.claude actually has this dir to
+            # symlink back to. A real dir with NO main counterpart is profile-local
+            # data this profile alone produced (a skill workspace, a usage report),
+            # not drift — init cannot repair it (no source) and must not touch it.
+            [ -e "$CLAUDE_BASE_DIR/$dname" ] || continue
             echo "[$profile] WARN: $dname is a real directory (expected symlink to $CLAUDE_BASE_DIR/$dname) — drift; run: claude-profiles-init --repair"
             profile_issues=$((profile_issues + 1))
         done


### PR DESCRIPTION
## What

Follow-up to #187. `claude-profiles-doctor` now only flags a real directory as drift when the main `~/.claude` actually has that directory to symlink back to.

## Why

A profile-local directory with **no counterpart in `~/.claude`** — e.g. a `skill-workspaces/` or `usage-data/` dir that this one profile produced alone — is not drift. `init` has no source to symlink to and must not touch it. Previously doctor reported these as drift, sending users to `claude-profiles-init --repair` which then reported `0 repaired` and could not fix them — a confusing dead end.

## How

One-line guard in the drift loop: skip the warning unless `[ -e "$CLAUDE_BASE_DIR/$dname" ]`.

## Found while

Repairing real drift on the maintainer machine. One profile carried `skill-workspaces/` + `usage-data/` as real dirs that main `~/.claude` doesn't have — doctor flagged them as drift, but they're legitimate profile-local data.

## Verification

- Repaired 19 real drift items via `claude-profiles-init --repair`; doctor then reported only the false positives — this PR clears those.
- After fix: `doctor` → **All profiles healthy.**
- `quick_validate` + `security_scan` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)