### PR TITLE
chore(marketplace): bump daymade-claude-code to 1.33.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -103,7 +103,7 @@
       "description": "Claude Code operations suite that bundles archive-aware local conversation discovery across Claude Code and Codex, internal-timestamp full-event session search and recovery, interrupted-work continuation, plugin/skill troubleshooting, CLAUDE.md progressive disclosure optimization, statusline configuration, exported .txt repair, full claude.ai conversation extraction with tool-call rendering and file download, plugin marketplace development, writing/testing/debugging Claude Code hooks, multi-provider profile isolation for running Kimi/GLM/DeepSeek/StepFun/Anthropic in separate windows, local source sync for Claude/Codex skill installs, personal-memory migration into tool-agnostic AGENTS.md reference docs, and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
       "source": "./daymade-claude-code",
       "strict": false,
-      "version": "1.32.1",
+      "version": "1.33.0",
       "category": "suite",
       "keywords": [
         "suite",


### PR DESCRIPTION
## What
Bump `daymade-claude-code` suite version `1.32.1 → 1.33.0`.

## Why
PR #261 shipped the `read-claude-web-conversation` archive-completion change — the `files:` stderr line as a render completion signal (file download is now part of the render step, not an optional next step, fixing the c580b38 "default download files" pseudo-fix that only relabeled the option) — **but left the suite version at 1.32.1**. Without this bump, installed users running `marketplace update` see no new version and won't receive the fix.

## Type
Minor — the archive-completion change is a user-visible behavior change (download mandatory at render completion, not optional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)