### PR TITLE
fix(skill-creator): protocol 文件落点指引同步——私有位置+两禁区(对齐 #223)

### DIFF
--- a/daymade-skill/skill-creator/references/independent-review-protocol.md
+++ b/daymade-skill/skill-creator/references/independent-review-protocol.md
@@ -153,7 +153,7 @@ load-bearing operational mechanism the skill kept referencing but never showed h
 
 ## The review file
 
-Write `<workspace>/independent-review.md`:
+Write `<your-private-knowledge-repo>/skill-reviews/<skill-name>/independent-review.md` — a private, git-tracked location you own. Two forbidden locations: **NOT** in `<skill>-workspace/` (gitignored scratch dirs that get wiped — this file is cross-session review evidence and must survive them) and **NOT** in the reviewed skill's own repo (review content inherently quotes private paths, real names, and project details; that repo may be public or get distributed with the skill):
 
 ```markdown
 # Independent review — <artifact>, <date>


### PR DESCRIPTION
## 问题

#223 把 SKILL.md 两处的 independent-review.md 落点改为「私有 git 跟踪位置+两个禁区」,但 standing discipline #5 明确指向的全流程文件 `references/independent-review-protocol.md:156` 仍是旧指引 `Write \`<workspace>/independent-review.md\``——读者按指针读协议文件会看到与 SKILL.md 自相矛盾的旧落点(改显眼处漏连带副本,本次自查 grep 全目录抓到)。

## 改动

protocol 文件 L156 同步为与 SKILL.md 一致的表述(私有 git 跟踪位置 + 易失 workspace/被审 skill 仓两个禁区)。纯文本一处替换。

本 PR 经 GitHub Contents API 完成(本地工作区被并行 session 占用,未触碰)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)