### PR TITLE
fix(feishu-doc-scraper): lark-cli 一直能导出妙记转录——该文件第一句话是错的

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -328,7 +328,7 @@
       "description": "Extract Feishu (Lark) Docs, Wiki pages, Wiki collections/hubs, spreadsheets (including cell-attachment file download), and Minutes (妙记) transcripts into clean high-fidelity local Markdown. The primary path is the lark-cli API — programmatic extraction with no LLM rewriting of the body — which recursively follows a collection's reference graph (mention-doc / sheet / cross-tenant links) and uses error codes to resolve permission boundaries precisely; a browser-DOM path is the fallback only when lark-cli cannot reach the content. Use this whenever the source is a Feishu/Lark URL and fidelity matters — including 导出飞书文档/合集/妙记转写, 把飞书 wiki/知识库转 markdown, scraping or archiving a Feishu collection, exporting a Feishu Minutes/妙记 transcript, or saving a Feishu page locally — even if the user only says clipping, archiving, converting, or \"save this\". Also covers the permission-denied path (owner-exported .docx → faithful Markdown with heading/highlight restoration).",
       "source": "./feishu-doc-scraper",
       "strict": false,
-      "version": "1.3.1",
+      "version": "1.3.2",
       "category": "productivity",
       "keywords": [
         "feishu",

--- a/feishu-doc-scraper/.security-scan-passed
+++ b/feishu-doc-scraper/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-07-10T05:27:07.280704
+Scanned at: 2026-08-01T03:29:53.156551+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 56bfc656b245ff8b7b7023a5393cad1134914363871f8dedd9e793a8cd58a471
+Content hash: a7d0c51a24dc54c2abd9f82311998f2b52d52aaf38193885d47373b46869d629

--- a/feishu-doc-scraper/references/feishu-minutes-transcript.md
+++ b/feishu-doc-scraper/references/feishu-minutes-transcript.md
@@ -1,21 +1,47 @@
 # Feishu Minutes (妙记) Transcript (Path C)
 
-How to export the **text transcript** of a Feishu Minutes recording. Verified end-to-end (2026-05).
+How to export the **text transcript** of a Feishu Minutes recording. Verified end-to-end 2026-05; re-verified against lark-cli 1.0.80 on 2026-08-01, which is when the `+detail` route below replaced the raw-API-only advice this file used to give.
 
 ## Contents
 
-- The key fact: lark-cli cannot do it directly
-- The native endpoint
+- Start here: `minutes +detail` exports transcripts, and it batches
+- The raw endpoint (SRT, or transcripts without speaker/timestamp)
+- Output paths: the one restriction both routes share
+- Verify the output — with `command grep`, not a bare `grep`
 - The scope and the `99991679` error
 - Granting the scope via device-flow (and the timeout trap)
 - Permission is per-minute, not per-tenant
 - Never re-ASR
 
-## The key fact: lark-cli cannot do it directly
+## Start here: `minutes +detail` exports transcripts, and it batches
 
-`lark-cli minutes` exposes `minutes get` (metadata), `+download` (audio/video), `search`, `upload`. **None export the transcript text.** `lark-cli minutes minutes get --params '{"minute_token":"<t>"}'` succeeds but returns only title/duration/url — no transcript. The transcript is a native endpoint not wrapped by lark-cli; call it through `lark-cli api`.
+```bash
+export LARK_CLI_NO_PROXY=1
+cd <target-dir> && lark-cli minutes +detail --profile <profile> \
+  --minute-tokens <tokenA>,<tokenB>,<tokenC> \
+  --transcript --output-dir ./out --overwrite
+```
 
-## The native endpoint
+Each token writes **speaker labels + millisecond timestamps** into its own directory under `./out`. The command prints per-token progress and ends with `done: N total, N succeeded, N failed`, so a partial failure is visible instead of silent. Batch limit is **50 tokens per call** (enforced client-side: 51 → exit 2).
+
+Three things about that command that are not obvious:
+
+- **`--profile` — get the value from `lark-cli profile list`, don't guess.** It reports each profile's name, which one is `active`, and a `tokenStatus` that can be `valid` / `expired` / `needs_refresh`. Picking an expired one fails at auth, not at permissions, so it looks nothing like the `2091005` case below.
+- **Read the output path from the response, don't reconstruct it.** Each result carries `artifacts.transcript_file` with the real relative path. The naming pattern is `artifact-<title>-<token>/transcript.txt`, but `<title>` is the *server-side* minute title — it can be arbitrary CJK, and in practice frequently contains **spaces**, which is enough on its own to break an unquoted downstream path. You do not know it before the call. Any grep/move/index built on a hand-built path silently finds nothing.
+  ```bash
+  … --transcript --output-dir ./out | jq -r '.data.minutes[].artifacts.transcript_file'
+  ```
+- **`--overwrite` is what makes a re-run work.** Without it, a token whose file already exists errors (`file already exists: … (use --overwrite to overwrite)`). Since the whole argument for this route is that failures are visible and therefore retryable, the retry has to actually be runnable — otherwise a second pass reports failures that are really just "already downloaded", and the permission section below then reads as license to skip them.
+
+> An earlier version of this file stated that `lark-cli minutes` could not export transcripts and sent readers straight to the raw API. That was wrong — `+detail` has carried `--transcript` for many releases. If you are pulling more than one or two transcripts, this is the route; the raw endpoint below costs you the batching, the progress reporting, and the failure count.
+
+## The raw endpoint (SRT, or transcripts without speaker/timestamp)
+
+Reach for the raw endpoint in three cases; otherwise use `+detail`.
+
+1. **You need SRT subtitles.** `+detail` writes plain text only; `file_format` is a raw-endpoint parameter (verified: returns standard `00:00:14,920 --> 00:00:16,040` cue blocks).
+2. **You want the transcript *without* speaker labels or timestamps.** `+detail` emits both unconditionally. Here they are opt-in flags — so a clean prose body for a Markdown knowledge base is only reachable this way.
+3. **You need to control the output filename exactly.** `+detail` derives it from the server-side title.
 
 ```
 GET https://open.feishu.cn/open-apis/minutes/v1/minutes/:minute_token/transcript
@@ -28,16 +54,46 @@ GET https://open.feishu.cn/open-apis/minutes/v1/minutes/:minute_token/transcript
 | `need_timestamp` | query | no | `true` → per-line timestamps |
 | `file_format` | query | no | `txt` or `srt`; `txt` is best for a Markdown KB |
 
-Auth: `user_access_token` (use `--as user`) or `tenant_access_token`.
+Auth: `--as` takes `user` or `bot` (there is no `--as tenant`; a tenant token is supplied through the environment instead). `--as user` is what these calls want.
 
 ```bash
 export LARK_CLI_NO_PROXY=1
-lark-cli api GET /open-apis/minutes/v1/minutes/<minute_token>/transcript \
-  --params '{"need_speaker":true,"need_timestamp":true,"file_format":"txt"}' \
-  --as user -o <speaker-and-timestamped-transcript>.txt
+cd <target-dir> && lark-cli api GET /open-apis/minutes/v1/minutes/<minute_token>/transcript \
+  --profile <profile> \
+  --params '{"need_speaker":true,"need_timestamp":true,"file_format":"srt"}' \
+  --as user -o ./<name>.srt
 ```
 
-A successful run yields the full transcript with speaker + millisecond timestamps; verify with the U+FFFD check (`LC_ALL=C grep -rl $'\xef\xbf\xbd' .` empty).
+**`--profile` matters on every call, both routes.** It is a global lark-cli flag, and *which identity fetches* is decisive: minutes are shared per-account, so the wrong profile returns `2091005` on a minute another profile reads fine. Run as the default and the "permission is per-minute" section below will tell you to skip a minute that was never out of reach.
+
+## Output paths: the one restriction both routes share
+
+**lark-cli refuses to write outside the working directory** — this applies to `--output-dir` on `+detail` and to `-o` on `api` alike, with the same error text, so switching routes does not escape it. Measured against 1.0.80:
+
+| You pass | Result |
+|---|---|
+| `./out` or `./sub/name.txt` | works; missing directories are created for you |
+| `name.txt` (no `./`) | works, same as `./name.txt` |
+| `../out` | refused — `--output "../out" resolves outside the current working directory` |
+| `/abs/path` | refused — `--output must be a relative path within the current directory` |
+| `~/out` | **not refused — and not expanded either.** Exit 0, writing to a literal directory named `~` |
+
+So **to land transcripts somewhere else, `cd` there and run lark-cli in the same command**: `cd <target> && lark-cli …`. Two separate steps is the trap, not a style preference — in agent harnesses (Claude Code's Bash tool among them) the working directory **resets between tool calls**, so a `cd` in one call and the fetch in the next writes `./out` relative to wherever the session started. And because `./out` is a perfectly legal relative path there too, you get exit 0, `done: N succeeded, 0 failed`, and N files in the wrong repository. Building an absolute path out of a variable is the other reflex to unlearn — that one at least fails loudly.
+
+Two consequences worth stating outright, because both have produced silent data loss:
+
+- **Omitting `-o` on the raw route is not a neutral default.** The body lands in the current directory under a name lark-cli derives itself — measured for a `txt` transcript: `download.txt`, reused for every subsequent fetch, so pulling several tokens in a row overwrites the same file and leaves only the last one. (The extension appears to follow the content type, so a different `file_format` may land elsewhere; the operative point is that you do not choose the name and it repeats.) `+detail` does not have this failure mode — it derives a per-token directory. Verifying that N tokens are reachable by running the command N times without `-o` leaves you with one file and the false impression that all N worked.
+- **The refusal itself is honest — exit code 2, message on stderr, empty stdout.** What destroys that signal is the calling script: `lark-cli … > "$log" 2>&1` without testing `$?` folds both the error text and the failure code into a file nobody reads, so N rejected fetches look exactly like N successful ones until you notice every output is missing. If you wrap lark-cli in a loop, either check `$?` per iteration or assert the output file is non-empty — otherwise you have built a silent-failure channel on top of a tool that was telling you the truth.
+
+## Verify the output — with `command grep`, not a bare `grep`
+
+This applies to **both** routes; run it after any fetch, including a 50-token `+detail` batch:
+
+```bash
+LC_ALL=C command grep -rl $'\xef\xbf\xbd' .     # empty = clean
+```
+
+A U+FFFD replacement character means an encoding step corrupted the text. **The reason for `command` is that a bare `grep` cannot be trusted to find it.** In some agent shells (Claude Code's Bash tool among them) `grep` resolves to a gitignore-aware implementation that silently skips files matched by `.gitignore`. Measured: in a repo whose `.gitignore` contains `*.txt`, a transcript carrying a genuine U+FFFD sequence returns *nothing* from bare `grep -rl` (exit 1, reads as "clean") while `command grep -rl` finds it. Transcripts are routinely written into exactly such a repo, so the bare form converts the only fidelity check here into a guaranteed pass. (`$'…'` is bash/zsh ANSI-C quoting; under a plain `sh` it degrades to a literal string and also yields a false clean.)
 
 > Spec lookups: use `https://open.feishu.cn/llms-docs/zh-CN/llms-minutes.txt` (stable, LLM-friendly). `WebFetch` against `open.feishu.cn/document/server-docs/...` is flaky. If lark-cli has no wrapper for something, the `lark-openapi-explorer` skill is the systematic way to mine the native spec.
 
@@ -58,18 +114,22 @@ The scope you need is **`minutes:minutes.transcript:export`**.
 ## Granting the scope via device-flow (and the timeout trap)
 
 ```bash
-lark-cli auth login --scope "minutes:minutes.transcript:export" --no-wait --json
-# → returns a device flow_id + user_code + a verify URL like:
-#   https://accounts.feishu.cn/oauth/v1/device/verify?flow_id=...&user_code=XXXX-XXXX
+lark-cli auth login --profile <profile> --scope "minutes:minutes.transcript:export" --no-wait --json
 ```
 
-- Send the **verify URL to the person who owns / can access the Minutes** so they approve it in a browser.
-- Resume polling with `lark-cli auth login --device-code <code>` — do **not** wrap the login in a short `timeout`. lark-cli explicitly warns: each restart invalidates the previous device code, so short-timeout-retry loops never converge. The login command can legitimately block for up to ~10 minutes waiting for approval.
-- After approval, re-run the `api … /transcript` call; it now succeeds.
+**Pass the same `--profile` you will fetch with.** Omitting it grants the scope to whichever profile is active, and the fetch under a different one still returns `99991679` — with nothing in the error to say the grant landed on the wrong identity, so the natural response is to run the device flow again and get the same result.
+
+- The JSON carries **`device_code`** and **`verification_url`**. `--device-code` takes the **`device_code`** field — not the `flow_id` or `user_code` you can also see embedded as query parameters in the verify URL. Picking either of those looks reasonable and fails on the one step that unblocks everything downstream.
+- Send `verification_url` to **the person who owns / can access the Minutes** so they approve it in a browser. Treat the URL as an opaque string — no re-encoding, no reassembling the query.
+- **End your turn after sending the URL.** Do not display it and then immediately start polling in the same turn: in a harness that only delivers final messages, the user never sees the URL and the poll blocks against an approval that cannot happen.
+- Then resume with `lark-cli auth login --profile <profile> --device-code <device_code>` — and do **not** wrap it in a short `timeout`. Each restart invalidates the previous device code, so short-timeout-retry loops never converge; the command can legitimately block ~10 minutes waiting for approval. Do not cache either value for reuse — re-issue `--no-wait --json` each time you need authorization.
+- After approval, re-run the fetch; it now succeeds.
 
 ## Permission is per-minute, not per-tenant
 
 One Minutes returning `permission deny` (e.g. code `2091005`) does **not** mean other Minutes in the same tenant are denied. Check each minute_token independently. Before chasing a denied one, check whether its content is already covered by another document you can access (a meeting's AI summary doc often duplicates the transcript) — if so, skip it instead of escalating the permission request.
+
+**Before you conclude a minute is out of reach, confirm you tried it under the right `--profile`.** Minutes are shared per-account, so a `2091005` frequently means "this identity cannot see it" rather than "nobody can" — measured: a document readable under one profile returned a permission error under two others on the same machine. Skipping on the strength of a default-profile failure discards minutes you could have fetched, and it does so quietly, because this section otherwise reads as permission to move on.
 
 ## Never re-ASR
 


### PR DESCRIPTION
## 问题

`references/feishu-minutes-transcript.md` 开篇断言：

> `lark-cli minutes` exposes `minutes get` (metadata), `+download` (audio/video), `search`, `upload`. **None export the transcript text.**

**这是错的。** `lark-cli minutes +detail --transcript` 一直存在：

```bash
lark-cli minutes +detail --profile <profile> \
  --minute-tokens <a>,<b>,<c> --transcript --output-dir ./out --overwrite
```

批量（上限 50，客户端强制）、按 token 自动建目录、输出**含说话人 + 毫秒时间戳**、结尾报 `done: N total, N succeeded, N failed`。

这句错话把每个读者推去手搓裸 API 循环。不是理论问题：我照着它拉 32 段转录，因 `-o` 只收 cwd 内相对路径而 **32 个文件全部 0 字节**。原计划是把这条坑补进文档，独立审阅指出这个补丁本身就不该存在。

## 改动

| 项 | 内容 |
|---|---|
| 路径优先级 | `+detail` 立为首选；裸 API 收窄为三种情形——SRT / **不要**说话人时间戳 / 精确控制文件名。后两条来自审阅：`+detail` 无条件输出说话人+时间戳，裸 API 才是 opt-in |
| 公开更正 | 正文写明这是对旧说法的更正，读过旧版的人能知道哪版权威 |
| `cd` 陷阱 | 改为 `cd <target> && lark-cli …` **必须同一条命令**。agent harness 里工作目录在两次工具调用之间重置，而 `./out` 在错目录也是合法相对路径 → exit 0 + `0 failed` + 文件进错仓库（实测复现） |
| 输出路径 | 从返回体 `artifacts.transcript_file` 读，别自己拼——标题是服务端的，常含空格 |
| `--overwrite` | 补上。主张「失败可见所以可重试」，就得让重试真的跑得动 |
| `--profile` | 写明取值来源 `lark-cli profile list`（含 `expired`/`needs_refresh` 状态）；`auth login` 两处补该 flag——此前与本文自己「每条命令都要带」的规则矛盾，会导致 device flow 死循环 |
| U+FFFD 检查 | 改 `command grep` 并提升为通用节。裸 `grep` 在 gitignore-aware 实现下对被 ignore 的文件静默跳过，而转录恰恰常写进这种仓库 → 检查恒绿（实测：`.gitignore` 含 `*.txt` 时，含真实 U+FFFD 的文件裸 grep 返回空 exit 1） |
| 路径对照表 | 补 `~/out`：既不被拒也不展开，exit 0 写进字面量 `~` 目录 |
| 事实修正 | `--as tenant` 不存在（只有 `user\|bot`）；`--device-code` 取 `device_code` 而非 `flow_id`/`user_code`；错误引文漏词 `working` |

## 验证

- 全部断言实测于 **lark-cli 1.0.80**
- **两轮 fresh-context 独立审阅**（非 fork），审阅档案含 prompt 逐字 + 26 条 finding 逐条处置 + 未验证项，存私有知识库
- 回归审计：11 candidates 全部分类（5 × `true_gap_fixed`，6 × `preserved_or_moved`，0 未分类）〔合并后订正：初版误写 4/7，第二轮重新分类后没重数〕，**464 处原文逐字保留**
- `quick_validate` / `security_scan` 通过；另跑私有串机械探针（先用已知存在的串标定探针有效）

## CHANGELOG

本 PR **未改 `CHANGELOG.md`**：提交时该文件有另一个 session 未提交的改动，`git add` 会把它的 WIP 卷进这个 commit。条目文本如下，合并后补一行即可：

```markdown
- **feishu-doc-scraper** v1.3.2: the Minutes-transcript reference opened by asserting that no `lark-cli minutes` subcommand can export transcript text, and routed every reader into a hand-rolled raw-API loop. Measured false against lark-cli 1.0.80 — `minutes +detail --transcript --minute-tokens a,b,c --output-dir ./out` batches up to 50 tokens, derives a per-token directory, emits speaker labels + millisecond timestamps, and reports `done: N total, N succeeded, N failed`. `+detail` is now the primary route and the raw endpoint is narrowed to the three cases that actually select it (SRT, transcripts *without* speaker/timestamp, exact filename control). Also fixes, all found by two independent reviews: `cd X` and the fetch must be **one** command (working directory resets between agent tool calls, and a relative `--output-dir` is legal in the wrong directory too — exit 0, zero failures, files in the wrong repo); output paths must be read from `artifacts.transcript_file` rather than reconstructed; `--overwrite` was missing so the recommended retry could not run; `--profile` had no stated source and was absent from both `auth login` calls despite the file declaring it mandatory; the U+FFFD fidelity check used a bare `grep`, which in gitignore-aware shells silently skips exactly the files transcripts land in, turning the only fidelity check into a guaranteed pass; `--as tenant` does not exist; `--device-code` takes `device_code`, not `flow_id`/`user_code`.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MChsJCAHrYJznMnq5zDoMW

