### PR TITLE
fix(transcript-fixer): repair cross-references broken by the ladder renumber

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -204,7 +204,7 @@
       "description": "Audio processing suite covering the full speech pipeline: ASR transcription (Qwen3, StepFun) with batch-mode guards against music-only repetition-loop hallucinations, speaker diarization and CAM++ voiceprint identification for multi-speaker recordings, transcript error correction, structured meeting minutes generation, and TTS voice synthesis (StepFun). Install once for the complete audio workflow.",
       "source": "./daymade-audio",
       "strict": false,
-      "version": "1.13.0",
+      "version": "1.13.1",
       "category": "suite",
       "keywords": [
         "suite",

--- a/daymade-audio/transcript-fixer/SKILL.md
+++ b/daymade-audio/transcript-fixer/SKILL.md
@@ -125,7 +125,7 @@ After native AI correction, review all applied fixes and decide which to save. U
 |-------------|---------|--------|
 | Non-word → correct term | 克劳锐→Claude, cloucode→Claude Code | ✅ Add (zero false positive risk) |
 | Rare word → correct term | 拉行链→LangChain, 哈金费斯→Hugging Face | ✅ Add (verify it's not a real word first) |
-| Person/company name ASR error | 卡帕西→Karpathy, Anthropics→Anthropic | For **important recurring people**, add to your **people roster** instead (see "People Roster" above) — it carries relationship context and survives DB resets. For one-off names: ✅ `--add --domain` (stable, unique) |
+| Person/company name ASR error | 卡帕西→Karpathy, Anthropics→Anthropic | For **important recurring people**, add to your **people roster** instead (see "People Roster" below) — it carries relationship context and survives DB resets. For one-off names: ✅ `--add --domain` (stable, unique) |
 | Common word → context word | 争→蒸, 减→剪, affect→effect | ❌ Never add as a rule — record the trap + its disambiguating cue in the domain's context file instead (see "Domain Correction Contexts") |
 | Real brand → different brand | Xcode→Claude Code, Clover→Claude | ❌ Skip (real words in other contexts) |
 | Real name → different real name | 张亮→肖亮 (two real people in different projects) | ❌ Never a rule — same hazard as real brand → brand, but it corrupts a real person's name. Domain context trap with a disambiguating cue instead (see the user-verdict refinements in Native AI Correction step 4) |
@@ -286,7 +286,7 @@ at Stage 1 time when `people_roster_path` is set in
 After this, every `--stage 1` run automatically merges roster corrections
 (in-memory only — never written to DB). The DB always wins on conflicts, so the
 roster fills gaps without overriding hand-tuned entries. See
-`core/people_roster.py` for the parser.
+`scripts/core/people_roster.py` for the parser.
 
 **When to use the roster vs `--add` to DB:**
 
@@ -344,33 +344,39 @@ A recording can be long but still fast-tier (two known speakers, plain language)
 3. **Load the domain's priors, then read the entire transcript.** If `~/.transcript-fixer/contexts/<domain>.md` exists for this transcript's domain, read it first — it primes which homophone traps to suspect and names the authoritative sources for step 4's ladder (see "Domain Correction Contexts" above). Then read the **entire** transcript before proposing corrections — later context disambiguates earlier errors (a name garbled near the start often becomes obvious later). For large files, read in chunks but finish the whole thing before deciding anything
 4. **Triage each candidate error into one of three buckets** — this triage is the part that takes judgment. **First override two reflexes that repeatedly misfile names** (both are real, recurring failures — they send a fixable name straight to "ask the user"):
    - **Judge ASR errors by SOUND, not by glyphs.** Chinese ASR errors are homophone / near-homophone substitutions, so decide "same entity?" by pronunciation, not by whether the characters match exactly. A name that comes through as `X小Y` when the roster or dictionary already holds `X晓Y` (小/晓 are the same sound) is the **same person → Confident fix** — do NOT downgrade it to Uncertain just because 小≠晓 on the page. Same logic for a foreign name whose syllables all map by sound to a near-homophone transliteration. The dictionary having a sound-alike canonical is *evidence for* the fix, not a mismatch to be dismissed.
-   - **A name you can't place defaults to the search ladder below, NOT to asking the user.** "Only the user knows this name" is the single most common wrong reflex. The canonical spelling is almost always already on this machine under a **different project's domain** — so you must query **all** domains at once (step 4.1's cross-domain SQL), not the one domain you happened to pass to `--stage 1`, which may be brand-new and empty. Querying only that one and giving up looks exactly like "I checked" while finding nothing that was right there.
+   - **A name you can't place defaults to the search ladder below, NOT to asking the user.** "Only the user knows this name" is the single most common wrong reflex. The canonical spelling is almost always already on this machine under a **different project's domain** — so you must query **all** domains at once (the cross-domain SQL in the ladder below), not the one domain you happened to pass to `--stage 1`, which may be brand-new and empty. Querying only that one and giving up looks exactly like "I checked" while finding nothing that was right there.
    - **Confident fix** — non-words, obvious garbling, product-name variants you already recognize, or a homophone that's unambiguous in context (`their`→`there` where context forces it; `彭波`→`彭博` when every other mention already reads `彭博`). Apply directly (step 5).
    - **Needs verification** — a proper noun you can't confirm from context: a person / company / ticker / product / place name (a misheard drug name in a medical interview, a researcher's surname in a podcast, a ticker on an earnings call), or any term you can't point to a specific source for — even one you think you recognize ("I'm pretty sure" is exactly how wrong names slip in). **Resolve it through a local-first search ladder before asking the user.** For project / personal entities the authoritative spelling almost always already lives on this machine, and WebSearch is near-useless on internal names — it returns wrong same-name people, or nothing — and worse, a fluent wrong guess becomes a confident fix that's hard to catch later. Search in this order:
 
 
-      0. **The transcript's OWN speaker labels — check these before you search
-         anything.** A diarized transcript already carries names: the speaker
-         label on each block. When a label is a **real name** (not `说话人 N` /
-         `Speaker N`), someone put it there deliberately — most often the user,
-         labeling the voices on the minute page by hand — which makes it a
-         **human identification, the single strongest source in this whole
-         ladder**, above the roster, above any document. So when the body text
-         garbles a name that the label spells out (the body shatters one person
-         into three different homophone spellings; the label prints it once,
-         correctly, above every block she speaks), the label **is** the answer: apply it as a
-         Confident fix and stop. Do not run the rest of the ladder, and above
-         all **do not put that name on the needs-checking list and ask the user
-         for it** — they already answered by labeling it, and asking again reads
-         as not having looked. (2026-07-23: did exactly this — ran roster / DB /
-         PKM / qcc / chatlog on a name that was printed at the top of every one
-         of that speaker's blocks, then asked the user to confirm it.)
-         The existing rule "never infer speaker identity, never revert a manual
-         label" is about protecting labels as *output*; this step is its other
-         half — labels are also authoritative *input*. Only when the label
-         itself is `说话人 N`, or the garbled name belongs to someone who is
-         **not** one of the speakers (a third party mentioned in passing), does
-         the search below apply.
+      0. **The transcript's OWN speaker labels — read them before you search
+         anything.** A diarized transcript already carries its speakers' names:
+         the label above each block. When the body garbles a name that a label
+         spells out — the body shatters one speaker into three homophone
+         spellings, the label prints it once, identically, above every block
+         that speaker says — **the label wins.** Not because labels are
+         magically accurate, but because of where each string came from: a
+         label is copied from a name *registry* (a human annotating the
+         recording, or the attendee list / voiceprint enrollment the diarizer
+         matched against), while the body is raw ASR of a spoken sound. Apply
+         the label as a Confident fix and stop; do not walk the rest of the
+         ladder hunting for a name already printed on screen. **This step costs
+         one glance, so it runs in every tier including fast.**
+         **When the labels were annotated by hand, they are a human
+         identification — outranking every source below, including the roster.
+         Do not put such a name on the needs-checking list and do not ask the
+         user to confirm it: they answered it by labeling it, and asking again
+         reads as not having looked.** (Real case: ran the entire ladder —
+         local dictionaries, project documents, a company registry, a chat
+         archive — on a name printed at the top of every one of that speaker's
+         blocks, found nothing, then asked the user to confirm it. They had
+         labeled it themselves.)
+         This corrects the **body text** to match the label; it never edits the
+         label, and never reassigns who said what. Fall through to the search
+         below when the label is `说话人 N` / `Speaker N`, when the garbled name
+         belongs to someone who is not one of the speakers (a third party
+         mentioned in passing), or when a label is itself visibly ASR-garbled —
+         an auto-assigned label is only as good as the roster it matched.
       1. **People roster** — `people.md` (or wherever `people_roster_path` in
          `~/.transcript-fixer/config.json` points). This is your curated SSOT
          of long-term recurring people with their ASR variants annotated under
@@ -381,7 +387,7 @@ A recording can be long but still fast-tier (two known speakers, plain language)
          transcripts whose speakers are confirmed NOT in the roster.
       2. **All domains of `corrections.db`, not just the current `--domain`.** The same entity shatters into different ASR variants across projects, and every prior fix already collapsed them to the canonical name — so the answer is often sitting in another domain you didn't pass to `--stage 1`. Checking only the current domain and giving up is the recurring failure mode.
          `sqlite3 ~/.transcript-fixer/corrections.db "SELECT from_text, to_text, domain FROM active_corrections WHERE to_text LIKE '%<fragment>%' OR from_text LIKE '%<fragment>%';"`
-      3. **Project delivery docs & the alias ledger** — cost reports, review sheets, deliverables, PKM notes for that project. These are human-written correct spellings, the strongest possible source. `grep -rl "<fragment>" <project-dir>` then read the hits. (The domain context file from step 3 usually names the project's alias ledger explicitly — start there.) **Read every name table the ledger holds, not just the one that looks like "the speaker list."** A project's people are almost always split across role-based tables — internal speakers, external collaborators, client-side, vendor/dealer-side, attendees — and the person you're chasing often lives in a sibling table you didn't open. If a name you end up confirming wasn't reachable from the context file's name-source manifest, that manifest is incomplete: add the missing table to it so the next run can't miss it. (See `domain_context_guide.md` Rule 6 for the failure case this prevents.)
+      3. **Project delivery docs & the alias ledger** — cost reports, review sheets, deliverables, PKM notes for that project. These are human-written correct spellings, the strongest possible source. `grep -rl "<fragment>" <project-dir>` then read the hits. (The domain context file you loaded before triage usually names the project's alias ledger explicitly — start there.) **Read every name table the ledger holds, not just the one that looks like "the speaker list."** A project's people are almost always split across role-based tables — internal speakers, external collaborators, client-side, vendor/dealer-side, attendees — and the person you're chasing often lives in a sibling table you didn't open. If a name you end up confirming wasn't reachable from the context file's name-source manifest, that manifest is incomplete: add the missing table to it so the next run can't miss it. (See `domain_context_guide.md` Rule 6 for the failure case this prevents.)
       4. **Memory** (`~/.claude/.../memory/`) — project relationship maps and person profiles often record canonical names explicitly.
       5. **WebSearch** — only for genuinely public entities (a public-company ticker, a known researcher, a drug name). Skip for anything project-internal.
 
@@ -407,7 +413,7 @@ A recording can be long but still fast-tier (two known speakers, plain language)
    - **Reject — evidence-free reconstruction.** A proposed fix with no phonetic basis (`半`→`分`) is a guess about meaning, not a correction.
    - **Minimal edit.** Fix the misrecognized word; never insert unspoken words (`打完`→`打算` ✓; rewriting as `打算怎么` inserts a `怎么` the speaker never uttered ✗).
    A second-pass subagent that returns 8 sharp rows beats one that returns 8000 tokens of narration every time. Task works when you're in the main context; if it isn't available — e.g. these instructions are themselves running inside a subagent, which can't spawn another — just do one more thorough independent re-read yourself. Never skip the second pass over a missing tool.
-7. **Emit a needs-checking list AND enqueue it** — the chat summary alone evaporates when the session ends, so every *Uncertain* item gets dual-written: (a) in your chat summary to the human — line number, the original text you left in place, what you suspect, why you couldn't confirm it; (b) into the persistent review queue via `--enqueue-review items.json` (see "Review Queue & Dashboard" below; item field/alias schema: `references/script_parameters.md` §Review Queue Item Schema — unknown keys are silently dropped, so write `line`, not `line_hint`) with the same fields plus a proposed action pack, so the human can one-keystroke-resolve it later in the dashboard — or a later agent session can close it with new evidence (`--resolve-review ID --decision … --note "<evidence>"`). Entity/name questions get `kind: entity` (they compound into the dictionary/roster, so they lead the queue); pure phrasing doubts get `kind: wording`. If nothing is uncertain, say so.
+7. **Emit a needs-checking list AND enqueue it** — the chat summary alone evaporates when the session ends, so every *Uncertain* item gets dual-written: (a) in your chat summary to the human — line number, the original text you left in place, what you suspect, why you couldn't confirm it; (b) into the persistent review queue via `--enqueue-review items.json` (see "Review Queue & Dashboard" above; item field/alias schema: `references/script_parameters.md` §Review Queue Item Schema — unknown keys are silently dropped, so write `line`, not `line_hint`) with the same fields plus a proposed action pack, so the human can one-keystroke-resolve it later in the dashboard — or a later agent session can close it with new evidence (`--resolve-review ID --decision … --note "<evidence>"`). Entity/name questions get `kind: entity` (they compound into the dictionary/roster, so they lead the queue); pure phrasing doubts get `kind: wording`. If nothing is uncertain, say so.
 8. Verify with diff against the file you actually edited (`diff <original> <your-working-file>`) — every change should trace back to a triage decision
 9. Finalize and archive:
    - **Primary path (recommended):** Re-run `--stage 1` on the original `file.md` — **plain, without `--apply-all`** (an explicit `--apply-all` always runs corrections and never finalizes, so a stale sidecar can't silently swallow the run). If `file_stage1.md` is newer than `file.md`, transcript-fixer automatically promotes it to `file.md` and removes the intermediate sidecars (`_stage1.md`, `_stage2.md`, `_dryrun.md`, `_changes.md`, `_needs_review.md`, `_uncertain.md`, `_对比.html`). This is the default way to finalize; it is atomic, preserves manual edits (it skips promotion when `file.md` is newer), and avoids macOS `mv` alias hazards.
@@ -425,7 +431,7 @@ A recording can be long but still fast-tier (two known speakers, plain language)
    - Keep or move the original `.txt` to the archive if you want it; otherwise delete it.
    - Re-grep the final file for a correction you know you applied to confirm the corrected version landed.
 10. **Filename hygiene — rename machine-generated gibberish before archiving.** A transcript whose filename is a raw ASR artifact, device tag, or opaque timestamp hash (`TX02_MIC021_20260720_095909_1.3x.md`, `soundcore Work_01-01 10-36.md`, `07-12-2026 20.07.md`) is not a useful artifact. Rename it to a human-readable form before the file enters a shared repo: `YYYY-MM-DD-HH-MM-<topic-or-speaker-summary>.md`, using Chinese or short English as appropriate to the project. The bar: a human should be able to identify the meeting from the filename alone. If the content clearly belongs to one business line, also encode that in the slug when the repo convention allows it.
-11. Save stable patterns to the dictionary (see "Dictionary Addition" below)
+11. Save stable patterns to the dictionary (see "Dictionary Addition" above)
 12. Strip any remaining Stage 1 false positives from the final file before archiving
 
 ### Common ASR Error Patterns


### PR DESCRIPTION
Follow-up to #205. An independent read-only review of that change found two defects it introduced and two claims it could not support, plus some pre-existing stale references in the same file.

## Introduced by #205

- **`step 4.1's cross-domain SQL` now points at the wrong item.** #205 inserted a new step 0 and renumbered the ladder, turning item 1 from the cross-domain SQL into the people roster — so this reference silently began pointing at the roster. Now referenced by name, which a future renumber cannot break.
- **`The domain context file from step 3` became a self-reference.** After the renumber this sentence sits *inside* ladder item 3, so "step 3" reads as the item containing it rather than the outer workflow's step 3. Referenced by description instead of number.

## Claims step 0 could not support

- It asserted that a real-name label means "someone put it there deliberately — most often the user". Diarizers also auto-assign names from attendee lists and voiceprint enrollment, and those can be wrong or themselves garbled. The rule still holds, but for a different reason: a label is copied from a name *registry*, while the body is raw ASR of a spoken sound. Rewritten on that basis, with an explicit fall-through when a label is itself visibly garbled.
- It cited "the existing rule 'never infer speaker identity, never revert a manual label'", which appears nowhere in this bundle. Restated self-containedly: this step corrects the body to match the label, and never edits the label or reassigns who said what.
- Fast tier says "skip the ladder", while step 0 forbids asking the user — together they left an unplaceable name with no legal disposition. Step 0 now states it runs in every tier (it costs one glance).
- Removed environment-specific jargon from the war story so an outside reader can follow it.

## Same-file bounded cleanup (pre-existing, verified)

- `"People Roster" above` → below (that section is 134 lines further down)
- `"Review Queue & Dashboard" below` → above (270 lines up)
- `"Dictionary Addition" below` → above
- `core/people_roster.py` → `scripts/core/people_roster.py` (actual path; every other script reference in the file carries the prefix)

## Verification

- `check_marketplace.sh` → PASSED; `check_doc_skill_lists.py` → in sync; `security_scan` → passed
- Every reference change re-read against the file after applying; `step 4.1` and the bare `core/` path are gone
- `daymade-audio` 1.13.0 → 1.13.1 (fixes = PATCH)

The review also raised substantive issues in sections this PR does not touch (a finalize path whose "recommended" label sits on the branch that never fires in default mode, an ordering problem across steps 9/10/12, a `--json` contract stated twice with different field counts, and an undocumented `--stage` default of 3). Those are left for a separate change rather than mixed into a cross-reference fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QsBbMU9HFoGMJAy6NsxfUp