### PR TITLE
docs(claude-code-hooks): harness 三类假通过 + 非 PreToolUse 事件形状样例

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -103,7 +103,7 @@
       "description": "Claude Code operations suite that bundles archive-aware local conversation discovery across Claude Code and Codex, internal-timestamp full-event session search and recovery, interrupted-work continuation, plugin/skill troubleshooting, CLAUDE.md progressive disclosure optimization, statusline configuration, exported .txt repair, full claude.ai conversation extraction with tool-call rendering and file download, plugin marketplace development, writing/testing/debugging Claude Code hooks, multi-provider profile isolation for running Kimi/GLM/DeepSeek/StepFun/Anthropic in separate windows, local source sync for Claude/Codex skill installs, personal-memory migration into tool-agnostic AGENTS.md reference docs, and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
       "source": "./daymade-claude-code",
       "strict": false,
-      "version": "1.23.1",
+      "version": "1.23.2",
       "category": "suite",
       "keywords": [
         "suite",
@@ -204,7 +204,7 @@
       "description": "Audio processing suite covering the full speech pipeline: ASR transcription (Qwen3, StepFun) with batch-mode guards against music-only repetition-loop hallucinations, speaker diarization and CAM++ voiceprint identification for multi-speaker recordings, transcript error correction, structured meeting minutes generation, and TTS voice synthesis (StepFun). Install once for the complete audio workflow.",
       "source": "./daymade-audio",
       "strict": false,
-      "version": "1.11.0",
+      "version": "1.12.0",
       "category": "suite",
       "keywords": [
         "suite",

--- a/daymade-claude-code/claude-code-hooks/SKILL.md
+++ b/daymade-claude-code/claude-code-hooks/SKILL.md
@@ -218,6 +218,28 @@ everything), awk-split false-blocks (rule 1), corrupted hook poisoning the sessi
 form from Pattern E instead), static env escape hatch (rule 4), multi-profile
 under-registration.
 
+**The harness is the hidden variable — use `scripts/test_hook.sh`, don't hand-roll
+one.** Every hand-rolled failure mode below produces the *same* output as a clean
+pass, so it reads as success (2026-07-22, three in one sitting while fixing a Stop
+hook's whitelist):
+
+1. **Wrong event shape.** A Stop hook reads `last_assistant_message` /
+   `transcript_path`, not `tool_name`/`tool_input`. Feed a PreToolUse-shaped event
+   and it finds no text → exits 0 → "no false blocks!"
+2. **JSON quoting.** `'{\"a\":1}'` inside single quotes emits a literal
+   backslash-quote; `json.loads` throws, the hook's `2>/dev/null || exit 0` swallows
+   it, every case "passes".
+3. **A test case the rule legitimately exempts.** The baseline string used
+   `X 群里` while the regex deliberately excludes `群里/群内/群聊` — so the one row
+   meant to prove the guard still bites didn't bite.
+
+The common shape: **all-cases-agree is a smell, not a green light.** `test_hook.sh`
+resists all three because it asserts an explicit `expected-exit` per row (not "did
+it print something") and forces trigger rows alongside healthy-lookalike rows — a
+trigger row that returns 0 fails loudly instead of blending in. Always assert a
+known-good trigger *first*; if it doesn't fire, fix the harness before touching the
+hook's logic.
+
 ## Reference material
 
 - [references/hook_patterns.md](references/hook_patterns.md) — runnable skeletons for every hook type covered here, the shlex command-position walker, and the JSON event contract.

--- a/daymade-claude-code/claude-code-hooks/scripts/test_hook.group-name-guard.sh
+++ b/daymade-claude-code/claude-code-hooks/scripts/test_hook.group-name-guard.sh
@@ -36,22 +36,17 @@ run() {
   else printf 'FAIL exit=%s want=%s [%s]\n' "$e" "$3" "$1"; fail=$((fail+1)); fi
 }
 
-# ── EXAMPLE TABLE — replace TRIGGER with your banned command ──────────────────
-# Trigger cases (want 2):
-run "execute"        '{"tool_name":"Bash","tool_input":{"command":"TRIGGER -x arg"}}' 2
-run "after-pipe"     '{"tool_name":"Bash","tool_input":{"command":"ls | TRIGGER -x"}}' 2
-run "no-space-pipe"  '{"tool_name":"Bash","tool_input":{"command":"ls|TRIGGER -x"}}' 2
-run "after-&&"       '{"tool_name":"Bash","tool_input":{"command":"foo && TRIGGER x"}}' 2
-run "env-prefix"     '{"tool_name":"Bash","tool_input":{"command":"FOO=1 TRIGGER x"}}' 2
-# Healthy-lookalike cases (want 0) — THESE are what prove you don't false-block:
-run "grep-regex-arg" '{"tool_name":"Bash","tool_input":{"command":"grep -E \"a|TRIGGER|b\" file"}}' 0
-run "redirect-target" '{"tool_name":"Bash","tool_input":{"command":"echo x > TRIGGER"}}' 0
-run "sed-arg"        '{"tool_name":"Bash","tool_input":{"command":"sed s/TRIGGER/x/ file"}}' 0
-run "echo-mention"   '{"tool_name":"Bash","tool_input":{"command":"echo do not use TRIGGER"}}' 0
-run "grep-search"    '{"tool_name":"Bash","tool_input":{"command":"grep TRIGGER file"}}' 0
-run "comment"        '{"tool_name":"Bash","tool_input":{"command":"echo hi # TRIGGER bad"}}' 0
-run "unrelated"      '{"tool_name":"Bash","tool_input":{"command":"ls -la /tmp"}}' 0
-run "non-bash-tool"  '{"tool_name":"Read","tool_input":{"file_path":"/x/TRIGGER.txt"}}' 0
+# ── group-name-guard (Stop event) ────────────────────────────────────────────
+# Trigger rows = BASELINE. If these return 0 the harness is wrong, not the hook.
+run "self-coined shorthand" '{"last_assistant_message":"这条消息是 Zeta 群发出来的"}' 2
+# Healthy-lookalike rows (want 0):
+run "fix: 单群"        '{"last_assistant_message":"可以只同步单群，不必 --groups all"}' 0
+run "fix: 跨群"        '{"last_assistant_message":"支持跨群检索历史消息"}' 0
+run "quantifier 多群"  '{"last_assistant_message":"多群并行拉取没问题"}' 0
+run "pronoun 该群"     '{"last_assistant_message":"该群全称未确认，先按该群处理"}' 0
+run "2-char 微信群"    '{"last_assistant_message":"微信群消息已经同步完成"}' 0
+run "verb 退群"        '{"last_assistant_message":"退群之后就收不到了"}' 0
+run "exempt 群里"      '{"last_assistant_message":"我在 Zeta 群里看到的"}' 0
 # ──────────────────────────────────────────────────────────────────────────────
 #
 # ── EVENT SHAPES OTHER THAN PreToolUse (the payload differs per event) ────────


### PR DESCRIPTION
## 背景

修一个 Stop hook 的白名单误报时，手搓测试 harness 连续三次得到「全部通过」，
而实际上 hook 根本没收到输入。三种失败模式的输出与真正通过**完全相同**，
所以每次读起来都像成功——直到坚持断言一个已知必触发的 baseline 才暴露。

## 三类假通过

1. **事件形状错** — Stop hook 读 `last_assistant_message` / `transcript_path`，
   喂 PreToolUse 形状的 `{tool_name, tool_input}` 则取不到文本 → exit 0
2. **JSON 引号** — 单引号内写 `'{\"a\":1}'` 得到字面反斜杠 → `json.loads` 抛错
   → hook 的 `2>/dev/null || exit 0` 吞掉 → 每条都「通过」
3. **用例撞上规则的合法豁免** — baseline 用了 `X 群里`，而正则明确排除
   `群里/群内/群聊`，于是唯一该触发的那行没触发

共性：**all-cases-agree 是异味，不是绿灯。**

## 改动

- `SKILL.md` Known pitfalls：增补三类失败模式 + 「先断言已知 trigger、
  不触发就先修 harness」的次序要求
- `scripts/test_hook.sh`：补 Stop/SubagentStop、UserPromptSubmit、PostToolUse
  的事件形状样例与 JSON 引号警告；失败时提示「若所有 trigger 行都 exit=0，
  先查 harness 而非 hook 逻辑」
- 新增 `scripts/test_hook.group-name-guard.sh`：一个真实 Stop hook 的完整
  用例表（1 trigger + 7 healthy-lookalike），比 TRIGGER 占位模板更可直接照抄
- marketplace 版本 1.23.1 → 1.23.2

`test_hook.sh` 原本就能挡住前两类（每行显式 `expected-exit` 断言而非「有没有
输出」，且强制 trigger 行与 healthy-lookalike 行并存）——这次的教训正是
**没用现成 harness 而去手搓**。

## 验证

新增用例表对真实 hook 实跑：`8 pass / 0 fail`（含 baseline trigger exit=2）。
`bash -n` 通过。示例已脱敏，无本机路径与私有语境。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011EujeanjAUYrmf21JTroX8