### PR TITLE
claude-code-hooks: pitfall #21 — prefix resolution must anchor on a typed tail (1.28.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -103,7 +103,7 @@
       "description": "Claude Code operations suite that bundles archive-aware local conversation discovery across Claude Code and Codex, internal-timestamp full-event session search and recovery, interrupted-work continuation, plugin/skill troubleshooting, CLAUDE.md progressive disclosure optimization, statusline configuration, exported .txt repair, full claude.ai conversation extraction with tool-call rendering and file download, plugin marketplace development, writing/testing/debugging Claude Code hooks, multi-provider profile isolation for running Kimi/GLM/DeepSeek/StepFun/Anthropic in separate windows, local source sync for Claude/Codex skill installs, personal-memory migration into tool-agnostic AGENTS.md reference docs, and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
       "source": "./daymade-claude-code",
       "strict": false,
-      "version": "1.28.0",
+      "version": "1.28.1",
       "category": "suite",
       "keywords": [
         "suite",

--- a/daymade-claude-code/claude-code-hooks/.security-scan-passed
+++ b/daymade-claude-code/claude-code-hooks/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-07-26T03:52:08.565017+00:00
+Scanned at: 2026-07-26T05:50:37.187342+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 49b0297ada477e585704e0b965d953cff25bce9619e91c65b159cb717e15b9e6
+Content hash: 023441a86ad5b977ab224287373910aa75b9fcb29d74cb3e9c6dd6d5565a37c7

--- a/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
+++ b/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
@@ -635,6 +635,33 @@ unresolvable path means **block**.
 
 ---
 
+## 21. Prefix-based resolution must anchor on a typed tail
+
+- **Symptom:** the hook resolves an entity by glob/prefix (a file, a name, a
+  token family) and silently picks the WRONG one — a verdict meant for agent A
+  lands on agent B, and the decision is inverted: a delegated write-and-push
+  gets the "independent review" stamp, or a genuine review reads as delegation.
+  Nothing looks wrong because each file in isolation is valid.
+- **Cause:** prefix matching ignores that names are **prefixes of other names**.
+  Real case (2026-07-26, reproduced both directions): a review-detection hook
+  resolved agent transcripts with `agent-a<name>-*.jsonl` — the agent pair
+  `r4-final-reviewer` and `r4-final-reviewer-2` (which really coexisted in the
+  session) both matched, and "newest by mtime" made the review read the wrong
+  agent's file. Sibling shapes in the same audit: a bundle-arity blind spot
+  (`-mn` = `-m n`, not `-n`), a flag-family table (`-am"msg"` attached value),
+  and a trailing-separator reset (a state machine whose `first` slot is
+  re-zeroed by a trailing `;` or comment line, losing the last real segment).
+- **Fix — anchor the typed tail, never the bare prefix:** for filenames,
+  require the delimiter + a typed suffix (`agent-a<name>-[0-9a-f]{8,}.jsonl`,
+  not `agent-a<name>-*`); for flag families, enumerate the family (`-aXXX`
+  bundled counts as `-a`) AND model arity (after a valued flag, the next thing
+  is data); for segment state machines, keep the last NON-EMPTY segment's head
+  (`last_first`), never the current slot after a trailing separator. Then pin
+  the colliding pair in a fixture — a singleton passing proves nothing about
+  resolution (compounding-edit-review's selftest grew exactly these).
+
+---
+
 ## Meta-principle: the ordering of these fixes
 
 When a guard is misbehaving, check in this order — cheapest and most common first:
@@ -706,3 +733,10 @@ When a guard is misbehaving, check in this order — cheapest and most common fi
     environment-schema drift blinds the review channel (rule 7's observability
     form — verify the predicate can see R in EVERY environment, not just the
     one you fixture-tested).
+18. Does a resolution step hand you the **wrong entity** — a verdict meant for
+    A landing on B, or a decision inverted (delegation stamped as review /
+    review read as delegation)? → prefix resolution without a typed tail (#21):
+    globs must anchor on delimiter+type (name-hex.jsonl, not name-*), flag
+    families need enumeration + arity, and segment state machines need the last
+    NON-EMPTY head — and only a fixture containing the colliding pair proves
+    resolution, a singleton proves nothing.


### PR DESCRIPTION
## 什么

对 P0-P3 循环审计修复批的 fixbatch 复审（~90 探针 + git 语义实证）发现的最深一类新问题不是循环——是**前缀解析静默选错实体、把判定反置**（委派写推被盖「独立审阅」章，或真审阅被读成委派）：

- 审阅检测用 `agent-a<name>-*.jsonl` 解析——真实共存的 `r4-final-reviewer` 与 `r4-final-reviewer-2` 同时命中，按 mtime 读错 agent 的文件
- bundle arity 盲：`-mn` = `-m n`（是消息）不是 bypass
- flag 族表漏粘连形态：`-am"msg"` 逃出精确表
- 尾分隔符重置：尾 `;`/尾注释行把状态机的 first 槽清零，最后一个真实段消失

修法——**锚定带类型的尾巴，绝不锚裸前缀**：分隔符+类型后缀（`agent-a<name>-[0-9a-f]{8,}.jsonl`）；flag 族枚举+arity 建模（值 flag 后的是数据）；段状态机取最后一个**非空**段段首（`last_first`）。并把碰撞对钉进 fixture——单例通过证明不了解析。meta 诊断序补第 18 条路由。生产修复已落 daymade/scripts。

## 验证

- 回归审计基线 main(7117141)：**0 候选（纯增量）**
- quick_validate + security_scan 绿

daymade-claude-code 1.28.0 → 1.28.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)