### PR TITLE
claude-code-hooks: pitfall #18 + #19 (1.27.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -103,7 +103,7 @@
       "description": "Claude Code operations suite that bundles archive-aware local conversation discovery across Claude Code and Codex, internal-timestamp full-event session search and recovery, interrupted-work continuation, plugin/skill troubleshooting, CLAUDE.md progressive disclosure optimization, statusline configuration, exported .txt repair, full claude.ai conversation extraction with tool-call rendering and file download, plugin marketplace development, writing/testing/debugging Claude Code hooks, multi-provider profile isolation for running Kimi/GLM/DeepSeek/StepFun/Anthropic in separate windows, local source sync for Claude/Codex skill installs, personal-memory migration into tool-agnostic AGENTS.md reference docs, and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
       "source": "./daymade-claude-code",
       "strict": false,
-      "version": "1.27.1",
+      "version": "1.27.2",
       "category": "suite",
       "keywords": [
         "suite",

--- a/daymade-claude-code/claude-code-hooks/.security-scan-passed
+++ b/daymade-claude-code/claude-code-hooks/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-07-25T13:42:27.767264+00:00
+Scanned at: 2026-07-25T15:53:53.649771+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: f29730c23521a79bba2019fdb63a24dca3e29691666fee89183f84db04238011
+Content hash: 63f17c7c2aa5e83500f751ad6856ddaf023becc9e8348815fb2ee64ac35b3141

--- a/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
+++ b/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
@@ -514,7 +514,6 @@ unresolvable path means **block**.
 ---
 
 ## 17. A Stop guard that reports only the first violation loses the rest (the retry round is a full pass-through)
-
 - **Symptom:** a Stop hook correctly blocks on finding X in the model's reply;
   the model fixes X and stops again — and the reply still contains violation Y
   from the same original turn, never reported, never caught.
@@ -535,6 +534,57 @@ unresolvable path means **block**.
   the first and ended the turn with the second intact. Found by an independent
   reviewer, fixed by collecting all matches (cap 5); regression row
   "多命中一次报全" pins it.
+
+---
+
+## 18. A blocked compound command silently discards the innocent segments' side effects
+
+- **Symptom:** you fixed something and ran the gated command in the SAME Bash
+  call (`fix_thing && gated_command`); the guard blocked it; next round the
+  SAME error reappears — as if your fix never happened. You re-diagnose,
+  "discover" the fix is missing, and only then realize why.
+- **Cause:** a PreToolUse block prevents the **whole** command from running —
+  including innocent segments (a heredoc updating a file, a map write, an edit)
+  chained before or after the gated one. The block error names the gated
+  segment, so all attention goes there; the innocent write's silent absence
+  leaves no signal of its own.
+- **Fix — two habits, one on each side of the block:** when *building*
+  commands, put state-changing steps (file writes, edits, map updates) in their
+  **own** Bash call, never bundled with a command a guard might block; when
+  *recovering* from a block, re-verify every write you *assumed* had landed
+  before the block (`grep` for the change) — "the error named the other
+  segment" is exactly the situation where your side effect is gone. Real case
+  (2026-07-25, twice in one session): a needle-fix heredoc bundled with the
+  validation command; the tooling guard blocked the bundle; the validator
+  re-reported byte-identical errors because the fix never landed — diagnosed
+  only on the second identical failure.
+
+---
+
+## 19. A block whose remediation demands cross-call memory re-fires all session
+
+- **Symptom:** the hook blocks, its message teaches the correct form, you
+  comply — and get blocked again for the same reason. And again. (One session
+  measured **10** blocks for the identical cause, plus 3 sibling failures —
+  including a feature branch created in the *wrong repository*.)
+- **Cause:** the remediation the hook demands is a **habit change across tool
+  calls** — e.g. "always prefix this command family with `cd <tool-root>`" —
+  but the working directory does not persist across Bash calls and attention
+  resets with each one. The lesson is re-read and re-forgotten every time; the
+  hook is correct every time, and it does not matter. This is not carelessness —
+  it is a property of the *class*: the remediation's success depends on the
+  weakest link (cross-call memory), so the block re-fires until the session
+  ends or the environment changes.
+- **Fix — pick the guard's answer deliberately, knowing the class:** (a) put
+  the corrective *in the environment* instead of the message (a wrapper script
+  that doesn't care about cwd, an env var, a `PYTHONPATH`) so the habit is no
+  longer required — strongest, because it removes the dependency; (b) convert
+  the block to a fail-open reminder for habit-class rules (a noisy PreToolUse
+  block trains bypass exactly as #2 warns); (c) accept and *measure* the
+  repetition as the cost of enforcement — 10 blocks can mean "guard working,
+  loudly", but then say so in the header so nobody "fixes" it. What does not
+  work: making the block message clearer. It was clear every one of the 10
+  times.
 
 ---
 
@@ -589,3 +639,12 @@ When a guard is misbehaving, check in this order — cheapest and most common fi
     from the same reply**? → first-only reporting (#17): the honored retry round
     is a full pass-through, so collect every finding before printing and assert
     both hits in a two-violations fixture.
+15. Did the **same block error return after you "fixed" it** — and your fix was
+    bundled into the same command as the gated one? → innocent-segment
+    side effects swallowed (#18): separate state changes from gated commands
+    into their own Bash call, and after any block re-verify writes you assumed
+    had landed.
+16. Are you blocked **repeatedly for the same thing despite complying** each
+    time? → the remediation demands cross-call memory (#19): it's a class
+    property, not carelessness — fix the environment, downgrade to a reminder,
+    or accept-and-measure; a clearer message was never the missing piece.

--- a/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
+++ b/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
@@ -567,24 +567,36 @@ unresolvable path means **block**.
   comply — and get blocked again for the same reason. And again. (One session
   measured **10** blocks for the identical cause, plus 3 sibling failures —
   including a feature branch created in the *wrong repository*.)
-- **Cause:** the remediation the hook demands is a **habit change across tool
-  calls** — e.g. "always prefix this command family with `cd <tool-root>`" —
-  but the working directory does not persist across Bash calls and attention
-  resets with each one. The lesson is re-read and re-forgotten every time; the
-  hook is correct every time, and it does not matter. This is not carelessness —
-  it is a property of the *class*: the remediation's success depends on the
-  weakest link (cross-call memory), so the block re-fires until the session
-  ends or the environment changes.
+- **Cause:** the remediation the hook demands is a **habit change that must be
+  remembered across tool calls** — e.g. "always prefix this command family with
+  `cd <tool-root>`" — and three things conspire against that memory, none of
+  which is carelessness: **attention resets per call** (the model re-reads the
+  lesson and re-forgets it each time, because at the moment of action the goal
+  is the task, not the form); **shell state does not persist** (env vars and
+  functions are re-initialized from the profile each call — so a remediation
+  that relies on an exported variable dies with the call; only settings.json's
+  `env` block or the shell profile makes one stick); and **environment drift in
+  `cd` behavior** — the documented contract is that the working directory
+  *does* persist between calls, yet harnesses/profiles deviate in practice, and
+  a `cd` that *does* stick creates its own failure mode (the next command then
+  runs in the wrong repo entirely — the sibling failure in the incident below:
+  a feature branch created in the wrong repository, which could only happen
+  *because* the directory persisted). The hook is correct every time, and it
+  does not matter: the remediation's success depends on memory surviving
+  boundaries it often doesn't survive, so the block re-fires until the session
+  ends or the environment changes. (2026-07-25, one session: **10** identical
+  blocks + those 3 sibling failures.)
 - **Fix — pick the guard's answer deliberately, knowing the class:** (a) put
   the corrective *in the environment* instead of the message (a wrapper script
-  that doesn't care about cwd, an env var, a `PYTHONPATH`) so the habit is no
-  longer required — strongest, because it removes the dependency; (b) convert
-  the block to a fail-open reminder for habit-class rules (a noisy PreToolUse
-  block trains bypass exactly as #2 warns); (c) accept and *measure* the
-  repetition as the cost of enforcement — 10 blocks can mean "guard working,
-  loudly", but then say so in the header so nobody "fixes" it. What does not
-  work: making the block message clearer. It was clear every one of the 10
-  times.
+  that doesn't care about cwd, a `PYTHONPATH` or variable set in settings.json's
+  `env` block or the shell profile — an ad-hoc exported var dies with the call,
+  per the Cause above) so the habit is no longer required — strongest, because
+  it removes the dependency; (b) convert the block to a fail-open reminder for
+  habit-class rules (a noisy PreToolUse block trains bypass exactly as #2
+  warns); (c) accept and *measure* the repetition as the cost of enforcement —
+  10 blocks can mean "guard working, loudly", but then say so in the header so
+  nobody "fixes" it. What does not work: making the block message clearer. It
+  was clear every one of the 10 times.
 
 ---
 
@@ -629,12 +641,14 @@ When a guard is misbehaving, check in this order — cheapest and most common fi
     content assertions, then mutate to prove they can die.
 12. Does it report a file **nobody wrote** — especially one containing a literal
     `$VAR`? → it is reading command text as if every redirect in it executed (#15).
-13. Does it fire **again right after you did exactly what it asked**? → its
-    condition is a temporal comparison that the remediation itself moves (#16).
+13. Does a **Stop hook** fire **again right after you did exactly what it asked**
+    (the turn ends, work happens, and the NEXT stop re-fires on the same grounds)?
+    → its condition is a temporal comparison that the remediation itself moves (#16).
     Not a tuning problem: change the predicate's *shape* — move the gate to the
     action with PreToolUse, or test an existence fact keyed on the thing that
     needed remediating — and add the after-remediation row pair that a
-    point-in-time suite structurally cannot have.
+    point-in-time suite structurally cannot have. (Same "recurring fire" symptom
+    as 15/16 below — split by hook type and by what you check first.)
 14. Did it catch the first violation and **silently never mention the second one
     from the same reply**? → first-only reporting (#17): the honored retry round
     is a full pass-through, so collect every finding before printing and assert
@@ -643,8 +657,10 @@ When a guard is misbehaving, check in this order — cheapest and most common fi
     bundled into the same command as the gated one? → innocent-segment
     side effects swallowed (#18): separate state changes from gated commands
     into their own Bash call, and after any block re-verify writes you assumed
-    had landed.
-16. Are you blocked **repeatedly for the same thing despite complying** each
-    time? → the remediation demands cross-call memory (#19): it's a class
+    had landed. (Cheapest check in the recurrence family — one grep — so run it
+    before 13/16's deeper reads.)
+16. Does a **PreToolUse hook** block you **repeatedly for the same thing despite
+    complying** each time (the block arrives before the command even runs)?
+    → the remediation demands cross-call memory (#19): it's a class
     property, not carelessness — fix the environment, downgrade to a reminder,
     or accept-and-measure; a clearer message was never the missing piece.


### PR DESCRIPTION
## 什么

两条新 pitfall,蒸馏自 2026-07-25 的 session 自审查校准语料(全部带 transcript 证据):

- **#18 A blocked compound command silently discards the innocent segments' side effects** — PreToolUse block 杀掉整条复合命令,无辜段(修复 heredoc/map 更新)的副作用一并消失;报错只点名被拦段,缺失的写入无任何信号,下一轮同一错误原样重现(一个 session 内两次真实复现)。修:状态变更独立成 Bash 调用;被拦后重新核验以为已发生的写入。
- **#19 A block whose remediation demands cross-call memory re-fires all session** — block 的补救要求跨调用习惯(如「永远给这族命令加 cd 前缀」),但 cwd 不跨 Bash 调用持久、注意力每次调用重置:实测一个 session 10 次同因拦截 + 3 次 sibling 失败(含错仓建分支)。修:改环境/降级为提醒/接受并度量——更清楚的消息从来不是缺的那块。

meta-principle 诊断序补 15/16 两条路由。

## 验证

- 回归审计基线 git-ref e518c38:**0 候选(纯增量)**;quick_validate + security_scan 绿
- 战例已去环境特定 hook 名(公开仓)
- 独立评审 agent 核销中(报告到达后合并)

🤖 Generated with [Claude Code](https://claude.com/claude-code)