### PR TITLE
feat(asr-transcribe-to-text): make the remote path self-contained

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -204,7 +204,7 @@
       "description": "Audio processing suite covering the full speech pipeline: ASR transcription (Qwen3, StepFun) with batch-mode guards against music-only repetition-loop hallucinations, speaker diarization and CAM++ voiceprint identification for multi-speaker recordings, transcript error correction, structured meeting minutes generation, and TTS voice synthesis (StepFun). Install once for the complete audio workflow.",
       "source": "./daymade-audio",
       "strict": false,
-      "version": "1.19.0",
+      "version": "1.20.0",
       "category": "suite",
       "keywords": [
         "suite",

--- a/daymade-audio/asr-transcribe-to-text/SKILL.md
+++ b/daymade-audio/asr-transcribe-to-text/SKILL.md
@@ -18,6 +18,20 @@ so transcription quality stays at full-audio fidelity.
 | **Local MLX** | macOS Apple Silicon | 15-27x realtime | Free |
 | **Remote API** | Any platform, or when local unavailable | Depends on GPU | API/self-hosted |
 
+**Choosing between them is usually not about speed — it's about where the audio already
+is.** A remote GPU can be several times faster (a 4090 running vLLM measured ~61x realtime
+against ~15x for local MLX), but that gap is small change next to moving the files:
+transcription output is text, and text is ~10,000× smaller than the audio it came from
+(18.5 h of speech ≈ 330 K characters ≈ 1 MB, from ~2.6 GB of WAV). So:
+
+> **Transcribe where the audio already lives, and move only the transcript.**
+
+Pulling a few hundred MB across a slow link to reach a faster GPU routinely costs more
+wall-clock than the entire transcription — measured once at 63 KB/s, which is over two
+hours for 500 MB, to save minutes of compute. If the recording is already on the remote
+box (it was recorded there, downloaded there, or lives in a share mounted there), run the
+ASR there and bring back the `.txt`.
+
 Configuration persists in `${CLAUDE_PLUGIN_DATA}/config.json`.
 
 > **Speaker labels are the default.** Every run produces `[start-end] SPEAKER_xx: text`
@@ -551,9 +565,41 @@ Note this loses the overlap-merge stitching, so sentences may break at the seams
 which is exactly what the server-side energy-based splitter in #5 exists to avoid.
 
 **If remote health check fails**, diagnose in order:
+
 1. Network: `ping -c 1 HOST` or `tailscale status | grep HOST`
 2. Service: `tailscale ssh USER@HOST "curl -s localhost:PORT/v1/models"`
 3. Proxy: retry with `--noproxy '*'` toggled
+
+**4. "Is anything actually listening?" — `ss` alone will lie to you.** It shows only
+your own user's processes, so a server running as another user or **inside a container**
+is invisible to it while happily serving traffic. Ask Docker in the same breath:
+
+```bash
+tailscale ssh USER@HOST "ss -ltn | grep -E ':(8000|8001|8002)'; \
+  docker ps --format '{{.Names}}\t{{.Ports}}\t{{.Status}}'"
+```
+
+**5. "Is the GPU free?"** — before starting another server, check whether one is really
+holding VRAM. An **empty** compute-apps list means nothing is using it, regardless of what
+an older note may claim about which service "has" the GPU:
+
+```bash
+tailscale ssh USER@HOST "nvidia-smi --query-compute-apps=pid,process_name,used_memory --format=csv"
+# under WSL nvidia-smi is often off PATH: /usr/lib/wsl/lib/nvidia-smi
+```
+
+**6. Restarting it? `pkill -f 'vllm serve'` kills the command that issued it.** `-f`
+matches against the whole command line — and the command line you just typed contains that
+exact string, so pkill matches your own shell. Symptom: the old process dies, the new one
+never starts, and **nothing reports an error**. Wrap the first letter in a character class
+so the pattern cannot match itself:
+
+```bash
+tailscale ssh USER@HOST "pgrep -f '[v]llm serve'"   # check
+tailscale ssh USER@HOST "pkill -f '[v]llm serve'"   # kill
+```
+
+The same trap applies to any `pkill -f` whose pattern you also typed on that line.
 
 ## Step 4: Verify Output
 


### PR DESCRIPTION
The skill sent you to a remote endpoint, then went quiet about everything needed to keep
that endpoint running. Those bits had been filed in a private machine note — filed there
because that is where I hit them, which is the wrong axis. The right axis is whether they
hold for anyone, and these do.

## Path B diagnosis gains three steps

- **`ss` alone lies about what is listening.** It shows only your own user's processes, so
  a server running as another user or **inside a container** is invisible to it while
  happily serving traffic. Ask `docker ps` in the same breath.
- **Check whether the GPU is actually held** before starting another server. An empty
  compute-apps list means nothing is using it — regardless of what an older note claims
  about which service "has" the GPU.
- **`pkill -f 'vllm serve'` kills the command that issued it.** `-f` matches the whole
  command line, and the line you just typed contains that exact string. The old process
  dies, the new one never starts, and nothing reports an error. Use `[v]llm serve`.

## The mode table gains the judgement that actually decides local vs remote

It is not speed — it is **where the audio already is**. A remote GPU may be ~4x faster
(measured ~61x realtime vs ~15x local), but transcript text is ~10,000x smaller than the
audio it came from (18.5 h ≈ 1 MB of text, from ~2.6 GB of WAV). Moving files to reach the
faster GPU routinely costs more wall-clock than the transcription itself — measured once at
63 KB/s, over two hours for 500 MB, to save minutes of compute.

> Transcribe where the audio lives; move only the transcript.

## Gates

`quick_validate` pass · regression audit **0 candidates / 683 exact preservations** (pure
addition, nothing rewritten) · `security_scan` clean · no host-specific values (all
`USER@HOST` placeholders, verified by grep with a calibration string).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017kQ815XTUwsQecfXQFuFoU