### PR TITLE
docs(claude-code-hooks): pitfall #26 — hook activation isn't retroactive

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -103,7 +103,7 @@
       "description": "Claude Code operations suite that bundles archive-aware local conversation discovery across Claude Code and Codex, internal-timestamp full-event session search and recovery, interrupted-work continuation, plugin/skill troubleshooting, CLAUDE.md progressive disclosure optimization, statusline configuration, exported .txt repair, full claude.ai conversation extraction with tool-call rendering and file download, plugin marketplace development, writing/testing/debugging Claude Code hooks, multi-provider profile isolation for running Kimi/GLM/DeepSeek/StepFun/Anthropic in separate windows, local source sync for Claude/Codex skill installs, personal-memory migration into tool-agnostic AGENTS.md reference docs, and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
       "source": "./daymade-claude-code",
       "strict": false,
-      "version": "1.29.2",
+      "version": "1.29.3",
       "category": "suite",
       "keywords": [
         "suite",

--- a/daymade-claude-code/claude-code-hooks/.security-scan-passed
+++ b/daymade-claude-code/claude-code-hooks/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-07-30T14:35:41.666206+00:00
+Scanned at: 2026-07-30T18:09:51.458792+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 076c71ddd243f215bc828d1c9d644189116764a814637bbbd3ab68a16c9f0733
+Content hash: 389d2c86e321dbca7f5d1fbe4385d0da930e86045a6949fa4b7dd9d107bab875

--- a/daymade-claude-code/claude-code-hooks/.security-scan-passed
+++ b/daymade-claude-code/claude-code-hooks/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-07-26T08:39:19.652941+00:00
+Scanned at: 2026-07-30T14:35:41.666206+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 9bae78fdea5d8f7594ab4ac62c23bcd20a9b30cd815f19bddbb595d7f4e27a51
+Content hash: 076c71ddd243f215bc828d1c9d644189116764a814637bbbd3ab68a16c9f0733

--- a/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
+++ b/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
@@ -834,6 +834,42 @@ unresolvable path means **block**.
 
 ---
 
+## 26. A hook that activates mid-session only guards what happens AFTER it — in-flight work from before stays uninspected
+
+- **Symptom:** a hook ships mid-session specifically because a systemic
+  anti-pattern was just caught, and it works exactly as designed — every
+  later attempt at the pattern gets blocked. It is tempting to treat the
+  problem as closed for the whole session. It isn't: anything already
+  running, already queued, or already reported before the hook existed sat
+  outside anything the hook could ever have inspected.
+- **Cause:** a hook is a gate on the tool-call path from the moment it is
+  registered onward. It has no mechanism to scan backward — not the
+  background processes already launched under the old pattern, not results
+  already returned and already believed, not commands still queued from
+  earlier in the same session. "The guard is now live" and "every prior
+  instance this session is accounted for" are two independent facts;
+  shipping the hook only ever establishes the first.
+- **Real case (2026-07-27):** `bg-exitcode-guard` was written and registered
+  mid-session to block backgrounded Bash commands whose last statement is
+  `echo`/`printf` after capturing `$?` (the always-zero echo exit code masks
+  the command's real failure). The SAME session had already used that exact
+  anti-pattern 13+ times before the hook existed — one of those had already
+  produced a false-success task-notification that had already been believed
+  and acted on. The hook, functioning correctly from that point on, blocked
+  every later attempt at the pattern; it did nothing about, and structurally
+  could not have done anything about, the 13 that already ran.
+- **Fix:** when a hook is born specifically because a systemic anti-pattern
+  was just caught mid-session, add one deliberate step right after
+  registering it: a one-time sweep of the session's own recent history for
+  the same pattern — grep prior background-command invocations for the same
+  shape, and independently re-verify (per Evidence Discipline — not by
+  re-reading the same task-notification) any "success" that was taken at
+  face value while the pattern was still live. Do this once, right after the
+  hook activates; do not rely on the hook itself to have covered it, because
+  by construction it cannot reach backward in time.
+
+---
+
 ## Meta-principle: the ordering of these fixes
 
 When a guard is misbehaving, check in this order — cheapest and most common first:

--- a/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
+++ b/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
@@ -840,33 +840,61 @@ unresolvable path means **block**.
   anti-pattern was just caught, and it works exactly as designed — every
   later attempt at the pattern gets blocked. It is tempting to treat the
   problem as closed for the whole session. It isn't: anything already
-  running, already queued, or already reported before the hook existed sat
-  outside anything the hook could ever have inspected.
-- **Cause:** a hook is a gate on the tool-call path from the moment it is
-  registered onward. It has no mechanism to scan backward — not the
-  background processes already launched under the old pattern, not results
-  already returned and already believed, not commands still queued from
-  earlier in the same session. "The guard is now live" and "every prior
-  instance this session is accounted for" are two independent facts;
-  shipping the hook only ever establishes the first.
-- **Real case (2026-07-27):** `bg-exitcode-guard` was written and registered
-  mid-session to block backgrounded Bash commands whose last statement is
-  `echo`/`printf` after capturing `$?` (the always-zero echo exit code masks
-  the command's real failure). The SAME session had already used that exact
-  anti-pattern 13+ times before the hook existed — one of those had already
-  produced a false-success task-notification that had already been believed
-  and acted on. The hook, functioning correctly from that point on, blocked
-  every later attempt at the pattern; it did nothing about, and structurally
-  could not have done anything about, the 13 that already ran.
-- **Fix:** when a hook is born specifically because a systemic anti-pattern
-  was just caught mid-session, add one deliberate step right after
-  registering it: a one-time sweep of the session's own recent history for
-  the same pattern — grep prior background-command invocations for the same
-  shape, and independently re-verify (per Evidence Discipline — not by
-  re-reading the same task-notification) any "success" that was taken at
-  face value while the pattern was still live. Do this once, right after the
-  hook activates; do not rely on the hook itself to have covered it, because
-  by construction it cannot reach backward in time.
+  running, already dispatched, or already reported before the hook existed
+  sat outside anything the hook could ever have inspected.
+- **Why this belongs in a "bug that shipped" catalog when the hook itself
+  didn't misbehave:** every other entry here is a broken guard; this one is
+  a correctly-working guard paired with a wrong assumption about what it
+  covers. It earns a slot anyway because it's exactly the mistake a hook
+  author makes in the minutes right after shipping a fix — "I closed this"
+  instead of "I closed this going forward" — and the file's own triage
+  method ("match the symptom") won't route a reader here unless they
+  already suspect coverage, not correctness, is the question.
+- **Cause:** a PreToolUse-style gate only ever sees the tool call in front
+  of it, at the moment it fires. It has no transcript access and no
+  mechanism to scan backward: not the background processes already
+  launched under the old pattern, not results already returned and
+  believed, not commands already dispatched from earlier in the same
+  session. (This is a property of tool-call gates specifically, not of
+  every hook type — a Stop hook with transcript access, like the one
+  behind entry 20, can and does look backward within a turn; the claim
+  here is scoped to hooks that only ever see one tool call at a time.)
+  "The guard is now live" and "every prior instance this session is
+  accounted for" are two independent facts; shipping the hook only ever
+  establishes the first.
+- **Real case (2026-07-21 to 2026-07-27, six days, one session):**
+  `bg-exitcode-guard` blocks backgrounded Bash commands whose last
+  statement is `echo`/`printf` after the script already captured `$?` — the
+  always-zero echo/printf exit code overwrites the real command's exit code
+  in the task-notification summary. The same session used that exact shape
+  13 times before the hook went live. Once, on day one, it produced a
+  genuinely misleading "completed (exit code 0)" notification for a deploy
+  that had actually failed — and the operator caught it ten seconds later,
+  same turn, by habitually re-grepping the real log instead of trusting the
+  notification text. That was a near miss, not a believed-and-acted-on
+  failure — but the near miss alone didn't stop anything: the same shape
+  recurred another 12 times over the following six days. Only the hook's
+  activation actually closed it (zero recurrences after). And the hook,
+  once live, could do nothing about the 13 uses that already happened — it
+  does not reach backward, per Cause above.
+- **Fix:** don't treat "I have a habit of double-checking" as equivalent to
+  "this is closed" — a habit is a per-instance save, not a guarantee, and
+  this exact case shows a real habit still needing 13 repetitions and 6
+  days before something durable (the hook) actually ended it. Once the hook
+  is live, two concrete checks, not just a resolution to be careful:
+  (1) look for backgrounded tasks that are already running or already
+  dispatched from before the hook existed — the harness's own task
+  list/tracker is the right place to check, not a manual re-read of the
+  transcript, since those tasks can still complete and report *after* the
+  hook exists and the hook will never see them; (2) if the session or
+  environment already runs some later, broader check (an end-of-session
+  review, a periodic audit), confirm it actually covers this exact gap
+  rather than assuming it does — in the case above, that later check is
+  literally what surfaced the true count of 13 uses, days after the hook
+  activated, not any deliberate sweep done at the moment the hook shipped.
+  If either check turns up an instance that was actually acted on, not just
+  printed, treat it as its own live incident — verify what state it left
+  behind before moving on, not just log it as another near miss.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds pitfall #26 to `claude-code-hooks`'s `references/hook_pitfalls.md`: a hook that goes live mid-session only guards tool calls made *after* it registers — it has no way to reach anti-pattern instances already running, dispatched, or already-reported from before it existed.
- Concrete example cited: `bg-exitcode-guard`, which blocks backgrounded Bash commands that swallow their real exit code behind a trailing `echo`. The same session had used that exact pattern 13 times before the hook went live.
- Bumps `daymade-claude-code` suite to 1.29.3 in `marketplace.json`.

## Correction (2nd commit)
A `compounding-edit-review` Stop hook caught that the first version shipped on mechanical gates alone, with no independent review. Dispatched a fresh-context, read-only reviewer with instructions to verify the entry's factual claims against the real session transcript and self-review receipt rather than trust the drafted prose. It found — and I independently reproduced against the primary transcript before accepting — that the "Real case" paragraph **inverted what actually happened**: it claimed a false-success notification "had already been believed and acted on," but the transcript shows it was caught within the same turn by habitual log-grepping (a good catch, not a failure). Also fixed: an unscoped "no hook can scan backward" claim entry 20 contradicts, a reference to a private-CLAUDE.md-only term ("Evidence Discipline") unreachable from this public skill, an unlocatable Fix step, and an unsupported "written and registered mid-session" authorship claim. Full review trail (verbatim prompt, per-finding disposition, what wasn't verified) recorded outside this public repo.

## Process
- Ran the skill-creator "update an existing skill" migration gate twice (before and after the correction): pre-edit snapshot → `audit_skill_regression compare` (0 candidates, 591 exact preservations both times — pure addition, nothing deleted) → `verify` → `quick_validate` → `security_scan`, all clean.
- Independent read-only review dispatched per skill-creator discipline #5 (fork explicitly excluded — a fork would inherit the same blind spots that produced the error).

## Test plan
- [x] `audit_skill_regression compare` reports 0 regression candidates (both rounds)
- [x] `quick_validate` passes
- [x] `security_scan` passes (gitleaks clean; manually re-read for CJK names/private context — none present)
- [x] Independent reviewer's factual-verification findings (5c/5d) independently reproduced against the primary transcript and self-review receipt, not just accepted on the reviewer's word

🤖 Generated with [Claude Code](https://claude.com/claude-code)