### PR TITLE
feat(llm-eval-harness): thinking-block history-replay check + testing disciplines

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -493,7 +493,7 @@
       "description": "Test/evaluate any LLM behind an OpenAI- or Anthropic-compatible endpoint: availability (max_tokens-aware), request fidelity (does system prompt/tools/history REACH the model, or does the gateway silently drop it), speed (TTFT+tok/s), concurrency (before a workshop), Anthropic protocol compliance, quality regression, vendor bug reports, deployment gates, resident canaries. Reach for this BEFORE hand-rolling a curl loop against any LLM endpoint — that instinct is the trap: it skips the N=10 sampling, Connection:close, and env-var key handling this bakes in. Use when someone tests/benchmarks/测评/压测 a model/endpoint, onboards a provider, decides whether to switch or temporarily fail over to an alternate channel (e.g. outage or quota exhaustion), writes a supported-models list, debugs \"model ignores system prompt\", or verifies a tok/s claim. Triggers on \"benchmark this model\", \"测一下这个模型/渠道/API\", \"接入新模型先测一下\", \"system prompt 不生效\", \"这个渠道能不能用/稳不稳\", \"临时切换过去顶一阵子\" — even without \"eval\", even wrapped in business narrative.",
       "source": "./llm-eval-harness",
       "strict": false,
-      "version": "1.3.0",
+      "version": "1.4.0",
       "category": "developer-tools",
       "keywords": [
         "llm",

--- a/llm-eval-harness/.security-scan-passed
+++ b/llm-eval-harness/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-07-21T00:38:53.889485+00:00
+Scanned at: 2026-07-21T15:12:23.260703+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 597cbccdf37eeb198c8224ea4cd208c2b44d6f6a89314459be623c793b70e7e5
+Content hash: dc1d8c91ee21b6ec64884e69cf0254d20a88807fbe7b71d0285762fbb22d3839

--- a/llm-eval-harness/SKILL.md
+++ b/llm-eval-harness/SKILL.md
@@ -1,18 +1,19 @@
 ---
 name: llm-eval-harness
 description: >-
-  Test and evaluate any LLM behind an OpenAI- or Anthropic-compatible endpoint across
-  six dimensions: availability (which model IDs work, without max_tokens false
-  negatives), request fidelity (does the system prompt / tools / history actually REACH
-  the model or does the gateway silently drop it), speed (thinking-aware TTFT + tok/s),
-  concurrency/stability, Anthropic protocol compliance, and quality regression with
-  blind judges. Also: vendor bug reports with deflection-proof evidence, deployment
-  gates, resident canaries. Use whenever someone tests/benchmarks/测评/压测 a model or
-  API endpoint, onboards a new gateway/provider, writes a supported-models list, debugs
-  "model ignores my system prompt", verifies a tok/s claim, compares models, or probes
-  concurrency before a workshop. Triggers on "benchmark this model", "测一下这个模型",
-  "测试这个 API", "接入新模型先测一下", "system prompt 不生效", "给厂商反馈 bug", even
-  without the word "eval".
+  Test/evaluate any LLM behind an OpenAI- or Anthropic-compatible endpoint:
+  availability (max_tokens-aware), request fidelity (does system prompt/tools/history
+  REACH the model, or does the gateway silently drop it), speed (TTFT+tok/s),
+  concurrency (before a workshop), Anthropic protocol compliance, quality regression,
+  vendor bug reports, deployment gates, resident canaries. Reach for this BEFORE
+  hand-rolling a curl loop against any LLM endpoint — that instinct is the trap: it
+  skips the N=10 sampling, Connection:close, and env-var key handling this bakes in. Use when someone tests/benchmarks/测评/压测 a model/endpoint, onboards a
+  provider, decides whether to switch or temporarily fail over to an alternate channel
+  (e.g. outage or quota exhaustion), writes a supported-models list, debugs "model
+  ignores system prompt", or verifies a tok/s claim. Triggers on "benchmark this
+  model", "测一下这个模型/渠道/API", "接入新模型先测一下", "system prompt 不生效",
+  "这个渠道能不能用/稳不稳", "临时切换过去顶一阵子" — even without "eval", even wrapped
+  in business narrative.
 ---
 
 # LLM Eval Harness
@@ -31,7 +32,7 @@ same bugs) every time:
 | **Request fidelity** | `scripts/fidelity_probe.py` | do system prompt / tools / history actually REACH the model? |
 | **Speed** | `scripts/speed_probe.py` | TTFT + sustained decode tok/s, **thinking-aware** |
 | **Concurrency / stability** | `scripts/concurrency_probe.py` | success rate, p50/p90 latency, where it breaks |
-| **Protocol compliance** | `scripts/protocol_probe.py` | does the Anthropic `thinking` block actually fire (N≥10)? |
+| **Protocol compliance** | `scripts/protocol_probe.py` | does the Anthropic `thinking` block actually fire when requested, AND does the endpoint accept one already sitting in history on a later turn (N≥10, both are separate checks — see Dimension 3)? |
 | **Quality / use-case regression** | `scripts/usecase_runner.py` + blind judges | does it pass *your* accumulated cases? |
 
 ## Which dimensions to run
@@ -45,6 +46,9 @@ Route from what the user is actually doing:
 - "模型不听 system prompt / agent 行为怪但没报错" → **Fidelity** (system canary)
 - "快不快 / tok/s 是真的吗" → **Speed**; "扛不扛得住" → **Concurrency**
 - "这个兼容端点是真兼容吗" → **Protocol** + Fidelity's tools/auth checks
+- "这个模型/渠道用着用着就 400 了 / session 断了 / continue 不下去了" (extended-thinking client,
+  multi-turn session) → **Protocol `--check history-replay`** specifically — this symptom is the
+  generation check passing while history-replay silently doesn't; don't stop at generation
 - "换模型质量会不会掉" → **Quality regression**
 - "要给厂商报 bug" → run the relevant probe with `--output`, then follow
   [references/vendor_evidence_protocol.md](references/vendor_evidence_protocol.md)
@@ -101,6 +105,13 @@ uv run --with aiohttp python scripts/availability_probe.py \
   docs. Current-generation model names postdate your training data — WebSearch the
   vendor's / model developer's model page instead of enumerating guesses; suffixes
   (`-preview`, dated variants, tier names) decide routability. Full traps: disciplines §9.
+- **Never probe a client-side marker as if it were a real model ID.** Bracket-suffixed
+  strings like `some-model[1m]` are frequently a CLI client's own local convention (Claude
+  Code parses and strips `[1m]` before the request is ever built — see
+  claude-switch-models-setup's "Configuring Context Window Size" section for the full
+  mechanism) — they never appear on the wire. The probe warns when it sees one, but the
+  discipline is yours: probe the bare model ID the vendor actually documents, not a string
+  copied out of a Claude Code `ANTHROPIC_MODEL` env var.
 - The gateway's `/v1/models` listing is one input, never the verdict — real gateways
   route models the listing omits.
 
@@ -171,20 +182,43 @@ uv run --with aiohttp python scripts/concurrency_probe.py \
 - Distinguish failure modes from the output: HTTP 429 (clean throttle, retriable) vs a TCP
   drop that hangs to timeout (much worse for UX) vs 5xx. They imply very different fixes.
 
-## Dimension 3 — Protocol compliance (Anthropic thinking block)
+## Dimension 3 — Protocol compliance (Anthropic thinking block: generation AND history-replay)
 
 ```bash
 uv run python scripts/protocol_probe.py \
-  --url <…/v1/messages> --model <model> --key-env <ENV> --repeat 10 --output /tmp/proto.json
+  --url <…/v1/messages> --model <model> --key-env <ENV> --check all --repeat 10 --output /tmp/proto.json
 ```
 
-- Only relevant for endpoints claiming Anthropic `/v1/messages` compatibility. It checks
-  whether `thinking: {type: enabled}` actually produces `thinking_delta` / `signature_delta`
-  SSE events.
-- **Compliance is often probabilistic, not binary.** One real vendor honored the thinking
-  block on only ~13% of requests (vs 100% for two competitors). That's why `--repeat`
-  defaults to 10 and the verdict has three states: `fully-implemented`, `intermittent
-  (k/N)`, `not-implemented`. Never conclude from a single sample.
+- Only relevant for endpoints claiming Anthropic `/v1/messages` compatibility. `--check all`
+  (default) runs BOTH sub-checks — they test different code paths and a vendor can pass one
+  while hard-failing the other:
+  - **generation**: does `thinking: {type: enabled}` actually produce `thinking_delta` /
+    `signature_delta` SSE events when you request it? (the original check)
+  - **history-replay**: does the endpoint ACCEPT a `type: "thinking"` block that's already
+    sitting in a prior assistant turn, when that history is replayed back on a later turn —
+    exactly what Claude Code and every other agentic client does on every continuation?
+    (`--check history-replay` to run just this one)
+- **Real incident (2026-07-21) that motivated the history-replay check**: a Kimi/Moonshot
+  model via a China reseller passed generation fine (emits thinking correctly when asked) but
+  hard-rejected history-replay — 400 "invalid part type: thinking" the instant a prior
+  thinking block came back as input, killing the session on every subsequent turn. Passing
+  generation told us nothing about this; they're orthogonal failure modes (response
+  generation vs. request validation).
+- **Don't conclude "vendor/reseller X is broken" from one cross-axis comparison.** The first
+  (wrong) diagnosis compared a different model AND a different reseller at once and blamed
+  the reseller. The comparison that held up changed **one axis** — same reseller, same
+  payload, only the model varied — and it turned out to track a **documented, named vendor
+  parameter** (Moonshot's own `preserve_thinking`, default on/off varies by model), not the
+  reseller. See disciplines §17 (single-axis comparisons) and §18 (check vendor docs for a
+  named parameter before ad-hoc probing) before writing an "X doesn't support thinking"
+  conclusion into anything.
+- **Compliance is often probabilistic, not binary, for BOTH checks.** One real vendor honored
+  the thinking block on only ~13% of generation requests (vs 100% for two competitors). That's
+  why `--repeat` defaults to 10; generation's verdict has three states (`fully-implemented`,
+  `intermittent (k/N)`, `not-implemented`), history-replay's has its own three-plus states
+  (`accepts-thinking-in-history`, `rejects-thinking-in-history`, `inconsistent`, or
+  `inconclusive` when errors look unrelated to thinking at all). Never conclude from a single
+  sample.
 - It forces `Connection: close` per request so a load balancer can't pin all samples to one
   replica and hide the real distribution (a real probe saw 0/10 with keep-alive vs 17/90
   with close on the same endpoint).

--- a/llm-eval-harness/references/evaluation_disciplines.md
+++ b/llm-eval-harness/references/evaluation_disciplines.md
@@ -152,6 +152,22 @@ Four traps, each of which has shipped a false conclusion into a real document:
   naming 400 on the Chat Completions endpoint, which pinned the outage to the inference
   engine without ever asking the vendor "is this ID right?". Distinguish the classes
   before concluding: `engine_error` ≠ `not_found` ≠ `wrong_endpoint`.
+- **A client-side marker is not a real model ID — never send it to a raw endpoint.** Some
+  CLI clients append a suffix to the model-name *string in their own local config* that the
+  client itself parses and strips before constructing the actual request — it never
+  reaches the wire. Claude Code's `[1m]` is a concrete case: setting
+  `ANTHROPIC_MODEL=some-model[1m]` makes Claude Code strip `[1m]` and add
+  `context-1m-2025-08-07` to the `anthropic-beta` header, but the literal string
+  `some-model[1m]` is never the value of the `model` field in the request body. Probing
+  `--models some-model[1m]` against a raw endpoint tests a string that was never supposed
+  to exist at that layer — the resulting `no-channel` verdict says nothing about the
+  vendor and nothing about whether `[1m]`-style large-context handling works; it only
+  proves the endpoint doesn't understand a client-internal token, which was never in
+  question. If the goal is verifying large-context behavior, probe context capacity
+  directly (a real needle-in-haystack request near the claimed limit, using the bare
+  model ID) instead of round-tripping a client marker through the API. `availability_probe.py`
+  warns on this pattern (bracket-suffixed IDs) but cannot catch every client's private
+  convention — know which layer a string belongs to before you probe with it.
 
 ## 10. Calibrate the meter before believing it
 
@@ -240,3 +256,49 @@ the failure and both pass the control, IP-blocking, account-level routing, and p
 middleboxes are excluded in one stroke. Handle the key on the second machine the same way as
 everywhere else (§1): a curl `--config` file with 0600 permissions keeps it out of `ps` and
 shell history there too.
+
+## 17. Change one axis at a time — a comparison across two axes proves nothing
+
+When endpoint A behaves differently from endpoint B, it is tempting to explain the gap with
+whatever also differs between them — but if TWO things differ at once (which model, which
+reseller/gateway, which region, which SDK version…), the comparison cannot tell you which one
+caused it. This produced a real wrong conclusion: a Kimi/Moonshot model via reseller X rejected
+a `thinking` block replayed in history; the same model FAMILY (a different specific model) via
+reseller Y accepted it. That comparison changed BOTH the model and the reseller at once, and it
+was read as "reseller Y's gateway is just better" — a plausible-sounding, entirely wrong
+conclusion. The comparison that actually held up changed **one axis**: same reseller, same
+model, only... no — same reseller, byte-identical payload, **only the model varied**. That
+isolated test showed the earlier "different reseller" model ALSO failed on the SAME reseller as
+the original failure, and a THIRD model on that same reseller worked fine — pinning the cause to
+the model, not the reseller, and revealing (§18) that it tracked a documented per-model vendor
+parameter.
+
+**The fix**: before concluding "X is why A differs from B," list every axis that differs between
+your two samples. If more than one does, that comparison is inadmissible as evidence — go run
+the single-axis version (same reseller/gateway/region, vary only the suspected cause) before
+writing the conclusion down. This is the same discipline as changing one variable in any
+controlled experiment; the compatibility-probing setting just makes it easy to forget, because
+"try a different vendor" and "try a different model" often happen in the same breath as you
+reach for whatever's convenient to test next.
+
+## 18. Check the vendor's own documentation for a NAMED parameter before ad-hoc probing
+
+An unexplained accept/reject split across models or resellers is often not a mystery to solve
+by more probing — it may already be a documented, named parameter in the vendor's own API
+reference, one probe-round away from being found if you'd searched first. The Kimi/Moonshot
+case in §17 resolved the instant the vendor's own model-integration guide was read: it names a
+`preserve_thinking` parameter, defaulting ON for some models and OFF for others, and the
+per-model defaults it lists correlate exactly with which models accepted vs. rejected the
+replayed thinking block in the single-axis test. Reading that ONE paragraph would have replaced
+several rounds of ad-hoc cross-reseller/cross-model curl probing with a five-minute WebFetch of
+the vendor's own docs.
+
+**The fix**: when a compatibility question feels vendor/model-specific ("why does this one model
+behave differently"), search the vendor's own API reference for a named parameter governing that
+behavior BEFORE spending probe cycles guessing at it empirically — `WebSearch "<vendor> API
+<capability> parameter"` or `WebFetch` the vendor's model-integration page. This is Retrieve
+Before You Produce applied to compatibility debugging specifically: the vendor has almost
+certainly already documented the axis you're trying to reverse-engineer through trial and error.
+Empirical probing (§17) is still how you VERIFY the documented parameter actually behaves as
+claimed on YOUR specific model/reseller/version — it's a confirmation step, not a replacement for
+reading the docs first.

--- a/llm-eval-harness/scripts/availability_probe.py
+++ b/llm-eval-harness/scripts/availability_probe.py
@@ -267,6 +267,19 @@ def main():
             models.append(item)
     args.model_list = models
 
+    # Client-side markers (e.g. Claude Code's "[1m]") get parsed and stripped by
+    # the CLI locally — they never reach a real endpoint, so a raw probe of the
+    # literal string tests something that was never supposed to exist at this
+    # layer. A no-channel verdict here proves nothing about the vendor. See
+    # references/evaluation_disciplines.md §9 for the full explanation.
+    bracket_suffixed = [m for m in models if re.search(r"\[[^\]]+\]$", m)]
+    if bracket_suffixed:
+        print(f"WARNING: {bracket_suffixed} look like client-side markers "
+              f"(bracket suffix), not real API model IDs — e.g. Claude Code's "
+              f"[1m] never reaches the wire, it's stripped locally before the "
+              f"request is built. Probing it here tests the wrong layer.",
+              file=sys.stderr)
+
     results = asyncio.run(run(args, key))
 
     by_model: dict[str, list] = {}

--- a/llm-eval-harness/scripts/protocol_probe.py
+++ b/llm-eval-harness/scripts/protocol_probe.py
@@ -1,23 +1,47 @@
 #!/usr/bin/env python3
-"""Anthropic Messages protocol-compliance probe — thinking-block trigger rate.
+"""Anthropic Messages protocol-compliance probe — thinking-block trigger rate AND
+history-replay acceptance.
 
 What it answers
 ---------------
-When a vendor advertises an Anthropic-compatible ``/v1/messages`` endpoint, does it
-ACTUALLY implement the ``thinking`` block protocol? Many vendors return a 200 and a
-plausible answer while silently NOT emitting the ``thinking_delta`` / ``signature_delta``
-events the protocol requires — which breaks every client (Claude Code, Cursor, Cline)
-that renders or relies on a foldable thinking block.
+Two DIFFERENT, orthogonal compatibility questions about a vendor's Anthropic-compatible
+``/v1/messages`` endpoint — a real 2026-07-21 incident showed that passing one says
+nothing about the other:
 
-The catch is that compliance is often PROBABILISTIC, not binary. One real vendor
-returned thinking blocks on only ~13% of requests (vs 100% for two competitors) — a
-single sample would have called it either "works" or "broken", both wrong.
+1. **generation** (the original check): does requesting ``thinking: {type: enabled}``
+   actually make the endpoint EMIT ``thinking_delta`` / ``signature_delta`` SSE events?
+   Many vendors return a 200 and a plausible answer while silently NOT emitting them —
+   which breaks every client (Claude Code, Cursor, Cline) that renders or relies on a
+   foldable thinking block.
+2. **history-replay** (added after the incident below): does the endpoint ACCEPT a
+   ``type: "thinking"`` block that already exists in an assistant turn's HISTORY, when
+   that history is replayed back on a later turn? This is what every real agentic client
+   does on every continuation — Claude Code always resends the full message array,
+   thinking blocks included. A vendor can pass check 1 (it emits thinking fine when asked)
+   and still hard-reject check 2 (it 400s the instant that same block comes back as
+   input) — these are different code paths (response generation vs request validation)
+   and testing one tells you nothing about the other.
 
-Two disciplines that make the verdict trustworthy
--------------------------------------------------
-- ``--repeat`` defaults to 10. A single probe (``--repeat 1``) cannot distinguish
-  "not implemented" from "implemented but probability < 100%". Do not trust a verdict
-  from one sample.
+Real incident that motivated check 2: a Kimi/Moonshot model, accessed through a China
+reseller's Anthropic-compatible endpoint, 400'd with "invalid part type: thinking" the
+moment a prior assistant turn's thinking block was replayed back — killing every
+subsequent request in that session. The determining factor turned out to be a
+DOCUMENTED, per-model vendor parameter (Moonshot's own ``preserve_thinking``, default
+on/off varies by model) — not the reseller, not the protocol layer in general. See
+references/evaluation_disciplines.md for the single-variable-testing methodology that
+found this (an earlier, confounded comparison — different model AND different reseller
+at once — produced a wrong conclusion first).
+
+The catch, for BOTH checks, is that vendor behavior is often PROBABILISTIC, not binary.
+One real vendor returned thinking blocks on only ~13% of generation requests (vs 100%
+for two competitors) — a single sample would have called it either "works" or "broken",
+both wrong. The same discipline applies to history-replay: don't trust N=1 there either.
+
+Two disciplines that make either verdict trustworthy
+------------------------------------------------------
+- ``--repeat`` defaults to 10 for both checks. A single probe (``--repeat 1``) cannot
+  distinguish "not implemented" from "implemented but probability < 100%". Do not trust
+  a verdict from one sample.
 - ``Connection: close`` on every request. Without it, HTTP keep-alive can pin all your
   requests to one upstream instance behind the vendor's load balancer, so you sample
   one replica's behavior and miss the real cross-fleet trigger-rate distribution.
@@ -27,15 +51,22 @@ Stdlib only — no pip install needed. Key passed by ENV VAR NAME, never on the 
 
 Usage
 -----
+    # Both checks (default) — most vendors should run this, not just generation
     uv run python protocol_probe.py \
         --url https://api.example.com/v1/messages \
         --model some-model --key-env MY_API_KEY --repeat 10
+
+    # Just the history-replay check (the one that catches the 2026-07-21-shaped bug)
+    uv run python protocol_probe.py \
+        --url https://api.example.com/v1/messages \
+        --model some-model --key-env MY_API_KEY --check history-replay
 """
 from __future__ import annotations
 
 import argparse
 import json
 import os
+import secrets
 import sys
 import time
 import urllib.error
@@ -103,33 +134,99 @@ def one_request(url, model, api_key, prompt, budget, max_tokens, timeout, proxy)
     return seen
 
 
-def main():
-    ap = argparse.ArgumentParser(description="Anthropic thinking-block protocol probe (N>=10)")
-    ap.add_argument("--url", required=True, help="…/v1/messages endpoint")
-    ap.add_argument("--model", required=True)
-    ap.add_argument("--key-env", required=True, help="NAME of the env var holding the API key")
-    ap.add_argument("--repeat", type=int, default=10, help="sample count — KEEP >=10 for a real verdict")
-    ap.add_argument("--budget", type=int, default=2000, help="thinking budget_tokens")
-    ap.add_argument("--max-tokens", type=int, default=4000)
-    ap.add_argument("--prompt", default="3 ^ 5 = ? Explain your reasoning briefly.")
-    ap.add_argument("--inter-delay", type=float, default=0.0, help="seconds between requests")
-    ap.add_argument("--timeout", type=float, default=90)
-    ap.add_argument("--proxy", default=None, help="optional proxy URL (default: direct)")
-    ap.add_argument("--output", help="write full JSON results here")
-    args = ap.parse_args()
+def history_replay_request(url, model, api_key, budget, max_tokens, timeout, proxy):
+    """Fire one /v1/messages request whose history ALREADY contains a `type: "thinking"`
+    block in a prior assistant turn, then check whether the endpoint accepts it or
+    rejects the request outright. This is the request-VALIDATION / multi-turn-continuity
+    question — orthogonal to one_request() above, which only tests whether the endpoint
+    EMITS thinking deltas when asked. A vendor can pass one and fail the other; see the
+    module docstring for the real incident that showed exactly this split.
 
-    api_key = os.environ.get(args.key_env)
-    if not api_key:
-        sys.exit(f"Env var {args.key_env} is empty or unset — export your key there first.")
+    The fake `signature` is a plausible-length random hex string, not a human-readable
+    placeholder — some vendors may do superficial signature-format checks, and a
+    signature that's obviously fake (e.g. the literal string "fake") could trigger a
+    different rejection than the one being tested (type-level acceptance)."""
+    fake_signature = secrets.token_hex(32)
+    payload = {
+        "model": model,
+        "max_tokens": max_tokens,
+        "stream": True,
+        "thinking": {"type": "enabled", "budget_tokens": budget},
+        "messages": [
+            {"role": "user", "content": "What is 12 * 7?"},
+            {"role": "assistant", "content": [
+                {"type": "thinking", "thinking": "12 times 7. 12 * 7 = 84.",
+                 "signature": fake_signature},
+                {"type": "text", "text": "12 * 7 = 84."},
+            ]},
+            {"role": "user", "content": "And what about 9 * 8?"},
+        ],
+    }
+    body = json.dumps(payload).encode()
+    headers = {
+        "Content-Type": "application/json",
+        "x-api-key": api_key,
+        "anthropic-version": "2023-06-01",
+        "Accept": "text/event-stream",
+        "Connection": "close",
+    }
+    handlers = [urllib.request.ProxyHandler({} if not proxy else {"http": proxy, "https": proxy})]
+    opener = urllib.request.build_opener(*handlers)
 
-    if args.repeat < 10:
-        print(f"⚠ --repeat {args.repeat} is below 10; a verdict from <10 samples is unreliable "
-              f"for a probabilistic feature. Proceeding, but treat the result as indicative only.\n")
+    result = {"accepted": None, "http_status": None, "error_text": None,
+              "answered_followup": False, "rejects_thinking_type": False}
+    req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+    try:
+        with opener.open(req, timeout=timeout) as resp:
+            result["http_status"] = resp.status
+            text_out = []
+            error_event = None
+            for raw in resp:
+                line = raw.decode("utf-8", "replace").strip()
+                if not line.startswith("data:"):
+                    continue
+                data = line[5:].strip()
+                if data in ("", "[DONE]"):
+                    continue
+                try:
+                    evt = json.loads(data)
+                except json.JSONDecodeError:
+                    continue
+                etype = evt.get("type")
+                if etype == "error":
+                    error_event = evt.get("error", evt)  # some vendors put a 200 + SSE error event
+                elif etype == "content_block_delta" and evt.get("delta", {}).get("type") == "text_delta":
+                    text_out.append(evt["delta"].get("text", ""))
+            if error_event is not None:
+                result["accepted"] = False
+                result["error_text"] = json.dumps(error_event, ensure_ascii=False)[:300]
+            else:
+                result["accepted"] = True
+                # "72" = 9*8 — proves the endpoint actually PROCESSED the follow-up
+                # turn using the replayed history, not just "didn't error".
+                result["answered_followup"] = "72" in "".join(text_out)
+    except urllib.error.HTTPError as e:
+        result["accepted"] = False
+        result["http_status"] = e.code
+        result["error_text"] = e.read()[:500].decode("utf-8", "replace")
+    except Exception as e:
+        result["accepted"] = None  # transport failure — not a protocol verdict either way
+        result["error_text"] = f"{type(e).__name__}: {e}"
 
+    if result["error_text"]:
+        low = result["error_text"].lower()
+        result["rejects_thinking_type"] = "thinking" in low and any(
+            kw in low for kw in ("invalid", "not support", "unsupported"))
+    return result
+
+
+def run_generation(args, api_key):
+    """The original check: does `thinking: {type: enabled}` make the endpoint EMIT
+    thinking_delta/signature_delta events? Returns the result dict for --output."""
     checks = ["transport_ok", "http_2xx", "thinking_delta", "signature_delta", "text", "message_stop"]
     counts = {c: 0 for c in checks}
     samples, model_fields = [], set()
-    print(f"# protocol probe  model={args.model}  N={args.repeat}  Connection: close\n")
+    print(f"# generation probe  model={args.model}  N={args.repeat}  Connection: close\n")
     for i in range(1, args.repeat + 1):
         s = one_request(args.url, args.model, api_key, args.prompt, args.budget,
                         args.max_tokens, args.timeout, args.proxy)
@@ -158,23 +255,140 @@ def main():
     print("\n# results (hits / N)")
     for c in checks:
         print(f"  {c:18} {counts[c]}/{n}  ({round(counts[c]/n*100)}%)")
-    # empty model field on non-stream paths is a known compatibility bug worth surfacing
     mf = ", ".join(repr(x) for x in sorted(model_fields, key=lambda x: (x is None, x)))
     print(f"  model field seen   : {mf or 'none'}")
-    print(f"\n# verdict: thinking-block protocol = {verdict}  (trigger rate {round(rate*100)}%)")
+    print(f"\n# verdict: generation (thinking-delta emission) = {verdict}  (trigger rate {round(rate*100)}%)")
     if 0 < rate < 1:
         print("  → probabilistic compliance: the endpoint sometimes honors `thinking: enabled`")
         print("    and sometimes silently drops it. Clients that need the thinking block will flake.")
 
+    return {"n": n, "counts": counts, "thinking_trigger_rate": rate,
+            "verdict": verdict, "samples": samples}
+
+
+def run_history_replay(args, api_key):
+    """The new check: does the endpoint ACCEPT a `type: "thinking"` block already
+    present in an assistant turn's history, replayed back on a later turn? This is
+    what every real agentic client does on every continuation."""
+    n = args.repeat
+    print(f"\n# history-replay probe  model={args.model}  N={n}  Connection: close")
+    print("# (prior assistant turn carries a `thinking` block; checks whether the")
+    print("#  follow-up turn is accepted, and whether it's actually answered using it)\n")
+    samples = []
+    accepted = rejected_thinking = rejected_other = transport_fail = answered = 0
+    for i in range(1, n + 1):
+        r = history_replay_request(args.url, args.model, api_key, args.budget,
+                                    args.max_tokens, args.timeout, args.proxy)
+        samples.append(r)
+        if r["accepted"] is True:
+            accepted += 1
+            if r["answered_followup"]:
+                answered += 1
+            mark = "✓" if r["answered_followup"] else "~"
+        elif r["accepted"] is False:
+            if r["rejects_thinking_type"]:
+                rejected_thinking += 1
+                mark = "✗"
+            else:
+                rejected_other += 1
+                mark = "?"
+        else:
+            transport_fail += 1
+            mark = "!"
+        extra = f"  {r['error_text'][:100]}" if r.get("error_text") else ""
+        print(f"  {i:>2}/{n} {mark} accepted={r['accepted']}{extra}")
+        if args.inter_delay:
+            time.sleep(args.inter_delay)
+
+    if rejected_thinking == n:
+        verdict = "rejects-thinking-in-history"
+    elif accepted == n and answered == n:
+        verdict = "accepts-thinking-in-history"
+    elif accepted > 0 and rejected_thinking > 0:
+        verdict = f"inconsistent (accepted {accepted}/{n}, rejected-as-thinking {rejected_thinking}/{n})"
+    elif rejected_other > 0 or transport_fail > 0:
+        verdict = (f"inconclusive (rejected_other={rejected_other} transport_fail={transport_fail} "
+                   f"— read error_text, may be auth/rate-limit and unrelated to thinking blocks)")
+    else:
+        verdict = f"accepts-but-followup-unanswered ({accepted}/{n} accepted, only {answered}/{n} correctly continued)"
+
+    print(f"\n# results: accepted={accepted}/{n}  rejected_as_thinking_type={rejected_thinking}/{n}  "
+          f"rejected_other={rejected_other}/{n}  transport_fail={transport_fail}/{n}  "
+          f"answered_followup={answered}/{n}")
+    print(f"# verdict: history-replay = {verdict}")
+    if verdict == "rejects-thinking-in-history":
+        print("  → every real agentic client (Claude Code, Cursor, Cline) resends full history on")
+        print("    every turn, thinking blocks included. This endpoint will 400 and KILL every")
+        print("    session the moment a thinking-capable turn happens once. Before concluding this")
+        print("    is a blanket vendor/model-family limitation, check for a documented per-model")
+        print("    vendor parameter first (e.g. Moonshot's `preserve_thinking`, default varies by")
+        print("    model) — see references/evaluation_disciplines.md.")
+
+    return {"n": n, "accepted": accepted, "rejected_as_thinking_type": rejected_thinking,
+            "rejected_other": rejected_other, "transport_fail": transport_fail,
+            "answered_followup": answered, "verdict": verdict, "samples": samples}
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Anthropic protocol probe: thinking-block generation AND history-replay acceptance (N>=10)")
+    ap.add_argument("--url", required=True, help="…/v1/messages endpoint")
+    ap.add_argument("--model", required=True)
+    ap.add_argument("--key-env", required=True, help="NAME of the env var holding the API key")
+    ap.add_argument("--check", choices=["generation", "history-replay", "all"], default="all",
+                    help="generation = does thinking:enabled emit deltas; history-replay = does "
+                         "a thinking block already in history get accepted on a later turn; "
+                         "all = both (default — they test different code paths, run both unless "
+                         "you already know which one you need)")
+    ap.add_argument("--repeat", type=int, default=10, help="sample count — KEEP >=10 for a real verdict")
+    ap.add_argument("--budget", type=int, default=2000, help="thinking budget_tokens")
+    ap.add_argument("--max-tokens", type=int, default=4000)
+    ap.add_argument("--prompt", default="3 ^ 5 = ? Explain your reasoning briefly.",
+                    help="prompt for the generation check only")
+    ap.add_argument("--inter-delay", type=float, default=0.0, help="seconds between requests")
+    ap.add_argument("--timeout", type=float, default=90)
+    ap.add_argument("--proxy", default=None, help="optional proxy URL (default: direct)")
+    ap.add_argument("--output", help="write full JSON results here")
+    args = ap.parse_args()
+
+    api_key = os.environ.get(args.key_env)
+    if not api_key:
+        sys.exit(f"Env var {args.key_env} is empty or unset — export your key there first.")
+
+    if args.repeat < 10:
+        print(f"⚠ --repeat {args.repeat} is below 10; a verdict from <10 samples is unreliable "
+              f"for a probabilistic feature. Proceeding, but treat the result as indicative only.\n")
+
+    run_gen = args.check in ("generation", "all")
+    run_hist = args.check in ("history-replay", "all")
+
+    output = {"model": args.model}
+    ok = True
+    if run_gen:
+        gen = run_generation(args, api_key)
+        output["generation"] = gen
+        ok = ok and gen["verdict"] == "fully-implemented"
+    if run_hist:
+        hist = run_history_replay(args, api_key)
+        output["history_replay"] = hist
+        ok = ok and hist["verdict"] == "accepts-thinking-in-history"
+
+    if run_gen and run_hist:
+        print(f"\n# combined verdict: generation={output['generation']['verdict']}  "
+              f"history_replay={output['history_replay']['verdict']}")
+        if output["generation"]["verdict"] == "fully-implemented" and \
+                output["history_replay"]["verdict"] == "rejects-thinking-in-history":
+            print("  → this is the split that motivated adding the history-replay check: the endpoint")
+            print("    happily EMITS thinking blocks when asked, but 400s the instant one comes back")
+            print("    as input on a later turn. Passing generation tells you nothing about this.")
+
     if args.output:
         with open(args.output, "w") as f:
-            json.dump({"model": args.model, "n": n, "counts": counts,
-                       "thinking_trigger_rate": rate, "verdict": verdict,
-                       "samples": samples}, f, ensure_ascii=False, indent=2)
+            json.dump(output, f, ensure_ascii=False, indent=2)
         print(f"  full JSON → {args.output}")
 
-    # exit non-zero if not fully compliant — handy in CI / batch vendor screening
-    sys.exit(0 if verdict == "fully-implemented" else 1)
+    # exit non-zero if not fully compliant on every check that ran — handy in CI / batch vendor screening
+    sys.exit(0 if ok else 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `protocol_probe.py` Dimension 3 only tested whether requesting `thinking: {enabled}` emits deltas (generation). A real 2026-07-21 production incident showed a vendor could pass that while hard-rejecting a thinking block already present in history on a later turn — request validation, not generation. This is exactly what every agentic client (Claude Code included) does on every continuation.
- Added `--check history-replay` (default `--check all` runs both). Verified against real endpoints with a known-rejecting model/reseller pair and a known-accepting one before shipping — not just a syntax check.
- Added two disciplines (§17/§18) to `evaluation_disciplines.md`: don't compare across two axes at once (model AND reseller) when diagnosing a behavior gap — a confounded version of this exact investigation produced a wrong conclusion first; and check the vendor's own docs for a named parameter before ad-hoc probing (here, Moonshot's documented `preserve_thinking` default explained the split).
- Bumped `llm-eval-harness` to 1.4.0 in the marketplace registry.

## Test plan
- [x] `python3 -m py_compile scripts/protocol_probe.py`
- [x] `quick_validate` passes
- [x] `security_scan` clean
- [x] Live-endpoint verification: known-rejecting model/reseller pair → `rejects-thinking-in-history`; known-accepting pair → `accepts-thinking-in-history`; `--check all` correctly reproduces the real incident's exact split (generation passes, history-replay fails)
- [x] `--check generation` (original behavior) re-verified unchanged against a live endpoint
- [x] Existing-skill regression audit (`audit_skill_regression compare/classify/verify`) passed — all preservation candidates classified `preserved_or_moved`

Co-Authored-By: Claude <noreply@anthropic.com>