### PR TITLE
fix(transcript-fixer): 修复 script_parameters.md TOC 四条死锚

### DIFF
--- a/daymade-audio/transcript-fixer/.security-scan-passed
+++ b/daymade-audio/transcript-fixer/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-07-22T13:44:47.591315+00:00
+Scanned at: 2026-07-22T14:57:43.786647+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: c49d8f51f4c818dbb3e5b2ce11f215a566bdf17c8b1cfc2d4651b4ed1322c987
+Content hash: 9b186a0b2610354debe8d1ae5fb28a066a40f72980a53772adc69e5898ed1857

--- a/daymade-audio/transcript-fixer/references/script_parameters.md
+++ b/daymade-audio/transcript-fixer/references/script_parameters.md
@@ -5,11 +5,10 @@ Detailed command-line parameters and usage examples for transcript-fixer Python 
 ## Table of Contents
 
 - [fix_transcription.py](#fixtranscriptionpy) - Main correction pipeline
-  - [Setup Commands](#setup-commands)
-  - [Correction Management](#correction-management)
-  - [Correction Workflow](#correction-workflow)
-  - [Learning Commands](#learning-commands)
+  - [Syntax](#syntax)
+  - [Parameters](#parameters)
   - [Review Queue Item Schema](#review-queue-item-schema)
+  - [Usage Examples](#usage-examples)
 - [fix_transcript_timestamps.py](#fix_transcript_timestampspy) - Normalize/repair speaker timestamps
 - [split_transcript_sections.py](#split_transcript_sectionspy) - Split transcript into named sections
 - [generate_word_diff.py](#generate_word_diffpy) - Generate word-level HTML diff


### PR DESCRIPTION
## 概要

文档治理巡检（交付后 documentation-governance pass，7a 路过清理）发现：`references/script_parameters.md` 的 TOC 中 4 条子节链接指向本文不存在的小节——`#setup-commands` / `#correction-management` / `#correction-workflow` / `#learning-commands` 在全文无任何对应标题，是断链。

修复：替换为 fix_transcription.py 下真实存在的子节链接 `Syntax` / `Parameters` / `Review Queue Item Schema` / `Usage Examples`（Exit Codes 顶层 TOC 已覆盖，不重复）。

## 质量门

- 回归审计：112 候选全分类 verify passed（4 条死锚按 intentional_sanitization 分类；2 条 heading 候选因裸词 needle 与新 TOC 行撞名，换上下文 needle 后通过）
- quick_validate ✓ · security_scan ✓（marker 随 commit 更新）

🤖 Generated with [Claude Code](https://claude.com/claude-code)