### PR TITLE
fix(transcript-fixer): actually add the role test #207 claimed to add

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -204,7 +204,7 @@
       "description": "Audio processing suite covering the full speech pipeline: ASR transcription (Qwen3, StepFun) with batch-mode guards against music-only repetition-loop hallucinations, speaker diarization and CAM++ voiceprint identification for multi-speaker recordings, transcript error correction, structured meeting minutes generation, and TTS voice synthesis (StepFun). Install once for the complete audio workflow.",
       "source": "./daymade-audio",
       "strict": false,
-      "version": "1.14.0",
+      "version": "1.14.1",
       "category": "suite",
       "keywords": [
         "suite",

--- a/daymade-audio/transcript-fixer/.security-scan-passed
+++ b/daymade-audio/transcript-fixer/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-07-23T14:15:18.062835+00:00
+Scanned at: 2026-07-23T14:18:08.603242+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: d900329296225f0374c23f2e899300c4f56f5231c2cd93a4da5f9af120abc861
+Content hash: f2a6de10d39f684663d05942297f1234566f5baed44b241487c97ba0a70f6726

--- a/daymade-audio/transcript-fixer/SKILL.md
+++ b/daymade-audio/transcript-fixer/SKILL.md
@@ -349,14 +349,23 @@ A recording can be long but still fast-tier (two known speakers, plain language)
      person, and the label carries the spelling — a label is copied from a name
      *registry* (a human annotating the recording, or the attendee list /
      voiceprint enrollment a diarizer matched against), while the body is raw
-     ASR of a spoken sound. Three things decide how far that gets you.
-     **(a) Match against ALL labels, not the one above the block** — people
-     rarely say their own name, so a garbled name usually sits in a block
-     spoken by someone else (`A` greeting `B`). **(b) The label settles WHO;
-     the roster still settles the canonical spelling** — a hand-typed `Joe`
-     normalizes to the roster's `Jo`. **(c) Labels annotated by a human are a
-     human identification: apply them, and do NOT put that name on the
-     needs-checking list or ask the user to confirm it — they answered it by
+     ASR of a spoken sound. Four qualifiers, and the first one is not optional.
+     **(a) Apply it only to a name being ADDRESSED or SELF-INTRODUCED, never one
+     being REFERRED TO.** "hi, <token>" and "my name is <token>" identify a
+     speaker; "I'll ask <token> from the bank" identifies a third party who may
+     merely *sound* like one — and rewriting them to a speaker's name corrupts a
+     real person, the exact hazard the dictionary table calls "Real name →
+     different real name ❌ Never a rule". Two acoustically identical tokens in
+     one file can need opposite answers for this reason alone, so a referred-to
+     name keeps walking the ladder rather than resolving here.
+     **(b) Match against ALL labels — including, but not limited to, the one
+     above the block** — a garbled name usually sits in a block spoken by
+     someone else (`A` greeting `B`), and sometimes in that speaker's own block
+     (a self-introduction). **(c) The label settles WHO; the roster still
+     settles the canonical spelling** — a hand-typed `Joe` normalizes to the
+     roster's `Jo`, spelling only, never length. **(d) Labels annotated by a
+     human are a human identification: apply them, and do NOT put that name on
+     the needs-checking list or ask the user to confirm it — they answered it by
      labeling it.** (Real case: walked the whole ladder on a name printed above
      every one of that speaker's blocks, found nothing, then asked the user to
      confirm it. They had labeled it themselves.)


### PR DESCRIPTION
**Correcting the record: #207 did not do what its description says.**

#207 was opened to fix a rule that renames a real third party. Its body and commit message describe a discriminator between a name being *addressed* and a name being *referred to*, as the rule's new first clause. **That edit was never applied.** The branch was committed carrying the pre-review text, the gates all passed (they check structure, not claims), and the failure shipped:

```
body:   "I'll ask Ellice from the bank to send it"
labels: Alice, Bob
→ `Ellice` matches speaker `Alice` by sound → rewritten to `Alice`
→ `--add`ed to a domain dictionary, permanently
```

Caught by grepping main for the strings the merge was supposed to have added — two of three returned 0.

## What this PR actually changes

- **(a) the role test**, for real: apply the label match only to a name being ADDRESSED (`"hi, X"`) or SELF-INTRODUCED (`"my name is X"`), never one being REFERRED TO (`"I'll ask X from the bank"`). Two acoustically identical tokens in one file can require opposite answers, which is exactly why a sound match alone cannot license the fix. A referred-to name keeps walking the ladder.
- **(b)** `"Match against ALL labels, not the one above the block"` → `"including, but not limited to"`. As written it read as *excluding* that label, under which a self-introduction has no candidate at all and falls through.
- **(c)** roster canonicalization narrowed to *spelling, never length*, so it cannot collide with the minimal-edit rule.

## Verification

- Regression gate against git-ref `cc6561e`: **0 candidates** (pure addition, nothing removed); `verify` passed.
- `quick_validate` valid · `check_marketplace.sh` PASSED · `security_scan` passed.
- Each added string grepped back out of the file after writing — the check that would have caught #207.
- `daymade-audio` 1.14.0 → 1.14.1.

Everything else in #207 (provenance default, unobservable-provenance handling, role labels in the fall-through list, ladder renumbering, structural move) **did** land and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QsBbMU9HFoGMJAy6NsxfUp