### PR TITLE
claude-code-hooks: 上限断言的一致性收口——三处下游副本改为限定 + 指向 #27

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -103,7 +103,7 @@
       "description": "Claude Code operations suite that bundles archive-aware local conversation discovery across Claude Code and Codex, internal-timestamp full-event session search and recovery, interrupted-work continuation, plugin/skill troubleshooting, CLAUDE.md progressive disclosure optimization, statusline configuration, exported .txt repair, full claude.ai conversation extraction with tool-call rendering and file download, plugin marketplace development, writing/testing/debugging Claude Code hooks, multi-provider profile isolation for running Kimi/GLM/DeepSeek/StepFun/Anthropic in separate windows, local source sync for Claude/Codex skill installs, personal-memory migration into tool-agnostic AGENTS.md reference docs, and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
       "source": "./daymade-claude-code",
       "strict": false,
-      "version": "1.31.0",
+      "version": "1.31.1",
       "category": "suite",
       "keywords": [
         "suite",

--- a/daymade-claude-code/claude-code-hooks/.security-scan-passed
+++ b/daymade-claude-code/claude-code-hooks/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-08-02T17:23:00.553228+00:00
+Scanned at: 2026-08-02T17:44:55.180994+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: d29a1b9ff9388b8dea852ce6d51dc246a1270c017729cfa1f560eb370a424940
+Content hash: 77f68c3c51550e1b0ce5b2b94819ae64318329e4f67e445bff27bc0e4cbd051d

--- a/daymade-claude-code/claude-code-hooks/SKILL.md
+++ b/daymade-claude-code/claude-code-hooks/SKILL.md
@@ -95,11 +95,14 @@ match tokens/patterns; it can't judge whether a design is good).
   hard gates ("this must not stand"). `hookSpecificOutput.additionalContext`
   shows as neutral "Stop hook feedback" with no error notification — for
   coaching and reminders the model should weigh, not gates. Both count toward
-  the same 8-consecutive-block ceiling from the table above, so the choice is
-  tone, not safety. What the ceiling means for message design: a blocked retry
+  the same consecutive-block ceiling from the table above, so the choice is
+  tone, not safety. What that means for message design: a blocked retry
   round (`stop_hook_active: true`) is let through **with whatever violations
-  remain**, and after 8 blocks the harness ends the turn the same way — so a
-  Stop guard gets exactly **one** informed bite. Report *all* findings in that
+  remain** — so a Stop guard gets exactly **one** informed bite. (The ceiling
+  reinforces this only when your remediation is "rewrite the reply"; if it
+  involves tool calls the counter resets and the ceiling never lands — #27.
+  Either way the one-bite conclusion holds, because it rests on the latch, not
+  on the ceiling.) Report *all* findings in that
   one block (a guard that prints only the first loses the rest permanently —
   pitfall #17), and write the message as an escape manual naming the exact
   acceptable fix, not a verdict — the model converges in one round or it burns

--- a/daymade-claude-code/claude-code-hooks/references/hook_patterns.md
+++ b/daymade-claude-code/claude-code-hooks/references/hook_patterns.md
@@ -865,11 +865,12 @@ Three things worth calling out beyond what the comments above already say:
   registered, another guard's block consumes the shared retry round, so your
   first block must be complete (the skeleton above collects all findings —
   pitfall #17 is the failure shape of reporting only the first). The other
-  loop-safety layers (the 8-consecutive-block harness ceiling, all Stop hooks
-  running in parallel per event, the `background_tasks` / `session_crons` pause
-  signal in v2.1.145+, and the gate-vs-guidance channel choice) are covered in
-  SKILL.md's hook-types table and Stop bullet — both share these same
-  protections.
+  loop-safety layers (the consecutive-block harness ceiling — which only lands
+  when the remediation involves no tool calls, see
+  [hook_pitfalls.md#27](hook_pitfalls.md), all Stop hooks running in parallel
+  per event, the `background_tasks` / `session_crons` pause signal in
+  v2.1.145+, and the gate-vs-guidance channel choice) are covered in SKILL.md's
+  hook-types table and Stop bullet — both share these same protections.
 - **…and handling it correctly still does not make the hook terminate.** The
   field covers **one layer of re-entry** — the stop you just blocked being
   retried. It does nothing for the *cross-turn* loop, where the model actually

--- a/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
+++ b/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
@@ -532,8 +532,9 @@ unresolvable path means **block**.
   honors by letting the turn end — so everything it did not say in round one
   sails through permanently. The anti-loop field that saves you from infinite
   re-entry is precisely what makes the first block your only informed bite.
-  (The harness separately ends the turn after 8 consecutive blocks — banking
-  on "I'll catch it next round" burns that cap and loses anyway.)
+  (The harness's consecutive-block ceiling does not rescue you either: banking
+  on "I'll catch it next round" burns it when the remediation is reply-only,
+  and never reaches it at all when the remediation involves tool calls — #27.)
 - **Fix:** collect *all* findings before printing (cap the list — five is
   plenty — so a pathological reply can't flood the model's context), and write
   the message as an escape manual: each finding plus the exact acceptable fix.


### PR DESCRIPTION
PR #245 在 SKILL.md 订正了两处「连续 block 上限是可依赖兜底」的失实断言，但**同一事实在别处还有三份未限定的副本**。按 SSOT 纪律，该事实现有权威定义（pitfall #27），下游应当指针而非复述机制。

| 位置 | 原文问题 | 处置 |
|---|---|---|
| `SKILL.md` 通道选择段 | 「both count toward the same 8-consecutive-block ceiling…after 8 blocks the harness ends the turn the same way」 | 「一次 informed bite」这个结论本身没错，但它靠的是**闩锁**不是上限。改为点明结论建立在闩锁上；上限只在「补救不含工具调用」时加固它 |
| `hook_patterns.md` loop-safety layers 枚举 | 上限被无限定地列为一层 | 补限定 + 链到 #27 |
| `hook_pitfalls.md` #17 | 「harness separately ends the turn after 8 consecutive blocks」 | 改为两种形态各说一句：reply-only 会烧掉它；含工具调用则永远到不了 |

## 刻意不改的一处

`hook_patterns.md` 里那句 `# burns the 8-consecutive-block harness cap guessing` —— 它讲的是**改写回复类** hook，那种补救不含工具调用、计数器确实累加，**上限在这种形态下有效**。读了上下文才发现，本来准备一并改掉。

## 验证

`quick_validate` 通过 · `security_scan` 通过并刷新 marker · `check_marketplace` 通过 · 新增行 PII 自查零命中、无 CJK · 全文检索确认剩余两处 `8-consecutive` 提及均正确（一处是「will **not** save you」，一处即上面刻意保留的）。

版本号（daymade-claude-code 1.31.1）在单独提交里，与 skill 内容分属不同顶层域。根 `CHANGELOG.md` 仍未加条目——理由同 #245（该文件有另一条工作线的未提交改动）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)