### PR TITLE
docs(promotion-policy): add issue #123 as precedent (ClawMama/Hermes outreach declined)

### DIFF
--- a/references/promotion-policy.md
+++ b/references/promotion-policy.md
@@ -58,3 +58,4 @@ Your marketplace can succeed on its own merits. Good luck with {project-name}!
 
 - **Issue #7**: "Add Community Marketplaces section - Protocol Thunderdome" → Declined, closed as "not planned"
 - **PR #5**: "Add Trail of Bits Security Skills to Related Resources" → Declined, closed
+- **Issue #123**: "Docs option: quick first run for competitors-analysis" — asked to embed a UTM-tracked link (`utm_campaign=skill_outreach_*`) to the ClawMama/Hermes hosted skill catalog inside the `competitors-analysis` skill docs → Declined per policy, closed as "not planned"


### PR DESCRIPTION
Updates promotion-policy.md Examples list with the just-closed issue #123.

- Issue #123 asked to embed a UTM-tracked link to the ClawMama/Hermes hosted skill catalog inside the `competitors-analysis` skill docs
- Declined per standing policy, closed as "not planned"
- Adding as precedent so future similar requests can reference a consistent pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)