### PR TITLE
claude-code-hooks: 订正两处关于 Stop hook 防循环机制的失实断言 + 新增 pitfall 27

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -103,7 +103,7 @@
       "description": "Claude Code operations suite that bundles archive-aware local conversation discovery across Claude Code and Codex, internal-timestamp full-event session search and recovery, interrupted-work continuation, plugin/skill troubleshooting, CLAUDE.md progressive disclosure optimization, statusline configuration, exported .txt repair, full claude.ai conversation extraction with tool-call rendering and file download, plugin marketplace development, writing/testing/debugging Claude Code hooks, multi-provider profile isolation for running Kimi/GLM/DeepSeek/StepFun/Anthropic in separate windows, local source sync for Claude/Codex skill installs, personal-memory migration into tool-agnostic AGENTS.md reference docs, and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
       "source": "./daymade-claude-code",
       "strict": false,
-      "version": "1.30.0",
+      "version": "1.31.0",
       "category": "suite",
       "keywords": [
         "suite",

--- a/daymade-claude-code/claude-code-hooks/.security-scan-passed
+++ b/daymade-claude-code/claude-code-hooks/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-08-02T16:24:44.092824+00:00
+Scanned at: 2026-08-02T17:23:00.553228+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 89fc97f709a64723447af8be3f1d84acf26a63eada8d753a6684dfc44052ff7b
+Content hash: d29a1b9ff9388b8dea852ce6d51dc246a1270c017729cfa1f560eb370a424940

--- a/daymade-claude-code/claude-code-hooks/SKILL.md
+++ b/daymade-claude-code/claude-code-hooks/SKILL.md
@@ -50,7 +50,7 @@ match tokens/patterns; it can't judge whether a design is good).
 | **PreToolUse** | before a tool runs | allow | **block** the call (stderr → shown to model as guidance) | any other exit = "non-blocking error" → **the call proceeds** |
 | **PostToolUse** | after a tool ran | quiet **unless it prints a `hookSpecificOutput` JSON on stdout — that is how context injection works, and it happens at exit 0** | feedback to the model (can't un-run the tool) | — |
 | **SessionStart** | session begins | proceed | — | **always exit 0** — never block a session |
-| **Stop** (+ `SubagentStop`) | the model is about to finish responding | let it stop | **block the stop** — forces the model to keep going (stderr → fed back as the reason) | loop safety is **two layers**: the hook checks `stop_hook_active` (necessary, **not** sufficient — rule 7), and the harness itself **ends the turn after 8 consecutive blocks** regardless. All Stop hooks for an event run **in parallel** — one block round can carry several hooks' feedback |
+| **Stop** (+ `SubagentStop`) | the model is about to finish responding | let it stop | **block the stop** — forces the model to keep going (stderr → fed back as the reason) | loop safety: the hook checks `stop_hook_active` (necessary, **not** sufficient — rule 7). The harness's consecutive-block ceiling (default 8) is **not** a general backstop — its counter resets on any continuation that executed tools, so it never arrives for a hook whose remediation involves tool calls, which is most of them (#27). Carry your own bound. All Stop hooks for an event run **in parallel** — one block round can carry several hooks' feedback |
 
 - **PreToolUse** is the workhorse — the only one that can *stop* an action.
   `matcher` selects the tool (`Bash`, `Agent`, `WebFetch`, …). Exit 2 blocks and
@@ -367,13 +367,17 @@ condition T is true → hook demands remediation R → model performs R → T ch
 ```
 
 **If completing R can make T true again, the loop does not converge.** Nothing
-errors, nothing crashes; it burns round after round until the harness's
-8-consecutive-block ceiling ends the turn — or a human interrupts first, which
-is what usually happens because each round is a *complete* remediation cycle
-(dispatch, wait, adopt, edit), not a cheap retry. That ceiling is a backstop
-against a runaway session, not a design: reaching it means the turn ends with
-the violation still standing and the model's last 8 rounds spent on work nobody
-asked for. "It eventually stops" is not termination in any sense you want. `stop_hook_active` does *not* save you here — that field covers
+errors, nothing crashes; it burns round after round until a human interrupts —
+which is what usually happens, because each round is a *complete* remediation
+cycle (dispatch, wait, adopt, edit), not a cheap retry. **And that same
+property is why the harness's 8-consecutive-block ceiling will not save you:
+its counter resets on every continuation that executed tools, so a remediation
+cycle made of tool calls keeps it pinned at 1 forever** (measured — #27). Even
+where it does arrive, it is a backstop against a runaway session, not a design:
+the turn ends with the violation still standing, and the harness reports that
+turn as `reason:"completed"` — indistinguishable from genuinely finishing.
+"It eventually stops" is not termination in any sense you want, and here it
+does not even eventually stop. `stop_hook_active` does *not* save you here — that field covers
 exactly **one layer of re-entry** ("the stop I just blocked is being retried").
 It says nothing about the *cross-turn* case, where the model genuinely goes off
 and does R (real work, many tool calls), then stops naturally: that is a brand

--- a/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
+++ b/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
@@ -499,7 +499,11 @@ unresolvable path means **block**.
 - **Why `stop_hook_active` doesn't cover it.** It means "the stop I just blocked
   is being retried" — one layer of re-entry inside one stop attempt. This loop is
   *cross-turn* (real work, then a fresh Stop with the field `false`). Handling it
-  is necessary and buys nothing here. Full contract: SKILL.md rule 7.
+  is necessary and buys nothing here. Full contract: SKILL.md rule 7. **Nor does
+  the harness's consecutive-block ceiling cover it** — that counter resets on any
+  continuation that executed tools, and remediation worth demanding is made of
+  tool calls, so it stays pinned at 1 (#27). Both runtime protections are blind
+  to exactly this loop; the bound has to be yours.
 - **Fix — change the shape of the predicate, not its threshold.** In order:
   (a) if what you're gating is an **action**, move the gate onto that action with
   PreToolUse instead of onto the turn with Stop — one evaluation per attempt, no
@@ -895,6 +899,76 @@ unresolvable path means **block**.
   If either check turns up an instance that was actually acted on, not just
   printed, treat it as its own live incident — verify what state it left
   behind before moving on, not just log it as another near miss.
+
+---
+
+## 27. A Stop hook's two runtime loop-protections both have blind spots — and a tool-calling remediation lands in both
+
+- **Symptom:** a Stop hook fires several times inside what the user experiences
+  as one request. Nothing errors. `stop_hook_active` is handled correctly. The
+  documented consecutive-block ceiling never arrives.
+- **Cause — the ceiling counts something narrower than its name suggests.**
+  Claude Code caps consecutive Stop-hook blocks (default **8**, overridable via
+  `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`; **setting it to `0` disables the cap
+  rather than forbidding blocks** — the guard is `cap > 0 &&`). None of this is
+  in the docs; it is readable from the shipped binary. The counter driving it is
+  **reset to 0 on every continuation that executed tools** — verified across all
+  six continuation branches in 2.1.220, each of which writes the counter back as
+  `0`; only the block branch increments it. So the cap's real meaning is *"blocked
+  eight times in a row without the model doing anything in between"* — it catches
+  a model that has stalled, not one that is diligently oscillating. **Any hook
+  whose remediation involves tool calls keeps the counter pinned at 1 forever.**
+  That is most Stop hooks worth writing: run the tests, dispatch the review,
+  regenerate the artifact. Note also that when the cap *does* fire, the turn ends
+  with `reason:"completed"` — the harness does not distinguish "forced abort"
+  from "genuinely done" (contrast OpenHands, whose goal controller carries an
+  explicit `complete` / `capped` split).
+- **Cause — the other protection is one bit, not a counter.** `stop_hook_active`
+  is a boolean: *"this turn has been blocked by a stop hook at least once."* The
+  hook cannot learn how many times it has fired, so "let the third one through"
+  is not expressible from the input alone. (Cursor hands its stop hook a numeric
+  `loop_count` plus a configurable `loop_limit`; Claude Code hands you the bit.)
+  The field is also undocumented — absent from the hooks reference, present in
+  the SDK's type declaration with no prose. Within one query loop it behaves as a
+  **latch**: once true it stays true.
+- **What is NOT the cause (tested, so you don't repeat the experiment):**
+  asynchronous background completions arriving *inside* the blocked window do
+  **not** clear the latch. Measured over 7 headless runs on 2.1.220 — three with
+  the notification verifiably landing after the block, including a real
+  subagent reply — the latch held `true` every time. A plausible-sounding
+  mechanism is not evidence; this one was wrong.
+- **Honest boundary:** one observed session had a Stop hook block **four** times
+  within a span containing a single real user message, each time with the latch
+  `false` — so *something* started a fresh query loop between them, and the above
+  rules out the obvious candidate. **The mechanism is unresolved.** That
+  uncertainty is itself the argument for the fix: do not hang termination on a
+  protection whose reset conditions you cannot predict.
+- **Fix:**
+  1. **Carry your own bound.** Neither runtime protection is one. If your hook
+     demands a remediation, key a counter on something the hook computes itself
+     (the turn-start offset it already derives, plus the session id) rather than
+     on a runtime field.
+  2. **Suppress the fires that are certainly useless — this is free.** The Stop
+     input carries `background_tasks[]`, which lists still-running subagents
+     (`type`, `status`, `agent_type`) and empties when they finish. If your
+     remediation is "dispatch an agent," firing while that agent is still
+     running is pure noise, and noise is what trains readers to ignore the hook
+     (#2). Going quiet on non-empty `background_tasks` / `session_crons` is a
+     **fact test, not a heuristic** — categorically unlike the semantic
+     stuck-detection SWE-agent tried and abandoned for false positives. It
+     defers rather than suppresses: the agent's return opens a new turn and the
+     hook fires then.
+  3. Sanity-check the shape first: #16 (is the predicate temporal, so the
+     remediation re-arms it?) and #19 (does the remediation require memory that
+     does not survive the call boundary?). This entry is about the layer
+     underneath both — what the runtime does *not* do for you either way.
+- **Self-test rows that see it:** same must-fire input three ways —
+  `background_tasks` non-empty → quiet; `background_tasks: []` → still fires;
+  `session_crons` non-empty → quiet. The middle row is the one people skip, and
+  without it you cannot distinguish "gate works" from "gate swallows
+  everything." Verified by mutation: forcing the gate true fails many rows,
+  forcing it false fails **exactly** the two quiet rows — proving no pre-existing
+  fixture covered the gate.
 
 ---
 


### PR DESCRIPTION
## 起因

SKILL.md 有两处把 harness 的「连续 8 次 block 上限」当作可依赖的兜底——**对它们各自描述的那个场景恰恰不成立**。第二处甚至自我推翻：它括号里写的 `(dispatch, wait, adopt, edit)` 正是上限**不会到达**的那种形态。

## 机制（读 2.1.220 二进制核实）

驱动该上限的计数器在**任何执行了工具的 continuation 上归零**——六个 continuation 分支逐一核对，全部写回 `0`；只有 block 分支自增。

所以它的真实语义是「连续八次被拦、其间模型什么都没干」——**防摆烂，不防勤奋地来回震荡**。而值得要求的补救几乎都由工具调用构成（跑测试、派审阅、重新生成），于是计数器永远停在 1。

## 新增 pitfall 27

把两道运行时保护的盲区一次讲清：

- **上限**：计数器归零条件；默认 8；`CLAUDE_CODE_STOP_HOOK_BLOCK_CAP` 设 `0` 是**关掉**而非禁止（守卫是 `cap > 0 &&`）；触顶时 turn 以 `reason:"completed"` 结束，不区分强制中止与真做完（对照 OpenHands goal controller 的 `complete` / `capped` 显式二分）
- **`stop_hook_active`**：是 1 bit 不是计数器，hook 无法得知自己已拦几次（Cursor 给的是数字 `loop_count` + 可配 `loop_limit`）；文档中不存在语义说明
- **写明什么不是原因**：异步后台完成落在被拦窗口内**不会**清掉该闩锁——7 次 headless 实测，其中三次通知确实晚于 block（含真实 subagent 回复），闩锁全程 `true`。听起来合理的机制不等于证据，这一个就是错的
- **诚实边界**：曾观察到某 Stop hook 在只含一条真实用户消息的区间里拦了四次、四次闩锁均为 `false`——说明中途开了新 query loop，而上面已排除最显然的候选。**机制未解**。这份不确定本身就是修法的理由
- **修法三条**，其中「`background_tasks[]` 非空即静默」是免费的：派 agent 期间提醒「你没派 agent」是纯噪音，而噪音正是训练读者无视 hook 的东西（#2）。它是**事实判定不是启发式**，与 SWE-agent 因误报率过高放弃的语义 stuck 检测不同类；且是**延后不是抑制**
- **自检行对**含「空数组仍须触发」那一行——缺了它无法区分「闸门生效」与「闸门吞掉一切」

#16 补一句回指（它原本只说 `stop_hook_active` 兜不住，现补上上限同样兜不住）。

## 验证

`quick_validate` 通过 · `security_scan` 通过并已刷新 marker · `check_marketplace` 58 plugins OK · 新增内容经 PII 自查（无本机路径 / 私有域名），非 ASCII 仅破折号与箭头、无 CJK。

## 两点说明

- 版本号（daymade-claude-code 1.31.0）在单独一个提交里：与 skill 内容分属不同顶层域，拆开以保持每次提交范围单一。
- **本 PR 未加根 `CHANGELOG.md` 条目**：该文件此刻有另一条工作线未提交的改动，加我的条目会把对方的一并卷进来。待其落地后补。

🤖 Generated with [Claude Code](https://claude.com/claude-code)