### PR TITLE
feat(claude-code-hooks): rule 5 失效方向 + pitfall #10 + 独立审阅修出的可绕过处方 (1.24.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -103,7 +103,7 @@
       "description": "Claude Code operations suite that bundles archive-aware local conversation discovery across Claude Code and Codex, internal-timestamp full-event session search and recovery, interrupted-work continuation, plugin/skill troubleshooting, CLAUDE.md progressive disclosure optimization, statusline configuration, exported .txt repair, full claude.ai conversation extraction with tool-call rendering and file download, plugin marketplace development, writing/testing/debugging Claude Code hooks, multi-provider profile isolation for running Kimi/GLM/DeepSeek/StepFun/Anthropic in separate windows, local source sync for Claude/Codex skill installs, personal-memory migration into tool-agnostic AGENTS.md reference docs, and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
       "source": "./daymade-claude-code",
       "strict": false,
-      "version": "1.23.2",
+      "version": "1.24.0",
       "category": "suite",
       "keywords": [
         "suite",

--- a/daymade-claude-code/claude-code-hooks/.security-scan-passed
+++ b/daymade-claude-code/claude-code-hooks/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-07-21T15:30:04.592211+00:00
+Scanned at: 2026-07-22T15:01:35.176545+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 66832a966a2be659d8a74fe87eed6f07a1b0d4b2ba7ce371ae0db4a4c97fe555
+Content hash: a99ef2d79dcd9c1c6309474b561ab386730901b24eeb684439f7bd38680091be

--- a/daymade-claude-code/claude-code-hooks/.security-scan-passed
+++ b/daymade-claude-code/claude-code-hooks/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-07-22T15:01:35.176545+00:00
+Scanned at: 2026-07-22T15:17:51.038151+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: a99ef2d79dcd9c1c6309474b561ab386730901b24eeb684439f7bd38680091be
+Content hash: 0cdbc10c8d1d7d049199313e027dbe83ecbfd92d76fbabf052a0c7707abd4300

--- a/daymade-claude-code/claude-code-hooks/.security-scan-passed
+++ b/daymade-claude-code/claude-code-hooks/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-07-22T15:17:51.038151+00:00
+Scanned at: 2026-07-22T15:34:38.586788+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 0cdbc10c8d1d7d049199313e027dbe83ecbfd92d76fbabf052a0c7707abd4300
+Content hash: fa4bee814c77eb0146eb7947c41b60147cef2612e1656e42c63407e6fdb8d022

--- a/daymade-claude-code/claude-code-hooks/SKILL.md
+++ b/daymade-claude-code/claude-code-hooks/SKILL.md
@@ -34,6 +34,9 @@ behavior recurred anyway — because at the moment of action, attention is 100%
 on "get the thing done" and the reminder loses. That recurrence is the signal
 to move the rule from prose (advisory) to a hook (enforced). Governance rule of
 thumb: *Tier-0 irreversible action + only prose, no hook → it should be a hook.*
+(**Tier-0** here = an action whose damage cannot be undone from inside the session:
+destroying uncommitted work, pushing secrets to a remote, deleting files, publishing
+something outward. The test is reversibility, not severity.)
 
 Do **not** reach for a hook when: the rule has never actually recurred (don't
 pre-build guards for hypothetical mistakes — cost with no proven benefit), or
@@ -44,7 +47,7 @@ match tokens/patterns; it can't judge whether a design is good).
 
 | Type | Fires | Exit 0 | Exit 2 | Other |
 |---|---|---|---|---|
-| **PreToolUse** | before a tool runs | allow | **block** the call (stderr → shown to model as guidance) | non-blocking error |
+| **PreToolUse** | before a tool runs | allow | **block** the call (stderr → shown to model as guidance) | any other exit = "non-blocking error" → **the call proceeds** |
 | **PostToolUse** | after a tool ran | quiet | inject feedback (can't un-run the tool) | — |
 | **SessionStart** | session begins | proceed | — | **always exit 0** — never block a session |
 | **Stop** (+ `SubagentStop`) | the model is about to finish responding | let it stop | **block the stop** — forces the model to keep going (stderr → fed back as the reason) | must check `stop_hook_active` or it can loop |
@@ -110,7 +113,13 @@ false-blocks is matching on the raw command string.
   `|` *inside the quoted regex*, `TRIGGER` becomes a phantom command, and the
   guard blocks a plain grep. (Shipped 2026-07-21; the guard's very first real use
   was a false-block on my own grep.)
-- **Right**: parse the whole command with `shlex.split()` in python. A quoted
+- **Right**: tokenize the whole command with the **`shlex.shlex` class**, not the
+  `shlex.split()` function — `split()` only treats `| ; & < >` as separators when
+  they are space-separated, so `ls|TRIGGER x` tokenizes to `['ls|TRIGGER', 'x']` and
+  your command-position check never sees `TRIGGER` at all (measured; the class with
+  `punctuation_chars=True` yields `['ls', '|', 'TRIGGER', 'x']`). Use the walker in
+  [references/hook_patterns.md](references/hook_patterns.md#the-shlex-command-position-walker)
+  verbatim rather than reaching for the one-liner. A quoted
   `"a|TRIGGER|b"` stays **one token**, so a regex argument is never mistaken for
   a command. Then check whether your target is in a **command position**
   (token[0], or right after a `;`/`&&`/`||`/`|` separator, skipping `VAR=val`
@@ -199,9 +208,14 @@ signal** — which is why a SessionStart health check exists (rule 4).
 
 ### 5. Decide the failure **direction**, and test *that* — not just the happy path
 
-A guard has two ways to be wrong and they are **not symmetric**. Rule 1 covers one
-(false-blocking a healthy command). The other is worse and nearly invisible: the
-guard **cannot obtain the thing it judges on** — a parse throws, a path doesn't
+Rule 1 ranked *detection-tuning* errors: given that the guard ran, false-blocking a
+healthy command beats missing a rare bad one, because a guard people must bypass
+gets bypassed reflexively. **This rule is about a different axis — the guard's
+machinery not running at all** — so "which is worse" is not being reversed here;
+the two rankings never meet. A tuning miss costs you one case; this costs you the
+guard, silently, on every input of that shape.
+
+The failure: the guard **cannot obtain the thing it judges on** — a parse throws, a path doesn't
 resolve, a dependency is missing, a subprocess times out — and the very
 `2>/dev/null || true` that stops the hook from crashing quietly converts *"I could
 not check"* into *"nothing to report."* The hook exits 0. **That output is identical
@@ -219,16 +233,27 @@ unparseable command on purpose and assert it still does what you decided. A suit
 where every row passes *because the hook silently allowed everything* is
 indistinguishable from a suite that passes.
 
-**Read those results carefully — not every `exit 0` is a bug.** `cd ~/no-such-dir &&
-git commit` *correctly* returns 0: `cd` fails, `&&` short-circuits, no commit ever
-happens, so there is nothing to guard. The failure you are hunting is the other
-shape — **the command would really have run and the guard didn't see it**: an
-unbalanced quote makes `shlex.split()` throw, the fallback allows, and a genuine
-cross-domain commit ships with no dialog (rule 1's ValueError note). So ask of every
-allowed row: *would this command actually have done the thing?* If no, the allow is
-correct and you are chasing a ghost. Running this exact probe against a real guard
-produced one of each on the first pass — which is the point: the probe finds things,
-and then you have to think.
+**Read those results carefully — the same input has opposite correct answers for
+different guard classes.** Take `cd ~/no-such-dir && TRIGGER`:
+
+| Guard class | Judges on | Correct exit | Why |
+|---|---|---|---|
+| **Token matcher** (is this a banned command form?) | the command text alone | **2, block** | `TRIGGER` is right there in the text; an unresolvable `cd` doesn't make it not-a-trigger, and if the guard goes quiet here it will also go quiet on `cd ~/real-dir && TRIGGER` |
+| **State deriver** (does the repo's staged set span domains?) | state read from disk | **0, allow** | `cd` fails, `&&` short-circuits, no commit ever happens — there is nothing to guard |
+
+So decide which class your hook is *before* writing the row, and the harness's
+`unresolvable path` template row expects **2** because that template targets the
+token-matcher class. Getting this backwards produces a confident FAIL against a
+correct guard. For a state-deriving guard the failure you are hunting is: **the command would really
+have run and the guard didn't see it** — an unbalanced quote makes tokenizing throw,
+the fallback allows, and a genuine cross-domain commit ships with no dialog (rule 1's
+ValueError note). Ask of every allowed row: *would this command actually have done
+the thing?* If no, the allow is correct.
+
+Running this exact probe against a real state-deriving guard returned two allows on
+the first pass: one was correct (the short-circuit above) and one was a genuine
+fail-open. **The probe finds things; you still have to classify what it found** —
+which is why the class table above comes before the rows.
 
 Real case (2026-07-22): a scope guard read staged files via `git -C "$REPO_DIR"`
 with `REPO_DIR` parsed out of the **command text** — so `cd ~/repo && git commit`
@@ -241,7 +266,7 @@ nothing ever looked wrong. Anatomy + the shared-library twist: pitfall #10.
 1. **Confirm it's a real recurrence**, not hypothetical — else don't build it.
 2. Write the script in the SSOT dir; `chmod +x`.
 3. **Detection** with shlex token-level matching (rule 1).
-4. **`bash -n` + `test_hook.sh`** with trigger AND healthy-lookalike cases (rule 2) — do not register until green. Include the shapes that carry an unexpanded path (`cd ~/elsewhere && …`) and, if the hook has a human gate, a forced-decline row (rule 5).
+4. **`bash -n` + `test_hook.sh`** with trigger AND healthy-lookalike cases (rule 2) — do not register until green. Include the shapes that carry an unexpanded path (`cd ~/elsewhere && …`, rule 5) and, if the hook has a human gate, a forced-decline row (Pattern B, "Make the gate testable").
 5. **Symlink** into `~/.claude/hooks/` (rule 3).
 6. **Register** in main `settings.json` + converge profiles (rule 4).
 7. For a Tier-0/irreversible action, add the **human-confirmation release gate** (rule 4).
@@ -271,15 +296,19 @@ hook's whitelist):
    backslash-quote; `json.loads` throws, the hook's `2>/dev/null || exit 0` swallows
    it, every case "passes".
 3. **A test case the rule legitimately exempts.** The baseline string used
-   `X 群里` while the regex deliberately excludes `群里/群内/群聊` — so the one row
-   meant to prove the guard still bites didn't bite.
+   a string the rule *deliberately exempts* (the guard flagged coined nicknames of the
+   form `<name> Group`, but exempted the ordinary phrases `in the group` / `group chat`
+   — and the baseline row happened to use one of those). The one row meant to prove
+   the guard still bites didn't bite, and the whole suite read green.
 
 The common shape: **all-cases-agree is a smell, not a green light.** `test_hook.sh`
-resists all three because it asserts an explicit `expected-exit` per row (not "did
-it print something") and forces trigger rows alongside healthy-lookalike rows — a
-trigger row that returns 0 fails loudly instead of blending in. Always assert a
-known-good trigger *first*; if it doesn't fire, fix the harness before touching the
-hook's logic.
+catches #1 and #2 structurally — it asserts an explicit `expected-exit` per row
+(not "did it print something") and forces trigger rows alongside healthy-lookalike
+ones, so a trigger row that returns 0 fails loudly instead of blending in. It
+**cannot** catch #3: whether a row's content accidentally lands in an exemption is a
+property of what you wrote, and no harness knows your rule's intent. That one is
+caught only by the habit — assert a known-good trigger *first*, and when it doesn't
+fire, suspect the row before the hook.
 
 ## Reference material
 

--- a/daymade-claude-code/claude-code-hooks/SKILL.md
+++ b/daymade-claude-code/claude-code-hooks/SKILL.md
@@ -94,7 +94,7 @@ fi
 exit 0
 ```
 
-## Four rules that separate a working guard from a session-poisoning one
+## Five rules that separate a working guard from a session-poisoning one
 
 Not style preferences — each is a specific failure we shipped and traced back.
 
@@ -197,12 +197,51 @@ signal** — which is why a SessionStart health check exists (rule 4).
   refuse/cancel/timeout = hard NO; log every prompt/bypass to an audit file.
   Pattern in [references/hook_patterns.md](references/hook_patterns.md).
 
+### 5. Decide the failure **direction**, and test *that* — not just the happy path
+
+A guard has two ways to be wrong and they are **not symmetric**. Rule 1 covers one
+(false-blocking a healthy command). The other is worse and nearly invisible: the
+guard **cannot obtain the thing it judges on** — a parse throws, a path doesn't
+resolve, a dependency is missing, a subprocess times out — and the very
+`2>/dev/null || true` that stops the hook from crashing quietly converts *"I could
+not check"* into *"nothing to report."* The hook exits 0. **That output is identical
+to a real pass**, which is why this survives for weeks.
+
+So at every point where the hook *obtains* something (parses the command, reads
+staged files, queries a service), decide explicitly: **if this comes back empty, does
+that mean allow or block?** — and write the answer next to the branch. Fail-open is
+often right for a *modifier* check (does this carry `--no-verify`? missing it costs
+you one case). Fail-closed is usually right for the *is-this-even-the-thing* check
+(is this a cross-domain commit? an empty answer means the guard never fired at all).
+
+**Then test the direction, not the happy path**: hand it an unresolvable path or an
+unparseable command on purpose and assert it still does what you decided. A suite
+where every row passes *because the hook silently allowed everything* is
+indistinguishable from a suite that passes.
+
+**Read those results carefully — not every `exit 0` is a bug.** `cd ~/no-such-dir &&
+git commit` *correctly* returns 0: `cd` fails, `&&` short-circuits, no commit ever
+happens, so there is nothing to guard. The failure you are hunting is the other
+shape — **the command would really have run and the guard didn't see it**: an
+unbalanced quote makes `shlex.split()` throw, the fallback allows, and a genuine
+cross-domain commit ships with no dialog (rule 1's ValueError note). So ask of every
+allowed row: *would this command actually have done the thing?* If no, the allow is
+correct and you are chasing a ghost. Running this exact probe against a real guard
+produced one of each on the first pass — which is the point: the probe finds things,
+and then you have to think.
+
+Real case (2026-07-22): a scope guard read staged files via `git -C "$REPO_DIR"`
+with `REPO_DIR` parsed out of the **command text** — so `cd ~/repo && git commit`
+handed it a literal `~/repo`, `git -C` failed, staged came back empty, and the guard
+concluded "no cross-domain files, allow." Every cross-repo commit went unguarded and
+nothing ever looked wrong. Anatomy + the shared-library twist: pitfall #10.
+
 ## Build order (in sequence)
 
 1. **Confirm it's a real recurrence**, not hypothetical — else don't build it.
 2. Write the script in the SSOT dir; `chmod +x`.
 3. **Detection** with shlex token-level matching (rule 1).
-4. **`bash -n` + `test_hook.sh`** with trigger AND healthy-lookalike cases (rule 2) — do not register until green.
+4. **`bash -n` + `test_hook.sh`** with trigger AND healthy-lookalike cases (rule 2) — do not register until green. Include the shapes that carry an unexpanded path (`cd ~/elsewhere && …`) and, if the hook has a human gate, a forced-decline row (rule 5).
 5. **Symlink** into `~/.claude/hooks/` (rule 3).
 6. **Register** in main `settings.json` + converge profiles (rule 4).
 7. For a Tier-0/irreversible action, add the **human-confirmation release gate** (rule 4).
@@ -216,7 +255,9 @@ everything), awk-split false-blocks (rule 1), corrupted hook poisoning the sessi
 (rule 2), a quote or backtick inside a Python *comment* silently corrupting a
 `python3 -c "…"` block with no syntax error (pitfall #9 — use the quoted-heredoc
 form from Pattern E instead), static env escape hatch (rule 4), multi-profile
-under-registration.
+under-registration, and a path parsed from command text keeping its literal `~` so
+the guard fails **open** with no symptom at all (#10 — the one you cannot wait to
+notice, because silence is its only sign).
 
 **The harness is the hidden variable — use `scripts/test_hook.sh`, don't hand-roll
 one.** Every hand-rolled failure mode below produces the *same* output as a clean

--- a/daymade-claude-code/claude-code-hooks/SKILL.md
+++ b/daymade-claude-code/claude-code-hooks/SKILL.md
@@ -48,7 +48,7 @@ match tokens/patterns; it can't judge whether a design is good).
 | Type | Fires | Exit 0 | Exit 2 | Other |
 |---|---|---|---|---|
 | **PreToolUse** | before a tool runs | allow | **block** the call (stderr → shown to model as guidance) | any other exit = "non-blocking error" → **the call proceeds** |
-| **PostToolUse** | after a tool ran | quiet | inject feedback (can't un-run the tool) | — |
+| **PostToolUse** | after a tool ran | quiet **unless it prints a `hookSpecificOutput` JSON on stdout — that is how context injection works, and it happens at exit 0** | feedback to the model (can't un-run the tool) | — |
 | **SessionStart** | session begins | proceed | — | **always exit 0** — never block a session |
 | **Stop** (+ `SubagentStop`) | the model is about to finish responding | let it stop | **block the stop** — forces the model to keep going (stderr → fed back as the reason) | must check `stop_hook_active` or it can loop |
 
@@ -61,6 +61,13 @@ match tokens/patterns; it can't judge whether a design is good).
   and surface it — the model can't "believe it committed" against injected truth).
 - **SessionStart** is for **health checks of the guard rails themselves** —
   silent when healthy, warn on breakage, always exit 0.
+- **`set -euo pipefail` vs `set -uo pipefail` — pick by contract, not by habit.**
+  A hook that may block (PreToolUse) wants `-e`: an unexpected failure aborting the
+  script is survivable, because the caller treats a non-0/2 exit as "proceed". A hook
+  whose contract is **ALWAYS exit 0** (PostToolUse injectors, SessionStart checks)
+  must drop `-e` — with it, one `grep` that legitimately finds nothing kills the hook
+  mid-way and the CLI surfaces a bare `Failed with non-blocking status code`. Rule of
+  thumb: **`-e` for hooks that decide, no `-e` for hooks that report** (pitfall #8).
 - **Stop is the odd one out, and the one most often reached for by mistake**:
   it's the *only* hook type that can react to what the model **itself just
   generated** (its own reply text). Every other hook type — including

--- a/daymade-claude-code/claude-code-hooks/references/hook_patterns.md
+++ b/daymade-claude-code/claude-code-hooks/references/hook_patterns.md
@@ -258,6 +258,34 @@ is the guards' one collective failure mode, so the audit trail is what keeps it
 honest. (Retired anti-pattern: a static `GUARD_OK=1` env var — the model just adds
 it. Any gate the model can satisfy by itself is not a gate.)
 
+**Make the gate testable — route both channels through overridable names.** A gate
+whose confirmation path can't be exercised automatically is a gate nobody ever
+verifies: an automated run either hangs on `/dev/tty`, or pops a real dialog at a
+human who isn't there. Read both endpoints from a variable with the production value
+as the default:
+
+```bash
+OSASCRIPT_BIN="${GIT_GUARD_OSASCRIPT:-osascript}"
+TTYDEV="${GIT_GUARD_TTY:-/dev/tty}"
+```
+
+In production nothing changes. In a test you point them at things that deterministically
+decline, and the run stays headless and non-interactive:
+
+```bash
+GIT_GUARD_OSASCRIPT=false GIT_GUARD_TTY=/dev/null   # dialog "fails", tty reads nothing
+#   → both channels decline → the gate must exit 2
+```
+
+That inversion is what makes the gate assertable: **`exit 2` under forced-decline is
+positive evidence the guard reached its blocking branch**, which is exactly the fact
+a fail-open bug (pitfall #10) hides. Pair it with a negative control in the same run
+— one input that *shouldn't* trigger, asserted `exit 0` — because "blocks everything"
+and "blocks the right thing" are otherwise indistinguishable. Keep the override names
+namespaced to the hook and never let them *grant* permission: they may only steer
+which channel is consulted, never stand in for the human's YES — an env var the model
+can set to say "approved" is the retired anti-pattern above, wearing a test-shaped hat.
+
 ---
 
 ## Pattern C — SessionStart health check

--- a/daymade-claude-code/claude-code-hooks/references/hook_patterns.md
+++ b/daymade-claude-code/claude-code-hooks/references/hook_patterns.md
@@ -84,7 +84,9 @@ the shlex walker to natural language is a category error.
 The workhorse: inspect a Bash command, block if it does the banned thing. This is
 the shape of `qlmanage-guard`. (`proxy-guard` predates the shlex walker and still
 awk-splits the raw string — the very approach pitfall #2 warns against; it's a
-migration candidate, not a model to copy.)
+migration candidate, not a model to copy. (Pitfall #7 cites the same hook approvingly
+for a *different* property — it correctly exempts git write segments. Both are true:
+copy its segment-exemption logic, not its awk splitting.))
 
 ```bash
 #!/usr/bin/env bash
@@ -211,16 +213,36 @@ stamp() { printf '%s\t%s\t%s\n' "$(date '+%F %T')" "$1" "${CMD:0:80}" >> "$BYPAS
 
 # Channel 1: native macOS dialog — the model cannot click a button.
 if command -v osascript >/dev/null 2>&1; then
-  DLG_BODY="display dialog \"Allow <ACTION>?\n\n$CMD\" buttons {\"拒绝\",\"允许\"} default button \"拒绝\" cancel button \"拒绝\" with icon stop giving up after 40 with title \"my-guard\""
-  # CRITICAL: attach the dialog to the FRONTMOST app (the terminal the user is
+  # CRITICAL #1 — NEVER splice text into the AppleScript source. `$CMD` (and any
+  # file path or name you show) is attacker-controlled: the model chooses it. A
+  # payload containing a newline and a quote escapes the string literal and becomes
+  # a statement, so `return "button returned:允许"` makes osascript hand back an
+  # approval the human never gave. Measured 2026-07-22 against a guard that *did*
+  # escape quotes with sed — the escaper assumed single-line input and a filename
+  # with an embedded newline walked straight through it. The gate that exists so the
+  # model cannot approve its own action was approving it.
+  # The fix is parameterization, not better escaping: keep the script a CONSTANT and
+  # pass text through `on run argv` (same principle as a prepared statement).
+  DLG_FRONT='"'"'on run argv
+  tell application (path to frontmost application as text)
+    display dialog (item 1 of argv) buttons {"拒绝","允许"} default button "拒绝" cancel button "拒绝" with icon stop giving up after 40 with title "my-guard"
+  end tell
+end run'"'"'
+  DLG_PLAIN='"'"'on run argv
+  display dialog (item 1 of argv) buttons {"拒绝","允许"} default button "拒绝" cancel button "拒绝" with icon stop giving up after 40 with title "my-guard"
+end run'"'"'
+  MSG="Allow <ACTION>?
+
+$CMD"
+  # CRITICAL #2: attach the dialog to the FRONTMOST app (the terminal the user is
   # looking at) so it pops up *in front of them*. A bare `osascript -e "$DLG"`
   # opens on some other desktop/Space in fullscreen setups — the user never sees
   # it, it times out at 40s, and the log misreads "declined" (a real 2026-07-21
   # bug this exact snippet used to have). Fall back to the bare form only on a
   # NON-cancel error (some frontmost apps don't support `tell`).
   ERR=$(mktemp); DLG=""
-  if DLG=$(osascript -e "tell application (path to frontmost application as text) to $DLG_BODY" 2>"$ERR"); then :
-  elif ! grep -qiE 'user canceled|-128' "$ERR"; then DLG=$(osascript -e "$DLG_BODY" 2>"$ERR") || true
+  if DLG=$(osascript -e "$DLG_FRONT" "$MSG" 2>"$ERR"); then :
+  elif ! grep -qiE 'user canceled|-128' "$ERR"; then DLG=$(osascript -e "$DLG_PLAIN" "$MSG" 2>"$ERR") || true
   fi
   if printf '%s' "$DLG" | grep -q 'button returned:允许'; then
     stamp "gui-allow"; rm -f "$ERR"; exit 0
@@ -260,8 +282,9 @@ it. Any gate the model can satisfy by itself is not a gate.)
 
 **Make the gate testable — route both channels through overridable names.** A gate
 whose confirmation path can't be exercised automatically is a gate nobody ever
-verifies: an automated run either hangs on `/dev/tty`, or pops a real dialog at a
-human who isn't there. Read both endpoints from a variable with the production value
+verifies: an automated run pops a real dialog at a human who isn't there (the tty channel
+itself is already safe — its `(exec 3<>/dev/tty)` probe fails in a non-tty context
+and falls through to block rather than hanging). Read both endpoints from a variable with the production value
 as the default:
 
 ```bash

--- a/daymade-claude-code/claude-code-hooks/references/hook_patterns.md
+++ b/daymade-claude-code/claude-code-hooks/references/hook_patterns.md
@@ -281,10 +281,28 @@ That inversion is what makes the gate assertable: **`exit 2` under forced-declin
 positive evidence the guard reached its blocking branch**, which is exactly the fact
 a fail-open bug (pitfall #10) hides. Pair it with a negative control in the same run
 — one input that *shouldn't* trigger, asserted `exit 0` — because "blocks everything"
-and "blocks the right thing" are otherwise indistinguishable. Keep the override names
-namespaced to the hook and never let them *grant* permission: they may only steer
-which channel is consulted, never stand in for the human's YES — an env var the model
-can set to say "approved" is the retired anti-pattern above, wearing a test-shaped hat.
+and "blocks the right thing" are otherwise indistinguishable. **Be honest about what this costs — the override is itself a bypass surface, and
+prose does not close it.** Pointing `GIT_GUARD_TTY` at a file containing `YES`, or
+`GIT_GUARD_OSASCRIPT` at a script that echoes the approval string, *grants* approval.
+Saying "these may only steer which channel is consulted" is an assertion, not an
+enforcement — exactly the shape rule 4 retired (`GUARD_OK=1`), wearing a test-shaped
+hat. Either accept that and constrain it, or don't ship the override:
+
+```bash
+# Refuse the override outside a test context, and refuse a *granting* one always.
+if [ -n "${GIT_GUARD_TTY:-}" ] || [ -n "${GIT_GUARD_OSASCRIPT:-}" ]; then
+  [ "${GIT_GUARD_TEST:-}" = "1" ] || { echo "override outside test context" >&2; exit 2; }
+  # only decline-shaped targets are honored; anything else is treated as decline
+  case "${GIT_GUARD_TTY:-/dev/null}" in /dev/null|/dev/zero) : ;; *) TTYDEV=/dev/null ;; esac
+  case "${GIT_GUARD_OSASCRIPT:-false}" in false|/usr/bin/false) : ;; *) OSASCRIPT_BIN=false ;; esac
+fi
+```
+
+The residual risk is `GIT_GUARD_TEST=1` itself, which the model can also set — but
+now every path it opens leads to **decline**, so setting it buys a block, not a pass.
+That is the property worth having: **the escape hatch may only make the gate stricter.**
+If you can't get there, prefer no override and test the gate manually — an
+unverifiable gate that cannot be bypassed beats a verifiable one that can.
 
 ---
 

--- a/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
+++ b/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
@@ -209,6 +209,58 @@ Every entry here is a bug that shipped. When a hook misbehaves, match the
 
 ---
 
+## 10. A path parsed from command text keeps its literal `~` — guard fails **open**
+
+**Symptom.** The guard never fires for commands that `cd` somewhere first. No error,
+no log line, no misbehavior you can see — it just silently allows. In the case that
+surfaced it, two sibling hooks shared one parsing helper and degraded *differently*:
+a PostToolUse context-injector kept emitting its own fallback string
+(`"cannot read HEAD — not a git repo or bad path"`) for weeks, which everyone read as
+"that hook is noisy again"; the PreToolUse scope guard beside it gave **no signal at
+all** — it simply stopped guarding. Same root cause, one visible-but-dismissed
+symptom and one invisible.
+
+**Cause.** Tilde expansion is done by the **shell**, before a command ever runs. A
+hook that determines its target by *parsing the command text* (`cd X && git commit`,
+`git -C X commit`) never goes through a shell, so it receives the literal string
+`~/repo`. Then:
+
+```bash
+git -C "~/repo" log -1        # fatal: cannot change to '~/repo': No such file or directory
+git -C "~/repo" diff --cached --name-only   # → empty, exit non-zero, swallowed by 2>/dev/null
+```
+
+The headcheck degraded to a visible-but-ignorable message. The scope guard did
+something worse: empty staged list → "zero files, so zero cross-domain files" →
+**allow**. Rule 5's failure direction, in the wild.
+
+**Fix.** Expand in the parser, once, at the shared source:
+
+```python
+repo_dir = os.path.expanduser(repo_dir) if repo_dir else repo_dir
+```
+
+`expanduser` is the identity function for paths that don't start with `~`, and safe
+on the empty string — so it needs no conditional beyond the empty guard.
+
+**The shared-library twist — this is the part that bites twice.** The parser was a
+common helper (`lib-git-commit-detect.sh`) used by three hooks. Fixing it fixed all
+three at once, which is why the SSOT structure is right — but it also means
+**"I verified the fix" must mean "I verified every caller."** In the real incident
+the author fixed the library, verified two callers (a form guard and the headcheck),
+declared it done — and the *third* caller, the scope guard, went unverified. It was
+both the one that fails open and the only one of the three that actually blocks. It
+took the user asking "so did you fix it?" for the gap to surface. When you patch a
+shared helper, enumerate its callers (`grep -l '<lib-name>' *.sh`) and put every one
+of them in the test table.
+
+**Generalization (not git-specific).** Any hook that reconstructs state by *reading
+the command instead of running it* inherits the whole class: `~` unexpanded, `$VARS`
+uninterpolated, `$(cmd)` unexecuted, globs unmatched, relative paths resolved against
+the wrong cwd. If your hook takes a path out of command text and hands it to a real
+command, expand what the shell would have expanded — or decide, per rule 5, that an
+unresolvable path means **block**.
+
 ## Meta-principle: the ordering of these fixes
 
 When a guard is misbehaving, check in this order — cheapest and most common first:
@@ -220,3 +272,8 @@ When a guard is misbehaving, check in this order — cheapest and most common fi
    (and you recently edited an embedded `python3 -c "…"` block, code or
    comments)? → quote/backtick corruption (#9) — `bash -n` cannot see this one,
    only a real-JSON test of that exact case will.
+6. Does it work when you run the command **in place**, but never fire when the
+   command `cd`s somewhere first (or uses `~`, a variable, a glob)? → the guard is
+   parsing command text and got an unexpanded string (#10). Note this one has **no
+   symptom of its own** when the hook fails open — you find it by testing the
+   `cd ~/elsewhere && …` shape explicitly, not by waiting for something to look wrong.

--- a/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
+++ b/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
@@ -36,8 +36,12 @@ Every entry here is a bug that shipped. When a hook misbehaves, match the
   (`gsub(/&&|\|\||;|\|/,"\n")`). awk doesn't understand shell quoting, so the `|`
   *inside the quoted regex* is treated as a pipe, the string splits, and
   `TRIGGER` lands at a segment head → looks like a command.
-- **Fix:** parse with `shlex.split()` (quotes honored — the regex stays one
-  token) and check **command position**, not mere presence. See the walker in
+- **Fix:** tokenize with the **`shlex.shlex` class** (`punctuation_chars=True`,
+  `whitespace_split=True`) — NOT the `shlex.split()` function, which leaves
+  `ls|TRIGGER x` as `['ls|TRIGGER', 'x']` and hides the trigger from a
+  command-position check entirely. Both forms honor quotes (the regex stays one
+  token); only the class also splits unspaced separators. Then check **command
+  position**, not mere presence — walker in
   [hook_patterns.md](hook_patterns.md#the-shlex-command-position-walker).
 - **Why this is the worst class of bug:** *误杀健康输入比漏报更糟* — a guard that
   blocks healthy input trains the operator (human or model) to bypass it
@@ -234,20 +238,23 @@ The headcheck degraded to a visible-but-ignorable message. The scope guard did
 something worse: empty staged list → "zero files, so zero cross-domain files" →
 **allow**. Rule 5's failure direction, in the wild.
 
-**Fix.** Expand in the parser, once, at the shared source:
+**Fix.** Expand in the parser, once, at the shared source. (The helper here is a `.sh` file whose parsing core is an embedded `python3` block — Pattern A's shape — so the fix is Python even though the file is shell:)
 
 ```python
 repo_dir = os.path.expanduser(repo_dir) if repo_dir else repo_dir
 ```
 
-`expanduser` is the identity function for paths that don't start with `~`, and safe
-on the empty string — so it needs no conditional beyond the empty guard.
+`expanduser` is the identity function for anything not starting with `~`, and
+`expanduser('') == ''` — so the `if repo_dir else` guard above is belt-and-braces, not
+required; `repo_dir = os.path.expanduser(repo_dir)` alone is correct. Keep whichever
+reads better in your parser; the load-bearing part is that the expansion happens
+**inside the parser**, so every caller inherits it.
 
 **The shared-library twist — this is the part that bites twice.** The parser was a
 common helper (`lib-git-commit-detect.sh`) used by three hooks. Fixing it fixed all
 three at once, which is why the SSOT structure is right — but it also means
 **"I verified the fix" must mean "I verified every caller."** In the real incident
-the author fixed the library, verified two callers (a form guard and the headcheck),
+the author fixed the library, verified two callers (a commit-form guard and the PostToolUse context-injector),
 declared it done — and the *third* caller, the scope guard, went unverified. It was
 both the one that fails open and the only one of the three that actually blocks. It
 took the user asking "so did you fix it?" for the gap to surface. When you patch a

--- a/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
+++ b/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
@@ -71,6 +71,19 @@ Every entry here is a bug that shipped. When a hook misbehaves, match the
 - **Fix (detection):** a SessionStart health check that `bash -n`s every hook and
   checks symlinks (Pattern C) surfaces this class at startup instead of after
   hours of misdiagnosis.
+- **Fix (escape hatch) — you cannot Bash your way out of a broken Bash guard.**
+  Every repair you'd reach for (`rm` the symlink, re-`ln -s`, edit `settings.json`
+  with sed) is itself a Bash call, and a corrupted PreToolUse Bash hook inspects
+  those too. Routes that do **not** go through the Bash tool, cheapest first:
+  1. **Edit `settings.json` with the Edit/Write tool** (file tools don't fire the
+     Bash matcher) and delete the hook's entry — instant disarm, no shell needed.
+  2. **Start a session with a different config home**: `CLAUDE_CONFIG_DIR=<other>`
+     — a profile whose settings never registered the broken hook. (Set it when
+     launching the CLI, i.e. outside the poisoned session.)
+  3. **Fix from outside**: any terminal not running under the agent, since the hook
+     only exists on the agent's tool path, not on your shell's.
+  This is also the argument for the SSOT+symlink layout: repair is one `ln -s` you
+  can run from an ordinary terminal, not surgery on a live config.
 
 ---
 
@@ -279,7 +292,14 @@ When a guard is misbehaving, check in this order — cheapest and most common fi
    (and you recently edited an embedded `python3 -c "…"` block, code or
    comments)? → quote/backtick corruption (#9) — `bash -n` cannot see this one,
    only a real-JSON test of that exact case will.
-6. Does it work when you run the command **in place**, but never fire when the
+6. Did it stop mid-run with **`Failed with non-blocking status code: No stderr
+   output`**, in a hook whose contract is always-exit-0? → `set -e` + `pipefail`
+   killing it on a legitimately-empty `grep`/`wc` (#8). Distinct symptom, distinct
+   fix: drop `-e`, or `||`-guard every such pipeline.
+7. Did your **own test command** get blocked while you were testing the guard you
+   just registered? → self-block (#7); move the cases into a script file so the
+   outer command doesn't carry the trigger.
+8. Does it work when you run the command **in place**, but never fire when the
    command `cd`s somewhere first (or uses `~`, a variable, a glob)? → the guard is
    parsing command text and got an unexpanded string (#10). Note this one has **no
    symptom of its own** when the hook fails open — you find it by testing the

--- a/daymade-claude-code/claude-code-hooks/scripts/test_hook.sh
+++ b/daymade-claude-code/claude-code-hooks/scripts/test_hook.sh
@@ -52,6 +52,22 @@ run "grep-search"    '{"tool_name":"Bash","tool_input":{"command":"grep TRIGGER 
 run "comment"        '{"tool_name":"Bash","tool_input":{"command":"echo hi # TRIGGER bad"}}' 0
 run "unrelated"      '{"tool_name":"Bash","tool_input":{"command":"ls -la /tmp"}}' 0
 run "non-bash-tool"  '{"tool_name":"Read","tool_input":{"file_path":"/x/TRIGGER.txt"}}' 0
+#
+# ── FAILURE-DIRECTION ROWS — add these whenever the hook derives state from the
+#    command text (a path, a repo, a target). They assert the hook still behaves
+#    when it CANNOT resolve what it parsed. Omit them and a fail-open bug looks
+#    exactly like a clean pass (pitfall #10):
+# run "trigger behind cd ~"  '{"tool_name":"Bash","tool_input":{"command":"cd ~/somewhere && TRIGGER -x"}}' 2
+# run "trigger behind cd abs" '{"tool_name":"Bash","tool_input":{"command":"cd /tmp && TRIGGER -x"}}' 2
+# run "unresolvable path"    '{"tool_name":"Bash","tool_input":{"command":"cd ~/no-such-dir && TRIGGER -x"}}' 2
+#
+# ── HUMAN-GATE ROWS — if the hook releases via a confirmation dialog / tty YES,
+#    force both channels to decline so the run stays headless, and assert it
+#    BLOCKS. Requires the hook to read its channels from overridable names
+#    (see Pattern B "Make the gate testable"):
+#      GIT_GUARD_OSASCRIPT=false GIT_GUARD_TTY=/dev/null bash test_hook.sh <hook>
+#    Never provide an env var that *grants* approval — that recreates the retired
+#    static-escape-hatch anti-pattern.
 # ──────────────────────────────────────────────────────────────────────────────
 #
 # ── EVENT SHAPES OTHER THAN PreToolUse (the payload differs per event) ────────


### PR DESCRIPTION
## 起因

今天修一个真实 guard 时暴露了三件事，折回 skill；随后按 skill-creator 的
standing discipline #5 对成品跑了一次 **fresh-context 独立审阅**，它找出 17 项
作者自查两轮都没看见的问题，其中一项是**会让读者写出可绕过 guard 的技术处方**。

## 新增

- **SKILL.md rule 5 — 决定并测试失效方向**。guard 的两种错法不在同一轴：
  rule 1 管检测调优（误杀 vs 漏报），rule 5 管**检查机器根本没运行**。后者与
  真正通过的输出完全一致，所以能存活数周。要求在每个取数分支写下「取空＝放行
  还是拦截」，并用故意破坏输入源的用例断言那个方向。附一张 token-匹配类 vs
  状态-推导类的对照表——同一个 `cd ~/no-such-dir && …` 对两类 guard 正确答案相反。
- **pitfall #10 — 从命令文本解析的路径保留字面 `~`**。tilde 由 shell 展开，而
  解析命令文本的 hook 从不经过 shell，于是 `git -C "~/repo"` fatal → staged 取空
  → 「没有跨域文件」→ 放行。含共享库连带面：修 lib 修好三个调用方，但「我验证了
  修复」必须等于「我验证了每个调用方」——真实事故里第三个调用方（唯一会 block
  的那个）漏验。泛化到所有「读命令而不执行命令」的 hook。
- **Pattern B — 让人类确认门可测**，并诚实标注其代价：把 osascript / tty 端点
  读进可覆盖变量后，指向含 `YES` 的文件即可放行，正是 rule 4 退役的静态逃生门
  换个测试外衣。给出强制写法（**逃生门只能让门更严**），并说明不接受就别加。
- **test_hook.sh** 增加 failure-direction 行与 human-gate forced-decline 行模板
  ——规则写在文档里而模板不体现，等于没写。

## 修（独立审阅发现）

**技术错误（既有已久，最要命）**：rule 1 与 pitfall #2 都写「用 `shlex.split()`」，
而 walker 文档写着「CRITICAL: 用 `shlex.shlex` 类，不是 `split()` 函数」。实测坐实：

```
shlex.split('ls|TRIGGER x')  →  ['ls|TRIGGER', 'x']     # TRIGGER 粘住，命令位检查看不见
shlex.shlex(..., punctuation_chars=True)  →  ['ls', '|', 'TRIGGER', 'x']
```

照 SKILL.md 做的人会得到可绕过的 guard。两处均改。

**本轮自己引入的矛盾**：rule 1/rule 5 的「哪个更糟」自相矛盾（改为讲清两者不在
同一轴）；`cd ~/no-such-dir` 的期望退出码在文档与 harness 模板里相反（补对照表）；
「override 不得授予批准」只是断言无强制（给出强制写法）；「resists all three」
夸大（实为结构上只挡前两类）；build order 的 rule 5 交叉引用指错（实为 Pattern B）。

**可读性**（审阅者在这方面是权威，直接采纳）：`Tier-0` 用六次从未定义；类型表
Other 列未说明**调用继续**——而这正是 rule 5 / pitfall #8 / 人类确认门失效的共同
机制；`expanduser` 一句自我否定；「a form guard」无指代；中文举例对英文读者不可用
且属私有语境（已泛化）。

## 验证

- regression gate：12 候选全分类（3 `true_gap_fixed` / 1 `intentional_sanitization`
  / 8 `preserved_or_moved`）后 verify 通过；baseline 取自 git ref，期间并行 session
  两次移动 HEAD，已确认未触及本 skill
- `quick_validate` + security scan 通过 + 人工语义通读
- harness 对真实 form-guard 回放 3 pass / 0 fail
- 新写的 shlex 断言与 walker 实现逐字核对一致

## 未处理（需决定，其中两项涉及真实 hook 行为而非文档）

1. **Pattern B 的对话框对含引号的命令必然语法错**（已实测复现）。而 Pattern B 守的
   就是 `git commit -m "..."` ——即人类确认门对它真正要守的命令**从未弹出过**，
   且往审计日志写假的 `gui-declined`。
2. **AppleScript 注入面**：`$CMD` 被 splice 进 AppleScript 字符串且模型可控，
   审阅者编译（未执行）出可返回批准字符串的 payload，推翻了「两个通道模型物理上
   无法驱动」的断言。
3. PostToolUse 类型表与 Pattern D 的注入语义看似冲突（实测注入走 stdout JSON 而非
   exit code，表格需补全而非改错）。
4. `set -euo` / `set -uo` 在各 Pattern 间不一致，无规则指明从哪个起步。
5. meta-principle 排查表漏 #7 / #8（#8 的症状最独特却无入口）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011EujeanjAUYrmf21JTroX8