### PR TITLE
claude-code-hooks: pitfall #28 — the fallback target that's right for one reason and wrong for another

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -103,7 +103,7 @@
       "description": "Claude Code operations suite that bundles archive-aware local conversation discovery across Claude Code and Codex, internal-timestamp full-event session search and recovery, interrupted-work continuation, plugin/skill troubleshooting, CLAUDE.md progressive disclosure optimization, statusline configuration, exported .txt repair, full claude.ai conversation extraction with tool-call rendering and file download, plugin marketplace development, writing/testing/debugging Claude Code hooks, multi-provider profile isolation for running Kimi/GLM/DeepSeek/StepFun/Anthropic in separate windows, local source sync for Claude/Codex skill installs, personal-memory migration into tool-agnostic AGENTS.md reference docs, and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
       "source": "./daymade-claude-code",
       "strict": false,
-      "version": "1.31.2",
+      "version": "1.32.0",
       "category": "suite",
       "keywords": [
         "suite",

--- a/daymade-claude-code/claude-code-hooks/.security-scan-passed
+++ b/daymade-claude-code/claude-code-hooks/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-08-04T13:31:01.069350+00:00
+Scanned at: 2026-08-04T14:53:53.369842+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 2ddaa3a0a86345c3aff07e11f958c5b5d5f574119ca319a8e4437d1bc9e6191a
+Content hash: a5a8d699d92a0c1aa64262b61ae8f06eaa6c8175552585585fbca4206f3f41aa

--- a/daymade-claude-code/claude-code-hooks/SKILL.md
+++ b/daymade-claude-code/claude-code-hooks/SKILL.md
@@ -329,6 +329,18 @@ handed it a literal `~/repo`, `git -C` failed, staged came back empty, and the g
 concluded "no cross-domain files, allow." Every cross-repo commit went unguarded and
 nothing ever looked wrong. Anatomy + the shared-library twist: pitfall #10.
 
+That parser has a second failure direction, and it is the nastier one. Once you
+add a fallback so it stops failing open, the fallback becomes correct for one
+reason and wrong for another — and both print the same line. `git push` (no
+explicit target) legitimately falls back to the event's `cwd`; `git -C "$R" push`
+*names* a target the hook cannot resolve, falls back to the same `cwd`, and then
+renders a confident ✅ about a different repository. Those two cases render
+byte-identically (measured, MD5-equal), so neither the hook nor the reader can
+tell the honest verdict from the misbound one. **A fallback value must carry the reason it was
+chosen**, and only "no explicit target" earns a verdict. Full anatomy, the
+confused-deputy framing, and why fixtures with literal paths never catch it:
+pitfall #28.
+
 ### 6. Judge on a fact the world can answer — never on your own rendering, never on a naming habit
 
 Rules 1 and 5 are about *how* you match and *which way* you fail. This one is

--- a/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
+++ b/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
@@ -290,6 +290,13 @@ the wrong cwd. If your hook takes a path out of command text and hands it to a r
 command, expand what the shell would have expanded — or decide, per rule 5, that an
 unresolvable path means **block**.
 
+  **The same parser has a second, sharper failure once you give it a fallback:**
+  it then answers confidently about the wrong repository instead of failing open.
+  Fixing #10 does not fix that — see #28. Note also that the shared-library
+  reassurance above has a boundary: it protects the hooks that *source* the
+  helper. A hook carrying its own inline parser inherits none of the fix and
+  has to be patched separately (that is exactly how #28 survived #10).
+
 ## 11. Newline-blind segmentation misses the multiline command (fixtures pass, real corpus barely fires)
 
 - **Symptom:** the hook passes every synthetic fixture (`git push origin main`,
@@ -1066,3 +1073,117 @@ When a guard is misbehaving, check in this order — cheapest and most common fi
     runaway process anywhere? → fork multiplier (#22): the fleet's per-call
     irrelevant path is the load. Slim every guard's fast path to zero forks;
     do not "fix" it by deleting guards.
+
+---
+
+## 28. The fallback target is right for one reason and wrong for another — and both print the same line
+
+> Worked example in this repo's sibling tooling: `git-push-verify.sh` and
+> `git-commit-headcheck.sh` (a private hooks repo, not shipped here) both had
+> exactly this defect and were fixed on 2026-08-04 by the prescription below.
+> Naming them matters — the entry is useless if you cannot go read a before/after.
+
+- **Symptom:** a verification hook reports a clean, confident, *correct* fact —
+  about the wrong object. `git push` to repo B triggers a push-verifier that
+  answers with repo A's HEAD, compares it against repo A's remote, and prints
+  `✅ push 已落地`. Nothing errored. The hash it printed is real. The comparison
+  it performed is sound. It just wasn't about the push you ran. And the message
+  opens with `权威源` / "authoritative — do not trust the in-command output",
+  which is an instruction to discard the very observation that would have caught
+  it.
+
+- **Cause — two different reasons for falling back share one fallback value.**
+  Such a hook derives its target from the command text (`git -C <path> …`) and
+  falls back to the event's `cwd` when it can't. That fallback is correct for
+  *one* of the two reasons it triggers and wrong for the other, and the code
+  path is identical:
+
+  | command | target parsed | falls back? | event cwd | verdict |
+  |---|---|---|---|---|
+  | `git push` | none — **there is no explicit target** | yes | the real target | ✅ correct |
+  | `git -C /literal/p push` | `/literal/p` | no | — | ✅ correct |
+  | `R=/p; git -C $R push` | `$R` — **explicit target, unreadable value** | yes | *not* the target | ❌ **bound to the wrong object** |
+
+  Rows 1 and 3 emit byte-identical shapes. The hook cannot tell them apart, and
+  neither can the reader: one is the strongest verdict the hook can give, the
+  other is that same verdict about an unrelated repository. Note the variable is
+  not exotic — assigning a path once and reusing it is ordinary shell, and it is
+  *more* likely in exactly the multi-repo sessions where the failure bites.
+
+  This is the checking-tool form of the **confused deputy** problem (Hardy,
+  1988): a component with the authority to answer becomes confused about *which
+  object it is answering for*. The security literature's diagnostic questions
+  port over directly — "who is the real requester? what resource is actually
+  being touched?" — and for a hook they become **"which target did the command
+  name, and is that the one I measured?"**
+
+- **The assumption that hides it.** Both hooks carried a comment asserting this
+  fallback was safe *because* "the wrong path will just fail to read, so the
+  failure direction is fail-loud — there is no false-green path here." That is
+  the reasoning to distrust. It holds only if the fallback lands somewhere
+  invalid; in a multi-repo session it lands in **another valid repository**, so
+  the read succeeds and returns a real, checkable, entirely irrelevant fact. The
+  false green grew directly out of the belief that a false green was impossible.
+  When you write "this can only fail loudly," name the input that would make it
+  fail quietly and go check that input exists.
+
+- **Why this is worse than a hook that fails open.** A fail-open hook (pitfall
+  #10) produces silence, and silence is at least honest about carrying no
+  information. This produces a *positive verdict with the wrong referent*, wearing
+  the vocabulary of authority. It also survives the reader's instinct to
+  double-check, because there is nothing to double-check: the command succeeded,
+  the output is well-formed, the hash is real.
+
+- **Fix — make the fallback carry its own reason, and downgrade the one that
+  can't be trusted.**
+  1. **Distinguish "no explicit target" from "explicit target, unresolvable."**
+     Only the first may silently adopt the event `cwd`. The second must refuse
+     to render a verdict: `目标是 $VAR，无法解析——本 hook 未核对，请手动比对`.
+     A hook that says "I didn't check" costs one manual check; one that says
+     "✅" about another object costs the thing it was built to protect.
+  2. **Put the referent where it is read, not where it is skipped.** If the
+     message must carry a caveat, it belongs *before* the verdict, not after it.
+     A trailing "⚠️ if the repo above isn't the one you pushed, this line is
+     unrelated" is a correct sentence that arrives after the reader has already
+     banked the ✅.
+  3. **Never claim more authority than the binding supports.** `权威源` is
+     earned by the *measurement* (asking the remote) and spent by the *binding*
+     (which repo). A hook whose binding is heuristic should not use the
+     vocabulary of a hook whose binding is exact.
+
+- **How this hides during development.** The author writes fixtures with literal
+  paths, because that is how you write a readable test. Literal paths are row 2 —
+  the one that works. The failure needs a variable, which appears in real
+  sessions and almost never in fixtures. Add a fixture whose target is a shell
+  variable and assert on the *rendered target string*, not on the exit code
+  (pitfall #14's rule applied here: for a hook whose product is text, the exit
+  code proves nothing).
+
+- **Calibration note for anyone tempted to "just always warn."** Research on static-analysis
+  alerts reports that a large majority of warnings go unacted-on — the
+  frequently-cited range is roughly **35%–91%** (Heckman & Williams' work on
+  actionable-vs-unactionable warnings is the usual entry point), with
+  false-positive rates reaching ~90% in some tools, and names the resulting
+  desensitisation *alert fatigue*. (Figures quoted from secondary summaries;
+  search "actionable static analysis warnings" for the primary sources and their
+  datasets.) That is the budget a hook spends
+  every time it emits an unreliable line. Choosing "I didn't check" over a
+  confident wrong answer is not timidity; it is spending that budget on the
+  cases that earn it.
+
+**The later entries route by shape, not by symptom order** (they were added after
+this list and describe defects you reach by asking a different question):
+
+- Does the guard **read a flag as data**, or drop a token it should have judged?
+  → arity table vs. the real tool (#23); boundary-regex negated class (#24).
+- Does the guard **block its own maintenance** — its health check, its fix commit,
+  its own read path? → read forms not modelled (#25); and #7 for the fix-commit form.
+- Is the guard **correct from now on but blind to what already happened**?
+  → mid-session activation guards only the future (#26).
+- Is a **Stop hook firing more times than the documented cap allows**?
+  → both loop-protections have blind spots (#27).
+- Does the guard emit a **confident verdict about the wrong object** — right facts,
+  wrong referent, no error anywhere? → fallback target sharing one value for two
+  different reasons (#28). This one does not announce itself as a malfunction;
+  you find it by asking "which target did the command name, and is that the one
+  the guard measured?"


### PR DESCRIPTION
## 起因

本 session 里 `git-push-verify` / `git-commit-headcheck` 连续五次报了**错仓**的 HEAD，措辞却是「权威源，勿信命令行内输出」——即它一边给出关于另一个仓库的正确事实，一边要求我放弃自己的观察。每次我都用 `git -C` 显式复核才没被带偏。

## 机制（喂真实 JSON 端到端测出来的，不是读代码推断）

| 命令形态 | hook 报的仓 | 实际目标 | |
|---|---|---|---|
| `git -C /字面路径 push` | 正确 | 同 | ✅ |
| `R=/路径; git -C $R push` | 事件 cwd | **另一个仓** | ❌ |
| `git push`（无 `-C`） | 事件 cwd | 同 | ✅ |

第 2 行与第 3 行输出**逐字节相同**（MD5 相等，独立评审与我各自测过）。根因：**「命令没有显式目标」和「有显式目标但值读不到」退回了同一个兜底值**，于是同一句 ✅ 既可能是最强判定、也可能是关于另一个仓的正确废话。而路径存在 shell 变量里根本不是奇技——恰恰是多仓 session 的常态，也就是这个缺陷最咬人的场景。

抽象出来的原则：**兜底值必须携带「我为什么用兜底」的原因**，因为不同原因下同一个值的可信度不同。

## 最该记的一层：藏住它的那个假设

两个 hook 的源码里都写着注释，断言这条路径「失效方向是 fail-loud，没有假绿路径」——因为「回退后的路径会读不到 HEAD」。**这个判断被实测推翻**：多仓 session 里回退到的事件 cwd 通常是另一个**有效** git 仓，`git log` 成功，返回一个真实、可核验、完全无关的事实。**假绿恰恰从「不可能假绿」这个假设里长出来。**

## 领域锚（两条都不在原文件里）

- **confused deputy problem**（Hardy 1988, ACM SIGOPS）的检查器变体：有权限作答的组件对「自己在为哪个对象作答」发生混淆。安全领域的诊断问句可直接移植 → 对 hook 就是「命令指名了哪个目标，我量的是不是它？」
- **alert fatigue** 的量化：静态分析告警约 **35%–91%** 不被采取行动，部分工具误报率达 ~90%。这给「宁可说『我没查』也不要给自信的错答案」提供了可引用的成本依据。

## 不只是文档 —— 参考实现也修了

独立评审的头条发现是：**我写的处方，被描述的那个 hook 并没有实现**，而且它当时的行为正是处方第 2 条点名的反模式（把免责句放在 ✅ 之后）。文档在说一件实现没做的事，读者去看实现会抄到不合规版本。

所以两个生产 hook 一并修了（私有仓 `daymade/scripts`，commit `41c4227`）：给兜底标原因，「有显式目标但读不到」拒绝作答，且不借用「权威源 / 以本行为准」的措辞——那是**测量**挣来的，被**绑定**花掉；绑定是猜的时候不该借用。四形态端到端回归零误伤，并已在本 session 的真实调用路径上自证（变量形态→未核对，字面路径→正确判定）。

## 其余 findings（全部来自独立评审，已复现后修）

- **导航断了**：Meta-principle 分诊表只索引 `#1–#22`，`#23–#28` 六条按文件自称的方法（「先匹配 symptom」）根本到不了。补齐全部六条的路由。
- **#10 不指向 #28**：#10 自己的 generalization 就把未展开的 `$VARS` 列为同类，但它给的修法（`expanduser`）对 `$VAR` 是 no-op——读者停在 #10 会以为这一类已覆盖。
- **共享库那句宽慰有边界**：它只保护 *source* 该 helper 的 hook；自带内联 parser 的那个一点也没继承到——#28 正是这样从 #10 底下活下来的。
- **告警疲劳数据缺可搜索锚**：原文只写 "published work"，现给出入口。
- **#28 从不点名它描述的文件**：读者无法去读 before/after 验证，已点名。
- **SKILL.md 悬空引用**：`that table` 的最近先行词是本文件里另一张无关的表。

## 闸门

| 闸门 | 结果 |
|---|---|
| Regression audit | 0 candidates / 621 exact preservations（基线取自 git ref 非工作树） |
| Regression verify | passed |
| quick_validate | Skill is valid |
| Security scan | 本次文件 0 命中 |
| 脱敏 | 0（先用已知必命中串标定 grep 再判） |
| hook 侧 | `bash -n` ×2 + 四形态真实 JSON 端到端 + hook-health-check 静默通过 |

## ⚠️ 欠着的

评审跑的是修复前的版本；上述文档修改与两个 hook 的改动**都没有再过一轮 fresh agent**。我做了实跑验证，但那是自审。所以没有自己合并——请你决定是先补一轮还是直接合。

🤖 Generated with [Claude Code](https://claude.com/claude-code)