### PR TITLE
photo-to-scanned-pdf: add digital-signature-synthesis branch

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -146,7 +146,7 @@
       "description": "Documentation suite plugin that exposes document conversion, Mermaid diagram generation, PDF/PPT/DOCX creation, and documentation cleanup skills under one shared namespace",
       "source": "./daymade-docs",
       "strict": false,
-      "version": "1.4.0",
+      "version": "1.5.0",
       "category": "suite",
       "keywords": [
         "suite",

--- a/daymade-docs/photo-to-scanned-pdf/.security-scan-passed
+++ b/daymade-docs/photo-to-scanned-pdf/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-07-10T17:40:04.420493
+Scanned at: 2026-07-31T14:49:59.882180+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: dfef341a022942d900d0458155be3621b65252777b2140b903d344ff2141a659
+Content hash: ec3c9fed1bcd8bbd0886446c3bc789511e3172b210ab8bffaa9296366bf6c23c

--- a/daymade-docs/photo-to-scanned-pdf/SKILL.md
+++ b/daymade-docs/photo-to-scanned-pdf/SKILL.md
@@ -1,22 +1,36 @@
 ---
 name: photo-to-scanned-pdf
 description: >-
-  Turn phone photos of paper documents (contracts, stamped certificates, receipts,
-  forms, handwritten notes) into a clean scanner-quality PDF: perspective
-  rectification + noteshrink background-whitening + A4 PDF assembly, with
-  colored-paper white-balance handling and a mandatory whole-document visual
-  check. Use this skill whenever the user has photos of paper documents and wants
-  them as a PDF / 扫描件 / scan — trigger on "把照片做成扫描件", "photos to
-  scanned PDF", "make this look scanned", "手机拍的文档转 PDF", "盖章文件扫描",
-  replacing pages inside an existing scanned PDF, or any CamScanner-like request.
-  Do NOT hand-roll levels/contrast enhancement for scan-look output — that path
-  was tried and rejected twice; this skill's pipeline is the proven one.
+  Two pipelines ending at a scanner-look PDF. (1) Phone photos of paper
+  documents (contracts, stamped certificates, receipts, forms, handwritten
+  notes) → clean scanner-quality PDF: perspective rectification + noteshrink
+  whitening + A4 assembly + mandatory whole-document check. Trigger: "把照片
+  做成扫描件", "photos to scanned PDF", "make this look scanned", "手机拍的
+  文档转 PDF", "盖章文件扫描", replacing pages in an existing scanned PDF,
+  any CamScanner-like request. (2) A digital document with no signature yet
+  (rendered docx/PDF, confirmation form, contract draft) → make it look
+  hand-signed and scanned: synthesize a handwriting-style signature, composite
+  it onto the signature line, apply the same scan-look post-processing.
+  Trigger: "帮我做个手写签名", "生成签名盖到这份文件上", "做成签过字的扫描件",
+  "synthesize a signature", any request for a document that needs to look
+  signed without a real photographed signature. Do NOT hand-roll
+  levels/contrast enhancement for scan-look — tried and rejected twice; this
+  skill's pipeline is the proven one.
 ---
 
 # Photo → Scanned PDF
 
-Phone photos of documents → scanner-look PDF. The pipeline that works, and the
-failure modes that ship wrong PDFs if skipped.
+Two related pipelines, same destination look, different starting point:
+phone photos of paper documents, or a digital document that needs a synthetic
+signature before it looks signed. The pipelines that work, and the failure
+modes that ship wrong PDFs if skipped.
+
+**Which one do you need?**
+
+| The input is... | Use |
+|---|---|
+| Phone photos of an already-signed/stamped paper document | This file, main pipeline below |
+| A digital document (docx/PDF) with **no signature yet**, and you need to make it look hand-signed | [references/digital-signature-synthesis.md](references/digital-signature-synthesis.md) |
 
 ```
 photos ──► rectify (photo_to_scan.py --raw)
@@ -30,7 +44,8 @@ photos ──► rectify (photo_to_scan.py --raw)
 **Division of labor**: scripts carry execution; you (the agent) carry the two
 judgment steps — content-based page ordering, and whole-document verification.
 Neither can be automated away: filenames lie about order, and per-page spot
-checks miss wrong-slot bugs.
+checks miss wrong-slot bugs. The digital-signature branch shares this same
+philosophy with its own two judgment calls — see the reference file.
 
 ## Step 0 — Dependencies
 

--- a/daymade-docs/photo-to-scanned-pdf/references/digital-signature-synthesis.md
+++ b/daymade-docs/photo-to-scanned-pdf/references/digital-signature-synthesis.md
@@ -1,0 +1,248 @@
+# Digital document → synthetic signature → scan-look
+
+The other branch of this skill. The main SKILL.md pipeline starts from **phone
+photos of paper**; this one starts from a **digital document that has no
+signature yet** (a rendered docx/PDF, a confirmation form, a contract draft)
+and needs to look like a physically-signed, scanned page. Different input,
+same destination look — and the same non-negotiable close: whole-document
+visual verification before you call it done.
+
+```
+digital doc ──► render to page images (soffice --convert-to pdf, pdftoppm)
+            ──► candidates: font × ink comparison sheet   ← show the user, they pick
+            ──► generate: chosen font/ink → transparent signature PNG
+            ──► locate: find the signature line's pixel bbox (pdftotext -bbox)
+            ──► composite: paste signature onto the page image
+            ──► scanify: rotation + noise + gradient + jpeg compression
+            ──► assemble_pdf.py + make_contact_sheet.py → READ IT   ← mandatory, same as main pipeline
+```
+
+All five signature-specific steps are one script:
+
+```bash
+uv run <skill>/scripts/synthesize_signature.py <subcommand> ...
+```
+
+**Division of labor, same shape as the main pipeline**: the script carries
+execution: font discovery, rendering, compositing, scan-look post-processing.
+You carry two judgment calls it cannot make for you — **which candidate looks
+right** (taste, not measurable), and **whether the composited result looks
+right on the actual page** (position, size, whether it reads as plausible
+handwriting in context). Never pick a font yourself and skip the candidates
+step; never skip reading the final composited page.
+
+## Step 1 — Render the target page(s) to images
+
+Same tools the main pipeline's Step 4/5 already use — nothing new here:
+
+```bash
+soffice --headless --convert-to pdf --outdir . document.docx
+pdftoppm -png -r 200 document.pdf page   # page-1.png, page-2.png, ...
+```
+
+200 dpi is a reasonable default — high enough that a composited signature
+doesn't look pixelated next to real text, low enough to keep file sizes sane.
+
+## Step 2 — Font candidates (show the user, don't guess)
+
+```bash
+uv run <skill>/scripts/synthesize_signature.py candidates --text "王小明" --out candidates.png
+```
+
+This discovers handwriting-style CJK fonts installed on the machine via
+`fc-list` — **not a hardcoded path table**. macOS ships several under
+on-demand font assets (content-addressed paths like
+`.../com_apple_MobileAsset_Font8/<hash>.asset/AssetData/Xingkai.ttc`, which
+can differ across OS versions/machines — querying `fc-list` by family name
+each time is what keeps this portable instead of breaking on the next
+machine). Families tried and known to work: **Hannotate** (手札体, cursive
+"handwriting-note" style), **HanziPen** (翩翩体), **Xingkai** (行楷, semi-cursive
+running script), **Kaiti/STKaiti** (楷体, more formal — reads less like a hand
+signature, more like careful printing).
+
+By default one representative face per family (first non-bold SC face found)
+— a `.ttc` collection commonly bundles Regular/Bold × SC/TC as separate face
+indices, and showing all of them roughly triples the sheet with near-duplicate
+rows. Pass `--all-faces` if you specifically need to compare bold vs regular
+within one family.
+
+**Send the candidates sheet to the user and get a number back — do not pick
+one yourself.** Which style reads as a plausible signature is a taste call,
+not something derivable from the document or the font's technical properties.
+A real session ran this exact step: generated an 8-candidate sheet (4 families
+× 2 ink colors), the user picked one by letter/number, and that choice is what
+went into the final document.
+
+## Step 3 — Generate the chosen signature
+
+`candidates` (Step 2) already printed the exact command for every number, and
+saved the same mapping to a sidecar `candidates.params.json` next to the sheet
+— **read the number off there, don't reconstruct it.** An independent review
+of this doc caught a real gap here: the sheet's *image* only has human labels
+like `3  手札体 Regular (Hannotate SC) - black`, nothing a reader can turn
+into `--font`/`--face` without opening the script's source. The printed table
+and JSON exist specifically to remove that step:
+
+```bash
+# candidates already printed this; the -only- thing you're filling in is the number
+uv run <skill>/scripts/synthesize_signature.py generate \
+    --text "王小明" --font <exact --font value candidates printed for the chosen number> \
+    --face <same, --face value> --ink <same, --ink value> \
+    --seed 727 --width 350 --out signature.png
+```
+
+`--ink` accepts `black`, `blue-black`, or a raw `R,G,B` string. The renderer
+gives each character independent random rotation (-6°..3°, tighter for
+interior characters than the first/last) and tight spacing (0.70-0.78× the
+character's font size) before a small overall rotation and light Gaussian
+blur — parameters tuned in a real session to avoid two failure modes:
+
+- **Spacing 0.82-0.90× looked too loose** — read as individually-stamped
+  characters, not connected handwriting. Tightening to 0.62-0.78× is what
+  made it read as a natural signature stroke.
+- **Zero rotation variance looked printed**, not handwritten — the per-character
+  random tilt (small for the middle characters, larger for the first/last, since
+  real signatures tend to swing more at the start/end of a stroke) is what
+  breaks the mechanical regularity.
+
+These are a *starting point*, not a universal constant — re-tune per font if a
+result still looks mechanical; a very geometric font (Kaiti) may need more
+rotation variance than a naturally-cursive one (Xingkai) to read as handwritten.
+
+`--seed` makes output reproducible — same seed + same inputs = same pixels,
+useful when you need to regenerate the exact signature the user approved
+(e.g., after fixing an unrelated field elsewhere in the document).
+
+## Step 4 — Locate the signature line
+
+```bash
+uv run <skill>/scripts/synthesize_signature.py locate --pdf document.pdf --text "簽名" --dpi 200
+```
+
+Wraps `pdftotext -bbox`, which reports word bounding boxes at a 72dpi basis
+regardless of the PDF's actual content — `locate` does the `dpi/72` scaling
+for you so the printed coordinates are directly usable against a page image
+rendered at that same dpi. Search on a short, distinctive substring of the
+signature line's own label text (e.g. `簽名` rather than the full line) —
+`pdftotext -bbox` matches per-word, so searching for text containing spaces or
+punctuation the tokenizer split differently will silently return nothing.
+
+Every hit prints its **1-based page number** first (`page=1`, `page=2`, ...) —
+`pdftotext -bbox` wraps each page's words in a `<page>` tag in document order,
+and a document requiring a signature on every page (an ordinary case for
+contracts) will match on more than one page with no other way to tell the
+hits apart.
+
+If nothing matches: confirm the dpi you pass here is the same dpi you used to
+render the page image in Step 1 — a mismatch doesn't error, it just places the
+signature at the wrong pixel offset on the page, which you won't notice until
+Step 7's whole-document read.
+
+**If a hit prints a `WARNING: matched word (N chars) is longer than your
+search text` line, do not trust its `xMax` for Step 5's `--x` formula.** This
+means `pdftotext` tokenized your label together with whatever sits right after
+it on the same line — most commonly a signature blank authored as underscores
+immediately following the label with no space (`簽名：_____`, an entirely
+ordinary way to type this in Word). The returned bbox spans the *whole merged
+run*, so `xMax` lands at the far end of the blank, not the end of the label
+glyphs — this was verified to place a signature floating in empty page space,
+silently, with no error anywhere in the pipeline. There is no general fix from
+`pdftotext`'s output alone (it doesn't expose sub-word granularity); when you
+see this warning, find the label's real right edge from the rendered page
+image instead of trusting the printed `xMax`:
+
+```python
+from PIL import Image
+import numpy as np
+im = np.array(Image.open("page-N.png").convert("L"))
+row = im[<yMin>:<yMax>, :]                    # the label's own y-range, from locate's output
+dark_cols = [x for x in range(<xMin>, <xMax>) if (row[:, x] < 180).sum() > 5]
+# > 5 dark pixels in the column filters out a thin underline row and keeps
+# actual glyph strokes; the label's real right edge is max(dark_cols).
+print(min(dark_cols), max(dark_cols))
+```
+
+## Step 5 — Composite onto the page
+
+```bash
+uv run <skill>/scripts/synthesize_signature.py composite \
+    --page page-2.png --signature signature.png \
+    --x <xMax-from-locate-plus-margin> --y <yMin-to-yMax-midpoint-minus-half-height> \
+    --width 350 --out page-2-signed.png
+```
+
+`--x`/`--y` are the top-left paste corner, in the same pixel space `locate`
+reported. A reasonable starting point: `x = locate's xMax + ~50px` (right
+after the label text — **only when Step 4 printed no merge warning**; if it
+did, use the pixel-scanned right edge from Step 4 instead, not `xMax`), `y`
+centered on the label's vertical midpoint minus roughly half the signature's
+height (`locate` reports both `yMin` and `yMax` for the label itself —
+average them, then shift up by the signature's height × ~0.55 so it sits ON
+the line rather than floating above or below it).
+
+The two axes are not equally reliable. **Y held up well in testing** — an
+independent reviewer confirmed the vertical formula landed correctly on the
+first try with no adjustment across multiple test documents. **X is the
+fragile half**, specifically because of the merge failure mode above — expect
+to redo it once when the merge warning fires (it's a structural, all-or-
+nothing miss when it happens, not a small per-font metric difference), and
+treat "once or twice by eye" as the realistic expectation even on documents
+that don't hit the merge case, since text-line vertical metrics still vary a
+little between fonts.
+
+## Step 6 — Scan-look post-processing
+
+```bash
+uv run <skill>/scripts/synthesize_signature.py scanify page-1.png page-2-signed.png page-3.png \
+    --out-dir scanned --seed 5
+```
+
+Pass **every page of the document, as explicit filenames in final order** —
+not just the page you signed, and never a glob pattern like `"page-*.png"`.
+This script does not expand or sort globs itself (an earlier version did, and
+an independent reviewer caught that its lexicographic sort put `page-10.png`
+before `page-2.png` on any 10+ page document — silently reproducing the exact
+wrong-page-order failure the main SKILL.md's Step 2 exists to prevent). List
+every filename by hand, the same discipline `assemble_pdf.py` already uses one
+step later.
+
+Per page, this applies: small random
+rotation (±0.3° default, simulating a slightly crooked scan), Gaussian noise
+(σ≈2.8, sensor noise), a linear horizontal brightness gradient (simulating
+uneven scanner-lamp illumination), light blur, and JPEG re-encoding at quality
+86 (compression artifacts a lossless PNG doesn't have). These five together are
+what the main SKILL.md's own troubleshooting table already warns about for the
+*inverse* mistake — hand-rolled levels/contrast enhancement reads as a "gray
+haze," not a scan; noteshrink-style background sampling is one way to get
+there for photographed paper, this parameter set is the equivalent for a
+digital-source page that was never noisy to begin with.
+
+## Step 7 — Verify the WHOLE document (mandatory, same as main pipeline)
+
+```bash
+uv run <skill>/scripts/assemble_pdf.py --out signed.pdf scanned/scan_01.jpg scanned/scan_02.jpg ...
+uv run <skill>/scripts/make_contact_sheet.py signed.pdf --out contact.png
+```
+
+Read `contact.png` and check every page — not just the one you signed. The
+main pipeline's Step 5 rationale applies unchanged: a page-replacement bug
+that only checks the edited page misses damage to its neighbors, and this
+branch reuses the exact same two scripts for exactly that reason — one
+verification discipline, not two divergent ones.
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| Can't turn a chosen candidate number into `generate` flags | Read them off `candidates`' own stdout table or its `<out>.params.json` sidecar — don't reverse-engineer the font path from the sheet image, it isn't in there. |
+| Candidate sheet has 20+ near-duplicate rows | You passed `--all-faces` (or a font family has many bold/regular/SC/TC face variants). Drop the flag — one representative face per family is the default. |
+| Two candidate rows print identical labels | Both are the same family/style in different scripts (Simplified vs Traditional Chinese) — check the `(... SC)` / `(... TC)` suffix; if your Pillow/script build predates that suffix, upgrade the skill. |
+| Candidate labels overlap the signature images | Label column width is measured from the longest actual label string on every run — this can't recur unless you're on a copy of the script older than this doc. |
+| `generate --ink black` crashes with `invalid literal for int()` | Can't recur on a current copy — was a `dict.get(key, expensive_default)` eager-evaluation bug, fixed. If you see this, you're on an old copy of the script. |
+| `locate` finds nothing | Search string doesn't match a single `pdftotext -bbox` word token (spaces/punctuation split differently than expected), or you searched the wrong page's PDF. Try a shorter, punctuation-free substring. |
+| `locate` prints a `WARNING: matched word (N chars) is longer than your search text` | Expected, not a bug — see Step 4's merge-warning section. Don't use the printed `xMax` for Step 5's `--x`; pixel-scan the rendered page for the label's real right edge instead. |
+| `locate` hits on more than one line and you can't tell which is which | Every hit now prints `page=N` first — check that, not just the y-coordinate, on a multi-page document. |
+| Signature lands in the wrong spot on the page | Two distinct causes, don't conflate them: (1) `--dpi` passed to `locate` doesn't match the dpi used to render the page image in Step 1 — a small, uniform offset across the whole page; (2) the merge-warning case above — a large, structural miss landing the signature in blank space, unrelated to dpi. |
+| Signature looks mechanical / stamped, not handwritten | Character spacing too loose (`--tight-hi` too high) or rotation range too narrow. Re-tune per font — see Step 3. |
+| Final PDF has one crisp page next to visibly-scanned ones | You ran `scanify` on only the signed page. Pass every page in the document, as explicit filenames, to one `scanify` call. |
+| Pages come out of `scanify` in the wrong order | You passed a glob pattern instead of explicit filenames — this script does not expand or sort globs (see Step 6). List every filename by hand in verified content order. |

--- a/daymade-docs/photo-to-scanned-pdf/scripts/synthesize_signature.py
+++ b/daymade-docs/photo-to-scanned-pdf/scripts/synthesize_signature.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pillow", "numpy"]
+# ///
+"""Synthesize a handwriting-style signature and composite it onto a digital
+document, then apply scan-look post-processing.
+
+For the OTHER half of this skill (phone photos of paper -> scanned PDF), see
+SKILL.md. This script is for the opposite direction: a digital document that
+needs a synthetic signature before it looks like a scanned, signed paper.
+
+Subcommands:
+  fonts       List handwriting-style CJK fonts discovered on this machine.
+  candidates  Render a labeled comparison sheet (font x ink) for human choice.
+  generate    Render one chosen font/ink combo as a transparent-background PNG.
+  locate      Find a text string's pixel bbox in a rendered PDF page (for composite placement).
+  composite   Paste a signature PNG onto a page image at given coordinates.
+  scanify     Apply scan-look post-processing (rotation/blur/noise/gradient/jpeg) to page images.
+
+Division of labor (matches this skill's existing photo-pipeline philosophy):
+this script carries execution; you (the agent) carry the judgment calls it
+cannot make for you — which candidate looks right, and whether the composited
+result looks right on the actual page. Never skip the human-facing candidates
+step by picking a font yourself, and never skip visually reading the final
+composited page (see SKILL.md Step 5 concept, reused here).
+"""
+import argparse
+import json
+import random
+import subprocess
+import sys
+from pathlib import Path
+
+from PIL import Image, ImageDraw, ImageFont, ImageFilter, ImageEnhance
+import numpy as np
+
+# Handwriting-style CJK font families worth trying, most-cursive first.
+# Matched by fc-list family name (not by hardcoded asset path -- those are
+# content-addressed and vary across macOS versions/updates).
+HANDWRITING_FAMILIES = [
+    ("Hannotate", "手札体"),
+    ("HanziPen", "翩翩体"),
+    ("Xingkai", "行楷"),
+    ("Kaiti", "楷体"),
+    ("STKaiti", "标准楷体"),
+]
+
+INK_COLORS = {
+    "black": (32, 32, 36),
+    "blue-black": (27, 42, 78),
+}
+
+
+def discover_fonts(all_faces=False):
+    """Return [(path, family_label, face_index, face_name)] for installed
+    handwriting-style CJK fonts, by querying fc-list -- not a hardcoded path
+    table, so this works on any machine with these fonts installed.
+
+    By default returns ONE representative face per family (first non-bold SC
+    face found) -- a .ttc collection commonly bundles Regular/Bold x SC/TC as
+    separate face indices, and showing all of them roughly doubles or triples
+    a comparison sheet with near-duplicate rows. Pass all_faces=True (the
+    `candidates --all-faces` flag) to see every face instead.
+    """
+    try:
+        out = subprocess.run(["fc-list"], capture_output=True, text=True, check=True).stdout
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        print("fc-list not found -- install fontconfig (brew install fontconfig) "
+              "or pass --font/--face explicitly.", file=sys.stderr)
+        return []
+
+    found = []
+    seen_paths = set()
+    for family, label in HANDWRITING_FAMILIES:
+        for line in out.splitlines():
+            if family.lower() not in line.lower():
+                continue
+            path = line.split(":")[0].strip()
+            if path in seen_paths or not path.lower().endswith((".ttc", ".ttf", ".otf")):
+                continue
+            seen_paths.add(path)
+            # Enumerate every face in the collection -- a .ttc often bundles
+            # Regular/Bold/SC/TC as different face indices, and ImageFont
+            # needs the index to pick a specific one.
+            family_faces = []
+            for i in range(12):
+                try:
+                    f = ImageFont.truetype(path, 60, index=i)
+                except Exception:
+                    break
+                face_name = " ".join(f.getname())
+                family_faces.append((path, label, i, face_name))
+            if not family_faces:
+                continue
+            if all_faces:
+                found.extend(family_faces)
+            else:
+                # Prefer a non-bold, Simplified-Chinese (SC) face; fall back
+                # to whatever face index 0 is if none matches.
+                pick = next(
+                    (f for f in family_faces if "bold" not in f[3].lower() and " SC " in f" {f[3]} "),
+                    family_faces[0],
+                )
+                found.append(pick)
+    return found
+
+
+def cmd_fonts(args):
+    fonts = discover_fonts(all_faces=args.all_faces)
+    if not fonts:
+        print("No handwriting-style CJK fonts found via fc-list.")
+        return
+    for path, label, idx, name in fonts:
+        print(f"{label}\tface={idx}\t{name}\t{path}")
+
+
+def _render_signature(text, font_path, face_index, ink, seed,
+                       size_base=150, tight_lo=0.70, tight_hi=0.78,
+                       rot_lo=-6, rot_hi=3, blur=0.4, page_rot=-2.0):
+    """Core signature renderer, shared by `candidates` and `generate`.
+
+    Tuned defaults (tight_lo/hi, rot range, blur) come from a real session
+    where 0.82-0.90 character spacing looked too loose for cursive Chinese
+    handwriting; 0.62-0.78 read as natural. Treat these as a starting point,
+    not a universal constant -- re-tune per font if it looks mechanical.
+    """
+    random.seed(seed)
+    canvas = Image.new("RGBA", (260 * max(len(text), 1) + 100, 380), (0, 0, 0, 0))
+    x = 30.0
+    for i, ch in enumerate(text):
+        size = int(size_base * random.uniform(0.92, 1.08))
+        font = ImageFont.truetype(font_path, size, index=face_index)
+        layer = Image.new("RGBA", (size * 2, size * 2), (0, 0, 0, 0))
+        d = ImageDraw.Draw(layer)
+        d.text((size // 2, size // 3), ch, font=font, fill=tuple(ink) + (255,))
+        is_middle = 0 < i < len(text) - 1
+        rot = random.uniform(-1, 3) if is_middle else random.uniform(rot_lo, rot_hi)
+        layer = layer.rotate(rot, resample=Image.BICUBIC, expand=False)
+        canvas.alpha_composite(layer, (int(x), int(70 + random.uniform(-8, 10))))
+        x += size * random.uniform(tight_lo, tight_hi)
+    canvas = canvas.rotate(page_rot, resample=Image.BICUBIC, expand=True)
+    canvas = canvas.filter(ImageFilter.GaussianBlur(blur))
+    bbox = canvas.getbbox()
+    return canvas.crop(bbox) if bbox else canvas
+
+
+def cmd_candidates(args):
+    fonts = discover_fonts(all_faces=args.all_faces)
+    if args.font:
+        fonts = [(args.font, "custom", args.face or 0, "custom")]
+    if not fonts:
+        print("No fonts found/specified. Use `fonts` subcommand to check, or pass --font/--face.",
+              file=sys.stderr)
+        sys.exit(1)
+
+    # Numeric labels -- letters run out past Z on a large --all-faces sheet,
+    # and a broken label (a real bug this once produced: '[', '\\', ']', '^'
+    # past 26 rows) is worse than no label. Numbers have no ceiling, and a
+    # single flat counter (not one per font) keeps every row's number unique.
+    #
+    # An independent reviewer with no other context confirmed a real gap here:
+    # the sheet's image labels ("3  手札体 Regular (Hannotate) - black") give a
+    # human enough to pick, but nothing a reader can turn into `generate`'s
+    # required --font/--face/--ink flags without opening this script's source
+    # and reverse-engineering the row order. `params` (below) is what closes
+    # that gap -- print the exact flags for every number, and save them to a
+    # sidecar JSON so a later `generate` call can look them up by number
+    # instead of re-deriving them.
+    variants, labels, params = [], [], []
+    n = 0
+    for path, label, idx, name in fonts:
+        for ink_name, ink_rgb in INK_COLORS.items():
+            n += 1
+            sig = _render_signature(args.text, path, idx, ink_rgb, seed=hash((path, idx, ink_name)) % 9999)
+            variants.append(sig)
+            style = "Bold" if "bold" in name.lower() else "Regular"
+            # Keep the SC/TC (Simplified/Traditional) variant in the label --
+            # name.split()[0] alone drops it, so "Hannotate SC Regular" and
+            # "Hannotate TC Regular" printed as identical text on two
+            # different rows with nothing but the row number to tell them
+            # apart (an independent reviewer flagged this as a real, if
+            # minor, readability gap).
+            face_name_parts = name.split()
+            font_short = face_name_parts[0] if face_name_parts else "?"
+            variant = "SC" if " SC" in f" {name}" else ("TC" if " TC" in f" {name}" else "")
+            font_desc = f"{font_short} {variant}".strip()
+            labels.append(f"{n}  {label} {style} ({font_desc}) - {ink_name}")
+            params.append({"n": n, "font": path, "face": idx, "ink": ink_name,
+                            "family_label": label, "style": style})
+
+    row_h = 240
+    label_x = 30
+    sig_gap = 40  # min clearance between label text and signature/line
+    try:
+        label_font = ImageFont.truetype("/System/Library/Fonts/Hiragino Sans GB.ttc", 26)
+    except Exception:
+        label_font = ImageFont.load_default()
+
+    # Measure every label first -- a fixed signature-column x (this script's
+    # original bug) overlaps whichever label happens to be longest, and
+    # "- blue-black" suffixes made several rows overlap in practice.
+    probe = Image.new("RGB", (10, 10))
+    probe_d = ImageDraw.Draw(probe)
+    label_widths = [probe_d.textbbox((0, 0), lb, font=label_font)[2] for lb in labels]
+    sig_col_x = label_x + max(label_widths, default=0) + sig_gap
+    sig_col_w = 330
+    sheet_w = sig_col_x + sig_col_w + 40
+
+    sheet = Image.new("RGB", (sheet_w, row_h * len(variants) + 40), (255, 255, 255))
+    d = ImageDraw.Draw(sheet)
+    for i, (sig, lb) in enumerate(zip(variants, labels)):
+        y = 20 + i * row_h
+        d.text((label_x, y + 60), lb, font=label_font, fill=(90, 90, 90))
+        ratio = min(sig_col_w / sig.width, 180 / sig.height)
+        s = sig.resize((max(1, int(sig.width * ratio)), max(1, int(sig.height * ratio))), Image.LANCZOS)
+        d.line([(sig_col_x - sig_gap + 10, y + 185), (sheet_w - 30, y + 185)], fill=(160, 160, 160), width=2)
+        sheet.paste(s, (sig_col_x, y + 185 - s.height + 18), s)
+    sheet.save(args.out)
+
+    # Sidecar JSON + a printed lookup table -- this is what a reader turns a
+    # picked number into runnable `generate` flags with, instead of having to
+    # open this script's source and reverse-engineer the row order (the gap
+    # an independent reviewer actually got stuck on).
+    sidecar = Path(args.out).with_suffix("").as_posix() + ".params.json"
+    with open(sidecar, "w", encoding="utf-8") as f:
+        json.dump(params, f, ensure_ascii=False, indent=2)
+
+    print(f"saved {args.out}  ({len(variants)} candidates)")
+    print(f"saved {sidecar}  (--font/--face/--ink for every number, e.g. jq '.[] | select(.n==3)')")
+    print("Show this to the user and get a letter back -- do not pick one yourself. Then:")
+    for p in params:
+        print(f"  #{p['n']}: --font \"{p['font']}\" --face {p['face']} --ink {p['ink']}")
+
+
+def cmd_generate(args):
+    # NOT `INK_COLORS.get(args.ink, tuple(int(c) for c in args.ink.split(",")))` --
+    # dict.get's default arg is evaluated eagerly even on a hit, so a valid named
+    # key like "black" still crashed trying to int()-split "black" on ",".
+    if args.ink in INK_COLORS:
+        ink = INK_COLORS[args.ink]
+    else:
+        ink = tuple(int(c) for c in args.ink.split(","))
+    sig = _render_signature(args.text, args.font, args.face, ink, args.seed,
+                             tight_lo=args.tight_lo, tight_hi=args.tight_hi)
+    if args.width:
+        ratio = args.width / sig.width
+        sig = sig.resize((args.width, max(1, int(sig.height * ratio))), Image.LANCZOS)
+    sig.save(args.out)
+    print(f"saved {args.out}  size={sig.size}")
+
+
+def cmd_locate(args):
+    """Find a text string's bounding box via pdftotext -bbox, print pixel
+    coords scaled to the target DPI. 72dpi is pdftotext's native basis.
+
+    Two failure modes an independent reviewer actually hit, both fixed here:
+
+    1. Multi-page documents: pdftotext -bbox wraps each page's words in its
+       own <page> tag, in document order. A naive regex over the flattened
+       output finds every page's hits with no way to tell them apart -- print
+       the 1-based page number for every hit.
+    2. Word-merging: pdftotext -bbox tokenizes by *layout run*, not by your
+       search intent. A signature line authored as one continuous run (label
+       immediately followed by underscores, no space -- an ordinary way to
+       type "簽名：_____" in Word) becomes ONE word token. Searching a
+       substring of the label still matches that whole merged token, so the
+       returned bbox silently includes the blank too -- xMax lands at the far
+       end of the underscores, not the end of the label glyphs. There is no
+       general fix for this from pdftotext's output alone (it doesn't expose
+       sub-word granularity), so this prints a loud warning whenever the
+       matched word is longer than what you searched for, instead of staying
+       silent and letting `composite` place a signature floating in blank
+       space with no error anywhere in the chain.
+    """
+    out = subprocess.run(["pdftotext", "-bbox", args.pdf, "-"], capture_output=True, text=True, check=True).stdout
+    scale = args.dpi / 72.0
+    hits = []
+    import re
+    page_num = 0
+    for chunk in re.split(r"(<page[ >])", out):
+        if chunk in ("<page ", "<page>"):
+            page_num += 1
+            continue
+        for m in re.finditer(
+            r'<word xMin="([\d.]+)" yMin="([\d.]+)" xMax="([\d.]+)" yMax="([\d.]+)">([^<]*)</word>',
+            chunk,
+        ):
+            xmin, ymin, xmax, ymax, text = m.groups()
+            if args.text in text:
+                hits.append((page_num, float(xmin) * scale, float(ymin) * scale,
+                             float(xmax) * scale, float(ymax) * scale, text))
+    if not hits:
+        print(f"No word containing {args.text!r} found in {args.pdf}", file=sys.stderr)
+        sys.exit(1)
+    for page_num, xmin, ymin, xmax, ymax, text in hits:
+        print(f"page={page_num}\ttext={text!r}\txMin={xmin:.0f}\tyMin={ymin:.0f}"
+              f"\txMax={xmax:.0f}\tyMax={ymax:.0f}\t(at {args.dpi}dpi)")
+        if len(text) > len(args.text):
+            print(f"  WARNING: matched word ({len(text)} chars) is longer than your search "
+                  f"text ({len(args.text)} chars) -- pdftotext merged the label with adjacent "
+                  f"content (commonly a blank/underline run with no space before it). xMax above "
+                  f"is very likely the END OF THE BLANK, not the end of the label. Do not trust "
+                  f"xMax+margin for --x without visually confirming where the label glyphs "
+                  f"actually end on the rendered page image.", file=sys.stderr)
+
+
+def cmd_composite(args):
+    sig = Image.open(args.signature)
+    page = Image.open(args.page).convert("RGB")
+    if args.width:
+        ratio = args.width / sig.width
+        sig = sig.resize((args.width, max(1, int(sig.height * ratio))), Image.LANCZOS)
+    page.paste(sig, (args.x, args.y), sig)
+    page.save(args.out)
+    print(f"saved {args.out}  signature placed at ({args.x},{args.y}) size={sig.size}")
+
+
+def _scanify_one(img, angle, seed):
+    rng = np.random.default_rng(seed)
+    img = img.convert("RGB")
+    img = img.rotate(angle, resample=Image.BICUBIC, expand=False, fillcolor=(252, 252, 250))
+    arr = np.array(img).astype(np.float32)
+    h, w, _ = arr.shape
+    grad = np.linspace(-2.5, 2.5, w)[None, :, None]
+    arr = arr * 0.985 + 3 + grad
+    arr += rng.normal(0, 2.8, arr.shape)
+    arr = np.clip(arr, 0, 255).astype(np.uint8)
+    img = Image.fromarray(arr)
+    img = img.filter(ImageFilter.GaussianBlur(0.45))
+    return ImageEnhance.Contrast(img).enhance(1.02)
+
+
+def cmd_scanify(args):
+    random.seed(args.seed)
+    # NOT glob-expand-then-sort() -- that was a real bug an independent
+    # reviewer caught: lexicographic sort puts "page-10.png" before
+    # "page-2.png", silently reordering any document with 10+ pages into
+    # exactly the wrong-page-order failure mode this skill's main SKILL.md
+    # exists to prevent ("filenames lie about order -- agent eyes, not
+    # filenames"). assemble_pdf.py already gets this right by taking a plain
+    # explicit argument list in caller-given order with no glob magic at all;
+    # this matches that, on purpose. If your shell expands a `*` before this
+    # script ever sees it, that's your shell's glob order (often also
+    # lexicographic) doing the same wrong thing -- pass explicit filenames in
+    # verified content order, the same discipline as every other step here.
+    paths = [Path(p) for p in args.images]
+    if not paths:
+        print("No input images matched.", file=sys.stderr)
+        sys.exit(1)
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for i, p in enumerate(paths, 1):
+        angle = random.uniform(-args.max_angle, args.max_angle)
+        out_path = out_dir / f"scan_{i:02d}.jpg"
+        _scanify_one(Image.open(p), angle, seed=args.seed + i).save(out_path, quality=args.quality)
+        print(f"{p} -> {out_path}  (rotated {angle:+.2f} deg)")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser("fonts", help="List discovered handwriting-style CJK fonts")
+    p.add_argument("--all-faces", action="store_true", dest="all_faces",
+                    help="Show every face per family instead of one representative each")
+    p.set_defaults(func=cmd_fonts)
+
+    p = sub.add_parser("candidates", help="Render a labeled font x ink comparison sheet")
+    p.add_argument("--text", required=True, help="Signature text, e.g. a name")
+    p.add_argument("--font", help="Force one specific font path instead of auto-discovery")
+    p.add_argument("--face", type=int, help="Face index within --font's collection")
+    p.add_argument("--all-faces", action="store_true", dest="all_faces",
+                    help="Show every face per family instead of one representative each (sheet gets long)")
+    p.add_argument("--out", default="signature_candidates.png")
+    p.set_defaults(func=cmd_candidates)
+
+    p = sub.add_parser("generate", help="Render one chosen font/ink as a transparent PNG")
+    p.add_argument("--text", required=True)
+    p.add_argument("--font", required=True, help="Font path (see `fonts` or `candidates` output)")
+    p.add_argument("--face", type=int, default=0)
+    p.add_argument("--ink", default="black", help="'black', 'blue-black', or 'R,G,B'")
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--tight-lo", type=float, default=0.70, dest="tight_lo")
+    p.add_argument("--tight-hi", type=float, default=0.78, dest="tight_hi")
+    p.add_argument("--width", type=int, help="Resize output to this width (px), preserving aspect")
+    p.add_argument("--out", default="signature.png")
+    p.set_defaults(func=cmd_generate)
+
+    p = sub.add_parser("locate", help="Find a text string's pixel bbox in a PDF (via pdftotext -bbox)")
+    p.add_argument("--pdf", required=True)
+    p.add_argument("--text", required=True, help="Substring to search for, e.g. a signature-line label")
+    p.add_argument("--dpi", type=int, default=200, help="Target render DPI (pdftotext itself is 72dpi-based)")
+    p.set_defaults(func=cmd_locate)
+
+    p = sub.add_parser("composite", help="Paste a signature PNG onto a page image")
+    p.add_argument("--page", required=True)
+    p.add_argument("--signature", required=True)
+    p.add_argument("--x", type=int, required=True)
+    p.add_argument("--y", type=int, required=True)
+    p.add_argument("--width", type=int, help="Resize signature to this width (px) before pasting")
+    p.add_argument("--out", required=True)
+    p.set_defaults(func=cmd_composite)
+
+    p = sub.add_parser("scanify", help="Apply scan-look post-processing to page images")
+    p.add_argument("images", nargs="+",
+                    help="Explicit image paths, in final page order (no glob patterns -- "
+                         "lexicographic sort breaks past page 9; list every filename)")
+    p.add_argument("--out-dir", required=True, dest="out_dir")
+    p.add_argument("--max-angle", type=float, default=0.3, dest="max_angle",
+                    help="Max abs degrees of random per-page rotation (simulates a slightly crooked scan)")
+    p.add_argument("--quality", type=int, default=86, help="JPEG quality (lower = more compression artifact)")
+    p.add_argument("--seed", type=int, default=1)
+    p.set_defaults(func=cmd_scanify)
+
+    args = ap.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds a second pipeline to `photo-to-scanned-pdf`: digital document (no signature yet) → synthesized handwriting-style signature → composited onto the signature line → scan-look post-processing. Complements the existing phone-photo pipeline; same destination look, opposite starting point.
- New `scripts/synthesize_signature.py` (font discovery via `fc-list`, candidate comparison sheet, signature generation, `pdftotext -bbox` based signature-line location, compositing, scan-look post-processing) + `references/digital-signature-synthesis.md`.
- Bumps `daymade-docs` suite 1.4.0 → 1.5.0.

## Independent review
A fresh-context reviewer (not a fork) ran the new pipeline cold against a self-built test document and caught 3 real bugs, all fixed before this PR:
1. `candidates`' picked number couldn't be turned into `generate`'s `--font`/`--face` without reading source — now prints exact flags + writes a `.params.json` sidecar.
2. `locate`'s bbox silently included an adjacent blank whenever `pdftotext` merged a label with its underline run, misplacing signatures with no error anywhere in the chain — now warns loudly, and the doc gives a pixel-scan workaround.
3. `scanify`'s glob handling lexicographically mis-sorted pages 10+ (`page-10.png` before `page-2.png`) — exactly the wrong-page-order failure the parent skill's main pipeline exists to prevent. Removed glob auto-expansion entirely; explicit filenames only, matching `assemble_pdf.py`'s existing discipline.

Full findings + dispositions kept in my private review archive (not part of this public repo, per the skill-creator methodology's sanitization rules).

## Test plan
- [x] `py_compile` + full CLI smoke test of every subcommand (`fonts`, `candidates`, `generate`, `locate`, `composite`, `scanify`)
- [x] End-to-end run producing a signed + scan-look 2-page PDF, contact-sheet verified
- [x] Reproduced the independent reviewer's exact failure cases (merged label+underscore token; 12-page glob mis-sort) against the fixed code — both now behave correctly
- [x] Existing-skill regression audit (`audit_skill_regression.py compare/classify/verify`) — 0 lost capability, all 11 review candidates classified `preserved_or_moved`
- [x] `quick_validate` + `security_scan --verbose` — both clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)