### PR TITLE
claude-code-hooks: rule 7 observability-form + pitfall #20 (1.28.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -103,7 +103,7 @@
       "description": "Claude Code operations suite that bundles archive-aware local conversation discovery across Claude Code and Codex, internal-timestamp full-event session search and recovery, interrupted-work continuation, plugin/skill troubleshooting, CLAUDE.md progressive disclosure optimization, statusline configuration, exported .txt repair, full claude.ai conversation extraction with tool-call rendering and file download, plugin marketplace development, writing/testing/debugging Claude Code hooks, multi-provider profile isolation for running Kimi/GLM/DeepSeek/StepFun/Anthropic in separate windows, local source sync for Claude/Codex skill installs, personal-memory migration into tool-agnostic AGENTS.md reference docs, and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
       "source": "./daymade-claude-code",
       "strict": false,
-      "version": "1.27.5",
+      "version": "1.28.0",
       "category": "suite",
       "keywords": [
         "suite",

--- a/daymade-claude-code/claude-code-hooks/.security-scan-passed
+++ b/daymade-claude-code/claude-code-hooks/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-07-26T02:01:36.047445+00:00
+Scanned at: 2026-07-26T03:52:08.565017+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 679aebb10eebb8c088046b73ed6c719e1f68a1130cda451bd8db410a87c8c696
+Content hash: 49b0297ada477e585704e0b965d953cff25bce9619e91c65b159cb717e15b9e6

--- a/daymade-claude-code/claude-code-hooks/SKILL.md
+++ b/daymade-claude-code/claude-code-hooks/SKILL.md
@@ -439,6 +439,28 @@ above and it falls out mechanically: R changes `last_edit` (Q1); `last_edit` is
 an operand of T (Q2); the smallest input that re-fires T is the remediation's own
 output (Q3) → no V.
 
+**A second failure form: the predicate can't see the remediation at all
+(observability gap).** The counter-example above is a temporal predicate that
+remediation *moves*. A quieter failure of the same family: remediation happens,
+but the channel the predicate reads it through doesn't exist in this
+environment. Real case (2026-07-26, found by a full-fleet loop audit): a Stop
+hook detected "an independent review happened" by scanning tool_results for
+`agentId: <hex>` and reading `subagents/agent-<hex>.jsonl` — correct on the
+main profile. Team-mode sessions use a different schema entirely (spawn
+receipts `agent_id: <name>@session-<uuid>`, deliveries as `teammate_id`
+teammate messages, files `agent-a<name>-<hex>.jsonl`) — zero matches, ever,
+so `last_review` stayed `None` forever and every compounding-edit∧push turn
+re-fired the demand: a false-positive loop, bounded to one block per stop
+sequence but unbounded across turns, and its "2/2 fires" that session were
+both on fully-reviewed work. Same family, different medicine: the temporal
+loop needs a better *predicate*; the observability loop needs a better
+*channel*. Add a fourth question to the checklist — **Q4: in every environment
+this hook will run in, can the predicate actually SEE R happen?** For
+transcript-reading hooks that means parsing a real session from each
+profile/mode, not fixture-testing one schema. (The repair for the case above:
+multi-schema detection + teammate deliveries excluded from turn boundaries so
+they can't truncate the detection window — pitfall #20.)
+
 **Pick by axis first, then by order — these are not five strengths of one thing.**
 0 decides *whether to block at all*; 1 decides *which event to hang it on*; 2–4
 are the *predicate's shape* (choose 1 and you still need one of 2–4). The 0→4
@@ -588,7 +610,10 @@ demand**. If your domain produces that density (compounding artifacts ship
 several times a day here), consider pairing mechanism 2 (the existence fact) with
 mechanism 3 (a session-scoped ceiling), or accept the optics deliberately and say so in the
 hook's output — "reminder 2 of at most N" reads as progress, an unadorned
-repeat reads as a loop.
+repeat reads as a loop. **(2026-07-26 sequel: the same hook's fires that looked
+like this density problem turned out to be 100% false positives — its review
+channel was schema-blind in team mode; see the observability form above. Before
+accepting density as "legitimate", verify the fires are evidence-based at all.)**
 
 ### 8. Waiting needs the same proof — notifications are advisory, polling must carry a budget
 

--- a/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
+++ b/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
@@ -606,6 +606,35 @@ unresolvable path means **block**.
 
 ---
 
+## 20. Agent deliveries counted as turn boundaries truncate the detection window
+
+- **Symptom:** a turn-scoped transcript hook (one that judges "did X happen
+  THIS turn") goes **quiet** even though unremediated work is sitting right
+  there — or its review-tracking never registers completed reviews. Nothing
+  errors; the reports just stop matching reality.
+- **Cause:** agent deliveries (teammate messages / completion receipts) arrive
+  as `type: "user"` records in the transcript. A turn-boundary rule that treats
+  every user message as a new turn lets **every delivery start a new "turn"** —
+  work done *before* the delivery falls outside the window. Real audit
+  (2026-07-26): the last turn-start in a long session sat 6 lines from the
+  transcript tail — the entire audit's edits and pushes were outside the window,
+  so a compounding-artifact hook reported nothing. The twin blind spot in the
+  same incident: the review channel itself was built on one schema
+  (`agentId: <hex>` in tool_results) while the environment used another
+  (`agent_id: <name>@session-<uuid>` + `teammate_id` deliveries), so no review
+  ever registered either — false quiet and false fire coexisting in one hook.
+- **Fix:** treat deliveries as events *inside* the turn, not as boundaries.
+  Exclude them by wrapper form — content starting `"Another Claude session sent
+  a message:"` / `<teammate-message` — in **both** content branches (string and
+  list), and audit every other system record the same way (isMeta injections,
+  interrupt receipts — compounding-edit-review's `is_turn_start` is the working
+  example; its selftest ⑰ pins "teammate must not truncate the window"). And
+  validate the *channel* per environment: parse a real transcript from every
+  profile/mode you run in — fixture-testing a single schema is how the twin
+  blind spot shipped (rule 7's observability form, SKILL.md).
+
+---
+
 ## Meta-principle: the ordering of these fixes
 
 When a guard is misbehaving, check in this order — cheapest and most common first:
@@ -670,3 +699,10 @@ When a guard is misbehaving, check in this order — cheapest and most common fi
     → the remediation demands cross-call memory (#19): it's a class
     property, not carelessness — fix the environment, downgrade to a reminder,
     or accept-and-measure; a clearer message was never the missing piece.
+17. Does a turn-scoped hook see **neither the work nor the review** that should
+    bound it — quiet when it should fire, or firing when the review already
+    happened? → the window/channel logic is eating system records: agent
+    deliveries counted as turn starts truncate the detection window (#20), and
+    environment-schema drift blinds the review channel (rule 7's observability
+    form — verify the predicate can see R in EVERY environment, not just the
+    one you fixture-tested).


### PR DESCRIPTION
## 什么

17 个生产 hook 的全量循环风险审计（4 路并行审计员，承重 claim 全部复验）发现：**07-25 那次补救循环的根因不是记录在案的 density 问题，而是审阅检测通道的 schema 失明**——compounding-edit-review 用 `agentId: <hex>` 识别审阅，而 team mode 的同类事件是另一套格式（spawn `agent_id: <name>@session-<uuid>`、投递 `teammate_id` 消息、文件 `agent-a<name>-<hex>.jsonl`），零命中 → `last_review` 恒 None → 每个「编辑∧push」轮次必开火，且当天 100% 是假阳性。回灌两个教训：

- **rule 7 新增第二种失效形态**：谓词不是被补救「重置」，而是**根本看不见补救**（observability gap）——同族不同药：temporal 要换谓词，observability 要换通道。检查清单加 Q4（谓词在每个运行环境里都能看见 R 吗——transcript hook 要逐 profile/mode 解析真实 session，不是只测一种 schema 的 fixture）。density 战例补 sequel：接受「合法密度」前先验证开火基于证据。
- **pitfall #20**：agent 投递（teammate 消息）计入轮次起点会截断检测窗口（真实审计：最后 turn-start 距尾 6 行，全部工作在窗外）——修：两种 content 分支都排除投递包装形态；meta 诊断序补第 17 条路由。

生产侧修复已落 daymade/scripts（多 schema 检测 + teammate 感知的轮次边界，selftest 37→42）。

## 验证

- 回归审计基线 main(e8fae8a)：**1 候选 preserved_or_moved 通过**
- quick_validate + security_scan 绿

daymade-claude-code 1.27.5 → 1.28.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)