### PR TITLE
feat(asr-transcribe-to-text): document what a self-hosted vLLM endpoint actually rejects

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -204,7 +204,7 @@
       "description": "Audio processing suite covering the full speech pipeline: ASR transcription (Qwen3, StepFun) with batch-mode guards against music-only repetition-loop hallucinations, speaker diarization and CAM++ voiceprint identification for multi-speaker recordings, transcript error correction, structured meeting minutes generation, and TTS voice synthesis (StepFun). Install once for the complete audio workflow.",
       "source": "./daymade-audio",
       "strict": false,
-      "version": "1.18.1",
+      "version": "1.19.0",
       "category": "suite",
       "keywords": [
         "suite",

--- a/daymade-audio/asr-transcribe-to-text/SKILL.md
+++ b/daymade-audio/asr-transcribe-to-text/SKILL.md
@@ -204,6 +204,7 @@ Wrote upload.m4a
   |---|---|---|
   | Local MLX pipeline (Path A) | `.wav` or `.m4a` | Both feed the pipeline directly (m4a verified 2026-07-18: a 3-min slice transcribed cleanly). M4A is ~5x smaller — 324 MB WAV → 63 MB M4A on a 2h49m merge, duration identical to the second |
   | Metered upload (Feishu Minutes, per-minute quota) | `.m4a` + `--speed 1.3` | AAC 48k is speech-transparent for ASR, ~30% smaller than mp3 at equal speech quality; speedup cuts billed duration ~23% |
+  | Self-hosted vLLM endpoint (Path B) | `.ogg` | Accepted where MP3 is refused, and ~8× smaller than WAV — which is what keeps a long recording under the server's 25 MB request cap. See Path B's limits section |
   | Lossless archive | `.flac` | ~50% of WAV, bit-perfect |
   | Only when the target rejects the above | `.mp3` | Compatibility fallback |
 - Keep the originals until the transcript passes Step 4 verification.
@@ -432,6 +433,123 @@ uv run ${CLAUDE_SKILL_DIR}/scripts/speaker_transcribe.py \
   INPUT_AUDIO OUTPUT_DIR --text-file OUTPUT.txt
 ```
 
+#### Self-hosted vLLM: the limits that fail in confusing ways
+
+**Version matters here — two of these changed between releases.** Behavior below was
+measured end-to-end against vLLM `0.15.2rc1.dev68` (a dev build; there is no `0.15.2`
+release — PyPI goes 0.15.1 → 0.16.0) serving `Qwen/Qwen3-ASR-1.7B`, then re-read
+against the `v0.26.0` sources. Check your own version first — `pip show vllm` — and
+read the version notes on #1 and #3.
+
+**1. Send OGG, not WAV — and never MP3.** MP3 is rejected outright on 0.15.x, but
+the reflex fix (convert to WAV) is what walks you into the size cap in #2:
+
+| Format | 60 s @ 16 kHz mono, 16-bit | Accepted (0.15.x) |
+|---|---|---|
+| WAV `pcm_s16le` | 1,920 KB | yes |
+| FLAC | 1,092 KB | yes |
+| **OGG Vorbis** | **245 KB** | **yes** |
+| MP3 | — | **no** |
+
+OGG is ~8× smaller than WAV at the same sample rate:
+
+```bash
+ffmpeg -nostdin -v error -i INPUT -ar 16000 -ac 1 -c:a libvorbis OUTPUT.ogg
+```
+
+Pin the bit depth when you compare formats yourself — decoding a lossy source
+leaves ffmpeg free to widen it, and a 24-bit FLAC comes out *larger* than 16-bit
+PCM, which reads as "FLAC doesn't compress" when the two simply weren't the same
+recording. Add `-sample_fmt s16`.
+
+The MP3 rejection is worth recognizing because **it arrives as HTTP 200 with an
+error body** — a check that only inspects `%{http_code}` reports success:
+
+```
+HTTP=200
+{"error": {"message": "Error opening <_io.BytesIO object>: Format not recognised.", ...}}
+```
+
+*Version note:* on 0.15.x the upload is read via `librosa`/soundfile on a `BytesIO`,
+which refuses MP3 there even where the host's libsndfile handles MP3 on disk. `v0.26.0`
+added a pyav fallback after a soundfile `LibsndfileError` (`multimodal/media/audio.py`),
+so MP3/M4A likely decode on current releases — but OGG stays the better choice for the
+size reason above.
+
+**2. Requests are capped at 25 MB.**
+
+```
+{"error":{"message":"Maximum file size exceeded (parameter=audio_filesize_mb, value=28.6)",...}}
+```
+
+`VLLM_MAX_AUDIO_CLIP_FILESIZE_MB` defaults to `25` (`vllm/envs.py`, unchanged from
+0.15.1 through v0.26.0). At OGG's ~245 KB/min that ceiling arrives around **100
+minutes** — comfortably past a meeting, but a full-day recording or a merged
+multi-segment dump will cross it. Raise it when the job is long enough to matter:
+
+```bash
+VLLM_MAX_AUDIO_CLIP_FILESIZE_MB=800 vllm serve <model> --port <port> ...
+```
+
+**3. `v0.26.0` added a second, independent limit: 10 minutes of audio.** Raising the
+size cap does **not** lift it — they are separate gates, and this one rejects rather
+than truncates:
+
+```
+Audio exceeds maximum allowed duration of 600s (metadata reports 5998.0s).
+Set VLLM_MAX_AUDIO_DECODE_DURATION_S to increase this limit.
+```
+
+`VLLM_MAX_AUDIO_DECODE_DURATION_S` defaults to `600` and sits on the line right after
+the size cap in `envs.py` — it does not exist in 0.15.x, so a lecture-length file that
+works on an older server gets refused by a freshly-installed one. On `v0.26.0`+ set
+both:
+
+```bash
+VLLM_MAX_AUDIO_CLIP_FILESIZE_MB=800 VLLM_MAX_AUDIO_DECODE_DURATION_S=36000 \
+  vllm serve <model> --port <port> ...
+```
+
+**4. On a host that can't reach huggingface.co, model loading fails even when the
+model is already cached locally.** vLLM issues a `HEAD` for `config.json` at
+startup, retries five times, then exits — the error says "couldn't find them in
+the cached files" even though they are right there:
+
+```bash
+HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 vllm serve <model> ...
+```
+
+Same symptom, different cause worth ruling out first: a **containerized** server
+has its own `HF_HOME` and cannot see the host user's `~/.cache/huggingface`, so a
+model you can `ls` is genuinely absent from its view.
+
+**5. vLLM already chunks long audio — better than a client-side splitter would.**
+`SpeechToTextConfig` carries `overlap_chunk_second=1` and
+`min_energy_split_window_size=1600`, i.e. it splits **at the quietest point inside
+a ~100 ms window** rather than at a fixed offset, so cuts land between words. Once
+the caps above are lifted, a 100-minute file goes in one request. This is why the
+Step 5 fallback below is scoped to servers that *don't* do this.
+
+**No permission to restart the server?** The caps in #2/#3 are set at server start, so
+when you can't touch it, splitting client-side is what's left — that is Step 5, and on
+such an endpoint it is the right tool rather than a fallback.
+
+⚠️ **But `overlap_merge_transcribe.py` cannot drive a 0.15.x vLLM endpoint as-is**: it
+cuts chunks with `-acodec copy` into `chunk_NN.mp3`, so it emits MP3 (rejected per #1)
+whenever the input already is MP3, and simply *fails* on any other input — it never
+checks ffmpeg's exit status, so a bad chunk surfaces later as a JSON parse error rather
+than as "ffmpeg failed". The chunks also live and die inside one `TemporaryDirectory`,
+so there is no point at which you could convert them. Against such an endpoint, split
+manually into OGG and post each piece:
+
+```bash
+ffmpeg -nostdin -v error -i INPUT -f segment -segment_time 900 \
+  -ar 16000 -ac 1 -c:a libvorbis chunk_%02d.ogg
+```
+
+Note this loses the overlap-merge stitching, so sentences may break at the seams —
+which is exactly what the server-side energy-based splitter in #5 exists to avoid.
+
 **If remote health check fails**, diagnose in order:
 1. Network: `ping -c 1 HOST` or `tailscale status | grep HOST`
 2. Service: `tailscale ssh USER@HOST "curl -s localhost:PORT/v1/models"`
@@ -463,7 +581,23 @@ D) Abort
 
 ## Step 5: Fallback — Overlap-Merge (Remote API Only)
 
-If single remote request fails (timeout, OOM), fall back to chunked transcription:
+**Check whether your server chunks internally before reaching for this.** vLLM does
+(Path B limit #5), and its energy-based split beats this script's fixed-offset one — so
+on a vLLM endpoint you control, a too-long file is fixed by lifting the caps rather than
+by splitting client-side.
+
+Chunk client-side when the endpoint **can't take the whole file**: it rejects long audio
+outright (fixed context window, hard per-request duration limit), it OOMs at the same
+input length every time, or it does chunk internally but you have no permission to raise
+its caps.
+
+**A timeout is a different failure and usually has a cheaper fix** — the request was
+accepted and was still running. Raise `max_timeout` in the config first (a 100-minute
+file at ~60× realtime still needs a couple of minutes, and the default can be tighter
+than that); reach for chunking only if it times out with a generous ceiling, which
+means the server is genuinely too slow for one pass.
+
+When one of those applies, fall back to chunked transcription:
 
 ```bash
 python3 ${CLAUDE_SKILL_DIR}/scripts/overlap_merge_transcribe.py \
@@ -624,6 +758,20 @@ transformers 5.0.0rc3
 ```
 
 Run the bundled `--smoke-test` command and confirm the dependency stack line matches. Do not start a long transcription until the smoke test succeeds.
+
+### A self-hosted remote endpoint rejects the audio
+
+Each of these points away from its real cause, which is why they are worth
+recognizing by symptom. Full detail and fixes: Path B's "Self-hosted vLLM: the
+limits that fail in confusing ways" section.
+
+| Symptom | Actual cause |
+|---|---|
+| `Maximum file size exceeded (parameter=audio_filesize_mb, ...)` | 25 MB cap, counted in **bytes not minutes** — converting to WAV is usually what crossed it; send OGG (~8× smaller) |
+| `HTTP 200` but the body is `{"error": ... "Format not recognised."}` | MP3 sent to a 0.15.x server — and a status-code-only check calls this success |
+| `Audio exceeds maximum allowed duration of 600s` | A **second, independent** cap added in `v0.26.0`; raising the size cap does not lift it → `VLLM_MAX_AUDIO_DECODE_DURATION_S` |
+| Server won't start: "couldn't find them in the cached files" while the model *is* cached | Startup tried to reach huggingface.co → `HF_HUB_OFFLINE=1`; if containerized, its `HF_HOME` may simply not see the host's cache |
+| Long file fails, and you are about to chunk it client-side | vLLM already splits at low-energy points — lift the caps instead, unless you can't restart the server (Step 5 explains when chunking *is* right) |
 
 ### `${CLAUDE_SKILL_DIR}` is not substituted
 


### PR DESCRIPTION
Path B (Remote API) told you to point at a remote endpoint but never said what that
endpoint refuses. Four failures, each reported in a way that points away from its cause.

## What changed

**Send OGG, not WAV — and never MP3.** MP3 is rejected on 0.15.x, and the rejection
arrives as **HTTP 200 with an error body**, so a status-code-only check reports success.
The reflex fix (convert to WAV) then walks straight into the 25 MB request cap, because
16 kHz mono PCM is ~32 KB/s. Measured at 60 s @ 16 kHz mono, 16-bit:

| Format | Size | Accepted (0.15.x) |
|---|---|---|
| WAV `pcm_s16le` | 1,920 KB | yes |
| FLAC | 1,092 KB | yes |
| **OGG Vorbis** | **245 KB** | **yes** |
| MP3 | — | no |

**`v0.26.0` added a second, independent cap: 10 minutes.**
`VLLM_MAX_AUDIO_DECODE_DURATION_S` (default 600) sits on the line right after the size
cap in `envs.py` and does not exist in 0.15.x. Raising the size cap does **not** lift it,
and it rejects rather than truncates — so a lecture-length file that works on an older
server is refused by a freshly-installed one.

**Offline hosts fail to load a model that is already cached.** vLLM HEADs
`config.json` at startup and reports "couldn't find them in the cached files".
`HF_HUB_OFFLINE=1`. (A containerized server has a separate `HF_HOME` — different cause,
same symptom, worth ruling out first.)

**vLLM already chunks long audio**, splitting at the quietest point in a ~100 ms window
with 1 s overlap. Step 5's client-side splitter is therefore redundant against it, and is
now scoped to endpoints that reject long audio outright or that you cannot reconfigure.
Its bundled script also cannot drive such an endpoint as-is (`-acodec copy` into
`chunk_NN.mp3`, and it never checks ffmpeg's exit status) — that limit is now stated
rather than left for the reader to discover.

Also: Troubleshooting gains a symptom→cause table, and the Preprocess format table gains
a Remote API row (it previously routed readers to `.m4a`, which this endpoint refuses).

## Verification

Behavior measured end-to-end against `0.15.2rc1.dev68` serving `Qwen3-ASR-1.7B`, then
re-read against the `v0.26.0` sources; every version-dependent claim is marked as such.

Two independent fresh-context review rounds (not forks), against a pre-work git ref:

- **R1** (executability + fidelity) — 7 findings, all adopted. The load-bearing one: my
  original text claimed the limit was "by size, not by duration" and cited a re-check
  against v0.26.0. That re-check was literally true and the conclusion still wrong — I
  had verified the line that didn't change and missed the second gate added directly
  below it. Readers on current vLLM would have had every file over 10 minutes rejected.
- **R2** (assertion accuracy) — 5 findings, all adopted; it verified every vLLM claim
  against PyPI + git tags + v0.15.1/v0.26.0 sources and found no factual error, but
  caught that my FLAC measurement compared a 24-bit FLAC against 16-bit WAV. Re-measured
  with the bit depth pinned.

Gates: `quick_validate` pass, regression audit 645 preservations / 1 candidate classified
/ verify pass, `security_scan` clean, PII guard clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017kQ815XTUwsQecfXQFuFoU