### PR TITLE
docs(transcript-fixer): align #24 narrative across the three #211 artifacts

### DIFF
--- a/daymade-audio/transcript-fixer/references/example_session_dji_minutes.md
+++ b/daymade-audio/transcript-fixer/references/example_session_dji_minutes.md
@@ -51,9 +51,9 @@ Transcript:
 
 ## enqueue 粒度决定 dashboard 裁决质量（#24 战例）
 
-20 条 uncertain 入队 → dashboard 裁决。**事故**：#24 enqueue 的 `original` 拖了整句「我栖云就完了」，用户 override 品牌名「栖云」→ CLI 的 file_edit 把**整句**替换成「栖云」，「就完了」被吞。修法三层：
+20 条 uncertain 入队 → dashboard 裁决。**事故**：#24 enqueue 的 `original` 拖了整句「我们的民宿就完了」，用户 override 品牌名「栖云」→ CLI 的 file_edit 把**整句**替换成「栖云」，上下文被吞。修法三层：
 
-1. **enqueue 粒度**（根因，零成本）：`original` 只放可疑 token（「栖云」对应的误写词），整句放 `context`——SKILL.md step 7 已写明
+1. **enqueue 粒度**（根因，零成本）：`original` 只放 ASR 误写的那个词，整句放 `context`——SKILL.md step 7 已写明
 2. **dashboard UI**（防线）：override 输入框上方恒显「替换范围（整段）：「<original>」」，输入远短于原文时琥珀色警告——已修（app.js `updateOverrideScope`）
 3. **裁决后抽查**：dashboard 批量裁决完，逐行 grep 核验落地 + 抽读关键行语义（本次靠这步发现丢字）
 

--- a/daymade-audio/transcript-fixer/scripts/review-dashboard/static/app.js
+++ b/daymade-audio/transcript-fixer/scripts/review-dashboard/static/app.js
@@ -352,8 +352,8 @@ function showOverride() {
   updateOverrideScope();
 }
 
-/* 整段替换范围明示（2026-07-25 #24 战例：original 拖了整句（约 6 字），
- * 用户 override 一个 3 字品牌名 → 整句被吞。override 的 file_edit 永远把
+/* 整段替换范围明示（2026-07-25 #24 战例：original 拖了整句，
+ * 用户 override 一个短品牌名 → 整句被吞。override 的 file_edit 永远把
  * original_text 整段换成输入值，所以输入框上方必须始终显示范围；短替换
  * （输入 ≤ 原文一半）多半是只想换其中一个词，加警告引导输入完整片段。 */
 function updateOverrideScope() {


### PR DESCRIPTION
Post-merge independent review of #211 caught two narrative defects in the case study (fix-forward, no history rewrite needed):

1. **Logically impossible example**: the #24 illustration sentence 「我栖云就完了」 already contained the *correct* brand — so the uncertain item it was supposed to explain couldn't exist. The pseudonym had replaced the wrong-word token itself. Aligned to the SKILL.md version: `original` = the clause 「我们的民宿就完了」, human types the brand 「栖云」, and the swallowed span is the whole clause.
2. **Three artifacts, three sets of numbers**: SKILL.md (8-char clause / 2-char brand) vs case study (6 chars) vs app.js comment (「约 6 字」/「3 字」). The app.js comment now drops specific counts — which also stops leaking the real brand's length.

Verification: `node --check` clean; old phrasings grep to zero; both files now read 「我们的民宿就完了」 identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)