### PR TITLE
claude-switch-models-setup: doctor detects orphan profiles (missing settings JSON)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -103,7 +103,7 @@
       "description": "Claude Code operations suite that bundles archive-aware local conversation discovery across Claude Code and Codex, internal-timestamp full-event session search and recovery, interrupted-work continuation, plugin/skill troubleshooting, CLAUDE.md progressive disclosure optimization, statusline configuration, exported .txt repair, full claude.ai conversation extraction with tool-call rendering and file download, plugin marketplace development, writing/testing/debugging Claude Code hooks, multi-provider profile isolation for running Kimi/GLM/DeepSeek/StepFun/Anthropic in separate windows, local source sync for Claude/Codex skill installs, personal-memory migration into tool-agnostic AGENTS.md reference docs, and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
       "source": "./daymade-claude-code",
       "strict": false,
-      "version": "1.23.0",
+      "version": "1.23.1",
       "category": "suite",
       "keywords": [
         "suite",

--- a/daymade-claude-code/claude-switch-models-setup/.security-scan-passed
+++ b/daymade-claude-code/claude-switch-models-setup/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-07-21T15:16:01.825525+00:00
+Scanned at: 2026-07-21T17:37:43.151065+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: c40d1bc1379e9762e29df099e906e2ecd0dfb68fad25327ade820f4ba3667066
+Content hash: 9aefbfc5e4a51b5eb11ed756d0aa8fcd4cc5b7e29b89db1d93c6bc0b7365b5c2

--- a/daymade-claude-code/claude-switch-models-setup/SKILL.md
+++ b/daymade-claude-code/claude-switch-models-setup/SKILL.md
@@ -197,6 +197,26 @@ The full step-2-16k template-correctness war-story (why an internally-consistent
 
 ## Troubleshooting
 
+### A profile directory exists but claude-profiles-doctor reports it as an "orphan profile"
+
+Symptom: `claude-profiles-doctor` reports
+`WARN: orphan profile — no settings/<name>.json; claude-profile <name> fails. Run: claude-profile-rm <name>`.
+
+Cause: the profile isolation directory exists under `~/.claude-profiles/` but
+the corresponding `~/.claude/settings/<name>.json` provider config file is
+missing. `claude-profiles-init` only scans `settings/*.json`, so an orphan
+profile's symlinks are never created or maintained, and `claude-profile <name>`
+will fail to launch with "Error: Settings file not found." The profile directory
+may still contain useful per-profile data (`history.jsonl`, `.claude.json` with
+provider credentials, `settings.json`, skill workspaces).
+
+Fix:
+- **If the profile is no longer needed**: `claude-profile-rm <name>` — this
+  safely removes the isolation directory (it checks for unexpected files first).
+- **If you want to revive it**: recreate the settings file at
+  `~/.claude/settings/<name>.json` (use a provider template from
+  `assets/templates/`), then run `claude-profiles-init`.
+
 ### A shared directory (skills/projects/hooks/agents/...) shows as a real directory, not a symlink
 
 Symptom: `claude-profiles-doctor` reports

--- a/daymade-claude-code/claude-switch-models-setup/scripts/claude-profiles.sh
+++ b/daymade-claude-code/claude-switch-models-setup/scripts/claude-profiles.sh
@@ -373,6 +373,21 @@ claude-profiles-doctor() {
         profile=$(basename "$profile_dir")
         local profile_issues=0
 
+        # Orphan profile: the claude-profiles/ directory exists but there is no
+        # settings/<profile>.json to drive it. init only processes profiles with
+        # a settings file, so this profile's symlinks are never maintained and
+        # `claude-profile <name>` will fail to launch (settings not found).
+        # Skip the rest — symlink/drift checks are moot when init won't maintain
+        # the profile at all.
+        # 2026-07-22: a dead profile carried real data (history/skill-workspaces
+        # /usage-data) for months; doctor reported drift but init could never fix
+        # it because the profile had no settings file — misleading signal.
+        if [ ! -f "$CLAUDE_BASE_DIR/$SETTINGS_DIR/$profile.json" ]; then
+            echo "[$profile] WARN: orphan profile — no $SETTINGS_DIR/$profile.json; claude-profile $profile fails. Run: claude-profile-rm $profile (or recreate settings)"
+            issues=$((issues + 1))
+            continue
+        fi
+
         if [ ! -f "$profile_dir/$CLAUDE_JSON" ]; then
             echo "[$profile] ERROR: Missing $CLAUDE_JSON"
             profile_issues=$((profile_issues + 1))


### PR DESCRIPTION
## What

`claude-profiles-doctor` now detects **orphan profiles** — a profile directory under `~/.claude-profiles/` that has no corresponding `~/.claude/settings/<name>.json` driver file.

Previously these were invisible: doctor reported them as per-dir drift (misleading — the real problem is the missing settings file), and init never maintained them (it scans `settings/*.json`, not the profiles directory). The user got no signal that `claude-profile <name>` would always fail to launch.

## How

Doctor checks `~/.claude/settings/<profile>.json` early in the per-profile loop. If missing: warns "orphan profile", adds the issue count, and `continue`s — skips symlink/drift/real-file checks that are moot when init doesn't maintain the profile.

## Why today

A dead profile carried real data (history/skill-workspaces/usage-data) for months; doctor's drift noise obscured the real signal — the profile itself was defunct. The user cleaned it with `claude-profile-rm` once the orphan signal was clear.

## Also

- SKILL.md troubleshooting: orphan section added (before the drift section — orphan is the more fundamental case)
- Suite version `1.23.0` → `1.23.1`

## Verification

- Constructed orphan profile scenario: doctor correctly reports orphan, skips per-dir checks, counts the issue
- `quick_validate` + `security_scan` clean
- Regression audit: 0 candidates (pure additions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)