### PR TITLE
skill-creator(quick_validate): Missing-internal-files error now teaches the resolution (1.15.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -230,7 +230,7 @@
       "description": "Daymade skills core suite. Bundles skill creation, quality review, governance, and marketplace development tooling under one shared namespace. Existing-skill edits use an old-vs-new capability audit and content-bound packaging attestation so prompt compression cannot silently delete runtime contracts. When the official skill-creator plugin is also installed, skill-creator detects the coexistence and offers a consent-based, reversible SessionStart routing hook so the daymade edition wins deterministically; on machines without the official plugin nothing is ever installed.",
       "source": "./daymade-skill",
       "strict": false,
-      "version": "1.15.0",
+      "version": "1.15.1",
       "category": "suite",
       "keywords": [
         "suite",

--- a/daymade-skill/skill-creator/scripts/quick_validate.py
+++ b/daymade-skill/skill-creator/scripts/quick_validate.py
@@ -357,7 +357,15 @@ def validate_skill(skill_path, audience=None):
     # Absolute paths (e.g., /Users/<user>/...) are external and NOT checked here.
     paths_valid, missing_paths = validate_internal_paths(skill_path, content)
     if not paths_valid:
-        return False, f"Missing internal skill files: {', '.join(missing_paths)}"
+        return False, (
+            f"Missing internal skill files: {', '.join(missing_paths)}\n"
+            "  A bare `scripts/...` / `references/...` / `assets/...` reference always means\n"
+            "  'inside this skill's own bundle'. Two ways to resolve:\n"
+            "  1. The file belongs to the bundle → create it at that path inside the skill.\n"
+            "  2. The prose points at a file in the TARGET project (not the bundle) →\n"
+            "     qualify it with a placeholder prefix, e.g. `<project-root>/scripts/x.sh`\n"
+            "     (paths preceded by `/` are not treated as bundle-internal)."
+        )
 
     # Scan SKILL.md AND bundled text files (references/, scripts/) for portability
     # issues. Scanning only SKILL.md is a proven blind spot: a hardcoded


### PR DESCRIPTION
## 什么

`Missing internal skill files: X` 报错过去只报名就停——而散文指向**目标项目**文件的作者,只能读校验器源码才能学会 `<project-root>/` 占位符前缀约定(一个真实 session 为此烧掉 4 轮返工)。现在消息直接给出约定与两条消解路径(文件放进 bundle,或给引用加占位符前缀)。

## 边界

**只改消息,不动检测逻辑**——已实证 lookbehind 对占位符前缀路径本就豁免(5 组用例),此前被拦的全是符合设计意图的真裸引用。合成失败用例展示新消息;两个真实 skill(setup-feishu-wiki-syncing / claude-code-hooks)回归仍 valid。

daymade-skill 1.15.0 → 1.15.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)