### PR TITLE
claude-code-hooks: coherence pass — 3 doc-vs-reality fixes + dedup + missing-rule promotion (1.27.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -103,7 +103,7 @@
       "description": "Claude Code operations suite that bundles archive-aware local conversation discovery across Claude Code and Codex, internal-timestamp full-event session search and recovery, interrupted-work continuation, plugin/skill troubleshooting, CLAUDE.md progressive disclosure optimization, statusline configuration, exported .txt repair, full claude.ai conversation extraction with tool-call rendering and file download, plugin marketplace development, writing/testing/debugging Claude Code hooks, multi-provider profile isolation for running Kimi/GLM/DeepSeek/StepFun/Anthropic in separate windows, local source sync for Claude/Codex skill installs, personal-memory migration into tool-agnostic AGENTS.md reference docs, and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
       "source": "./daymade-claude-code",
       "strict": false,
-      "version": "1.27.0",
+      "version": "1.27.1",
       "category": "suite",
       "keywords": [
         "suite",

--- a/daymade-claude-code/claude-code-hooks/.security-scan-passed
+++ b/daymade-claude-code/claude-code-hooks/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-07-25T05:18:41.966739+00:00
+Scanned at: 2026-07-25T13:42:27.767264+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 24cfc7bb7f25a6ec745946684b62cbf1150de708511d2d11b03ed8b281fd9dae
+Content hash: f29730c23521a79bba2019fdb63a24dca3e29691666fee89183f84db04238011

--- a/daymade-claude-code/claude-code-hooks/SKILL.md
+++ b/daymade-claude-code/claude-code-hooks/SKILL.md
@@ -61,13 +61,20 @@ match tokens/patterns; it can't judge whether a design is good).
   and surface it — the model can't "believe it committed" against injected truth).
 - **SessionStart** is for **health checks of the guard rails themselves** —
   silent when healthy, warn on breakage, always exit 0.
-- **`set -euo pipefail` vs `set -uo pipefail` — pick by contract, not by habit.**
-  A hook that may block (PreToolUse) wants `-e`: an unexpected failure aborting the
-  script is survivable, because the caller treats a non-0/2 exit as "proceed". A hook
-  whose contract is **ALWAYS exit 0** (PostToolUse injectors, SessionStart checks)
-  must drop `-e` — with it, one `grep` that legitimately finds nothing kills the hook
-  mid-way and the CLI surfaces a bare `Failed with non-blocking status code`. Rule of
-  thumb: **`-e` for hooks that decide, no `-e` for hooks that report** (pitfall #8).
+- **`set -euo pipefail` vs `set -uo pipefail` — pick by contract, and know there
+  are two ways to keep an always-exit-0 contract.** A hook that may block
+  (PreToolUse) wants `-e`: an unexpected failure aborting the script is
+  survivable, because the caller treats a non-0/2 exit as "proceed". A hook whose
+  contract is **ALWAYS exit 0** (PostToolUse injectors, SessionStart checks) has
+  two honest shapes: (a) **drop `-e`** and `||`-guard every risky command —
+  with `-e` on, one `grep` that legitimately finds nothing kills the hook
+  mid-way and the CLI surfaces a bare `Failed with non-blocking status code`
+  (pitfall #8, Pattern E's shape); or (b) **keep `-e` and add `trap 'exit 0' ERR`**
+  so any failure still converts to exit 0 while `-e` keeps guarding the plumbing
+  (`git-commit-headcheck`'s production shape, Pattern D). Either is correct;
+  what you cannot do is `-e` alone with no trap and no `||`-guards. Rule of
+  thumb: **`-e` for hooks that decide; for hooks that report, drop `-e` or trap
+  it** (pitfall #8).
 - **Stop is the odd one out, and the one most often reached for by mistake**:
   it's the *only* hook type that can react to what the model **itself just
   generated** (its own reply text). Every other hook type — including
@@ -81,7 +88,7 @@ match tokens/patterns; it can't judge whether a design is good).
   the trigger pattern. This is a category mistake, not a tuning problem — no
   amount of regex refinement on the wrong event fixes it. Full contract
   (`last_assistant_message` vs `transcript_path`, the anti-loop check) in
-  Pattern E below.
+  Pattern E in [references/hook_patterns.md](references/hook_patterns.md).
 - **Stop has two block channels with identical loop protections — pick by
   intent, and make the first (only) block carry everything.** `decision:
   "block"` + `reason`, or plain exit 2 + stderr, shows as a hook *error* — for
@@ -152,6 +159,22 @@ false-blocks is matching on the raw command string.
   [references/hook_patterns.md](references/hook_patterns.md).
 - Corollary: `echo "…TRIGGER…"`, `grep TRIGGER`, `# TRIGGER`, `man TRIGGER` must
   all pass. Your test set MUST include these mention-not-execute cases.
+- **Corollary — exempt `git` write segments before they reach the walker.** A
+  commit message is arbitrary data, and the whole message text reaches your
+  command-position walk as pseudo-command-text — `git commit -F - <<EOF` with a
+  body quoting `foo|TRIGGER` lands `TRIGGER` in command position, and the guard
+  blocks its own fix commit (pitfall #7 is exactly this, shipped). Any Bash guard
+  that inspects command strings must skip segments whose head is `git` +
+  `commit`/`rebase`/`tag`/`am`/`cherry-pick` — and do it at the whole-command
+  level, before any line splitting (Pattern A shows the order; the production
+  version is `lib-git-commit-detect`'s adjacency check).
+- **Corollary — the walker is two-stage for a reason.** `whitespace_split=True`
+  treats newlines as ordinary whitespace, so a multiline block
+  (`cd /x\ngit add\nTRIGGER -y`) collapses into one segment headed by `cd` and
+  the trigger is never in command position — replayed trigger rate 0 on real
+  transcripts (pitfall #11). Split on newlines as text first, then shlex-walk
+  each line (both Pattern A and the walker section already do this); the
+  heredoc-body residual and when to accept it are #11's call.
 - **But shlex isn't a silver bullet, and *what* you detect changes whether
   fail-open is safe.** `shlex.split()` itself throws `ValueError` on an unbalanced
   quote — a multi-line `git commit -m "…` message with a `#` or an unclosed quote
@@ -165,6 +188,11 @@ false-blocks is matching on the raw command string.
   narrow **regex** (`git` and `commit` as separate words, any flag tokens between)
   that's immune to multi-line-quote breakage; reserve the shlex walker for the
   *command-position / modifier* checks where fail-open is the safe direction.
+  (The boundary: regex when the predicate is "is this a specific common command
+  at all" — `git commit`, `git push` — whose own message/arguments are what breaks
+  tokenizing; walker when the predicate is "is a *banned* command or modifier in
+  command position" — there the banned thing is rare and a ValueError fail-open
+  errs safe, Rule 1's direction.)
 
 ### 2. Test with **bash -n + a real JSON event, end-to-end, BEFORE registering**
 
@@ -196,8 +224,8 @@ the actual failing JSON case). The escalation is a multi-lens agent-team
 review where every finding must be reproduced by *executing* a real payload
 against the live script, not by reading the code and agreeing — this is the
 general Counter Review methodology
-([skill-development-methodology.md](../../daymade-skill/skill-creator/references/skill-development-methodology.md)
-Phase 6), applied to a hook instead of a skill. In one such pass, 3 lenses (matching
+(skill-creator's `skill-development-methodology` reference, Phase 6), applied to
+a hook instead of a skill. In one such pass, 3 lenses (matching
 logic / shell-embedding safety / event-contract robustness) surfaced 13
 confirmed, independently-reproduced bugs and 1 finding whose own cited
 evidence turned out to be a hallucinated doc quote — caught only because the
@@ -208,22 +236,30 @@ rather than trust the citation.
 
 Real script in a version-controlled dir, **symlinked** into the hooks dir Claude reads:
 ```
-~/scripts/claude-hooks/<name>.sh      # SSOT (git: private repo)
+~/scripts/claude-hooks/<name>.sh      # SSOT (this setup: a private git repo)
 ~/.claude/hooks/<name>.sh             # symlink → SSOT
+
+# install / recover:
+ln -s ~/scripts/claude-hooks/<name>.sh ~/.claude/hooks/<name>.sh
 ```
 A `~/.claude` reinstall wipes the hooks dir; the symlink target survives, and
 recovery is one `ln -s`. A dangling symlink disables a Tier-0 guard with **zero
-signal** — which is why a SessionStart health check exists (rule 4).
+signal** — which is why a SessionStart health check exists (rule 4; runnable
+skeleton: Pattern C in [references/hook_patterns.md](references/hook_patterns.md)).
 
 ### 4. Registration is per-profile — converge ALL profiles, release via a HUMAN gate
 
 - A hook in `~/.claude/hooks/` protects **nothing** if the *active profile's*
   `settings.json` doesn't call it. Multi-profile users ran with zero guards until
-  every profile was converged. Register in the **main** profile's `settings.json`
-  (PreToolUse → matcher `Bash` → your hook), then converge the rest (this setup
+  every profile was converged. Register in the **main** profile's settings
+  (`~/.claude/settings.json` in this setup; the Registration section of
+  [references/hook_patterns.md](references/hook_patterns.md) has the exact jsonc
+  shape) — PreToolUse → matcher `Bash` → your hook — then converge the rest (this setup
   uses `sync-profile-settings.py --all`, owned by the `claude-switch-models-setup`
   skill). A SessionStart health check greps each profile for the Tier-0 guards to
-  catch drift.
+  catch drift. Settings edits are picked up by the CLI's file watcher (official
+  hooks docs), so registration is live without a restart — confirm by watching
+  the guard fire on a safe probe, or at next session's health-check line.
 - **If the guard needs a release valve, make it a *human* gate, not an env var.**
   A static `GUARD_OK=1` escape hatch is no gate — the model can set the env var
   itself. Replace with: a native macOS dialog (`osascript` — model can't click)
@@ -619,7 +655,9 @@ everything), awk-split false-blocks (rule 1), corrupted hook poisoning the sessi
 (rule 2), a quote or backtick inside a Python *comment* silently corrupting a
 `python3 -c "…"` block with no syntax error (pitfall #9 — use the quoted-heredoc
 form from Pattern E instead), static env escape hatch (rule 4), multi-profile
-under-registration, and a path parsed from command text keeping its literal `~` so
+under-registration, a commit message reaching the walker as pseudo-command-text
+and false-blocking your own fix commit unless `git` write segments are exempted
+(#7), and a path parsed from command text keeping its literal `~` so
 the guard fails **open** with no symptom at all (#10 — the one you cannot wait to
 notice, because silence is its only sign), a branch reading the hook's own
 truncated display string (#12) or keyed on a naming convention this repo doesn't
@@ -678,3 +716,4 @@ fire, suspect the row before the hook.
 - [references/hook_patterns.md](references/hook_patterns.md) — runnable skeletons for every hook type covered here, the shlex command-position walker, and the JSON event contract.
 - [references/hook_pitfalls.md](references/hook_pitfalls.md) — every real failure mode with symptom → cause → fix.
 - [scripts/test_hook.sh](scripts/test_hook.sh) — end-to-end test harness; copy it next to any new hook.
+- [scripts/test_hook.group-name-guard.sh](scripts/test_hook.group-name-guard.sh) — a worked harness instance for a real Stop guard (event shapes, `says` rows, both polarities).

--- a/daymade-claude-code/claude-code-hooks/references/hook_patterns.md
+++ b/daymade-claude-code/claude-code-hooks/references/hook_patterns.md
@@ -119,24 +119,62 @@ printf '%s' "$CMD" | grep -qw 'TRIGGER' || exit 0     # fast path: token absent 
 HOOK_CMD="$CMD" python3 - <<'PY'
 import os, sys, shlex, re
 cmd = os.environ["HOOK_CMD"]
+SEPS = {";","&&","||","|","&","(",")","{","}","|&"}   # NOT <> — a redirect target is a filename, not a command
+ENV = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+GIT_WRITES = {"commit","rebase","tag","am","cherry-pick"}
+
 def toks(c):
     lex = shlex.shlex(c, posix=True, punctuation_chars=True); lex.whitespace_split = True
     return list(lex)                       # |;&<>() are boundaries even without spaces
-try: TS = toks(cmd)
-except ValueError: TS = cmd.split()        # unbalanced quotes → best effort (SKILL.md Rule 1 nuance)
-SEPS = {";","&&","||","|","&","(",")","{","}","|&"}   # NOT <> — a redirect target is a filename, not a command
-ENV = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
-at_cmd = True
-for t in TS:
-    if t in SEPS: at_cmd = True; continue
-    if at_cmd:
-        if ENV.match(t): continue          # VAR=val prefix, command is still ahead
-        if t == "TRIGGER":                 # command-position hit → print guidance + block
+
+def segments(line):
+    """(head, tokens) per command segment in ONE line (shlex keeps quotes atomic)."""
+    try: TS = toks(line)
+    except ValueError: TS = line.split()   # unbalanced quotes → best effort (SKILL.md Rule 1 nuance)
+    at_cmd, head, cur = True, "", []
+    for t in TS:
+        if t in SEPS:
+            if head: yield head, cur
+            at_cmd, head, cur = True, "", []
+            continue
+        if at_cmd and ENV.match(t): continue   # VAR=val prefix, command is still ahead
+        if at_cmd: head = t; at_cmd = False
+        cur.append(t)
+    if head: yield head, cur
+
+def is_git_write(seg):
+    # seg[0]=="git"; the subcommand is the first non-flag token (skip flag values)
+    skip = False
+    for t in seg[1:]:
+        if skip: skip = False; continue
+        if t in ("-C","-c","--git-dir","--work-tree"): skip = True; continue
+        if t.startswith("-"): continue
+        return t in GIT_WRITES
+    return False
+
+# Pitfall #7 (whole command, BEFORE any splitting): a git *write*'s message is DATA —
+# `git commit -F - <<EOF` whose body quotes `foo|TRIGGER` reaches the walk below as
+# pseudo-command-text and the guard blocks its own fix commit (this skill's own
+# qlmanage-guard shipped exactly that). Exempt the whole command when any segment is
+# a git write. Bias-to-under (pitfall #11): this also lets `git commit -m x &&
+# TRIGGER` through — the rare miss is the deliberate trade for a blocker; stricter
+# needs a real shell grammar (production: lib-git-commit-detect's adjacency check).
+if any(h == "git" and is_git_write(seg) for h, seg in segments(cmd)):
+    sys.exit(0)
+
+# Pitfall #11: shlex treats newlines as ordinary whitespace, so a multiline command
+# (`cd /x\ngit add\nTRIGGER -y`) collapses into ONE segment whose head is `cd` and
+# the trigger is never in command position — replayed trigger rate 0 on real
+# transcripts. Split on newlines as TEXT first, then walk each line. Residual (same
+# entry): a heredoc body still fragments — for a fail-open reminder declare it; the
+# whole-command git exemption above is what keeps heredoc commits safe here.
+for line in cmd.split("\n"):
+    for head, seg in segments(line):
+        if head == "TRIGGER":                # command-position hit → print guidance + block
             sys.stderr.write("BLOCKED: <BANNED THING> is not allowed here.\n"
                              "WHY: <the failure mode this prevents>.\n"
                              "USE INSTEAD: <the correct command / workflow>.\n")
             sys.exit(2)
-        at_cmd = False                     # this token is the command; rest are args
 sys.exit(0)
 PY
 # set -e propagates python's exit 2 straight out of the hook — nothing left for
@@ -174,16 +212,30 @@ def _tokens(cmd: str):
     lex.whitespace_split = True
     return list(lex)
 
-def executes(cmd: str, target: str) -> bool:
-    try: toks = _tokens(cmd)             # quotes honored, # comment dropped, |;& are boundaries
-    except ValueError: toks = cmd.split()# unbalanced quotes → best effort (see SKILL.md Rule 1 nuance)
-    at_cmd = True                        # start of line is a command slot
+def _segments(line: str):
+    """(head, tokens) per command segment in ONE physical line."""
+    try: toks = _tokens(line)            # quotes honored, # comment dropped, |;& are boundaries
+    except ValueError: toks = line.split()  # unbalanced quotes → best effort (see SKILL.md Rule 1 nuance)
+    at_cmd, head, cur = True, "", []
     for t in toks:
-        if t in SEPS: at_cmd = True; continue   # separator → next token is a command
-        if at_cmd:
-            if ENV.match(t): continue           # skip VAR=val prefixes
-            if t == target: return True         # command-position match
-            at_cmd = False                      # this is the command; args follow
+        if t in SEPS:
+            if head: yield head, cur
+            at_cmd, head, cur = True, "", []
+            continue
+        if at_cmd and ENV.match(t): continue  # skip VAR=val prefixes
+        if at_cmd: head = t; at_cmd = False
+        cur.append(t)
+    if head: yield head, cur
+
+def executes(cmd: str, target: str) -> bool:
+    # Two stages, order matters (pitfall #11): shlex swallows newlines as ordinary
+    # whitespace, so a multiline block (`cd /x\ngit add\nTRIGGER -y`) would
+    # collapse into ONE segment headed by `cd` and hide the trigger. Split on
+    # newlines as TEXT first, then shlex-walk each line — a quoted `a|TRIGGER|b`
+    # still stays one token inside its line, so no phantom command is made.
+    for line in cmd.split("\n"):
+        for head, _seg in _segments(line):
+            if head == target: return True      # command-position match
     return False
 ```
 
@@ -196,9 +248,12 @@ Why each piece matters:
   miss it — a real, silent bypass). `whitespace_split=True` stops it from also
   splitting inside flags/paths.
 - Comments (`# TRIGGER`) are dropped by the posix lexer, so they don't match.
-- The `at_cmd` flag + `SEPS` means `ls | TRIGGER x` matches (after the pipe) but
+- The per-segment walk means `ls | TRIGGER x` matches (after the pipe) but
   `grep TRIGGER f` does not (TRIGGER is grep's argument).
 - `ENV` skip means `FOO=1 TRIGGER` matches (TRIGGER is still the command).
+- The outer `cmd.split("\n")` means `cd /x\ngit add\nTRIGGER -y` matches (its own
+  line) — without it the newline collapses into whitespace and the head stays
+  `cd` (pitfall #11: replayed trigger rate 0 on real transcripts).
 
 **What it deliberately does NOT catch:** `$(TRIGGER)` / backtick command
 substitution. A raw-string regex for `$(TRIGGER` would misfire on a *quoted*
@@ -206,6 +261,18 @@ literal `'$(TRIGGER)'` (which doesn't execute). Since the real use of most
 banned commands is a direct call, missing the rare substitution case beats
 false-positives. If you truly need it, detect it in a context that distinguishes
 single- from double-quotes — usually not worth it.
+
+**What it splits but cannot fully parse:** a newline **inside** a quoted string
+or heredoc body — the text-level `split("\n")` is quote-blind about newlines, so
+`git commit -F - <<'MSG'` whose body quotes a trigger-looking line fragments
+into a phantom command. That residual is pitfall #11's: for a fail-open
+reminder, declare it and move on; for a fail-closed blocker, lift the git-write
+exemption (pitfall #7) to the whole command BEFORE this walk — exactly the
+order Pattern A shows. But note the exemption's name: it rescues **git**
+heredocs only. A non-git one (`cat <<'EOF'` whose body contains
+trigger-looking data) still false-blocks a fail-closed guard, and for that
+shape the honest options are declare-it-fail-open or a real shell grammar —
+there is no cheap middle ground.
 
 ---
 
@@ -386,7 +453,13 @@ later hallucination can't stand. This is `git-commit-headcheck`: after any real
 ```bash
 #!/usr/bin/env bash
 # PostToolUse (matcher: Bash): after a real `git commit`, inject the true HEAD.
+# Contract: ALWAYS exit 0 — a reporter, not a decider. Kept TWO ways in
+# production: drop -e entirely (Pattern E's shape), or keep -e and convert every
+# failure to exit 0 with `trap 'exit 0' ERR` (git-commit-headcheck's shape —
+# used here so set -e still guards the plumbing). See SKILL.md's "-e or trap"
+# bullet for the choice.
 set -euo pipefail
+trap 'exit 0' ERR
 INPUT=$(cat)
 CMD=$(printf '%s' "$INPUT" | python3 -c "import sys,json;print(json.load(sys.stdin).get('tool_input',{}).get('command',''))" 2>/dev/null||echo "")
 printf '%s' "$CMD" | grep -qE '(^|[^[:alnum:]])git[[:space:]].*commit([[:space:]]|$)' || exit 0
@@ -397,21 +470,32 @@ printf '%s' "$CMD" | grep -q -- '--dry-run' && exit 0
 # *as if it were truth* — the exact failure this pattern exists to prevent. A
 # real hook must extract the `-C`/`cd` target from $CMD (sed) and run
 # `git -C "$dir" …`; kept minimal here on purpose.
-# CRITICAL with `set -euo pipefail`: a git PIPE is a trap. If git fails (not a
-# repo / dubious ownership / bad `cd`-path), pipefail propagates git's exit code,
-# `set -e` kills the WHOLE script, and this hook's "ALWAYS exit 0" promise breaks
-# SILENTLY — the CLI shows only "Failed with non-blocking status code: No stderr
-# output" (a real 2026-07-21 bug). EVERY git command feeding output MUST have a
-# `|| <fallback>`, including the pipe.
+# CRITICAL: a git PIPE is a trap under pipefail — see pitfall #8. The `||` goes
+# OUTSIDE the $(…): `wc` prints 0 even when git fails, so `… | wc -l || echo '?'`
+# INSIDE the substitution yields the malformed two-line value `0\n?`.
 HEAD=$(git rev-parse --short HEAD 2>/dev/null || echo "?")
 SUBJ=$(git log -1 --format='%s' 2>/dev/null || echo "?")
-STAGED=$(git diff --cached --name-only 2>/dev/null | wc -l | tr -d ' ' || echo '?')
-echo "[headcheck] real HEAD = $HEAD $SUBJ | staged remaining = $STAGED" >&2
+STAGED=$(git diff --cached --name-only 2>/dev/null | wc -l | tr -d ' ') || STAGED='?'
+
+# The injection channel is `hookSpecificOutput` JSON on STDOUT, not stderr:
+# at exit 0 the CLI routes stderr nowhere the model sees (it only reaches the
+# model at exit 2), while a hookSpecificOutput payload is added to the model's
+# context as "additional context". Emitting the line below via `>&2` — as an
+# earlier version of this pattern did — delivers it to NO ONE. Production
+# (git-commit-headcheck) emits exactly this shape.
+CTX="[headcheck] real HEAD = $HEAD $SUBJ | staged remaining = $STAGED"
+python3 -c "import json,sys; print(json.dumps({'hookSpecificOutput':{'hookEventName':'PostToolUse','additionalContext':sys.argv[1]}}, ensure_ascii=False))" "$CTX"
 exit 0
 ```
 
 The value is that the model **cannot forget a check that runs automatically**.
 Injected truth beats "I think the commit worked."
+
+**Testing note:** the `says` helper in `scripts/test_hook.sh` captures **stderr**
+— right for blocking hooks (their contract text lives there) but blind for this
+pattern, whose payload is stdout JSON. For an exit-0 injector, assert on stdout
+instead (`out=$(printf '%s' "$2" | "$HOOK" 2>/dev/null)`) and match a fixed
+string from `additionalContext`, or stay with `run` rows for the exit contract.
 
 ---
 
@@ -422,11 +506,9 @@ tool call or a file. Use it for a rule about what the model itself *writes* —
 "never invent a shorthand name for something unverified", "always cite a
 source" — never for a rule about what the model writes **into** a file or a
 shell command (that's PreToolUse on `Write`/`Edit`/`Bash` instead; Stop only
-sees plain chat text). Getting the event wrong here isn't a tuning problem —
-`UserPromptSubmit` structurally cannot see the model's own text, so a hook
-built on it will never once fire for what it was built to catch, while still
-false-blocking the user's own unrelated typing whenever it happens to contain
-the trigger pattern (a real, shipped incident).
+sees plain chat text). Getting the event wrong here is a category mistake, not
+a tuning problem — full argument (why `UserPromptSubmit` structurally cannot
+substitute, and the shipped incident) in SKILL.md's Stop bullet.
 
 ```bash
 #!/usr/bin/env bash
@@ -532,44 +614,25 @@ exit 0
 Three things worth calling out beyond what the comments above already say:
 
 - **This skeleton uses `python3 - <<'PY' ... PY` (a QUOTED heredoc) everywhere,
-  never `python3 -c "…multi-line…"`.** With a quoted delimiter, bash treats
-  the entire body as inert literal text — no variable expansion, no command
-  substitution, no quote-parsing at all — so a stray `"` or `` ` `` **inside a
-  comment** (which is exactly where one tends to sneak in unnoticed, since
-  bash doesn't know it's "just a comment" the way Python does) cannot corrupt
-  anything. This is the same technique the JSON event contract section above
-  uses to avoid the stdin-consumption trap, and it happens to close the
-  quote-embedding hazard too — see
-  [hook_pitfalls.md](hook_pitfalls.md#9-a-literal-quote-or-backtick-inside-a-python-comment-corrupts-a-hook-silently)
-  for what goes wrong with the `-c "…"` form instead, and why `bash -n` alone
-  doesn't always catch it.
+  never `python3 -c "…multi-line…"`.** The quoted delimiter makes the body inert
+  literal text to bash — mechanism in the JSON event contract section above;
+  what goes wrong with the `-c "…"` form (a stray quote *inside a comment*
+  silently corrupts the block, and `bash -n` can't see it) is
+  [hook_pitfalls.md](hook_pitfalls.md#9-a-literal-quote-or-backtick-inside-a-python-comment-corrupts-a-hook-silently).
 - **`stop_hook_active` is the single most safety-critical field in this
   pattern.** Every other mistake in this hook fails toward "block too much" or
   "miss one case"; getting this one wrong in the permissive direction fails
   toward "silently do nothing, forever, with zero error signal."
-- **…and the two other loop-safety layers the flag does NOT give you, both
-  documented facts of the runtime (2026-07-25 verified against the official
-  hooks reference).** One: the harness itself **ends the turn after 8
-  consecutive blocks** — a guard whose message the model cannot act on does not
-  loop forever, it bounces 8 times and the violation passes anyway, so the cap
-  is a ceiling to stay far below, never a design target; the message is the
-  escape manual (name the exact acceptable fix) and the first block must carry
-  **all** findings, since the honored retry round passes with whatever was not
-  reported (the skeleton above collects them; pitfall #17 is the failure
-  shape). Two: **all Stop hooks for an event run in parallel** — your block
-  shares the round with every other Stop hook's feedback, so write the message
-  to compose (state your finding and your fix), not to own the channel. The
-  same Stop input also carries `background_tasks` / `session_crons`
-  (v2.1.145+): a blocking hook can tell "session is done" from "session merely
-  paused for background work" — blocking a pause burns the cap on pointless
-  continuations. One ownership nuance the docs state and the flag's name
-  hides: `stop_hook_active` is set by **any** stop hook's block, not
-  specifically yours ("already continuing as a result of **a** stop hook") —
-  with several Stop hooks registered, another guard's block consumes the same
-  retry round, one more reason the first block must be complete: you cannot
-  count on a second one. For the gate-vs-guidance channel choice
-  (`decision:"block"`/exit 2 vs `hookSpecificOutput.additionalContext`), see
-  SKILL.md's Stop bullet — both share these same protections.
+- **The flag is set by ANY stop hook's block, not specifically yours** —
+  "already continuing as a result of **a** stop hook": with several Stop hooks
+  registered, another guard's block consumes the shared retry round, so your
+  first block must be complete (the skeleton above collects all findings —
+  pitfall #17 is the failure shape of reporting only the first). The other
+  loop-safety layers (the 8-consecutive-block harness ceiling, all Stop hooks
+  running in parallel per event, the `background_tasks` / `session_crons` pause
+  signal in v2.1.145+, and the gate-vs-guidance channel choice) are covered in
+  SKILL.md's hook-types table and Stop bullet — both share these same
+  protections.
 - **…and handling it correctly still does not make the hook terminate.** The
   field covers **one layer of re-entry** — the stop you just blocked being
   retried. It does nothing for the *cross-turn* loop, where the model actually
@@ -585,16 +648,16 @@ Three things worth calling out beyond what the comments above already say:
   SKILL.md rule 7 and
   [hook_pitfalls.md](hook_pitfalls.md#16-the-remediation-the-hook-demands-re-arms-the-hook-a-loop-with-no-variant).
 - **Wrap every python3 subprocess call with the same `2>/dev/null` + `|| <fallback>`
-  guard, and put the `2>/dev/null` INSIDE the `$(...)` on the python3 call.** The
-  outer form `X=$(python3 … ) 2>/dev/null || fallback` only suppresses on bash ≥5;
-  on bash 3.2 (macOS system bash) the redirection does not reach the command
-  substitution and a crash leaks the raw traceback to the model's stderr
-  (independent-review measurement, 2026-07-25: same snippet, 5.3.15 silent /
-  3.2.57 leaks). Placement costs nothing on new bash and is the only portable
-  form. The guard itself is unchanged either way: an inconsistency here doesn't
-  change the block-vs-allow decision (the hook is already fail-open by
-  construction), it only decides whether a crash degrades to "no match" cleanly
-  or noisily.
+  guard, and put the `2>/dev/null` INSIDE the `$(...)`.** The outer form
+  `X=$(python3 … ) 2>/dev/null || fallback` leaks the raw traceback to the
+  model's stderr on **both** bash 3.2.57 (macOS system bash) and bash 5.x —
+  reproduced on both 2026-07-25 (an earlier note here claiming the outer form
+  "only suppresses on bash ≥5" was wrong; the redirection after a command
+  substitution does not reliably reach it on either). Inside placement costs
+  nothing and is the only portable form. The guard itself is unchanged either
+  way: an inconsistency here doesn't change the block-vs-allow decision (the
+  hook is already fail-open by construction), it only decides whether a crash
+  degrades to "no match" cleanly or noisily.
 
 ---
 

--- a/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
+++ b/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
@@ -37,10 +37,9 @@ Every entry here is a bug that shipped. When a hook misbehaves, match the
   *inside the quoted regex* is treated as a pipe, the string splits, and
   `TRIGGER` lands at a segment head → looks like a command.
 - **Fix:** tokenize with the **`shlex.shlex` class** (`punctuation_chars=True`,
-  `whitespace_split=True`) — NOT the `shlex.split()` function, which leaves
-  `ls|TRIGGER x` as `['ls|TRIGGER', 'x']` and hides the trigger from a
-  command-position check entirely. Both forms honor quotes (the regex stays one
-  token); only the class also splits unspaced separators. Then check **command
+  `whitespace_split=True`) — NOT the `shlex.split()` function (the `ls|TRIGGER x`
+  divergence is measured in [hook_patterns.md](hook_patterns.md#the-shlex-command-position-walker),
+  whose code comments carry it verbatim). Then check **command
   position**, not mere presence — walker in
   [hook_patterns.md](hook_patterns.md#the-shlex-command-position-walker).
 - **Caveat — `whitespace_split=True` also swallows newlines.** If your commands
@@ -97,10 +96,11 @@ Every entry here is a bug that shipped. When a hook misbehaves, match the
   set an env var to wave itself through.
 - **Cause:** the release valve was a static `GUARD_OK=1` / `SCOPE_OK=1` env var.
   Anything the model can add to its own command is not a gate.
-- **Fix:** a **human-confirmation gate** the model physically can't drive — a
-  native macOS `osascript` dialog (can't click) and/or a typed `YES` on
-  `/dev/tty` (can't type into the user's terminal); refuse/cancel/timeout = hard
-  NO; log every bypass. Pattern B in [hook_patterns.md](hook_patterns.md#pattern-b--pretooluse-with-a-human-confirmation-release-gate).
+- **Fix:** a **human-confirmation gate** the model physically can't drive —
+  full two-channel pattern (native dialog / typed YES, hard-NO semantics,
+  audit log, testability) in
+  [hook_patterns.md](hook_patterns.md#pattern-b--pretooluse-with-a-human-confirmation-release-gate)
+  and the rule-of-thumb form in SKILL.md rule 4.
   (Both `WORKTREE_GUARD_OK` and `GIT_COMMIT_SCOPE_OK` were retired to this in
   2026-07.)
 - **Nuance — an ack marker that's a real acknowledgement, not a free pass:** the
@@ -145,9 +145,8 @@ Every entry here is a bug that shipped. When a hook misbehaves, match the
 - **Cause:** the hook is already live in the session, so any Bash command you
   issue that contains the trigger token is inspected (and blocked) before it runs.
 - **Fix:** put the test cases in a **script file** and run `bash test_hook.sh` —
-  the outer command (`bash test_hook.sh`) doesn't contain the trigger, so it isn't
-  self-blocked; the triggers live inside the file where the PreToolUse hook
-  doesn't see them. This is what `scripts/test_hook.sh` is for.
+  the outer command carries no trigger, so it isn't self-blocked (mechanism in
+  SKILL.md rule 2 and the harness header comment).
 - **The same trap bites your own `git commit`.** A commit message that merely
   *mentions* the trigger — e.g. a fix whose message quotes `foo|TRIGGER` as an
   example — is parsed by the live hook and blocked: the heredoc message text
@@ -174,9 +173,15 @@ Every entry here is a bug that shipped. When a hook misbehaves, match the
   dubious-ownership / bad-`cd`-path context. pipefail propagates the left
   command's non-zero exit through the pipe, `set -e` kills the whole script, and
   the `2>/dev/null` already swallowed the stderr.
-- **Fix:** every command feeding a substitution needs a `|| <fallback>` — the
-  pipe included: `STAGED=$(git diff … | wc -l || echo '?')`. (2026-07-21 in
-  git-commit-headcheck.)
+- **Fix:** every command feeding a substitution needs a `|| <fallback>` — the pipe
+  included, and the `||` goes **OUTSIDE** the `$(…)`: `STAGED=$(git diff … | wc -l
+  | tr -d ' ') || STAGED='?'`. Put it inside (`… | wc -l || echo '?'`) and `wc`
+  still prints `0` when git fails, yielding the malformed two-line value `0\n?`.
+  (2026-07-21 in git-commit-headcheck.)
+- **Alternative shape — keep `-e` and trap the contract:** `set -euo pipefail` +
+  `trap 'exit 0' ERR` converts every failure to exit 0 while `-e` keeps guarding
+  the plumbing (git-commit-headcheck's production form; the choice between this
+  and dropping `-e` is SKILL.md's "-e or trap" bullet).
 - **Why it's insidious:** it only fires in *edge* contexts (bad path, not-a-repo),
   so it passes every test in a healthy repo and breaks in the field — same class
   as #1 (stdin) and #3 (poisoning): a promise broken, hard to locate. If your hook
@@ -413,19 +418,17 @@ unresolvable path means **block**.
   optional paragraph, let a heredoc swallow a section: the exit code stays
   exactly 2, and every row still passes. The suite is structurally blind to the
   only thing that hook produces.
-- **Fix:** add content assertions alongside the exit-code rows. Use the `says`
-  helper shipped in [scripts/test_hook.sh](../scripts/test_hook.sh) rather than
-  re-typing one here — a copy in prose drifts from the one people actually run
-  (this entry shipped with a copy that had no pass/fail counters, so a failing
-  content row printed FAIL and the suite still ended "ALL PASS"). It captures
-  stderr, matches a **fixed string** (a BRE `[skill]` is a character class, so
-  bracket-tagged output makes the row vacuously true), and counts into the same
-  gate as the exit-code rows. Assert **both polarities across two fixtures**:
-  present for the input it targets, absent for the lookalike it skips — a lone
-  `want=no` passes vacuously when the hook prints nothing at all.
+- **Fix:** add content assertions alongside the exit-code rows, with the `says`
+  helper shipped in [scripts/test_hook.sh](../scripts/test_hook.sh) — its header
+  comment carries the full doctrine (both polarities across two fixtures,
+  fixed-string matching because a BRE `[skill]` is a character class, and the
+  mutation pass that proves each row can die), which SKILL.md's harness section
+  repeats at rule length. Use the shipped helper rather than re-typing one — a
+  copy in prose drifts from the one people actually run (this entry shipped with
+  a copy that had no pass/fail counters, so a failing content row printed FAIL
+  and the suite still ended "ALL PASS").
 - **Then prove the assertions are not vacuous — mutate and confirm they die.**
-  A passing suite carries **zero information** until you have seen it fail for
-  the right reason. Copy the hook, inject the specific bug each assertion claims
+  Copy the hook, inject the specific bug each assertion claims
   to catch (invert the branch condition, delete the fact-check, revert to the
   display-string match), and confirm *that* assertion goes red — and ideally only
   that one. Real case: four separate mutations each killed exactly their intended

--- a/daymade-claude-code/claude-code-hooks/scripts/test_hook.sh
+++ b/daymade-claude-code/claude-code-hooks/scripts/test_hook.sh
@@ -14,7 +14,8 @@
 #   3. Fill the `run` table: trigger cases (want exit 2) + healthy-lookalike
 #      cases (want exit 0). The healthy-lookalike rows are the important ones —
 #      they prove you don't false-block (误杀健康输入比漏报更糟).
-#   4. bash test_hook.sh   # NOT ./test_hook.sh through a live hook's shell
+#   4. bash test_hook.sh   # run it through bash, not ./test_hook.sh: the copy
+#      may not carry an exec bit, and `bash <file>` works regardless.
 #
 # It runs `bash -n` (syntax — a corrupted PreToolUse hook poisons the whole
 # session) then every case, and reports pass/fail.
@@ -49,6 +50,10 @@ run() {
 #   speaks. Do not try to put both polarities on ONE fixture: a healthy input is
 #   supposed to be silent, so it has no want=yes partner — its partner is the
 #   trigger fixture.
+#   CHANNEL NOTE: `says` captures STDERR (right for blocking hooks — their
+#   contract text lives there). An exit-0 injector (PostToolUse emitting
+#   hookSpecificOutput JSON on STDOUT, Pattern D) is invisible to it — assert on
+#   stdout instead: out=$(printf '%s' "$2" | "$HOOK" 2>/dev/null).
 says() {
   local out hit=no
   out=$(printf '%s' "$2" | "$HOOK" 2>&1 >/dev/null) || true
@@ -70,6 +75,11 @@ run "after-pipe"     '{"tool_name":"Bash","tool_input":{"command":"ls | TRIGGER 
 run "no-space-pipe"  '{"tool_name":"Bash","tool_input":{"command":"ls|TRIGGER -x"}}' 2
 run "after-&&"       '{"tool_name":"Bash","tool_input":{"command":"foo && TRIGGER x"}}' 2
 run "env-prefix"     '{"tool_name":"Bash","tool_input":{"command":"FOO=1 TRIGGER x"}}' 2
+run "multiline"      '{"tool_name":"Bash","tool_input":{"command":"cd /x && ls\nTRIGGER -y"}}' 2
+#   ↑ the multiline row is not optional: shlex treats newlines as whitespace, so
+#   a one-stage walker collapses the block into one segment headed by `cd` and
+#   never sees TRIGGER (pitfall #11). It only passes if your hook splits on
+#   newlines as text FIRST (Pattern A / the walker section both do).
 # Healthy-lookalike cases (want 0) — THESE are what prove you don't false-block:
 run "grep-regex-arg" '{"tool_name":"Bash","tool_input":{"command":"grep -E \"a|TRIGGER|b\" file"}}' 0
 run "redirect-target" '{"tool_name":"Bash","tool_input":{"command":"echo x > TRIGGER"}}' 0
@@ -83,7 +93,13 @@ run "non-bash-tool"  '{"tool_name":"Read","tool_input":{"file_path":"/x/TRIGGER.
 # ── FAILURE-DIRECTION ROWS — add these whenever the hook derives state from the
 #    command text (a path, a repo, a target). They assert the hook still behaves
 #    when it CANNOT resolve what it parsed. Omit them and a fail-open bug looks
-#    exactly like a clean pass (pitfall #10):
+#    exactly like a clean pass (pitfall #10).
+#    ⚠️ These rows expect 2 because this template targets the TOKEN-MATCHER
+#    class (the banned thing is right there in the command text). A STATE-
+#    DERIVING guard (does staged state span domains?) has the OPPOSITE correct
+#    answer for `cd ~/no-such-dir && …` — the && short-circuits, nothing ever
+#    runs, allow is correct. Derive your expected exits from SKILL.md rule 5's
+#    guard-class table BEFORE writing the row, or you'll fail a correct guard.
 # run "trigger behind cd ~"  '{"tool_name":"Bash","tool_input":{"command":"cd ~/somewhere && TRIGGER -x"}}' 2
 # run "trigger behind cd abs" '{"tool_name":"Bash","tool_input":{"command":"cd /tmp && TRIGGER -x"}}' 2
 # run "unresolvable path"    '{"tool_name":"Bash","tool_input":{"command":"cd ~/no-such-dir && TRIGGER -x"}}' 2


### PR DESCRIPTION
## 什么

对 `daymade-claude-code/claude-code-hooks` 的一次双轴整体体检（可执行性走查 + 重复/矛盾扫描,均为 fresh-context 独立评审）,修复全部 15 项发现 + 2 项修复连带发现。

## 关键修复

- **Pattern D 注入信道**:stderr-at-exit-0（模型不可见的死信道）→ `hookSpecificOutput` JSON on stdout（与类型表、生产 git-commit-headcheck 对齐）;`||` 挪出 `$( )`（内侧形式非 repo 产 `0\n?` 畸形值）;改生产形态 `set -e + trap 'exit 0' ERR`
- **Pattern A/walker 补 git-write 段豁免**（commit message 全文到达命令位 → 误杀自己的 fix commit,pitfall #7 的 must 此前骨架与 SKILL.md 双缺）+ **换行两段式**（pitfall #11 的多行命令塌陷,真实语料重放触发率 0 的根因）
- **-e 契约三方矛盾调和**:「报告类 must drop -e」vs Pattern D vs pitfall #8 → 双契约（drop -e 或 -e+trap）,pitfall #8 同步修处方（它还在开被 Pattern D 判 malformed 的内侧 `||`）
- **bash 实测纠错**:外层 `2>/dev/null` 在 3.2.57 与 5.x 都漏（复现）,内层唯一 portable
- **重复压缩 7 组**（SKILL.md 侧 load-bearing 的保留,references 侧换指针;有意双写维持）
- **缺口提升**:rule 1 两条 corollary（git 豁免 + 两段式）、headliners #7、跨 suite 裸链接改散文、Pattern C/Registration 指针、注册成功信号、`ln -s` 字面命令、main profile 点名

## 验证

- Pattern A 代码抽跑 **20/20**（含多行/git 豁免/误杀对照）;walker 节 **6/6**;shipped harness **14/14**;JSON 信道形状验证;`bash -n` 双脚本过
- 回归审计 git-ref 基线 `214093d`:**27 候选全部 classify + verify passed**
- **核销 agent 独立复跑 F1-F15 全 FIXED**（关键数值经独立执行,非仅读文本）;其 2 项连带发现（#8 同步、非 git heredoc 限定）已再修
- 公开仓脱敏:语义通读 232 行新增仅技术内容;security_scan 绿
- 全程记录:`daymade-claude-code/claude-code-hooks-workspace/independent-review-2026-07-25-coherence.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)