### PR TITLE
docs(claude-code-hooks): pitfall #11 换行盲分段 + harness 也是嫌疑 (1.24.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -103,7 +103,7 @@
       "description": "Claude Code operations suite that bundles archive-aware local conversation discovery across Claude Code and Codex, internal-timestamp full-event session search and recovery, interrupted-work continuation, plugin/skill troubleshooting, CLAUDE.md progressive disclosure optimization, statusline configuration, exported .txt repair, full claude.ai conversation extraction with tool-call rendering and file download, plugin marketplace development, writing/testing/debugging Claude Code hooks, multi-provider profile isolation for running Kimi/GLM/DeepSeek/StepFun/Anthropic in separate windows, local source sync for Claude/Codex skill installs, personal-memory migration into tool-agnostic AGENTS.md reference docs, and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
       "source": "./daymade-claude-code",
       "strict": false,
-      "version": "1.24.0",
+      "version": "1.24.1",
       "category": "suite",
       "keywords": [
         "suite",

--- a/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
+++ b/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
@@ -43,6 +43,10 @@ Every entry here is a bug that shipped. When a hook misbehaves, match the
   token); only the class also splits unspaced separators. Then check **command
   position**, not mere presence — walker in
   [hook_patterns.md](hook_patterns.md#the-shlex-command-position-walker).
+- **Caveat — `whitespace_split=True` also swallows newlines.** If your commands
+  can be multiline (`cd x\ngit add\ngit push`), tokenizing the whole string
+  collapses every line into one segment and hides everything but the first line's
+  head. Split on newlines as text *first*; see #11.
 - **Why this is the worst class of bug:** *误杀健康输入比漏报更糟* — a guard that
   blocks healthy input trains the operator (human or model) to bypass it
   reflexively, and a reflexively-bypassed guard protects nothing. When choosing
@@ -281,6 +285,55 @@ the wrong cwd. If your hook takes a path out of command text and hands it to a r
 command, expand what the shell would have expanded — or decide, per rule 5, that an
 unresolvable path means **block**.
 
+## 11. Newline-blind segmentation misses the multiline command (fixtures pass, real corpus barely fires)
+
+- **Symptom:** the hook passes every synthetic fixture (`git push origin main`,
+  `cd x && git push`) yet fires far less than expected on real transcripts — in one
+  incident its replayed trigger rate was **0** where the targeted population should
+  have shown ~5%.
+- **Cause:** the git operations this kind of guard targets are usually written as
+  *multiline* blocks — `cd /repo\ngit add -A\ngit commit -m x\ngit push`. A
+  segmenter built on `shlex.shlex(..., whitespace_split=True)` — the very tokenizer
+  #2 recommends for quoting-safety — treats the **newline as ordinary whitespace and
+  drops it**, so the lines collapse into ONE token stream with no separator token,
+  yielding a single segment whose head is `cd`. The `git push` further down is no
+  longer at a segment head, and the command-position check (#2) never sees it.
+  Single-line fixtures cannot expose this: they have no newline to swallow.
+- **Fix — two stages, and the order matters.** First split on **newlines only, as
+  text** (`cmd.split("\n")`). Then, *within each line*, use #2's `shlex` tokenizer
+  to segment on `;`/`&&`/`|` and walk for command position. This defeats the common
+  #2 trap: a `|` inside `grep -E "a|git push|b"`, or an `&&` inside a *single-line*
+  `git commit -m "… && git push"`, stays inside one `shlex` token, so no phantom
+  `git push` segment is manufactured. Do **not** instead do the whole job with one
+  quote-blind split like `re.split(r"[\n;]|&&|\|\||[|&]", cmd)`: that cuts those same
+  separators *inside* quotes — pitfall #2, the worst bug in this file — and orphans
+  the inner text from its `git commit` head, defeating #7's exemption.
+- **Name its residual, don't hide it.** The text `cmd.split("\n")` is itself
+  quote-blind about *newlines*: a newline **inside** a quoted string or a heredoc
+  body still fragments. The clean witness is a heredoc — `git commit -F - <<'MSG'`
+  whose body contains a bare `git push` line splits that line off and reads it as a
+  command it isn't. (A multiline `-m "…\ngit push"` message fragments too, but its
+  torn line has an unbalanced quote, so whether it over- or under-fires depends on how
+  you handle the `shlex` `ValueError` — a witness for the same residual, less clean.)
+  So the two-stage is not "#2-proof", only *less* exposed than the one-shot regex.
+  Whether that residual is acceptable follows the same **bias-to-under** call as #2:
+  for a **fail-open reminder** an extra over-fire costs nothing — declare it and move
+  on; for a **fail-closed blocker** it re-creates #2's false-block, so you must lift
+  #7's `git commit`/heredoc exemption to the **whole-command** level *before*
+  splitting, or parse with a real shell grammar.
+- **Why you only catch it with real data:** this is the `合成 fixture 全绿 ≠ 正确`
+  trap — the fixtures you invent share the blind spot that wrote the bug (you think
+  in one-liners; production is multiline). So replay the hook over a **real corpus**
+  before shipping. And when a replay returns "0 / clean", treat the **harness
+  itself** as a suspect too: a random-sample replay can read 0 purely because the
+  sample was diluted (measure the *population that can possibly fire*, not a uniform
+  sample), and a mutation test can report "survived" because the mutation never
+  applied. Both are the same failure as the hook's own — the instrument lying in the
+  safe-looking direction. Confirm the harness can report "dirty" on an input you have
+  *independently proven* should fire, before you believe any "clean".
+
+---
+
 ## Meta-principle: the ordering of these fixes
 
 When a guard is misbehaving, check in this order — cheapest and most common first:
@@ -304,3 +357,9 @@ When a guard is misbehaving, check in this order — cheapest and most common fi
    parsing command text and got an unexpanded string (#10). Note this one has **no
    symptom of its own** when the hook fails open — you find it by testing the
    `cd ~/elsewhere && …` shape explicitly, not by waiting for something to look wrong.
+9. Does it pass every fixture but **barely fire on a real corpus** — and the missed
+   commands are **multiline / newline-separated** (as opposed to #10's single-line
+   `cd ~/x && …` with an unexpanded `~`)? → newline-blind segmentation (#11): the
+   tokenizer drops the newline in real multiline commands, so the head is `cd`. Also
+   suspect the replay/mutation **harness** itself — make it report "dirty" on a
+   known-positive before trusting its "clean".


### PR DESCRIPTION
## 背景

folding 今天修 `compounding-edit-review` Stop hook 时踩的一个坑进 skill：为检测 `git push`，用 `shlex(whitespace_split)` 分段会把**换行当空白吃掉**，多行 `cd\n git add\n git push`（真实语料里 git 命令的主干形态）合成一段、段首是 `cd`、`git push` 看不见——**合成 fixture 全过、真实语料触发率却是 0**。这是 `合成 fixture 全绿 ≠ 正确` 在 hook 场景的具体化。

## 改动

- **新增 pitfall #11**「Newline-blind segmentation misses the multiline command」
- **#2 加 caveat**：`whitespace_split=True` 也吞换行，指向 #11
- **meta-item 9**：加「多行/换行 vs #10 的单行未展开 `~`」判别
- **suite 版本 1.24.0 → 1.24.1**

## 三轮独立审阅打磨（每轮都命中真问题）

1. 首版给的「修复」是一段式 quote-blind 正则 `re.split(r"[\n;]|&&|...", cmd)`——审阅逮到它 **re-introduce pitfall #2**（引号里的 `|`/`&&` 被误切、造假 push 段）。**这个错正则我上线的 hook 里也用了**，`git commit -m "… && git push"` 会误触发——已一并修复（另仓 private）。改为两段式（先按换行文本切、再逐行 shlex 认引号）。
2. 第二轮：两段式**仍有残留**——换行在引号/heredoc 体**内部**时 `cmd.split("\n")` 还是会切碎。已如实标注「less exposed, not #2-proof」+ fail-open/fail-closed 各自的处置。
3. 第三轮收口：`-m` 多行 message 因引号不配对 raise、方向依赖 except 处理，非干净 witness——co-example 收敛到 heredoc。

## 闸门

- `check_marketplace.py` ✅ 58 plugins，source/name 全解析
- `check_shell_syntax.sh` ✅ 46 脚本
- PII Guard ✅ clean（public 仓已扫，示例全用 `cd /repo` 占位、无真实项目名/路径）

🤖 Generated with [Claude Code](https://claude.com/claude-code)