### PR TITLE
claude-code-hooks: walker/Pattern A backport split_shell_lines from production (1.27.3)

### DIFF
--- a/daymade-claude-code/claude-code-hooks/.security-scan-passed
+++ b/daymade-claude-code/claude-code-hooks/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-07-25T15:53:53.649771+00:00
+Scanned at: 2026-07-26T00:16:54.483674+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 63f17c7c2aa5e83500f751ad6856ddaf023becc9e8348815fb2ee64ac35b3141
+Content hash: 469f7c4db1b7cf4e11c4e79d4071f3bbc6d334f437a9a34901ea3b5b6ceb6205

--- a/daymade-claude-code/claude-code-hooks/SKILL.md
+++ b/daymade-claude-code/claude-code-hooks/SKILL.md
@@ -172,9 +172,12 @@ false-blocks is matching on the raw command string.
   treats newlines as ordinary whitespace, so a multiline block
   (`cd /x\ngit add\nTRIGGER -y`) collapses into one segment headed by `cd` and
   the trigger is never in command position — replayed trigger rate 0 on real
-  transcripts (pitfall #11). Split on newlines as text first, then shlex-walk
-  each line (both Pattern A and the walker section already do this); the
-  heredoc-body residual and when to accept it are #11's call.
+  transcripts (pitfall #11). Split into lines **shell-aware** first (quote state
+  and backslash continuations honored, so quoted multiline strings don't
+  fragment), then shlex-walk each line — both Pattern A and the walker section
+  ship that splitter (`split_shell_lines`, production-proven in qlmanage-guard).
+  What even it cannot parse is a heredoc body (not quote syntax); when to accept
+  that residual is #11's call.
 - **But shlex isn't a silver bullet, and *what* you detect changes whether
   fail-open is safe.** `shlex.split()` itself throws `ValueError` on an unbalanced
   quote — a multi-line `git commit -m "…` message with a `#` or an unclosed quote

--- a/daymade-claude-code/claude-code-hooks/references/hook_patterns.md
+++ b/daymade-claude-code/claude-code-hooks/references/hook_patterns.md
@@ -122,6 +122,7 @@ cmd = os.environ["HOOK_CMD"]
 SEPS = {";","&&","||","|","&","(",")","{","}","|&"}   # NOT <> — a redirect target is a filename, not a command
 ENV = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
 GIT_WRITES = {"commit","rebase","tag","am","cherry-pick"}
+WRAPPERS = {"command","env","sudo","time","timeout","nice","stdbuf","nohup","builtin","exec","xargs"}
 
 def toks(c):
     lex = shlex.shlex(c, posix=True, punctuation_chars=True); lex.whitespace_split = True
@@ -152,23 +153,72 @@ def is_git_write(seg):
         return t in GIT_WRITES
     return False
 
+def eff_head_idx(toks):
+    """Effective command index: skip ENV prefixes and transparent wrappers (their
+    flags included — production carries per-wrapper valued-flag tables; kept
+    compact here). Without it the exemption below only sees a literal `git` head
+    and false-blocks `sudo git commit` (its own commit message!) — qlmanage-guard
+    Finding 1."""
+    i = 0
+    while i < len(toks):
+        t = toks[i]
+        if ENV.match(t): i += 1; continue
+        if t in WRAPPERS:
+            i += 1
+            while i < len(toks) and toks[i].startswith("-"): i += 1
+            continue
+        return i
+    return -1
+
+def split_shell_lines(c):
+    r"""Split on newlines as SHELL sees them: quote state tracked (a newline
+    inside '…' or "…" does not split — `gh pr create -b "…\nTRIGGER…"` never
+    executes it), backslash-newline joined (posix), and `$'…'` ANSI-C escapes
+    honored (`\'` does not close). Heredoc bodies are not quote syntax and
+    still fragment (the declared residual, pitfall #11)."""
+    lines, cur, quote, ansi, i = [], [], None, False, 0
+    n = len(c)
+    while i < n:
+        ch = c[i]
+        if ch == "\\" and i + 1 < n:
+            nx = c[i + 1]
+            if nx == "\n" and (quote != "'" or ansi): i += 2; continue
+            if quote == '"' and nx in ('"', "\\", "$", "`"): cur.append(ch); cur.append(nx); i += 2; continue
+            if quote is None and nx in ("'", '"', "\\"): cur.append(ch); cur.append(nx); i += 2; continue
+            if quote == "'" and ansi: cur.append(ch); cur.append(nx); i += 2; continue
+        if quote is None and ch in ("'", '"'):
+            quote = ch; ansi = ch == "'" and len(cur) > 0 and cur[-1] == "$"
+        elif quote == ch:
+            quote = None; ansi = False
+        if ch == "\n" and quote is None:
+            lines.append("".join(cur)); cur = []
+        else:
+            cur.append(ch)
+        i += 1
+    lines.append("".join(cur))
+    return lines
+
 # Pitfall #7 (whole command, BEFORE any splitting): a git *write*'s message is DATA —
 # `git commit -F - <<EOF` whose body quotes `foo|TRIGGER` reaches the walk below as
 # pseudo-command-text and the guard blocks its own fix commit (this skill's own
-# qlmanage-guard shipped exactly that). Exempt the whole command when any segment is
-# a git write. Bias-to-under (pitfall #11): this also lets `git commit -m x &&
-# TRIGGER` through — the rare miss is the deliberate trade for a blocker; stricter
-# needs a real shell grammar (production: lib-git-commit-detect's adjacency check).
-if any(h == "git" and is_git_write(seg) for h, seg in segments(cmd)):
+# qlmanage-guard shipped exactly that). Exempt the whole command when any segment's
+# EFFECTIVE command is a git write. Bias-to-under (pitfall #11): this also lets
+# `git commit -m x && TRIGGER` through — the rare miss is the deliberate trade for
+# a blocker; stricter needs a real shell grammar (production: qlmanage-guard's
+# eff_head_idx + lib-git-commit-detect's adjacency check).
+if any(
+    (idx := eff_head_idx(seg[1])) >= 0
+    and (seg[1][idx] == "git" or seg[1][idx].endswith("/git"))
+    and is_git_write(seg[1][idx:])
+    for seg in segments(cmd)
+):
     sys.exit(0)
 
 # Pitfall #11: shlex treats newlines as ordinary whitespace, so a multiline command
 # (`cd /x\ngit add\nTRIGGER -y`) collapses into ONE segment whose head is `cd` and
 # the trigger is never in command position — replayed trigger rate 0 on real
-# transcripts. Split on newlines as TEXT first, then walk each line. Residual (same
-# entry): a heredoc body still fragments — for a fail-open reminder declare it; the
-# whole-command git exemption above is what keeps heredoc commits safe here.
-for line in cmd.split("\n"):
+# transcripts. Split shell-aware FIRST, then walk each line.
+for line in split_shell_lines(cmd):
     for head, seg in segments(line):
         if head == "TRIGGER":                # command-position hit → print guidance + block
             sys.stderr.write("BLOCKED: <BANNED THING> is not allowed here.\n"
@@ -227,13 +277,57 @@ def _segments(line: str):
         cur.append(t)
     if head: yield head, cur
 
+def split_shell_lines(c: str):
+    r"""Split on newlines as SHELL sees them (production: qlmanage-guard).
+    - Newlines inside single/double quotes do NOT split — `gh pr create -b
+      "line1\nTRIGGER was the culprit\nline3"` never executes TRIGGER, and a
+      text-level split would put it at a line head and false-block (a more
+      common shape than heredocs).
+    - Backslash-newline continuations are deleted and joined (posix), so
+      `echo a \⏎TRIGGER` keeps TRIGGER as an argument of echo.
+    - `$'…'` ANSI-C quoting is tracked: `\'` inside it is an escaped quote,
+      not a close — `$'a\'⏎TRIGGER'` does not execute TRIGGER.
+    Heredoc bodies are not quote syntax: they still fragment (residual below)."""
+    lines, cur, quote, ansi, i = [], [], None, False, 0
+    n = len(c)
+    while i < n:
+        ch = c[i]
+        if ch == "\\" and i + 1 < n:
+            nx = c[i + 1]
+            if nx == "\n" and (quote != "'" or ansi):
+                i += 2
+                continue
+            if quote == '"' and nx in ('"', "\\", "$", "`"):
+                cur.append(ch); cur.append(nx); i += 2
+                continue
+            if quote is None and nx in ("'", '"', "\\"):
+                cur.append(ch); cur.append(nx); i += 2
+                continue
+            if quote == "'" and ansi:
+                cur.append(ch); cur.append(nx); i += 2
+                continue
+        if quote is None and ch in ("'", '"'):
+            quote = ch
+            ansi = ch == "'" and len(cur) > 0 and cur[-1] == "$"
+        elif quote == ch:
+            quote = None
+            ansi = False
+        if ch == "\n" and quote is None:
+            lines.append("".join(cur)); cur = []
+        else:
+            cur.append(ch)
+        i += 1
+    lines.append("".join(cur))
+    return lines
+
 def executes(cmd: str, target: str) -> bool:
     # Two stages, order matters (pitfall #11): shlex swallows newlines as ordinary
     # whitespace, so a multiline block (`cd /x\ngit add\nTRIGGER -y`) would
-    # collapse into ONE segment headed by `cd` and hide the trigger. Split on
-    # newlines as TEXT first, then shlex-walk each line — a quoted `a|TRIGGER|b`
-    # still stays one token inside its line, so no phantom command is made.
-    for line in cmd.split("\n"):
+    # collapse into ONE segment headed by `cd` and hide the trigger. Split into
+    # lines shell-aware FIRST (quote state + continuations), then shlex-walk
+    # each line — a quoted `a|TRIGGER|b` still stays one token inside its line,
+    # so no phantom command is made.
+    for line in split_shell_lines(cmd):
         for head, _seg in _segments(line):
             if head == target: return True      # command-position match
     return False
@@ -251,9 +345,11 @@ Why each piece matters:
 - The per-segment walk means `ls | TRIGGER x` matches (after the pipe) but
   `grep TRIGGER f` does not (TRIGGER is grep's argument).
 - `ENV` skip means `FOO=1 TRIGGER` matches (TRIGGER is still the command).
-- The outer `cmd.split("\n")` means `cd /x\ngit add\nTRIGGER -y` matches (its own
+- The outer `split_shell_lines(cmd)` means `cd /x\ngit add\nTRIGGER -y` matches (its own
   line) — without it the newline collapses into whitespace and the head stays
-  `cd` (pitfall #11: replayed trigger rate 0 on real transcripts).
+  `cd` (pitfall #11: replayed trigger rate 0 on real transcripts). Being
+  quote-state-aware it also leaves `gh pr create -b "…\nTRIGGER…"` alone
+  (quoted, never executed) and joins `echo a \⏎TRIGGER` back into one line.
 
 **What it deliberately does NOT catch:** `$(TRIGGER)` / backtick command
 substitution. A raw-string regex for `$(TRIGGER` would misfire on a *quoted*
@@ -262,10 +358,12 @@ banned commands is a direct call, missing the rare substitution case beats
 false-positives. If you truly need it, detect it in a context that distinguishes
 single- from double-quotes — usually not worth it.
 
-**What it splits but cannot fully parse:** a newline **inside** a quoted string
-or heredoc body — the text-level `split("\n")` is quote-blind about newlines, so
-`git commit -F - <<'MSG'` whose body quotes a trigger-looking line fragments
-into a phantom command. That residual is pitfall #11's: for a fail-open
+**What it splits but cannot fully parse:** a newline **inside a heredoc body** —
+a heredoc is not quote syntax, so `git commit -F - <<'MSG'` whose body quotes a
+trigger-looking line still fragments into a phantom command even with
+quote-state-aware splitting. (Multiline *quoted strings* used to be in this
+list too; `split_shell_lines` handles those — the residual is heredoc-only.)
+That residual is pitfall #11's: for a fail-open
 reminder, declare it and move on; for a fail-closed blocker, lift the git-write
 exemption (pitfall #7) to the whole command BEFORE this walk — exactly the
 order Pattern A shows. But note the exemption's name: it rescues **git**

--- a/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
+++ b/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
@@ -320,7 +320,13 @@ unresolvable path means **block**.
   command it isn't. (A multiline `-m "…\ngit push"` message fragments too, but its
   torn line has an unbalanced quote, so whether it over- or under-fires depends on how
   you handle the `shlex` `ValueError` — a witness for the same residual, less clean.)
-  So the two-stage is not "#2-proof", only *less* exposed than the one-shot regex.
+  **2026-07-26 refinement (production qlmanage-guard, three review rounds with
+  100+ executed probes):** split shell-aware instead — `split_shell_lines`
+  (walker section / Pattern A) tracks quote state, backslash continuations, and
+  `$'…'` ANSI-C escapes, which removes the *quoted-string* half of the residual
+  (the `gh pr create -b "…\nTRIGGER…"` shape — more common than heredocs in real
+  tool calls). What remains is heredoc bodies only: they are not quote syntax,
+  so no quote-state machine can see them.
   Whether that residual is acceptable follows the same **bias-to-under** call as #2:
   for a **fail-open reminder** an extra over-fire costs nothing — declare it and move
   on; for a **fail-closed blocker** it re-creates #2's false-block, so you must lift

--- a/daymade-claude-code/claude-code-hooks/scripts/test_hook.sh
+++ b/daymade-claude-code/claude-code-hooks/scripts/test_hook.sh
@@ -81,6 +81,10 @@ run "multiline"      '{"tool_name":"Bash","tool_input":{"command":"cd /x && ls\n
 #   never sees TRIGGER (pitfall #11). It only passes if your hook splits on
 #   newlines as text FIRST (Pattern A / the walker section both do).
 # Healthy-lookalike cases (want 0) — THESE are what prove you don't false-block:
+run "quoted-multiline" '{"tool_name":"Bash","tool_input":{"command":"echo \"line1\nTRIGGER was the culprit\nline3\""}}' 0
+#   ↑ quoted-multiline is the trap sibling of "multiline": a text-level line
+#   split fragments it and false-blocks (pitfall #11 residual); only a
+#   quote-state-aware splitter (split_shell_lines) passes it.
 run "grep-regex-arg" '{"tool_name":"Bash","tool_input":{"command":"grep -E \"a|TRIGGER|b\" file"}}' 0
 run "redirect-target" '{"tool_name":"Bash","tool_input":{"command":"echo x > TRIGGER"}}' 0
 run "sed-arg"        '{"tool_name":"Bash","tool_input":{"command":"sed s/TRIGGER/x/ file"}}' 0


### PR DESCRIPTION
## 什么

生产 qlmanage-guard 在 skill 的两段式 walker 发布后又过了三轮独立评审（100+ 实跑探针）,切行器变得比 skill 教的更强——回灌,让 pattern 不再落后于自己的生产实例:

- **`split_shell_lines` 进 Pattern A 与 walker 节**:引号态跟踪(多行**引号字符串**不再碎片化——`gh pr create -b "…\nTRIGGER…"` 误拦类)、反斜杠续行按 posix 拼接、`$'…'` ANSI-C 转义(`\'` 不闭合)。生产实测形状 + 反向探针(引号行后真命令仍拦)全过。
- **Pattern A 的 git-write 豁免经 `eff_head_idx` 解 wrapper/路径**(不再要求字面 `git` head——`sudo git commit` 不再误拦自己的 message,qlmanage-guard Finding 1)。
- **残余文档收窄为 heredoc-only**(walker 节/pitfall #11 refinement/SKILL.md corollary);test_hook.sh 加 quoted-multiline 健康对照行(multiline 行的陷阱姊妹形)。

## 验证

- Pattern A 抽跑 **15/15**(含引号多行/gh-pr-body/续行/ANSI-C/sudo-git-heredoc);walker 节 **7/7**
- 回归审计基线 main(d57dc34):**6 候选全部分类通过**
- quick_validate + security_scan 绿

daymade-claude-code 1.27.2 → 1.27.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)