### PR TITLE
feat(claude-code-hooks): where a guard's judgement comes from (rule 6, pitfalls 12-15)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -103,7 +103,7 @@
       "description": "Claude Code operations suite that bundles archive-aware local conversation discovery across Claude Code and Codex, internal-timestamp full-event session search and recovery, interrupted-work continuation, plugin/skill troubleshooting, CLAUDE.md progressive disclosure optimization, statusline configuration, exported .txt repair, full claude.ai conversation extraction with tool-call rendering and file download, plugin marketplace development, writing/testing/debugging Claude Code hooks, multi-provider profile isolation for running Kimi/GLM/DeepSeek/StepFun/Anthropic in separate windows, local source sync for Claude/Codex skill installs, personal-memory migration into tool-agnostic AGENTS.md reference docs, and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
       "source": "./daymade-claude-code",
       "strict": false,
-      "version": "1.24.1",
+      "version": "1.25.0",
       "category": "suite",
       "keywords": [
         "suite",

--- a/daymade-claude-code/claude-code-hooks/.security-scan-passed
+++ b/daymade-claude-code/claude-code-hooks/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-07-22T15:34:38.586788+00:00
+Scanned at: 2026-07-23T15:03:50.983249+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: fa4bee814c77eb0146eb7947c41b60147cef2612e1656e42c63407e6fdb8d022
+Content hash: 932afd1c7ffde24bdd3199cca37d4184a2e33d4f03d7bf0a7b2d72620b5dcf32

--- a/daymade-claude-code/claude-code-hooks/SKILL.md
+++ b/daymade-claude-code/claude-code-hooks/SKILL.md
@@ -104,7 +104,7 @@ fi
 exit 0
 ```
 
-## Five rules that separate a working guard from a session-poisoning one
+## Six rules that separate a working guard from a session-poisoning one
 
 Not style preferences — each is a specific failure we shipped and traced back.
 
@@ -268,6 +268,34 @@ handed it a literal `~/repo`, `git -C` failed, staged came back empty, and the g
 concluded "no cross-domain files, allow." Every cross-repo commit went unguarded and
 nothing ever looked wrong. Anatomy + the shared-library twist: pitfall #10.
 
+### 6. Judge on a fact the world can answer — never on your own rendering, never on a naming habit
+
+Rules 1 and 5 are about *how* you match and *which way* you fail. This one is
+about **where the thing you match on came from**, and it has two failure shapes
+that both go silent:
+
+- **Never branch on a string you formatted for a human.** If the hook builds a
+  report — sorted, joined, truncated to the first N with a `(+M more)` tail — and
+  then pattern-matches its own decision against that report, the branch inherits
+  the rendering's losses. Items past the cutoff simply do not exist to it, so the
+  branch works on every small fixture and stops firing on exactly the large
+  sessions it was built for. Emit the machine fact on its own channel (one
+  untruncated `KINDS:a,b,c` line) and match *that*. A rendering is an output, not
+  a data source (pitfall #12).
+- **Prefer a checkable fact over a naming convention.** Classifying by path shape
+  (`/skills?/[^/]+/references/`) encodes one directory layout; a repo laid out any
+  other way is classified `None` — silently, forever. The fix is *not* to widen the
+  pattern, which trades a silent miss for machine-wide false positives (rule 1
+  forbids exactly that trade); it is to ask a question the filesystem can answer —
+  *is there a `SKILL.md` beside this `references/` directory?* Facts survive
+  layout changes; conventions do not. (When the candidate **is** a `SKILL.md`,
+  there is no sibling to ask about — classify by basename; #13 explains why that
+  is a spec-defined fact and not the naming habit this rule warns against.)
+
+The tell for both: a branch that has never once fired in production while its
+tests are green. Print the raw pre-formatting classification and you will see
+which of the two you have.
+
 ## Build order (in sequence)
 
 1. **Confirm it's a real recurrence**, not hypothetical — else don't build it.
@@ -289,7 +317,10 @@ everything), awk-split false-blocks (rule 1), corrupted hook poisoning the sessi
 form from Pattern E instead), static env escape hatch (rule 4), multi-profile
 under-registration, and a path parsed from command text keeping its literal `~` so
 the guard fails **open** with no symptom at all (#10 — the one you cannot wait to
-notice, because silence is its only sign).
+notice, because silence is its only sign), a branch reading the hook's own
+truncated display string (#12) or keyed on a naming convention this repo doesn't
+follow (#13) — both invisible while the suite asserts only exit codes (#14) — and
+command text that merely *contains* a redirect counted as a write (#15).
 
 **The harness is the hidden variable — use `scripts/test_hook.sh`, don't hand-roll
 one.** Every hand-rolled failure mode below produces the *same* output as a clean
@@ -308,8 +339,26 @@ hook's whitelist):
    — and the baseline row happened to use one of those). The one row meant to prove
    the guard still bites didn't bite, and the whole suite read green.
 
+**And if the hook's product is its message, exit codes cannot test it.** A
+blocking hook's contract is mostly its exit code, so `run` rows cover it. But a
+hook that exists to *say* something — a PreToolUse explanation of the correct
+alternative, a Stop reminder — has a second output channel the codes never see:
+break the wording, invert a conditional paragraph, let a heredoc swallow a
+section, and the exit code stays exactly 2 while every row passes. Add
+`says <label> <event> <pattern> <yes|no>` rows from `scripts/test_hook.sh`,
+asserting **both polarities across two fixtures** (present for the input it
+targets, absent for the lookalike it skips) — a lone `want=no` passes vacuously
+when the hook prints nothing at all, so it only means something beside a
+`want=yes` row proving the hook speaks. Match **fixed strings**, not regexes: the
+phrases worth asserting often contain brackets, and as a BRE `[skill]` is a
+character class matching any text with an s, k, i or l in it. Then **mutate to prove the rows can die**: copy the hook, inject
+the exact bug each row claims to catch, and confirm that row goes red. A green
+suite carries zero information until you have watched it fail for the right
+reason — two real bugs once survived a fully green 24-case suite because every
+row looked only at exit codes (pitfall #14).
+
 The common shape: **all-cases-agree is a smell, not a green light.** `test_hook.sh`
-catches #1 and #2 structurally — it asserts an explicit `expected-exit` per row
+catches shapes 1 and 2 above structurally — it asserts an explicit `expected-exit` per `run` row
 (not "did it print something") and forces trigger rows alongside healthy-lookalike
 ones, so a trigger row that returns 0 fails loudly instead of blending in. It
 **cannot** catch #3: whether a row's content accidentally lands in an exemption is a

--- a/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
+++ b/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
@@ -334,6 +334,144 @@ unresolvable path means **block**.
 
 ---
 
+## 12. The decision reads the string built for humans — and that string is lossy
+
+- **Symptom:** a conditional branch inside the hook works in every test and
+  silently stops firing in production. Nothing errors; the branch just never
+  matches, so a whole paragraph of guidance (or a whole check) disappears for
+  exactly the sessions that needed it most.
+- **Cause:** the hook computed a **display string** first — sorted, joined,
+  truncated to the first N with a `(+M more)` tail — and then pattern-matched
+  its own decision against that string. Truncation is lossy by design, so any
+  item past the cutoff is invisible to the branch. The tests never showed it
+  because a fixture has two or three items and a real session has ten.
+  Real case (2026-07-23): a Stop hook reported `path [kind], path [kind], … (+N
+  more)` and then did `case "$REPORT" in *"[skill]"*)`. A session that touched six
+  artifacts with the skill sorting sixth dropped the `[skill]` tag out of the
+  rendered list, and the skill-specific guidance vanished — in a hook whose entire
+  target population is large multi-artifact sessions.
+- **Fix:** emit the machine-readable fact on its own channel, never re-derive it
+  from the rendering. One extra line is enough — a `KINDS:a,b,c` header line that
+  is never truncated, with the human list below it, and the branch matches the
+  header. General form: **a rendering is an output, not a data source.** If you
+  find yourself grepping something your own code formatted for a reader, you have
+  a second, undeclared parser of your own display format — and it will drift the
+  moment you change how things look.
+- **Test that pins it:** a fixture with **more items than the display cutoff**,
+  where the item the branch cares about sorts *after* the cutoff. Without that
+  row the bug is invisible; with it, reverting to the display-string match fails
+  loudly.
+
+---
+
+## 13. Classification keyed on a naming convention the real layout doesn't follow
+
+- **Symptom:** a whole category of input is never detected. Not misdetected —
+  *absent*. The hook reports nothing for it, which is indistinguishable from
+  "there was nothing to report."
+- **Cause:** the classifier matched a path shape (`/skills?/[^/]+/(references|scripts|assets)/`)
+  that encodes one directory convention. Real repositories use others. Real case:
+  a marketplace repo lays skills out as `claude-code-skills/<suite>/<skill>/references/…`
+  — not one path segment equals `skills`, so every edit to a skill's reference or
+  script files was classified `None`. The pattern had been in the table for
+  months, tested only against `~/.claude/skills/<name>/…`, which does match.
+- **Fix — do NOT just widen the regex.** Widening to `/[^/]+/(references|scripts|assets)/`
+  makes every repository on the machine with a `scripts/` directory match, trading a
+  silent miss for pervasive false positives — the trade rule 1 explicitly forbids
+  (误杀健康输入比漏报更糟). Key the decision on a **verifiable fact** instead: *is
+  there a `SKILL.md` next to this `references/` directory?* One `os.path.exists`
+  against the filesystem is layout-independent, cannot fire on an unrelated
+  project, and stays correct when someone invents a new directory convention
+  tomorrow. Wrap it so an `OSError` falls to the safe direction (rule 5).
+- **When the candidate IS the anchor.** The question above is "is there a
+  `SKILL.md` beside this `references/` directory", which has no answer for a path
+  that *is* `…/myskill/SKILL.md`. Classify that one by basename — and note why
+  that is not the naming-habit trap this entry warns about: `SKILL.md` is a name
+  the platform's spec defines and the loader actually keys on, whereas
+  `/skills?/` was a habit of one directory layout. The test is whether something
+  outside your head enforces the name.
+- **The general rule:** when a hook classifies a resource, prefer a check the
+  world can answer (does this file exist, what does the API return, what is the
+  actual git ref) over a check that only your naming habit can answer. Conventions
+  are per-repo and per-era; facts are not. Reach for a name pattern only when
+  there is no fact to query — and then say so in a comment, so the next reader
+  knows it is a heuristic standing in for evidence.
+
+---
+
+## 14. The self-test asserts exit codes — but this hook's product is its text
+
+- **Symptom:** the suite is green, the hook exits with the right codes on every
+  row, and the message it prints is wrong, missing a paragraph, or emitting a
+  section that should have been conditional. Nobody notices until a human reads
+  the output.
+- **Cause:** for a **blocking** hook the exit code *is* most of the contract, so
+  exit-code assertions cover it. But a hook whose real product is the **stderr
+  guidance** — a PreToolUse message explaining the correct alternative, a Stop
+  reminder telling the model what to do next — has a second output channel that
+  exit codes cannot see. Break the message body, invert the condition on an
+  optional paragraph, let a heredoc swallow a section: the exit code stays
+  exactly 2, and every row still passes. The suite is structurally blind to the
+  only thing that hook produces.
+- **Fix:** add content assertions alongside the exit-code rows. Use the `says`
+  helper shipped in [scripts/test_hook.sh](../scripts/test_hook.sh) rather than
+  re-typing one here — a copy in prose drifts from the one people actually run
+  (this entry shipped with a copy that had no pass/fail counters, so a failing
+  content row printed FAIL and the suite still ended "ALL PASS"). It captures
+  stderr, matches a **fixed string** (a BRE `[skill]` is a character class, so
+  bracket-tagged output makes the row vacuously true), and counts into the same
+  gate as the exit-code rows. Assert **both polarities across two fixtures**:
+  present for the input it targets, absent for the lookalike it skips — a lone
+  `want=no` passes vacuously when the hook prints nothing at all.
+- **Then prove the assertions are not vacuous — mutate and confirm they die.**
+  A passing suite carries **zero information** until you have seen it fail for
+  the right reason. Copy the hook, inject the specific bug each assertion claims
+  to catch (invert the branch condition, delete the fact-check, revert to the
+  display-string match), and confirm *that* assertion goes red — and ideally only
+  that one. Real case: four separate mutations each killed exactly their intended
+  row; the same suite had previously been green while two real bugs (#12, #13)
+  were live in the file, because no row looked at the text.
+
+---
+
+## 15. Command text that merely *contains* a write, treated as a write
+
+- **Symptom:** a forensic hook (one that scans a transcript or command history to
+  decide what a session touched) reports a file nobody wrote — sometimes a path
+  that is obviously not a path, like `$AD/SKILL.md`.
+- **Cause:** the hook extracts write targets from **command text**, and command
+  text routinely carries *data that looks like commands*: a heredoc body being
+  written into another file, a fixture string inside a `python3 -` script, a
+  snippet of shell being embedded in documentation. The redirect it "found" was
+  never executed in this process — it was cargo.
+- **Cheap filter, and be honest that it under-reports.** Dropping any candidate
+  path that still contains an unexpanded variable or a backtick —
+  ``re.compile(r"[$\x60]")`` against the candidate — kills the common cargo case
+  in one line. But **do not tell yourself this has no false negatives.** Command
+  text is *pre-expansion* (that is #10's whole thesis), so a genuine
+  `cat > "$OUT/file"` with `$OUT` set writes a real file whose path arrives with
+  the `$` still in it — this filter drops that too. You are trading *missing some
+  real writes* for *not inventing fake ones*, which is the right trade for a
+  **fail-open reporter** and the wrong one for anything that blocks. Say which you
+  are in a comment next to the filter.
+- **The same class has a sibling this filter does not cover:** a literal `~`
+  survives it, then silently fails whatever you do with the path afterwards —
+  `cat > ~/skills/x/references/a.md` passes the `$` filter and then makes an
+  `os.path.exists` check (#13) return False for a file that plainly exists. Run
+  `os.path.expanduser` before any filesystem check, exactly as #10 requires.
+- **The deeper case has no cheap fix, and #11 does not solve it either.** A
+  fully-literal path inside a heredoc body needs real heredoc boundary tracking;
+  #11 lists that same residual as *unsolved* on its own axis and points at "parse
+  with a real shell grammar". So for a blocking hook the over-report is a false
+  block and you owe it that parse; for a reporter, accept the noise and say so.
+- **Why it matters beyond noise:** a false entry does not just add a line. If
+  the hook branches on *kind* (#12), one phantom path of the wrong kind switches
+  on guidance the session never needed — the reader is handed a procedure for
+  work they did not do, which is exactly the "误杀" that trains people to stop
+  reading the hook's output.
+
+---
+
 ## Meta-principle: the ordering of these fixes
 
 When a guard is misbehaving, check in this order — cheapest and most common first:
@@ -363,3 +501,15 @@ When a guard is misbehaving, check in this order — cheapest and most common fi
    tokenizer drops the newline in real multiline commands, so the head is `cd`. Also
    suspect the replay/mutation **harness** itself — make it report "dirty" on a
    known-positive before trusting its "clean".
+10. Is one **branch** of the hook — an optional paragraph, a kind-specific check —
+    never firing, while everything else works? → either the branch is reading the
+    hook's own **display string** and the item fell past a truncation (#12), or the
+    **classifier** never produced that kind at all because it keys on a naming
+    convention this repo doesn't follow (#13). Distinguish by printing the raw
+    classification before it is formatted: present-but-truncated is #12,
+    never-classified is #13.
+11. Is the suite **green while the output is visibly wrong**? → the assertions only
+    check exit codes and this hook's product is its text (#14). Add both-polarity
+    content assertions, then mutate to prove they can die.
+12. Does it report a file **nobody wrote** — especially one containing a literal
+    `$VAR`? → it is reading command text as if every redirect in it executed (#15).

--- a/daymade-claude-code/claude-code-hooks/scripts/test_hook.sh
+++ b/daymade-claude-code/claude-code-hooks/scripts/test_hook.sh
@@ -36,6 +36,33 @@ run() {
   else printf 'FAIL exit=%s want=%s [%s]\n' "$e" "$3" "$1"; fail=$((fail+1)); fi
 }
 
+# says <label> <json-event> <grep-pattern> <yes|no>
+#   Asserts on the hook's stderr TEXT, not its exit code. Needed whenever the
+#   hook's real product is its guidance message — a PreToolUse explanation, a Stop
+#   reminder. Break the wording, invert an optional paragraph's condition, let a
+#   heredoc swallow a section: the exit code is unchanged and every `run` row still
+#   passes, so an exit-code-only suite is structurally blind to it (pitfall #14).
+#   Assert BOTH polarities, across two fixtures: the paragraph appears for the
+#   input it targets (want=yes), and is absent for the lookalike it must skip
+#   (want=no). A want=no row alone passes vacuously when the hook prints nothing
+#   at all — so it is only meaningful next to a want=yes row proving the hook
+#   speaks. Do not try to put both polarities on ONE fixture: a healthy input is
+#   supposed to be silent, so it has no want=yes partner — its partner is the
+#   trigger fixture.
+says() {
+  local out hit=no
+  out=$(printf '%s' "$2" | "$HOOK" 2>&1 >/dev/null) || true
+  # -F (fixed string), NOT a regex: the patterns you actually want to assert are
+  # literal phrases, and the most useful ones contain brackets — a hook that tags
+  # `path [skill]` is the motivating case. As a BRE, "[skill]" is a CHARACTER
+  # CLASS: it matches any text containing s, k, i or l, so `says … "[skill]" yes`
+  # is true of almost any English output and the row is decorative. Measured.
+  # Need a real regex? call grep -qE explicitly in a copy of this helper.
+  printf '%s' "$out" | grep -qF -- "$3" && hit=yes
+  if [ "$hit" = "$4" ]; then printf 'PASS text=%s [%s]\n' "$hit" "$1"; pass=$((pass+1))
+  else printf 'FAIL text=%s want=%s [%s]\n' "$hit" "$4" "$1"; fail=$((fail+1)); fi
+}
+
 # ── EXAMPLE TABLE — replace TRIGGER with your banned command ──────────────────
 # Trigger cases (want 2):
 run "execute"        '{"tool_name":"Bash","tool_input":{"command":"TRIGGER -x arg"}}' 2
@@ -60,6 +87,23 @@ run "non-bash-tool"  '{"tool_name":"Read","tool_input":{"file_path":"/x/TRIGGER.
 # run "trigger behind cd ~"  '{"tool_name":"Bash","tool_input":{"command":"cd ~/somewhere && TRIGGER -x"}}' 2
 # run "trigger behind cd abs" '{"tool_name":"Bash","tool_input":{"command":"cd /tmp && TRIGGER -x"}}' 2
 # run "unresolvable path"    '{"tool_name":"Bash","tool_input":{"command":"cd ~/no-such-dir && TRIGGER -x"}}' 2
+#
+# ── CONTENT ROWS — assert the MESSAGE, when the message is the product ────────
+# run rows prove the hook decided correctly; says rows prove it said the right
+# thing. Both polarities on conditional paragraphs (pitfall #14):
+# says "explains alternative" '{"tool_name":"Bash","tool_input":{"command":"TRIGGER x"}}' "USE INSTEAD" yes
+# says "quiet on healthy"     '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}'    "BLOCKED"     no
+#
+# ── PROVE THE SUITE CAN FAIL (mutation) — do this once per assertion you add ──
+# A green suite carries ZERO information until you have watched it go red for the
+# right reason. For each assertion, copy the hook, inject the exact bug that
+# assertion claims to catch, and confirm THAT row dies — ideally only that one:
+#     cp "$HOOK" /tmp/mutant.sh
+#     # invert a branch condition / delete a fact-check / revert to a display-string match
+#     bash test_hook.sh /tmp/mutant.sh     # expect exactly the intended row to FAIL
+# If the mutant still passes, the assertion is decorative — it is testing something
+# other than what its label claims. Two real bugs once lived in a hook through a
+# fully green 24-case suite because every row looked only at exit codes.
 #
 # ── HUMAN-GATE ROWS — if the hook releases via a confirmation dialog / tty YES,
 #    force both channels to decline so the run stays headless, and assert it


### PR DESCRIPTION
Four failures from one session of hardening a real Stop hook, plus the rule they share: **the guard was matching on the wrong thing, and nothing could see it.**

## The four

| # | Failure | Why it stayed invisible |
|---|---|---|
| **12** | The conditional branch matched against the hook's own **display string** — sorted, joined, truncated to five with a `(+N more)` tail. Items past the cutoff did not exist to it. | Fixtures have two items; production has ten. It worked in every test and stopped firing on exactly the large sessions the hook exists for. |
| **13** | The classifier keyed on a **naming convention**: a literal `/skills/` path segment. The marketplace layout (`claude-code-skills/<suite>/<skill>/references/`) has no such segment, so every edit to a skill's references or scripts classified as `None`. | Absent ≠ misdetected. "Nothing to report" and "I cannot see this category" produce identical output. |
| **14** | Both of the above lived through a **fully green 24-case suite**, because every row asserted an exit code — and this hook's product is its stderr text. | Break the message, invert a paragraph's condition, let a heredoc swallow a section: the exit code stays exactly 2. |
| **15** | Command text that merely **contains** a redirect was counted as a write, so a pure hook change was reported as touching a skill. | It handed the reader a procedure for work they never did — the "误杀" that trains people to stop reading the hook's output. |

**Rule 6** in SKILL.md states the shared principle: judge on a fact the world can answer, never on your own rendering and never on a naming habit — and specifically **do not fix #13 by widening the regex**, which trades a silent miss for machine-wide false positives (the trade rule 1 forbids).

The harness gains a **`says` content-assertion helper** and a **mutation-testing step**, because an assertion is decorative until you have watched it go red for the right reason.

## What the independent review caught

Run before shipping, fresh context, anchored on the pre-edit ref `c73df12`, given the artifact + a reader spec and no design rationale. It found **the change's own headline capability broken**:

`says` used `grep -q`, so the bracket-tagged patterns #12 exists to teach — `"[skill]"` — are a **character class** matching any text containing s, k, i or l. `printf 'session list' | grep -q -- "[skill]"` matches. Following the new material would produce a vacuously-true assertion that survives its own mutation test. Reproduced, then switched to `grep -qF`.

It also caught #15 asserting the `$`-filter has "no false negatives worth the name, because a genuinely written path arrives already expanded" — while **#10, two entries above, says command text is pre-expansion**. A real `cat > "$OUT/f"` writes a real file whose path carries a literal `$`. Rewritten as an explicitly accepted under-report, scoped to fail-open reporters and wrong for blockers, with `expanduser` required for the `~` sibling that slips through and then silently fails #13's `exists()`.

Nine further findings (a dangling pointer into #11 for a fix #11 does not contain; a code span broken by an unescapable backtick; a "same fixture" pairing rule the bundle's own example cannot follow; a prose copy of the helper that had drifted from the shipped one at birth) were fixed. Two were accepted and named rather than fixed: the fact-check still *locates* itself by directory names, and `says` captures stderr only, so a PostToolUse hook whose product is a stdout `hookSpecificOutput` gets a vacuous `want=no`. Full table with a disposition and reason each — plus what was not checked — in the workspace review artifact.

## Verification

- Regression gate against git-ref `c73df12`: 4 candidates, all classified `preserved_or_moved` with evidence; `verify` passed.
- `quick_validate` valid · `check_marketplace.sh` PASSED · `check_doc_skill_lists.py` in sync · `security_scan` passed.
- `says` exercised on a throwaway hook: two real assertions pass, one deliberately-wrong assertion fails — proving it is not vacuous.
- `daymade-claude-code` 1.24.1 → 1.25.0.

**Not verified**: the post-review fixes were not re-reviewed by a second fresh agent, and the pitfalls themselves are prose — never tested against an agent actually following them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QsBbMU9HFoGMJAy6NsxfUp