### PR TITLE
claude-code-hooks: rule 7 — prove a demanded-remediation loop terminates

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -103,7 +103,7 @@
       "description": "Claude Code operations suite that bundles archive-aware local conversation discovery across Claude Code and Codex, internal-timestamp full-event session search and recovery, interrupted-work continuation, plugin/skill troubleshooting, CLAUDE.md progressive disclosure optimization, statusline configuration, exported .txt repair, full claude.ai conversation extraction with tool-call rendering and file download, plugin marketplace development, writing/testing/debugging Claude Code hooks, multi-provider profile isolation for running Kimi/GLM/DeepSeek/StepFun/Anthropic in separate windows, local source sync for Claude/Codex skill installs, personal-memory migration into tool-agnostic AGENTS.md reference docs, and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
       "source": "./daymade-claude-code",
       "strict": false,
-      "version": "1.26.0",
+      "version": "1.27.0",
       "category": "suite",
       "keywords": [
         "suite",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -103,7 +103,7 @@
       "description": "Claude Code operations suite that bundles archive-aware local conversation discovery across Claude Code and Codex, internal-timestamp full-event session search and recovery, interrupted-work continuation, plugin/skill troubleshooting, CLAUDE.md progressive disclosure optimization, statusline configuration, exported .txt repair, full claude.ai conversation extraction with tool-call rendering and file download, plugin marketplace development, writing/testing/debugging Claude Code hooks, multi-provider profile isolation for running Kimi/GLM/DeepSeek/StepFun/Anthropic in separate windows, local source sync for Claude/Codex skill installs, personal-memory migration into tool-agnostic AGENTS.md reference docs, and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
       "source": "./daymade-claude-code",
       "strict": false,
-      "version": "1.25.0",
+      "version": "1.26.0",
       "category": "suite",
       "keywords": [
         "suite",

--- a/daymade-claude-code/claude-code-hooks/.security-scan-passed
+++ b/daymade-claude-code/claude-code-hooks/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-07-23T15:03:50.983249+00:00
+Scanned at: 2026-07-25T04:58:27.798922+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 932afd1c7ffde24bdd3199cca37d4184a2e33d4f03d7bf0a7b2d72620b5dcf32
+Content hash: 28e4830ece8cad792ed1a0e875326095b378568c03efe86ce726f817b5bec023

--- a/daymade-claude-code/claude-code-hooks/.security-scan-passed
+++ b/daymade-claude-code/claude-code-hooks/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-07-25T04:58:27.798922+00:00
+Scanned at: 2026-07-25T05:18:41.966739+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 28e4830ece8cad792ed1a0e875326095b378568c03efe86ce726f817b5bec023
+Content hash: 24cfc7bb7f25a6ec745946684b62cbf1150de708511d2d11b03ed8b281fd9dae

--- a/daymade-claude-code/claude-code-hooks/SKILL.md
+++ b/daymade-claude-code/claude-code-hooks/SKILL.md
@@ -50,7 +50,7 @@ match tokens/patterns; it can't judge whether a design is good).
 | **PreToolUse** | before a tool runs | allow | **block** the call (stderr → shown to model as guidance) | any other exit = "non-blocking error" → **the call proceeds** |
 | **PostToolUse** | after a tool ran | quiet **unless it prints a `hookSpecificOutput` JSON on stdout — that is how context injection works, and it happens at exit 0** | feedback to the model (can't un-run the tool) | — |
 | **SessionStart** | session begins | proceed | — | **always exit 0** — never block a session |
-| **Stop** (+ `SubagentStop`) | the model is about to finish responding | let it stop | **block the stop** — forces the model to keep going (stderr → fed back as the reason) | must check `stop_hook_active` or it can loop |
+| **Stop** (+ `SubagentStop`) | the model is about to finish responding | let it stop | **block the stop** — forces the model to keep going (stderr → fed back as the reason) | check `stop_hook_active` — necessary, **not** sufficient (rule 7) |
 
 - **PreToolUse** is the workhorse — the only one that can *stop* an action.
   `matcher` selects the tool (`Bash`, `Agent`, `WebFetch`, …). Exit 2 blocks and
@@ -104,7 +104,7 @@ fi
 exit 0
 ```
 
-## Six rules that separate a working guard from a session-poisoning one
+## Rules that separate a working guard from a session-poisoning one
 
 Not style preferences — each is a specific failure we shipped and traced back.
 
@@ -247,6 +247,7 @@ different guard classes.** Take `cd ~/no-such-dir && TRIGGER`:
 |---|---|---|---|
 | **Token matcher** (is this a banned command form?) | the command text alone | **2, block** | `TRIGGER` is right there in the text; an unresolvable `cd` doesn't make it not-a-trigger, and if the guard goes quiet here it will also go quiet on `cd ~/real-dir && TRIGGER` |
 | **State deriver** (does the repo's staged set span domains?) | state read from disk | **0, allow** | `cd` fails, `&&` short-circuits, no commit ever happens — there is nothing to guard |
+| **Termination-state reader** (has the remediation already happened?) | a receipt / counter file (rule 7) | **0, allow** | an unreadable state file means the hook cannot know it already fired; failing closed here blocks forever with no remediation possible and no human-visible cause — that *is* the loop, and it is the one failure worse than a missed case |
 
 So decide which class your hook is *before* writing the row, and the harness's
 `unresolvable path` template row expects **2** because that template targets the
@@ -296,12 +297,252 @@ The tell for both: a branch that has never once fired in production while its
 tests are green. Print the raw pre-formatting classification and you will see
 which of the two you have.
 
+### 7. If the hook **demands remediation**, prove the loop terminates
+
+A hook that **blocks** (exit 2) until X is done — Stop hooks especially, since
+they re-fire on every subsequent stop — is not a check, it's a **feedback loop**.
+(A hook that merely *injects* a demand and exits 0 has no loop at all: nothing
+re-evaluates. That is mechanism 0 below, and it is the right default more often
+than people reach for it.)
+
+```
+condition T is true → hook demands remediation R → model performs R → T checked again
+```
+
+**If completing R can make T true again, the loop does not terminate.** Nothing
+errors, nothing crashes; it just burns round after round until a human
+interrupts. `stop_hook_active` does *not* save you here — that field covers
+exactly **one layer of re-entry** ("the stop I just blocked is being retried").
+It says nothing about the *cross-turn* case, where the model genuinely goes off
+and does R (real work, many tool calls), then stops naturally: that is a brand
+new Stop, the field is `false`, and the hook fires again on the same grounds.
+
+**The test, borrowed from termination proofs in program verification** — a [loop
+variant / ranking function](https://en.wikipedia.org/wiki/Loop_variant): write
+down a quantity **V** mapping into a well-founded order (usually just ℕ), and
+show that **V strictly decreases across every `trigger → remediate → re-check`
+cycle**. No V, no termination proof — don't register the hook.
+
+**V is a design-time obligation, not code** — you never compute it in the hook.
+What ships is the *predicate* (the mechanisms below); V is the argument that the
+predicate converges. Put it where the next reader will trip over it — the script
+header:
+
+```bash
+# TERMINATION: V = 1 - exists(<receipt path>)
+# decreased by: R writes the receipt; nothing R does afterwards can remove it.
+```
+
+"Show it decreases" is three concrete questions, and the answers go in that
+comment:
+
+1. **What does R change?** Name the exact file / field / timestamp.
+2. **Is that thing an operand of T?** If yes, and R moves it back toward "fire" →
+   there is no V.
+3. **After R, what is the smallest input that makes T true again?** If the answer
+   is "the same input I just fired on" → there is no V. Redesign the predicate;
+   do not retune the threshold.
+
+**A real counter-example.** A Stop hook required an independent review before
+compounding artifacts (rule files, skills, other hooks) could be pushed:
+
+- **T** (the condition that makes the hook **fire**) = "there are edits no review
+  has covered", implemented as the timestamp comparison
+  `last_edit > last_review` (`last_edit` = newest mtime across the artifact set,
+  `last_review` = mtime of the review record — two single numbers, which is
+  exactly what makes the comparison feel safe)
+- **R** = dispatch an independent reviewer
+
+But a review that is worth running **has output**: its findings get adopted **by
+the same agent, immediately, before it next tries to stop** → that produces new
+edits → `last_edit` moves past `last_review` → **T is true again**. (If a human
+adopted them later, out of band, there would be no loop — the loop needs the
+remediation and the re-check inside one agent's turn, which is exactly what a
+Stop hook guarantees.) There is no V — remediation doesn't decrease a quantity, it *resets*
+one. The only escape is "review, then change nothing," which is precisely the
+case where dispatching the reviewer was pointless. Observed: three consecutive
+rounds, each a complete review-and-adopt cycle, exited only by the user saying
+stop.
+
+Two things make this hard to see. **The comparison looks perfectly reasonable in
+isolation** — "the review must be newer than the last edit" is exactly what you'd
+write. And that sentence is the **pass** condition, so the moment you write the
+code you are one negation away from stating T backwards; keep T oriented as the
+**fire** condition or you will reason about the wrong operand. Run the checklist
+above and it falls out mechanically: R changes `last_edit` (Q1); `last_edit` is
+an operand of T (Q2); the smallest input that re-fires T is the remediation's own
+output (Q3) → no V.
+
+**Converging mechanisms, most to least reliable. Check them in this order — the
+first two remove the loop instead of taming it.**
+
+0. **Don't block — inject.** If the demand is advisory (you want the model to
+   *consider* R, not to be unable to finish without it), print it and exit 0.
+   Nothing re-evaluates, so there is no loop to prove terminating. Right default
+   for anything short of Tier-0, and the cost is honest: a reminder can be
+   ignored, so say in the header that it is fail-open — rule 4's point stands,
+   a gate the subject can walk past is not a gate. If you need a *gate*, use 2
+   and pay for the receipt. (Injection channel: see Pattern D — a plain
+   `echo … >&2; exit 0` reaches the model, which is what the shipped
+   PostToolUse injectors here use.)
+
+1. **Move the check to the action boundary.** If what you want to gate is an
+   *action* — a push, a publish, a delete — guard **the action** with PreToolUse
+   instead of guarding **the turn** with Stop. A PreToolUse block is evaluated
+   once per attempt: block → R → the model re-issues the command → the guard now
+   sees a satisfied instance. Nothing re-fires across turns, so the variant is
+   trivial (`V` = attempts remaining on this command). **Stop-hook remediation
+   loops are usually action gates attached to the wrong event** — and note the
+   counter-example above is exactly that shape ("before … could be **pushed**",
+   implemented on Stop). Check this before reaching for a receipt; it is the
+   concrete case of "Stop is the odd one out, and the one most often reached for
+   by mistake" from the hook-types section.
+
+2. **Make "already remediated" an existence fact, not a temporal one — and key it
+   on the thing that needed remediating.** Have R land an artifact and test *does
+   it exist*; the key is what makes this work:
+
+   ```bash
+   KEY=$(git rev-parse HEAD 2>/dev/null || printf 'nogit')   # or a hash of the
+   RECEIPT="${TMPDIR:-/tmp}/my-guard.${KEY}.ok"              # reviewed content
+   [ -f "$RECEIPT" ] && exit 0            # V = 1 - exists, for THIS key
+   ```
+
+   `V = 1 - exists` is **per key**: it decreases exactly once per key and can
+   never be pushed back up *for that key*. New work mints a *new* key — that is a
+   new demand, not a re-arm. Both naive keyings fail: one global path makes the
+   hook fire once per machine and then sit dead forever with zero signal, and a
+   time-based key is the temporal predicate this rule exists to forbid. **A
+   temporal predicate is almost always the wrong shape**, because the remediation
+   you demanded is usually what moves the operand you compare against.
+   ⚠️ If the **model** can create the receipt, this is rule 4's retired
+   `GUARD_OK=1` escape hatch wearing a new hat. Have it written by something the
+   model doesn't drive (the reviewer subagent's own output file, a git note), or
+   accept that the hook is advisory and say so in its header.
+
+3. **A ceiling on repetitions.** At most N reminders per session per target —
+   `session_id` is the only stable key for this (it is on every event; see the
+   JSON contract in Pattern references):
+
+   ```bash
+   SID=$(printf '%s' "$INPUT" | python3 -c "import sys,json;print(json.load(sys.stdin).get('session_id','nosid'))" 2>/dev/null || echo nosid)
+   CNT="${TMPDIR:-/tmp}/my-guard.${SID}.count"
+   N=$(cat "$CNT" 2>/dev/null || echo 0); N=$((N+1)); printf '%s' "$N" > "$CNT"
+   [ "$N" -gt 3 ] && exit 0                # V = 3 - N, reaches 0 and stays
+   ```
+
+   Crude, and deliberately blind to whether R actually happened — but *finite*,
+   which is the property that was missing. Do **not** substitute `$$` or `$PPID`:
+   each hook run is a fresh process, so those change every invocation and the
+   counter never accumulates. Print the count ("reminder 2 of 3") — see the war
+   story below for why that wording earns its place.
+
+4. **Hysteresis / a cool-down window** (the control-theory answer to
+   [alert flapping](https://utcc.utoronto.ca/~cks/space/blog/sysadmin/HysteresisMeaningAndAlerts)):
+   after firing, suppress re-evaluation for a window — a stamp file plus
+   `[ $(( $(date +%s) - <stamp mtime> )) -lt 900 ] && exit 0` (mtime is
+   `stat -f %m` on BSD/macOS, `stat -c %Y` on GNU — as are the other snippets
+   here). Right for conditions that *oscillate around a threshold*; **wrong** for
+   conditions that remediation **resets** — those need 2 or 3.
+
+**Failure direction for the state itself (rule 5): fail *open*.** If the receipt
+or counter can't be read or written — unwritable `TMPDIR`, sandbox, full disk —
+**allow the stop**. This is the one place in this skill where fail-open is
+mandatory rather than a judgement call: a termination mechanism that cannot read
+its own state and blocks anyway *is* the loop, now with no human-visible cause.
+
+**Prose in the demand text does not substitute for a converging predicate.** A
+hook whose message says "if you judge this unnecessary, just finish again" still
+costs a full remediation cycle every round, because a model that has been told it
+must do X will usually do X. The escape hatch has to be in the **predicate**, not
+in the advice.
+
+**The testing requirement, and the easiest thing here to skip:** the self-test
+needs an **"after remediation"** case — not just "fires when it should," but
+**"stops firing once R is complete."** Without it, non-termination is
+*structurally invisible*: every fixture is one isolated point-in-time judgment,
+while non-termination is a property of the **sequence**. A suite that only
+checks single points has zero coverage of convergence no matter how many cases
+it has — which is how a hook can ship with a green self-test and still loop on
+its first real encounter. The row pair that *can* see it (receipt absent → fires,
+receipt present → quiet, with the setup/teardown a plain `run` row can't express)
+is templated in `scripts/test_hook.sh` under "AFTER-REMEDIATION ROWS"; symptom →
+cause → fix is pitfall #16.
+
+**Termination proved ≠ it *feels* terminated (2026-07-25 war story).** A Stop
+hook with a correct existence-fact V fired three times in one session — each
+fire a legitimate *new* push from a *different* completed task, the mechanism
+working exactly as designed — and the user's experience was still "why is this
+thing stuck in a loop?" (No contradiction with mechanism 2's "nothing R does can
+push it back up": **V is per key** — three distinct keys, three separate one-way
+decreases. That is also the diagnostic when you can't tell which situation you
+are in: if each fire carries a *new* key, the mechanism is right and the density
+is the problem; if repeated fires share the *same* key — or the predicate has no
+key at all because it compares timestamps — you are in the counter-example above
+and the predicate needs replacing.) Three independent remediation cycles back-to-back are
+indistinguishable from a loop from the outside. The variant-proof settles the
+mechanism; it says nothing about **how many distinct remediations a session can
+demand**. If your domain produces that density (compounding artifacts ship
+several times a day here), consider pairing mechanism 1 with mechanism 2 (a
+session-scoped ceiling), or accept the optics deliberately and say so in the
+hook's output — "reminder 2 of at most N" reads as progress, an unadorned
+repeat reads as a loop.
+
+### 8. Waiting needs the same proof — notifications are advisory, polling must carry a budget
+
+Rule 7 covers loops a *hook* creates. The same shape recurs with no hook
+involved: **an agent polling for an asynchronous result** — a subagent's
+report, a background task's completion notice, a CI status. Real session
+(2026-07-25): subagent completion notices arrive through a mailbox that can
+delay or drop them; three separate agents finished their work while the
+notification sat undelivered, and the waiting agent burned a dozen
+`sleep 240` + nag cycles over ~40 minutes until the human asked what it was
+even doing. Nothing errored; the loop just had no variant.
+
+Rule 7's mechanisms map over — the first two directly; hysteresis has no
+analogue (a wait doesn't oscillate), and its slot is taken by a trap specific to
+waiting:
+
+1. **Poll the artifact, not the notification.** If what you actually need is a
+   result (a file, a git ref, an API state, a row in a DB), wait on *that*, not
+   on "did it say it's done." The notification is a hint; the artifact is the
+   fact. An existence check terminates the moment the fact lands, regardless of
+   whether any message ever arrives.
+2. **Every wait carries a budget, chosen when the loop is written.** Max rounds
+   × interval (e.g. 3 × 4 min), and a degradation path that exists *before* the
+   first sleep: do it yourself, ask the user, or mark it pending and move on to
+   other work. "Wait indefinitely and see" is not a degradation path — it's
+   the loop.
+3. **Delivery protocols are advisory, not mechanism.** "Report back via
+   SendMessage when done — silence counts as incomplete" is worth writing, but
+   it governs whether the agent *sends*, not whether the mailbox *delivers*.
+   Three agents with the protocol in their prompt all went silent in one
+   session. Design the wait as if the notification may never arrive — because
+   it may not.
+
+Two adjacent traps, both paid for in the same session: **TaskStopping a
+"stuck" agent that is actually mid-work** — mailbox delay is not idleness;
+one reviewer doing 20 minutes of real corpus testing was killed as "stuck"
+minutes before delivering. And **`--dry-run`-style probes of the wait itself**:
+before concluding the other side is silent, confirm your own observation
+channel works (in that session, System Events window-counting returned a
+confident 0 for a dialog that was on screen — a permission failure masquerading
+as evidence).
+
 ## Build order (in sequence)
 
 1. **Confirm it's a real recurrence**, not hypothetical — else don't build it.
+   If the hook will **demand a remediation** rather than just block, write its
+   termination variant **V** into the script header as a `# TERMINATION:` line
+   (rule 7) before any logic — and first check whether the thing you're gating is
+   an *action*, in which case a PreToolUse guard on that action removes the loop
+   instead of taming it. Can't name a quantity that strictly decreases per
+   `trigger → remediate → re-check` cycle? The design is non-terminating — fix the
+   design, not the regex.
 2. Write the script in the SSOT dir; `chmod +x`.
-3. **Detection** with shlex token-level matching (rule 1).
-4. **`bash -n` + `test_hook.sh`** with trigger AND healthy-lookalike cases (rule 2) — do not register until green. Include the shapes that carry an unexpanded path (`cd ~/elsewhere && …`, rule 5) and, if the hook has a human gate, a forced-decline row (Pattern B, "Make the gate testable").
+3. **Detection** with shlex token-level matching (rule 1), keyed on a fact the
+   world can answer rather than your own rendering or a naming convention (rule 6).
+4. **`bash -n` + `test_hook.sh`** with trigger AND healthy-lookalike cases (rule 2) — do not register until green. Include the shapes that carry an unexpanded path (`cd ~/elsewhere && …`, rule 5); if the hook has a human gate, a forced-decline row (Pattern B, "Make the gate testable"); and if it demands remediation, the **after-remediation row pair** — fires without the receipt, quiet with it (template in `scripts/test_hook.sh`; rule 7 — point-in-time fixtures structurally cannot see non-termination).
 5. **Symlink** into `~/.claude/hooks/` (rule 3).
 6. **Register** in main `settings.json` + converge profiles (rule 4).
 7. For a Tier-0/irreversible action, add the **human-confirmation release gate** (rule 4).
@@ -319,8 +560,11 @@ under-registration, and a path parsed from command text keeping its literal `~` 
 the guard fails **open** with no symptom at all (#10 — the one you cannot wait to
 notice, because silence is its only sign), a branch reading the hook's own
 truncated display string (#12) or keyed on a naming convention this repo doesn't
-follow (#13) — both invisible while the suite asserts only exit codes (#14) — and
-command text that merely *contains* a redirect counted as a write (#15).
+follow (#13) — both invisible while the suite asserts only exit codes (#14) —
+command text that merely *contains* a redirect counted as a write (#15), and a
+hook whose **demanded remediation re-arms it**, looping with a green self-test
+because point-in-time fixtures structurally cannot see non-termination (#16,
+rule 7).
 
 **The harness is the hidden variable — use `scripts/test_hook.sh`, don't hand-roll
 one.** Every hand-rolled failure mode below produces the *same* output as a clean

--- a/daymade-claude-code/claude-code-hooks/SKILL.md
+++ b/daymade-claude-code/claude-code-hooks/SKILL.md
@@ -389,15 +389,23 @@ stop.
 
 Two things make this hard to see. **The comparison looks perfectly reasonable in
 isolation** — "the review must be newer than the last edit" is exactly what you'd
-write. And that sentence is the **pass** condition, so the moment you write the
-code you are one negation away from stating T backwards; keep T oriented as the
-**fire** condition or you will reason about the wrong operand. Run the checklist
+write. And that sentence is the **pass** condition — T is its negation. Copy it
+into your head as-is, without that negation, and you are reasoning about the
+wrong operand for the rest of the analysis; keep T oriented as the **fire**
+condition. (Writing the *code* as an early-exit guard clause — `… && exit 0` — is
+normal shell style and not what this is about; the discipline is about which
+orientation you reason in. And note equality: same-second mtimes land on the pass
+side, i.e. fail-open, which matches what this rule requires of state reads below.) Run the checklist
 above and it falls out mechanically: R changes `last_edit` (Q1); `last_edit` is
 an operand of T (Q2); the smallest input that re-fires T is the remediation's own
 output (Q3) → no V.
 
-**Converging mechanisms, most to least reliable. Check them in this order — the
-first two remove the loop instead of taming it.**
+**Pick by axis first, then by order — these are not five strengths of one thing.**
+0 decides *whether to block at all*; 1 decides *which event to hang it on*; 2–4
+are the *predicate's shape* (choose 1 and you still need one of 2–4). The 0→4
+order is "how completely the loop is removed", and it runs **inversely to how
+much you can enforce** — so take the first one that still gives you the
+enforcement you actually need, not simply the first one.
 
 0. **Don't block — inject.** If the demand is advisory (you want the model to
    *consider* R, not to be unable to finish without it), print it and exit 0.
@@ -405,21 +413,45 @@ first two remove the loop instead of taming it.**
    for anything short of Tier-0, and the cost is honest: a reminder can be
    ignored, so say in the header that it is fail-open — rule 4's point stands,
    a gate the subject can walk past is not a gate. If you need a *gate*, use 2
-   and pay for the receipt. (Injection channel: see Pattern D — a plain
-   `echo … >&2; exit 0` reaches the model, which is what the shipped
-   PostToolUse injectors here use.)
+   and pay for the receipt. Injection channel: Pattern D.
+   ⚠️ **This option does not exist on Stop** — and rule 7's main subject *is*
+   Stop, so read this before reaching for it. On Stop, `exit 0` means "let the
+   turn end", so there is no later reasoning step for the text to land in; and
+   `hookSpecificOutput.additionalContext` counts toward the same 8-block ceiling
+   as `exit 2` (see the hook-types section), i.e. it is also a block. Stop has
+   exactly two modes: gate, or silence. Choosing mechanism 0 on Stop therefore
+   means **changing the event** — hang the injection on the tool call that
+   produced the artifact (PostToolUse, Pattern D) — or admitting you wanted a
+   gate after all, and going to mechanism 2.
+   ⚠️ **"No loop" holds only if R isn't your own matcher's target.** An injector
+   on `Bash` that tells the model to run `git ls-remote` fires again on that very
+   command, and re-injects. Same shape, softer — the model can ignore it, so
+   there is no forced iteration, but it is broadcast-on-repeat rather than
+   nothing. Check that the R you recommend is not an action this hook matches.
 
 1. **Move the check to the action boundary.** If what you want to gate is an
    *action* — a push, a publish, a delete — guard **the action** with PreToolUse
-   instead of guarding **the turn** with Stop. A PreToolUse block is evaluated
-   once per attempt: block → R → the model re-issues the command → the guard now
-   sees a satisfied instance. Nothing re-fires across turns, so the variant is
-   trivial (`V` = attempts remaining on this command). **Stop-hook remediation
-   loops are usually action gates attached to the wrong event** — and note the
-   counter-example above is exactly that shape ("before … could be **pushed**",
-   implemented on Stop). Check this before reaching for a receipt; it is the
-   concrete case of "Stop is the odd one out, and the one most often reached for
-   by mistake" from the hook-types section.
+   instead of guarding **the turn** with Stop. **Stop-hook remediation loops are
+   often action gates attached to the wrong event**, and this is the concrete
+   case of "Stop is the odd one out, and the one most often reached for by
+   mistake" from the hook-types section.
+   **Be precise about what this buys.** PreToolUse only re-fires when the model
+   *voluntarily retries the gated action*, and the model can always decline and
+   end its turn normally. So it guarantees **the turn terminates** — the worst
+   case drops from "the turn can't end" to "this action doesn't happen". It does
+   **not** make a non-converging predicate converge: take the counter-example
+   above, move it to PreToolUse unchanged, and the loop survives intact (push →
+   blocked → review → findings adopted → new edits → retry → `last_edit` is ahead
+   again → blocked). That case is sick in its **predicate**, not in its event, so
+   you still pick a shape from 2–4. Note also that PreToolUse has **no** harness
+   backstop — the 8-block ceiling in the hook-types table is Stop-only — so a
+   self-resetting predicate moved here has *fewer* safety nets, not more.
+   ⚠️ Two shapes where this mechanism is the wrong answer: **R has to be done
+   with the very tool you gated** (a guard on `Edit` demanding you fix a file
+   header first — deadlock, nothing can ever satisfy it), and **an action that
+   recurs within one session** (a `git push` gate in a session that pushes five
+   repos = five full demands; that is the density problem in the war story
+   below, and mechanism 1 doesn't exempt you from it).
 
 2. **Make "already remediated" an existence fact, not a temporal one — and key it
    on the thing that needed remediating.** Have R land an artifact and test *does
@@ -467,6 +499,14 @@ first two remove the loop instead of taming it.**
    `stat -f %m` on BSD/macOS, `stat -c %Y` on GNU — as are the other snippets
    here). Right for conditions that *oscillate around a threshold*; **wrong** for
    conditions that remediation **resets** — those need 2 or 3.
+   ⚠️ **Hysteresis supplies no V — it is a rate limiter, not a termination
+   proof.** The loop ends only if the condition subsides on its own, and what
+   ends it then is the world, not your hook. So its `# TERMINATION:` line has to
+   name that external fact ("by the time the stamp expires, X has been resolved
+   by &lt;whom&gt;"). If you can't write that line honestly, what you needed was 2
+   or 3. (Family resemblance worth seeing: mechanism 0 is the limit case of both
+   — mechanism 3 with the ceiling set to 0, or mechanism 4 with the window set to
+   ∞. They differ in enforcement, not in termination.)
 
 **Failure direction for the state itself (rule 5): fail *open*.** If the receipt
 or counter can't be read or written — unwritable `TMPDIR`, sandbox, full disk —
@@ -506,8 +546,8 @@ and the predicate needs replacing.) Three independent remediation cycles back-to
 indistinguishable from a loop from the outside. The variant-proof settles the
 mechanism; it says nothing about **how many distinct remediations a session can
 demand**. If your domain produces that density (compounding artifacts ship
-several times a day here), consider pairing mechanism 1 with mechanism 2 (a
-session-scoped ceiling), or accept the optics deliberately and say so in the
+several times a day here), consider pairing mechanism 2 (the existence fact) with
+mechanism 3 (a session-scoped ceiling), or accept the optics deliberately and say so in the
 hook's output — "reminder 2 of at most N" reads as progress, an unadorned
 repeat reads as a loop.
 

--- a/daymade-claude-code/claude-code-hooks/SKILL.md
+++ b/daymade-claude-code/claude-code-hooks/SKILL.md
@@ -50,7 +50,7 @@ match tokens/patterns; it can't judge whether a design is good).
 | **PreToolUse** | before a tool runs | allow | **block** the call (stderr → shown to model as guidance) | any other exit = "non-blocking error" → **the call proceeds** |
 | **PostToolUse** | after a tool ran | quiet **unless it prints a `hookSpecificOutput` JSON on stdout — that is how context injection works, and it happens at exit 0** | feedback to the model (can't un-run the tool) | — |
 | **SessionStart** | session begins | proceed | — | **always exit 0** — never block a session |
-| **Stop** (+ `SubagentStop`) | the model is about to finish responding | let it stop | **block the stop** — forces the model to keep going (stderr → fed back as the reason) | check `stop_hook_active` — necessary, **not** sufficient (rule 7) |
+| **Stop** (+ `SubagentStop`) | the model is about to finish responding | let it stop | **block the stop** — forces the model to keep going (stderr → fed back as the reason) | loop safety is **two layers**: the hook checks `stop_hook_active` (necessary, **not** sufficient — rule 7), and the harness itself **ends the turn after 8 consecutive blocks** regardless. All Stop hooks for an event run **in parallel** — one block round can carry several hooks' feedback |
 
 - **PreToolUse** is the workhorse — the only one that can *stop* an action.
   `matcher` selects the tool (`Bash`, `Agent`, `WebFetch`, …). Exit 2 blocks and
@@ -82,6 +82,24 @@ match tokens/patterns; it can't judge whether a design is good).
   amount of regex refinement on the wrong event fixes it. Full contract
   (`last_assistant_message` vs `transcript_path`, the anti-loop check) in
   Pattern E below.
+- **Stop has two block channels with identical loop protections — pick by
+  intent, and make the first (only) block carry everything.** `decision:
+  "block"` + `reason`, or plain exit 2 + stderr, shows as a hook *error* — for
+  hard gates ("this must not stand"). `hookSpecificOutput.additionalContext`
+  shows as neutral "Stop hook feedback" with no error notification — for
+  coaching and reminders the model should weigh, not gates. Both count toward
+  the same 8-consecutive-block ceiling from the table above, so the choice is
+  tone, not safety. What the ceiling means for message design: a blocked retry
+  round (`stop_hook_active: true`) is let through **with whatever violations
+  remain**, and after 8 blocks the harness ends the turn the same way — so a
+  Stop guard gets exactly **one** informed bite. Report *all* findings in that
+  one block (a guard that prints only the first loses the rest permanently —
+  pitfall #17), and write the message as an escape manual naming the exact
+  acceptable fix, not a verdict — the model converges in one round or it burns
+  the cap guessing. v2.1.145+ inputs `background_tasks` / `session_crons` let a
+  blocking hook tell "the session is done" from "the session is merely paused
+  waiting for background work" — blocking a pause forces pointless
+  continuations and wastes the same cap.
 
 Full runnable skeletons: [references/hook_patterns.md](references/hook_patterns.md).
 
@@ -309,9 +327,14 @@ than people reach for it.)
 condition T is true → hook demands remediation R → model performs R → T checked again
 ```
 
-**If completing R can make T true again, the loop does not terminate.** Nothing
-errors, nothing crashes; it just burns round after round until a human
-interrupts. `stop_hook_active` does *not* save you here — that field covers
+**If completing R can make T true again, the loop does not converge.** Nothing
+errors, nothing crashes; it burns round after round until the harness's
+8-consecutive-block ceiling ends the turn — or a human interrupts first, which
+is what usually happens because each round is a *complete* remediation cycle
+(dispatch, wait, adopt, edit), not a cheap retry. That ceiling is a backstop
+against a runaway session, not a design: reaching it means the turn ends with
+the violation still standing and the model's last 8 rounds spent on work nobody
+asked for. "It eventually stops" is not termination in any sense you want. `stop_hook_active` does *not* save you here — that field covers
 exactly **one layer of re-entry** ("the stop I just blocked is being retried").
 It says nothing about the *cross-turn* case, where the model genuinely goes off
 and does R (real work, many tool calls), then stops naturally: that is a brand

--- a/daymade-claude-code/claude-code-hooks/references/hook_patterns.md
+++ b/daymade-claude-code/claude-code-hooks/references/hook_patterns.md
@@ -442,11 +442,11 @@ INPUT=$(cat)                                     # is explicitly ||-guarded inst
 # check treats it as an already-blocked retry and silently, permanently
 # disarms the guard for that turn. Test this explicitly: a payload with
 # `"stop_hook_active": "false"` (string) must NOT be treated as active.
-ACTIVE=$(HOOK_JSON="$INPUT" python3 - <<'PY'
+ACTIVE=$(HOOK_JSON="$INPUT" python3 - 2>/dev/null <<'PY'
 import json, os
 print(json.loads(os.environ['HOOK_JSON']).get('stop_hook_active') is True)
 PY
-) 2>/dev/null || exit 0
+) || exit 0
 [ "$ACTIVE" = "True" ] && exit 0
 
 # Prefer last_assistant_message (official docs: use it INSTEAD OF the
@@ -455,7 +455,7 @@ PY
 # shape is a plain string, but defensive extraction costs nothing and the
 # SAME helper is genuinely required for the transcript fallback below, where
 # message.content really is a list of typed blocks in practice.
-TEXT=$(HOOK_JSON="$INPUT" python3 - <<'PY'
+TEXT=$(HOOK_JSON="$INPUT" python3 - 2>/dev/null <<'PY'
 import json, os, sys
 
 d = json.loads(os.environ['HOOK_JSON'])
@@ -496,14 +496,14 @@ if not text:
 
 print(text)
 PY
-) 2>/dev/null || exit 0
+) || exit 0
 [ -n "$TEXT" ] || exit 0
 
 printf '%s' "$TEXT" | grep -qw 'TRIGGER' || exit 0    # fast path, same idea as Pattern A —
 # but NOT the shlex walker below this line: TEXT is free-form prose, not a
 # shell command, so match with substring/regex per the JSON event contract's
 # "shlex is for shell commands" rule above.
-HITS=$(HOOK_TEXT="$TEXT" python3 - <<'PY'
+HITS=$(HOOK_TEXT="$TEXT" python3 - 2>/dev/null <<'PY'
 import os, re
 t = os.environ['HOOK_TEXT']
 # ... precise detection here — regex/substring over free text ...
@@ -514,7 +514,7 @@ t = os.environ['HOOK_TEXT']
 hits = [m.group(0) for m in re.finditer(r'TRIGGER', t)]
 print(' / '.join(hits[:5]))
 PY
-) 2>/dev/null || HITS=''
+) || HITS=''
 
 if [ -n "$HITS" ]; then
   # This message is read by the MODEL, not the user — once Stop blocks, the
@@ -562,7 +562,12 @@ Three things worth calling out beyond what the comments above already say:
   same Stop input also carries `background_tasks` / `session_crons`
   (v2.1.145+): a blocking hook can tell "session is done" from "session merely
   paused for background work" — blocking a pause burns the cap on pointless
-  continuations. For the gate-vs-guidance channel choice
+  continuations. One ownership nuance the docs state and the flag's name
+  hides: `stop_hook_active` is set by **any** stop hook's block, not
+  specifically yours ("already continuing as a result of **a** stop hook") —
+  with several Stop hooks registered, another guard's block consumes the same
+  retry round, one more reason the first block must be complete: you cannot
+  count on a second one. For the gate-vs-guidance channel choice
   (`decision:"block"`/exit 2 vs `hookSpecificOutput.additionalContext`), see
   SKILL.md's Stop bullet — both share these same protections.
 - **…and handling it correctly still does not make the hook terminate.** The
@@ -579,13 +584,17 @@ Three things worth calling out beyond what the comments above already say:
   loop rather than taming it), and the self-test case that catches it:
   SKILL.md rule 7 and
   [hook_pitfalls.md](hook_pitfalls.md#16-the-remediation-the-hook-demands-re-arms-the-hook-a-loop-with-no-variant).
-- **Wrap every python3 subprocess call in the same `2>/dev/null || <fallback>`
-  pattern, not just some of them.** An inconsistency here doesn't change the
-  block-vs-allow decision (a hook built this defensively is already fail-open
-  by construction — nothing prints before a match succeeds), but the
-  unguarded call leaks a raw Python traceback straight to the model's stderr
-  on any internal crash, instead of degrading cleanly to "no match" like the
-  guarded calls do.
+- **Wrap every python3 subprocess call with the same `2>/dev/null` + `|| <fallback>`
+  guard, and put the `2>/dev/null` INSIDE the `$(...)` on the python3 call.** The
+  outer form `X=$(python3 … ) 2>/dev/null || fallback` only suppresses on bash ≥5;
+  on bash 3.2 (macOS system bash) the redirection does not reach the command
+  substitution and a crash leaks the raw traceback to the model's stderr
+  (independent-review measurement, 2026-07-25: same snippet, 5.3.15 silent /
+  3.2.57 leaks). Placement costs nothing on new bash and is the only portable
+  form. The guard itself is unchanged either way: an inconsistency here doesn't
+  change the block-vs-allow decision (the hook is already fail-open by
+  construction), it only decides whether a crash degrades to "no match" cleanly
+  or noisily.
 
 ---
 

--- a/daymade-claude-code/claude-code-hooks/references/hook_patterns.md
+++ b/daymade-claude-code/claude-code-hooks/references/hook_patterns.md
@@ -503,22 +503,27 @@ printf '%s' "$TEXT" | grep -qw 'TRIGGER' || exit 0    # fast path, same idea as 
 # but NOT the shlex walker below this line: TEXT is free-form prose, not a
 # shell command, so match with substring/regex per the JSON event contract's
 # "shlex is for shell commands" rule above.
-HIT=$(HOOK_TEXT="$TEXT" python3 - <<'PY'
+HITS=$(HOOK_TEXT="$TEXT" python3 - <<'PY'
 import os, re
 t = os.environ['HOOK_TEXT']
 # ... precise detection here — regex/substring over free text ...
-for m in re.finditer(r'TRIGGER', t):
-    print(m.group(0))
-    break
+# Collect EVERY finding, not just the first: the blocked retry round
+# (stop_hook_active: true) passes with whatever you did not report, so a
+# first-only report loses the rest permanently (pitfall #17). Cap the list so
+# a pathological text cannot flood the model's context.
+hits = [m.group(0) for m in re.finditer(r'TRIGGER', t)]
+print(' / '.join(hits[:5]))
 PY
-) 2>/dev/null || HIT=''
+) 2>/dev/null || HITS=''
 
-if [ -n "$HIT" ]; then
+if [ -n "$HITS" ]; then
   # This message is read by the MODEL, not the user — once Stop blocks, the
   # model sees this text and must act on it before it can actually stop.
-  # Write it as an instruction ("rewrite X"), not a user-facing explanation.
-  echo "BLOCKED: your last reply contains <BANNED THING> (\"$HIT\"). WHY: ...
-FIX: rewrite it using <the correct alternative>, then finish this turn." >&2
+  # Write it as an instruction ("rewrite X"), not a user-facing explanation,
+  # and name the exact acceptable fix — the model converges in one round or it
+  # burns the 8-consecutive-block harness cap guessing.
+  echo "BLOCKED: your last reply contains <BANNED THING> (\"$HITS\"). WHY: ...
+FIX: rewrite each one using <the correct alternative>, then finish this turn." >&2
   exit 2
 fi
 exit 0
@@ -542,6 +547,24 @@ Three things worth calling out beyond what the comments above already say:
   pattern.** Every other mistake in this hook fails toward "block too much" or
   "miss one case"; getting this one wrong in the permissive direction fails
   toward "silently do nothing, forever, with zero error signal."
+- **…and the two other loop-safety layers the flag does NOT give you, both
+  documented facts of the runtime (2026-07-25 verified against the official
+  hooks reference).** One: the harness itself **ends the turn after 8
+  consecutive blocks** — a guard whose message the model cannot act on does not
+  loop forever, it bounces 8 times and the violation passes anyway, so the cap
+  is a ceiling to stay far below, never a design target; the message is the
+  escape manual (name the exact acceptable fix) and the first block must carry
+  **all** findings, since the honored retry round passes with whatever was not
+  reported (the skeleton above collects them; pitfall #17 is the failure
+  shape). Two: **all Stop hooks for an event run in parallel** — your block
+  shares the round with every other Stop hook's feedback, so write the message
+  to compose (state your finding and your fix), not to own the channel. The
+  same Stop input also carries `background_tasks` / `session_crons`
+  (v2.1.145+): a blocking hook can tell "session is done" from "session merely
+  paused for background work" — blocking a pause burns the cap on pointless
+  continuations. For the gate-vs-guidance channel choice
+  (`decision:"block"`/exit 2 vs `hookSpecificOutput.additionalContext`), see
+  SKILL.md's Stop bullet — both share these same protections.
 - **…and handling it correctly still does not make the hook terminate.** The
   field covers **one layer of re-entry** — the stop you just blocked being
   retried. It does nothing for the *cross-turn* loop, where the model actually
@@ -551,8 +574,9 @@ Three things worth calling out beyond what the comments above already say:
   must converge: prefer an **existence test** on an artifact the remediation
   lands (`does the record exist` — sets once, can't be unset) over a **temporal
   test** (fire when `last_offense > last_remediation`), because the remediation
-  you asked for is usually what moves the operand you are comparing against. Full analysis, the three
-  converging mechanisms, and the self-test case that catches it:
+  you asked for is usually what moves the operand you are comparing against. Full
+  analysis, the converging mechanisms (ordered by how completely each removes the
+  loop rather than taming it), and the self-test case that catches it:
   SKILL.md rule 7 and
   [hook_pitfalls.md](hook_pitfalls.md#16-the-remediation-the-hook-demands-re-arms-the-hook-a-loop-with-no-variant).
 - **Wrap every python3 subprocess call in the same `2>/dev/null || <fallback>`

--- a/daymade-claude-code/claude-code-hooks/references/hook_patterns.md
+++ b/daymade-claude-code/claude-code-hooks/references/hook_patterns.md
@@ -23,10 +23,19 @@ The hook reads one JSON object on **stdin**. The fields you care about:
 ```jsonc
 // PreToolUse / PostToolUse
 {
+  "session_id": "…",                         // stable for the whole session
+  "cwd": "…",
+  "hook_event_name": "PreToolUse",
   "tool_name": "Bash",                       // or "Agent", "WebFetch", "Edit", …
   "tool_input": { "command": "…" }           // Bash: .command; Agent: .prompt; Edit: .file_path/.new_string
 }
 ```
+
+**`session_id` is the only correct key for per-session state** a hook keeps
+(counters, cool-downs — rule 7 mechanisms 3 and 4). Nothing else is stable:
+`$$` / `$PPID` change on every invocation because each hook run is a fresh
+process, and a fixed path makes the state global, which turns a one-shot guard
+into a permanently dead one.
 
 Extract them defensively (never assume the shape — a parse failure should
 **allow**, not crash):
@@ -533,6 +542,19 @@ Three things worth calling out beyond what the comments above already say:
   pattern.** Every other mistake in this hook fails toward "block too much" or
   "miss one case"; getting this one wrong in the permissive direction fails
   toward "silently do nothing, forever, with zero error signal."
+- **…and handling it correctly still does not make the hook terminate.** The
+  field covers **one layer of re-entry** — the stop you just blocked being
+  retried. It does nothing for the *cross-turn* loop, where the model actually
+  goes and does what you demanded (many tool calls, a natural stop afterwards)
+  and arrives at a **fresh** Stop with `stop_hook_active: false`. If this hook
+  **demands a remediation** rather than merely reporting, the predicate itself
+  must converge: prefer an **existence test** on an artifact the remediation
+  lands (`does the record exist` — sets once, can't be unset) over a **temporal
+  test** (fire when `last_offense > last_remediation`), because the remediation
+  you asked for is usually what moves the operand you are comparing against. Full analysis, the three
+  converging mechanisms, and the self-test case that catches it:
+  SKILL.md rule 7 and
+  [hook_pitfalls.md](hook_pitfalls.md#16-the-remediation-the-hook-demands-re-arms-the-hook-a-loop-with-no-variant).
 - **Wrap every python3 subprocess call in the same `2>/dev/null || <fallback>`
   pattern, not just some of them.** An inconsistency here doesn't change the
   block-vs-allow decision (a hook built this defensively is already fail-open

--- a/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
+++ b/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
@@ -472,6 +472,44 @@ unresolvable path means **block**.
 
 ---
 
+## 16. The remediation the hook demands re-arms the hook (a loop with no variant)
+
+- **Symptom:** a Stop hook fires, the model does exactly what it asked, the hook
+  fires again on the same grounds. Repeat until a human interrupts. No error, no
+  crash, green self-test, and `stop_hook_active` **is** handled correctly.
+- **Cause:** the hook's condition is a **temporal comparison** whose operand is
+  moved by the very remediation it demands. Canonical **fire** condition:
+  `last_offending_action > last_remediation`. Remediation that is worth doing
+  produces work — findings get adopted, files get edited — so
+  `last_offending_action` jumps back ahead and the condition re-arms.
+  (Watch the orientation: what you naturally *write* is the **pass** condition —
+  "the review must be newer than the last edit". T is its negation. State T as
+  the fire condition or you will reason about the wrong operand.) The loop has
+  no [variant](https://en.wikipedia.org/wiki/Loop_variant): nothing strictly
+  decreases per cycle, so nothing forces termination.
+- **Why `stop_hook_active` doesn't cover it.** It means "the stop I just blocked
+  is being retried" — one layer of re-entry inside one stop attempt. This loop is
+  *cross-turn* (real work, then a fresh Stop with the field `false`). Handling it
+  is necessary and buys nothing here. Full contract: SKILL.md rule 7.
+- **Fix — change the shape of the predicate, not its threshold.** In order:
+  (a) if what you're gating is an **action**, move the gate onto that action with
+  PreToolUse instead of onto the turn with Stop — one evaluation per attempt, no
+  cross-turn re-fire; (b) else test an **existence fact keyed on the thing that
+  needed remediating** (`V = 1 - exists` per key — a global key kills the hook
+  forever, a time-based key is the temporal predicate again); (c) else a
+  per-session **repetition ceiling** (`V = N - fired`), crude but finite. Cool-down
+  windows (hysteresis) fix a *different* problem — a condition oscillating around
+  a threshold — not one that remediation **resets**. Runnable snippets and the
+  design-time `# TERMINATION:` convention: SKILL.md rule 7.
+- **The self-test row pair that can see it.** Same event, receipt absent → fires;
+  receipt present → quiet, with `rm -f` / `: >` around them (the state lives on the
+  filesystem, so a plain `run` row cannot express it). Template in
+  [../scripts/test_hook.sh](../scripts/test_hook.sh), "AFTER-REMEDIATION ROWS". If
+  the second row also fires, the predicate is temporal — fix the predicate, not
+  the fixture.
+
+---
+
 ## Meta-principle: the ordering of these fixes
 
 When a guard is misbehaving, check in this order — cheapest and most common first:
@@ -513,3 +551,9 @@ When a guard is misbehaving, check in this order — cheapest and most common fi
     content assertions, then mutate to prove they can die.
 12. Does it report a file **nobody wrote** — especially one containing a literal
     `$VAR`? → it is reading command text as if every redirect in it executed (#15).
+13. Does it fire **again right after you did exactly what it asked**? → its
+    condition is a temporal comparison that the remediation itself moves (#16).
+    Not a tuning problem: change the predicate's *shape* — move the gate to the
+    action with PreToolUse, or test an existence fact keyed on the thing that
+    needed remediating — and add the after-remediation row pair that a
+    point-in-time suite structurally cannot have.

--- a/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
+++ b/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
@@ -582,3 +582,7 @@ When a guard is misbehaving, check in this order — cheapest and most common fi
     action with PreToolUse, or test an existence fact keyed on the thing that
     needed remediating — and add the after-remediation row pair that a
     point-in-time suite structurally cannot have.
+14. Did it catch the first violation and **silently never mention the second one
+    from the same reply**? → first-only reporting (#17): the honored retry round
+    is a full pass-through, so collect every finding before printing and assert
+    both hits in a two-violations fixture.

--- a/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
+++ b/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
@@ -510,6 +510,31 @@ unresolvable path means **block**.
 
 ---
 
+## 17. A Stop guard that reports only the first violation loses the rest (the retry round is a full pass-through)
+
+- **Symptom:** a Stop hook correctly blocks on finding X in the model's reply;
+  the model fixes X and stops again — and the reply still contains violation Y
+  from the same original turn, never reported, never caught.
+- **Cause:** the hook printed the first finding and stopped looking. The retry
+  round arrives with `stop_hook_active: true`, which the hook (correctly)
+  honors by letting the turn end — so everything it did not say in round one
+  sails through permanently. The anti-loop field that saves you from infinite
+  re-entry is precisely what makes the first block your only informed bite.
+  (The harness separately ends the turn after 8 consecutive blocks — banking
+  on "I'll catch it next round" burns that cap and loses anyway.)
+- **Fix:** collect *all* findings before printing (cap the list — five is
+  plenty — so a pathological reply can't flood the model's context), and write
+  the message as an escape manual: each finding plus the exact acceptable fix.
+  Test it: a two-violations fixture must exit 2 with BOTH in stderr — a suite
+  that only ever feeds one violation per case structurally cannot see this.
+- **Real case (2026-07-25):** a group-name guard reported only the first
+  coined shorthand in a reply that coined two; the honored retry round fixed
+  the first and ended the turn with the second intact. Found by an independent
+  reviewer, fixed by collecting all matches (cap 5); regression row
+  "多命中一次报全" pins it.
+
+---
+
 ## Meta-principle: the ordering of these fixes
 
 When a guard is misbehaving, check in this order — cheapest and most common first:

--- a/daymade-claude-code/claude-code-hooks/scripts/test_hook.sh
+++ b/daymade-claude-code/claude-code-hooks/scripts/test_hook.sh
@@ -158,8 +158,10 @@ run "non-bash-tool"  '{"tool_name":"Read","tool_input":{"file_path":"/x/TRIGGER.
 #       run "stop_hook_active" '{"stop_hook_active":true,"last_assistant_message":"...trigger text..."}' 0
 #     And if the guard can find MULTIPLE violations in one reply: a
 #     two-violations row asserting BOTH appear in stderr — the blocked retry
-#     round passes unreported findings permanently (pitfall #17):
-#       says "reports all hits" '{"last_assistant_message":"TRIGGER and TRIGGER2"}' "TRIGGER2" yes
+#     round passes unreported findings permanently (pitfall #17). Use two
+#     clearly distinct tokens (TRIGGER2 CONTAINS "TRIGGER" — a substring-style
+#     detector would make this row pass for the wrong reason):
+#       says "reports all hits" '{"last_assistant_message":"TRIGGER and SECONDHIT"}' "SECONDHIT" yes
 #
 #   UserPromptSubmit — hook reads the user's prompt:
 #     run "prompt-trigger" '{"prompt":"...text under test..."}' 2

--- a/daymade-claude-code/claude-code-hooks/scripts/test_hook.sh
+++ b/daymade-claude-code/claude-code-hooks/scripts/test_hook.sh
@@ -113,7 +113,8 @@ run "non-bash-tool"  '{"tool_name":"Read","tool_input":{"file_path":"/x/TRIGGER.
 #    Never provide an env var that *grants* approval — that recreates the retired
 #    static-escape-hatch anti-pattern.
 #
-# ── AFTER-REMEDIATION ROWS — required whenever the hook DEMANDS something (rule 7).
+# ── AFTER-REMEDIATION ROWS (mechanism 2 / receipt-shaped) — required whenever the
+#    hook DEMANDS something (rule 7).
 #    Point-in-time fixtures are structurally blind to non-termination: each `run`
 #    row asks "given this event, fire or not?", while non-termination is a property
 #    of the SEQUENCE. This pair is the only row type that can see it.
@@ -121,16 +122,26 @@ run "non-bash-tool"  '{"tool_name":"Read","tool_input":{"file_path":"/x/TRIGGER.
 #    JSON (on the filesystem), so the rows need setup/teardown around them:
 #
 #      EVT='{"last_assistant_message":"…text that triggers the demand…"}'
-#      RECEIPT="${TMPDIR:-/tmp}/my-guard.$(printf %s "$EVT" | shasum | cut -c1-12).ok"
+#      RECEIPT="…"                       # ← MUST be the key YOUR hook computes
 #      rm -f "$RECEIPT";  run "demands R (no receipt)"       "$EVT" 2
 #      : > "$RECEIPT";    run "quiet after R (receipt present)" "$EVT" 0
 #      rm -f "$RECEIPT"
 #
-#    Derive RECEIPT with the SAME key the hook uses. If you can't work out that key
-#    from the hook's source, the key is undiscoverable — and that is the bug, not a
-#    testing inconvenience. If the second row ALSO returns 2, the predicate is
-#    temporal rather than existence-based: it WILL loop in production (pitfall #16).
-#    Fix the predicate, not the fixture.
+#    ⚠️ FIRST prove your RECEIPT string is the one the hook actually computes —
+#    temporarily `echo "$RECEIPT" >&2` inside the hook, run one case, and compare.
+#    There is no universal key: rule 7's sample hook uses `git rev-parse HEAD`,
+#    a content-keyed guard hashes the reviewed text, yours may use neither. Copying
+#    a key from an example is the most likely reason row 2 fails.
+#    ONLY after the paths match does the diagnosis below apply: if row 2 STILL
+#    returns 2, the predicate is temporal rather than existence-based and it WILL
+#    loop in production (pitfall #16) — fix the predicate, not the fixture.
+#
+#    Other mechanisms need a differently-shaped pair:
+#      • mechanism 3 (ceiling): no receipt to touch — feed the SAME event N+1 times
+#        and assert the last one is 0. `rm -f "$CNT"` before AND after, or a stale
+#        counter makes the whole suite pass/fail depending on run history.
+#      • mechanism 1 (PreToolUse gate): the second row isn't "receipt present", it
+#        is "the world now satisfies the demand" — same command, state fixed.
 # ──────────────────────────────────────────────────────────────────────────────
 #
 # ── EVENT SHAPES OTHER THAN PreToolUse (the payload differs per event) ────────
@@ -141,8 +152,14 @@ run "non-bash-tool"  '{"tool_name":"Read","tool_input":{"file_path":"/x/TRIGGER.
 #   Stop / SubagentStop — hook reads the assistant's final message:
 #     run "stop-trigger" '{"last_assistant_message":"...text under test..."}' 2
 #     (fallback path: '{"transcript_path":"/abs/path.jsonl"}' where the file has a
-#      line {"type":"assistant","message":{"content":[{"type":"text","text":"..."}]}};
-#      also honors {"stop_hook_active":true} as an early no-op exit)
+#      line {"type":"assistant","message":{"content":[{"type":"text","text":"..."}]}})
+#     REQUIRED anti-loop row for every blocking Stop hook — the one field that
+#     bounds re-entry (Pattern E); the hook must exit 0 on it:
+#       run "stop_hook_active" '{"stop_hook_active":true,"last_assistant_message":"...trigger text..."}' 0
+#     And if the guard can find MULTIPLE violations in one reply: a
+#     two-violations row asserting BOTH appear in stderr — the blocked retry
+#     round passes unreported findings permanently (pitfall #17):
+#       says "reports all hits" '{"last_assistant_message":"TRIGGER and TRIGGER2"}' "TRIGGER2" yes
 #
 #   UserPromptSubmit — hook reads the user's prompt:
 #     run "prompt-trigger" '{"prompt":"...text under test..."}' 2

--- a/daymade-claude-code/claude-code-hooks/scripts/test_hook.sh
+++ b/daymade-claude-code/claude-code-hooks/scripts/test_hook.sh
@@ -112,6 +112,25 @@ run "non-bash-tool"  '{"tool_name":"Read","tool_input":{"file_path":"/x/TRIGGER.
 #      GIT_GUARD_OSASCRIPT=false GIT_GUARD_TTY=/dev/null bash test_hook.sh <hook>
 #    Never provide an env var that *grants* approval — that recreates the retired
 #    static-escape-hatch anti-pattern.
+#
+# ── AFTER-REMEDIATION ROWS — required whenever the hook DEMANDS something (rule 7).
+#    Point-in-time fixtures are structurally blind to non-termination: each `run`
+#    row asks "given this event, fire or not?", while non-termination is a property
+#    of the SEQUENCE. This pair is the only row type that can see it.
+#    A plain `run` line is NOT enough — the state the hook judges lives OUTSIDE the
+#    JSON (on the filesystem), so the rows need setup/teardown around them:
+#
+#      EVT='{"last_assistant_message":"…text that triggers the demand…"}'
+#      RECEIPT="${TMPDIR:-/tmp}/my-guard.$(printf %s "$EVT" | shasum | cut -c1-12).ok"
+#      rm -f "$RECEIPT";  run "demands R (no receipt)"       "$EVT" 2
+#      : > "$RECEIPT";    run "quiet after R (receipt present)" "$EVT" 0
+#      rm -f "$RECEIPT"
+#
+#    Derive RECEIPT with the SAME key the hook uses. If you can't work out that key
+#    from the hook's source, the key is undiscoverable — and that is the bug, not a
+#    testing inconvenience. If the second row ALSO returns 2, the predicate is
+#    temporal rather than existence-based: it WILL loop in production (pitfall #16).
+#    Fix the predicate, not the fixture.
 # ──────────────────────────────────────────────────────────────────────────────
 #
 # ── EVENT SHAPES OTHER THAN PreToolUse (the payload differs per event) ────────


### PR DESCRIPTION
## What

A hook that outputs *"you must do X"* is not a check — it's a **feedback loop**. If completing the remediation can make the trigger condition true again, it never converges. No error, no crash, **green self-test**; it just burns round after round until the harness's 8-block ceiling ends the turn.

`stop_hook_active` does **not** cover this. That field is one layer of re-entry *inside a single stop attempt*; this loop is **cross-turn** — the model genuinely goes off and does the work, then reaches a natural stop, which is a fresh event with the field `false`.

### The test, borrowed from program verification

A [loop variant / ranking function](https://en.wikipedia.org/wiki/Loop_variant): name a quantity **V** that strictly decreases per `trigger → remediate → re-check` cycle, or don't register the hook. V is a **design-time obligation** recorded in a `# TERMINATION:` header — never runtime code — plus a 3-question checklist that makes *"there is no V"* fall out mechanically.

### Five mechanisms, ordered so the first two remove the loop rather than tame it

| # | Mechanism | V |
|---|---|---|
| 0 | Don't block — inject (exit 0, nothing re-evaluates) | vacuous |
| 1 | Move the gate to the **action boundary** (PreToolUse), not the turn (Stop) | attempts remaining |
| 2 | Existence fact **keyed on what needed remediating** | `1 - exists`, per key |
| 3 | Per-session repetition ceiling via `session_id` | `N - fired` |
| 4 | Hysteresis / cool-down — for *oscillating* conditions, **not** reset-by-remediation ones | window |

Plus the failure direction for the state itself (**fail open** — a termination mechanism that can't read its own state and blocks anyway *is* the loop), and why prose in the demand text (*"just finish again if unnecessary"*) doesn't substitute for a converging predicate.

## Also in here

- **pitfall #16** (symptom → cause → fix), entered into **both** indexes — its symptom *"it fired again right after I did what it asked"* is a classic lookup
- **`test_hook.sh`: AFTER-REMEDIATION ROWS template.** Point-in-time fixtures are structurally blind to non-termination (it's a property of the *sequence*), and the row pair can't be plain `run` lines because the state lives on the filesystem, outside the JSON
- **`session_id` documented** in the JSON event contract — it was absent from the entire package, which made the counter mechanism literally unbuildable
- rule 5 gains a *Termination-state-reader* row; rule 6 joins the build order; Pattern E notes that handling `stop_hook_active` correctly still doesn't make it terminate

## Review

Fresh-context read-only adversarial pass found **23 issues; all 5 P0 and all 8 P1 adopted**, each factual claim reproduced before acting. The sharpest:

> **The temporal predicate was stated BACKWARDS in all three files.** `last_review > last_edit` is the *pass* condition, not the fire condition — so a reader implementing from the formula would have built a hook that fires exactly when the review **is** current.

Others: `session_id` undocumented → mechanism unbuildable; receipt keying unspecified → both naive answers fail (global = hook dead forever, per-session = blocked on the above); "write down V" had no landing place; #16 unreachable from either index.

Public-repo scan clean — no private names, paths, or repos. The war story deliberately **declines to name the real hook**, since the filename appears in a private file alongside the same phrasing.

Gates: `quick_validate` ✅ · `security_scan` ✅ · regression audit (6 candidates classified + verified) ✅ · `bash -n` ✅ · PII Guard ✅

## ⚠️ Before merging

This branch also carries a **concurrent session's** work on the same skill (their lane, left intact):

- **rule 8** — waiting/polling needs the same proof; cross-references rule 7 and its mechanisms map onto 7's
- the **8-consecutive-block ceiling** fact, which corrected an error in my own first commit (`0761148`)
- a bullet on Stop's two block channels

**Their text forward-references `pitfall #17`, which is not written yet** — that link is dangling until they land it. I flagged rather than removed it: deleting a placeholder from another session's in-flight work is worse than a temporarily unresolvable link. **Suggest waiting for #17 before merge.**

Version bumped `daymade-claude-code` 1.25.0 → 1.26.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VsFEBLozQ3DcMoc4BbMTsg