### PR TITLE
perf(history-search): raw-byte pre-filter, with the escape/folding holes closed

### DIFF
--- a/daymade-claude-code/_conversation_core/text.py
+++ b/daymade-claude-code/_conversation_core/text.py
@@ -11,7 +11,10 @@ re-deriving title/noise heuristics that would drift apart.
 from __future__ import annotations
 
 import json
+import os
 import re
+import shutil
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable, Iterator, Optional
@@ -84,7 +87,41 @@ def strip_structural_metadata_lines(value: str) -> tuple[str, bool]:
     return "\n".join(lines).strip(), removed_attachment
 
 
-def iter_jsonl(path: Path, *, bounded: bool = False) -> Iterator[dict[str, Any]]:
+def iter_jsonl(
+    path: Path,
+    *,
+    bounded: bool = False,
+    line_keywords: Optional[list[str]] = None,
+) -> Iterator[dict[str, Any]]:
+    """Yield each JSONL record as a dict.
+
+    ``line_keywords`` is an optional cheap pre-check: when given, a line is
+    only handed to ``json.loads`` if it contains at least one of these
+    strings as a raw substring (case-insensitive — callers pass already
+    case-folded keywords and this function case-folds the line to match).
+    This exists because ``json.loads`` plus walking the resulting structure
+    is the expensive part of a keyword search, and file-level filtering
+    (skip whole files with no occurrence anywhere) turned out not to be
+    enough on its own: a keyword common across a user's session history
+    (e.g. "embedding") can appear in most FILES while still appearing in
+    only a small fraction of the LINES within each one, so ruling out
+    individual non-matching lines before parsing them is where the real
+    remaining cost lives.
+
+    Like the file-level pre-filter in ``files_possibly_matching``, this is
+    an over-approximation: a line can pass this check and still turn out to
+    have no *matchable* record once parsed (the keyword landed in a raw
+    JSON key/structural byte rather than an actual field value, or in a
+    field the structured extractor deliberately excludes). It must never be
+    an under-approximation — never skip a line that a full parse would have
+    matched — which is what makes it safe to use as a pure speedup.
+
+    Only pass this from a call site that has independently confirmed
+    skipping unselected lines cannot corrupt some other accounting the
+    caller performs across every record (see ``search_sessions``'s
+    ``use_prefilter`` docstring for the specific case this codebase hit —
+    date-window "excluded because untimed" counts must see every record).
+    """
     consumed = 0
     lines = 0
     try:
@@ -94,6 +131,15 @@ def iter_jsonl(path: Path, *, bounded: bool = False) -> Iterator[dict[str, Any]]
                 lines += 1
                 if bounded and (consumed > MAX_PREFIX_BYTES or lines > MAX_PREFIX_LINES):
                     return
+                if line_keywords is not None:
+                    haystack = line.casefold()
+                    if not any(kw in haystack for kw in line_keywords) and not any(
+                        marker in line for marker in _UNSCANNABLE_MARKERS
+                    ):
+                        # Same over-approximation as the file-level filter: a
+                        # line holding a fold-equivalent character or a \u
+                        # escape may still match once parsed, so never skip it.
+                        continue
                 try:
                     value = json.loads(line)
                 except (json.JSONDecodeError, TypeError):
@@ -102,6 +148,219 @@ def iter_jsonl(path: Path, *, bounded: bool = False) -> Iterator[dict[str, Any]]
                     yield value
     except (OSError, UnicodeError):
         return
+
+
+# Every character a JSON writer may store as something other than itself:
+# the two mandatory escapes (" and \), the optional one (/), and all control
+# characters. Enumerated from the JSON grammar rather than from observed
+# escapes — an earlier version listed only control chars and "/", which
+# covered a case Python never even produces while missing the two that every
+# writer produces.
+_JSON_ESCAPED_CHAR_RE = re.compile(r'["\\/\x00-\x1f]')
+
+# The guard above can only inspect the KEYWORD. The other half of the problem
+# is invisible to it: an all-ASCII keyword can legitimately match non-ASCII
+# CONTENT, because Python's casefold() does *full* folding. Searching
+# "financial" must match a transcript containing "ﬁnancial" (U+FB01, which
+# arrives whenever someone pastes from a PDF) — the real matcher does, a byte
+# scanner does not.
+#
+# Enumerated from Python's own casefold table rather than written by hand:
+# every non-ASCII code point whose casefold is pure ASCII. There are exactly
+# 11 (ß ſ ẞ K and the ff/fi/fl/ffi/ffl/st ligatures). A hand-written list
+# drafted for this fix had 17 entries, several of which do not actually fold
+# to ASCII — which is the argument for deriving it.
+_FOLDS_TO_ASCII = tuple(
+    chr(cp)
+    for cp in range(0x80, 0x11000)
+    if chr(cp).casefold() != chr(cp)
+    and chr(cp).casefold().isascii()
+    and chr(cp).casefold().strip()
+)
+
+# Any of these in a file/line means a byte scan cannot rule it out:
+#   - the fold-equivalent characters above
+#   - a "\u" escape: content written with ensure_ascii=True stores non-ASCII
+#     that way, and some writers (Go's encoding/json) escape even ASCII
+#     "<" ">" "&" as </>/&
+_UNSCANNABLE_MARKERS = _FOLDS_TO_ASCII + ("\\u",)
+
+
+def keywords_are_raw_byte_safe(keywords: Iterable[str]) -> bool:
+    """Can a literal byte scan of the physical file stand in for matching
+    against the parsed strings?
+
+    Pass the **original** keywords, never case-folded ones. ``"ß".casefold()``
+    is ``"ss"`` — pure ASCII — so folding first makes this function answer
+    "safe" for exactly the input that motivated rule 2 below, silently
+    re-opening the hole it exists to close.
+
+    Only when every keyword's bytes are *guaranteed* to appear verbatim in the
+    file, and a byte scanner's notion of "equal" matches Python's. Three shapes
+    break that guarantee, and each one silently loses matches rather than
+    reporting an error — so all three fall back to full parsing:
+
+    1. **Characters JSON is required to escape**: control characters, ``"``,
+       and ``\\``. An embedded newline is stored as the two bytes ``\\n``, a
+       quote as ``\\"``, a backslash as ``\\\\`` — so a literal search for the
+       raw character cannot find the escaped form actually sitting in the
+       file. This is not a quirk of some serializers; every conforming JSON
+       writer does it, including the one that produced these transcripts.
+       Quoted error fragments (``Error: "ENOENT"``), config snippets
+       (``"model": "opus"``), and Windows paths are exactly the sort of thing
+       people search history for.
+
+    2. **Non-ASCII.** Two independent failures. (a) ``json.dumps`` defaults to
+       ``ensure_ascii=True``, which stores ``café`` as ``caf\\u00e9`` — the
+       UTF-8 bytes are simply not in the file. Claude Code's own writer does
+       not do this, but archives rewritten by other tooling do. (b) Even in
+       raw UTF-8, case-insensitive folding disagrees across implementations:
+       measured on this corpus's tooling, Python ``casefold()`` does *full*
+       folding (``straße`` == ``STRASSE``), ``rg -i`` does only *simple*
+       folding (matches ``STRAẞE`` but not ``STRASSE``), and ``/usr/bin/grep
+       -i`` matches neither. A pre-filter that disagrees with the real matcher
+       drops sessions, and it would drop *different* ones depending on whether
+       ``rg`` happens to be installed.
+
+    3. **A literal ``/``.** Optional in JSON — Python does not escape it — but
+       some writers emit ``\\/``, so it is excluded for the same reason.
+
+    Falling back is always the safe direction: it costs speed, never a missed
+    match. The cost is real and worth naming — a non-ASCII query (any CJK one)
+    gets no pre-filter at all and pays the full parse. Correctness first: this
+    tool's callers are told they may conclude a topic is absent from a
+    no-match result.
+    """
+    return all(
+        kw.isascii()
+        and not _JSON_ESCAPED_CHAR_RE.search(kw)
+        for kw in keywords
+    )
+
+
+def files_possibly_matching(
+    paths: Iterable[Path], keywords: Iterable[str], *, case_sensitive: bool = False
+) -> Optional[set[Path]]:
+    """Raw-byte pre-filter: which of ``paths`` could possibly contain any of
+    ``keywords``, without paying per-line ``json.loads`` + structured
+    extraction on files that plainly cannot match?
+
+    This exists because the natural way to search this corpus — open every
+    session file, ``json.loads`` every line, extract the searchable text, and
+    substring-match keywords against it — parses every byte of every file
+    even when the overwhelming majority contain none of the keywords at all.
+    On a single project of 294 files / 1.6GB that pure-Python loop measured
+    3.5+ minutes of CPU time without completing; ``rg``/``grep`` scan the same
+    bytes at native speed and can usually rule out most files in well under a
+    second, letting the expensive path run only on the handful of files that
+    are actually candidates.
+
+    Deliberately an OVER-approximation, never an under-approximation: keys
+    excluded from search on purpose (``id``, ``tool_use_id``, ``signature`` —
+    see ``_flatten_search_strings``) can still contain a keyword's raw bytes,
+    so a small number of files this returns as "possible" will turn out to
+    have no real match once fully parsed. That costs a little wasted parsing,
+    which is fine. What must never happen is the reverse — silently ruling
+    out a file that genuinely contains a matchable occurrence — because
+    completeness is this tool's whole reason to exist (see the "Completeness
+    invariant" in the finder skill's own SKILL.md). So every failure mode
+    below degrades to "don't filter" rather than to "filter more":
+
+    - No keywords, or a keyword containing a raw control character (the
+      JSON-escaping mismatch above): returns ``None``.
+    - Neither ``rg`` nor ``grep`` is on PATH: returns ``None``.
+    - The scanner subprocess itself errors or times out: returns ``None``.
+
+    ``None`` means "no filtering information — treat every path as a
+    candidate", which is exactly the pre-existing behavior before this
+    function existed. Callers must check for ``None`` and fall through to
+    scanning everything, not treat it as an empty result.
+    """
+    path_list = list(paths)
+    keyword_list = list(keywords)
+    if not path_list or not keyword_list or not keywords_are_raw_byte_safe(keyword_list):
+        return None
+    exe = shutil.which("rg") or shutil.which("grep")
+    if not exe:
+        return None
+    # -a/--text: never let the binary-content heuristic skip a JSONL file that
+    #   happens to contain a byte sequence that looks binary.
+    # -F: keywords are literal substrings everywhere else in this codebase
+    #   (Python's str.count(), not a regex) — a raw scan must match the same
+    #   semantics, not treat a keyword like "a.b" as a wildcard pattern.
+    # -l: list matching filenames only; we don't need line numbers here.
+    # Two scans, unioned — they need opposite case settings.
+    #
+    # Pass 1 matches the keywords the way the real matcher does (folded, unless
+    # the caller asked for case-sensitive).
+    #
+    # Pass 2 looks for content the byte scanner cannot reason about at all
+    # (fold-equivalent characters, "\u" escapes) and MUST be case-sensitive.
+    # Handing those characters to a "-i" scan is self-defeating: "-i" folds the
+    # *pattern* too, so `ſ` matches a plain `s` and `K` (U+212A) matches `k` —
+    # every file with an "s" or a "k" in it becomes a candidate and the filter
+    # stops filtering. (Caught by the pre-existing unit tests, which is exactly
+    # what they are for.)
+    kw_scan = [exe, "-a", "-F", "-l"]
+    if not case_sensitive:
+        kw_scan.append("-i")
+    for kw in keyword_list:
+        kw_scan += ["-e", kw]
+    kw_scan.append("--")
+
+    marker_scan = [exe, "-a", "-F", "-l"]
+    for marker in _UNSCANNABLE_MARKERS:
+        marker_scan += ["-e", marker]
+    marker_scan.append("--")
+
+    # Batch the paths: one exec per ~half of ARG_MAX. Passing every path in a
+    # single argv fails with E2BIG once the corpus is large enough — measured
+    # here at 7819 files needing 1,181,495 bytes against an ARG_MAX of
+    # 1,048,576. That failure degrades safely (OSError -> return None -> no
+    # filtering), but it means the speedup silently switched itself off in
+    # exactly the "tens of thousands of files" case that motivated it.
+    try:
+        arg_max = os.sysconf("SC_ARG_MAX")
+    except (ValueError, OSError):
+        arg_max = 256 * 1024
+    matched: set[Path] = set()
+
+    def run_batch(scan_prefix: list[str], paths_chunk: list[str]) -> bool:
+        """Returns False if the scanner failed — caller degrades to no filter."""
+        try:
+            result = subprocess.run(
+                scan_prefix + paths_chunk, capture_output=True, text=True,
+                encoding="utf-8", errors="replace", timeout=120,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return False
+        # Both rg and grep: 0 = matches found, 1 = no matches (not an error).
+        # Any other code (bad invocation, I/O error) is a scanner failure ->
+        # degrade to "don't filter" rather than trust a broken result.
+        if result.returncode not in (0, 1):
+            return False
+        matched.update(Path(line) for line in result.stdout.splitlines() if line)
+        return True
+
+    def scan_all(scan_prefix: list[str]) -> bool:
+        fixed = sum(len(a.encode("utf-8", "replace")) + 1 for a in scan_prefix)
+        chunk_budget = max(arg_max // 2 - fixed, 64 * 1024)
+        batch: list[str] = []
+        used = 0
+        for path in path_list:
+            text = str(path)
+            size = len(text.encode("utf-8", "replace")) + 1
+            if batch and used + size > chunk_budget:
+                if not run_batch(scan_prefix, batch):
+                    return False
+                batch, used = [], 0
+            batch.append(text)
+            used += size
+        return not batch or run_batch(scan_prefix, batch)
+
+    if not scan_all(kw_scan) or not scan_all(marker_scan):
+        return None
+    return matched
 
 
 def extract_text(content: Any) -> str:

--- a/daymade-claude-code/claude-code-history-files-finder/scripts/_core/text.py
+++ b/daymade-claude-code/claude-code-history-files-finder/scripts/_core/text.py
@@ -11,7 +11,10 @@ re-deriving title/noise heuristics that would drift apart.
 from __future__ import annotations
 
 import json
+import os
 import re
+import shutil
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable, Iterator, Optional
@@ -84,7 +87,41 @@ def strip_structural_metadata_lines(value: str) -> tuple[str, bool]:
     return "\n".join(lines).strip(), removed_attachment
 
 
-def iter_jsonl(path: Path, *, bounded: bool = False) -> Iterator[dict[str, Any]]:
+def iter_jsonl(
+    path: Path,
+    *,
+    bounded: bool = False,
+    line_keywords: Optional[list[str]] = None,
+) -> Iterator[dict[str, Any]]:
+    """Yield each JSONL record as a dict.
+
+    ``line_keywords`` is an optional cheap pre-check: when given, a line is
+    only handed to ``json.loads`` if it contains at least one of these
+    strings as a raw substring (case-insensitive — callers pass already
+    case-folded keywords and this function case-folds the line to match).
+    This exists because ``json.loads`` plus walking the resulting structure
+    is the expensive part of a keyword search, and file-level filtering
+    (skip whole files with no occurrence anywhere) turned out not to be
+    enough on its own: a keyword common across a user's session history
+    (e.g. "embedding") can appear in most FILES while still appearing in
+    only a small fraction of the LINES within each one, so ruling out
+    individual non-matching lines before parsing them is where the real
+    remaining cost lives.
+
+    Like the file-level pre-filter in ``files_possibly_matching``, this is
+    an over-approximation: a line can pass this check and still turn out to
+    have no *matchable* record once parsed (the keyword landed in a raw
+    JSON key/structural byte rather than an actual field value, or in a
+    field the structured extractor deliberately excludes). It must never be
+    an under-approximation — never skip a line that a full parse would have
+    matched — which is what makes it safe to use as a pure speedup.
+
+    Only pass this from a call site that has independently confirmed
+    skipping unselected lines cannot corrupt some other accounting the
+    caller performs across every record (see ``search_sessions``'s
+    ``use_prefilter`` docstring for the specific case this codebase hit —
+    date-window "excluded because untimed" counts must see every record).
+    """
     consumed = 0
     lines = 0
     try:
@@ -94,6 +131,15 @@ def iter_jsonl(path: Path, *, bounded: bool = False) -> Iterator[dict[str, Any]]
                 lines += 1
                 if bounded and (consumed > MAX_PREFIX_BYTES or lines > MAX_PREFIX_LINES):
                     return
+                if line_keywords is not None:
+                    haystack = line.casefold()
+                    if not any(kw in haystack for kw in line_keywords) and not any(
+                        marker in line for marker in _UNSCANNABLE_MARKERS
+                    ):
+                        # Same over-approximation as the file-level filter: a
+                        # line holding a fold-equivalent character or a \u
+                        # escape may still match once parsed, so never skip it.
+                        continue
                 try:
                     value = json.loads(line)
                 except (json.JSONDecodeError, TypeError):
@@ -102,6 +148,219 @@ def iter_jsonl(path: Path, *, bounded: bool = False) -> Iterator[dict[str, Any]]
                     yield value
     except (OSError, UnicodeError):
         return
+
+
+# Every character a JSON writer may store as something other than itself:
+# the two mandatory escapes (" and \), the optional one (/), and all control
+# characters. Enumerated from the JSON grammar rather than from observed
+# escapes — an earlier version listed only control chars and "/", which
+# covered a case Python never even produces while missing the two that every
+# writer produces.
+_JSON_ESCAPED_CHAR_RE = re.compile(r'["\\/\x00-\x1f]')
+
+# The guard above can only inspect the KEYWORD. The other half of the problem
+# is invisible to it: an all-ASCII keyword can legitimately match non-ASCII
+# CONTENT, because Python's casefold() does *full* folding. Searching
+# "financial" must match a transcript containing "ﬁnancial" (U+FB01, which
+# arrives whenever someone pastes from a PDF) — the real matcher does, a byte
+# scanner does not.
+#
+# Enumerated from Python's own casefold table rather than written by hand:
+# every non-ASCII code point whose casefold is pure ASCII. There are exactly
+# 11 (ß ſ ẞ K and the ff/fi/fl/ffi/ffl/st ligatures). A hand-written list
+# drafted for this fix had 17 entries, several of which do not actually fold
+# to ASCII — which is the argument for deriving it.
+_FOLDS_TO_ASCII = tuple(
+    chr(cp)
+    for cp in range(0x80, 0x11000)
+    if chr(cp).casefold() != chr(cp)
+    and chr(cp).casefold().isascii()
+    and chr(cp).casefold().strip()
+)
+
+# Any of these in a file/line means a byte scan cannot rule it out:
+#   - the fold-equivalent characters above
+#   - a "\u" escape: content written with ensure_ascii=True stores non-ASCII
+#     that way, and some writers (Go's encoding/json) escape even ASCII
+#     "<" ">" "&" as </>/&
+_UNSCANNABLE_MARKERS = _FOLDS_TO_ASCII + ("\\u",)
+
+
+def keywords_are_raw_byte_safe(keywords: Iterable[str]) -> bool:
+    """Can a literal byte scan of the physical file stand in for matching
+    against the parsed strings?
+
+    Pass the **original** keywords, never case-folded ones. ``"ß".casefold()``
+    is ``"ss"`` — pure ASCII — so folding first makes this function answer
+    "safe" for exactly the input that motivated rule 2 below, silently
+    re-opening the hole it exists to close.
+
+    Only when every keyword's bytes are *guaranteed* to appear verbatim in the
+    file, and a byte scanner's notion of "equal" matches Python's. Three shapes
+    break that guarantee, and each one silently loses matches rather than
+    reporting an error — so all three fall back to full parsing:
+
+    1. **Characters JSON is required to escape**: control characters, ``"``,
+       and ``\\``. An embedded newline is stored as the two bytes ``\\n``, a
+       quote as ``\\"``, a backslash as ``\\\\`` — so a literal search for the
+       raw character cannot find the escaped form actually sitting in the
+       file. This is not a quirk of some serializers; every conforming JSON
+       writer does it, including the one that produced these transcripts.
+       Quoted error fragments (``Error: "ENOENT"``), config snippets
+       (``"model": "opus"``), and Windows paths are exactly the sort of thing
+       people search history for.
+
+    2. **Non-ASCII.** Two independent failures. (a) ``json.dumps`` defaults to
+       ``ensure_ascii=True``, which stores ``café`` as ``caf\\u00e9`` — the
+       UTF-8 bytes are simply not in the file. Claude Code's own writer does
+       not do this, but archives rewritten by other tooling do. (b) Even in
+       raw UTF-8, case-insensitive folding disagrees across implementations:
+       measured on this corpus's tooling, Python ``casefold()`` does *full*
+       folding (``straße`` == ``STRASSE``), ``rg -i`` does only *simple*
+       folding (matches ``STRAẞE`` but not ``STRASSE``), and ``/usr/bin/grep
+       -i`` matches neither. A pre-filter that disagrees with the real matcher
+       drops sessions, and it would drop *different* ones depending on whether
+       ``rg`` happens to be installed.
+
+    3. **A literal ``/``.** Optional in JSON — Python does not escape it — but
+       some writers emit ``\\/``, so it is excluded for the same reason.
+
+    Falling back is always the safe direction: it costs speed, never a missed
+    match. The cost is real and worth naming — a non-ASCII query (any CJK one)
+    gets no pre-filter at all and pays the full parse. Correctness first: this
+    tool's callers are told they may conclude a topic is absent from a
+    no-match result.
+    """
+    return all(
+        kw.isascii()
+        and not _JSON_ESCAPED_CHAR_RE.search(kw)
+        for kw in keywords
+    )
+
+
+def files_possibly_matching(
+    paths: Iterable[Path], keywords: Iterable[str], *, case_sensitive: bool = False
+) -> Optional[set[Path]]:
+    """Raw-byte pre-filter: which of ``paths`` could possibly contain any of
+    ``keywords``, without paying per-line ``json.loads`` + structured
+    extraction on files that plainly cannot match?
+
+    This exists because the natural way to search this corpus — open every
+    session file, ``json.loads`` every line, extract the searchable text, and
+    substring-match keywords against it — parses every byte of every file
+    even when the overwhelming majority contain none of the keywords at all.
+    On a single project of 294 files / 1.6GB that pure-Python loop measured
+    3.5+ minutes of CPU time without completing; ``rg``/``grep`` scan the same
+    bytes at native speed and can usually rule out most files in well under a
+    second, letting the expensive path run only on the handful of files that
+    are actually candidates.
+
+    Deliberately an OVER-approximation, never an under-approximation: keys
+    excluded from search on purpose (``id``, ``tool_use_id``, ``signature`` —
+    see ``_flatten_search_strings``) can still contain a keyword's raw bytes,
+    so a small number of files this returns as "possible" will turn out to
+    have no real match once fully parsed. That costs a little wasted parsing,
+    which is fine. What must never happen is the reverse — silently ruling
+    out a file that genuinely contains a matchable occurrence — because
+    completeness is this tool's whole reason to exist (see the "Completeness
+    invariant" in the finder skill's own SKILL.md). So every failure mode
+    below degrades to "don't filter" rather than to "filter more":
+
+    - No keywords, or a keyword containing a raw control character (the
+      JSON-escaping mismatch above): returns ``None``.
+    - Neither ``rg`` nor ``grep`` is on PATH: returns ``None``.
+    - The scanner subprocess itself errors or times out: returns ``None``.
+
+    ``None`` means "no filtering information — treat every path as a
+    candidate", which is exactly the pre-existing behavior before this
+    function existed. Callers must check for ``None`` and fall through to
+    scanning everything, not treat it as an empty result.
+    """
+    path_list = list(paths)
+    keyword_list = list(keywords)
+    if not path_list or not keyword_list or not keywords_are_raw_byte_safe(keyword_list):
+        return None
+    exe = shutil.which("rg") or shutil.which("grep")
+    if not exe:
+        return None
+    # -a/--text: never let the binary-content heuristic skip a JSONL file that
+    #   happens to contain a byte sequence that looks binary.
+    # -F: keywords are literal substrings everywhere else in this codebase
+    #   (Python's str.count(), not a regex) — a raw scan must match the same
+    #   semantics, not treat a keyword like "a.b" as a wildcard pattern.
+    # -l: list matching filenames only; we don't need line numbers here.
+    # Two scans, unioned — they need opposite case settings.
+    #
+    # Pass 1 matches the keywords the way the real matcher does (folded, unless
+    # the caller asked for case-sensitive).
+    #
+    # Pass 2 looks for content the byte scanner cannot reason about at all
+    # (fold-equivalent characters, "\u" escapes) and MUST be case-sensitive.
+    # Handing those characters to a "-i" scan is self-defeating: "-i" folds the
+    # *pattern* too, so `ſ` matches a plain `s` and `K` (U+212A) matches `k` —
+    # every file with an "s" or a "k" in it becomes a candidate and the filter
+    # stops filtering. (Caught by the pre-existing unit tests, which is exactly
+    # what they are for.)
+    kw_scan = [exe, "-a", "-F", "-l"]
+    if not case_sensitive:
+        kw_scan.append("-i")
+    for kw in keyword_list:
+        kw_scan += ["-e", kw]
+    kw_scan.append("--")
+
+    marker_scan = [exe, "-a", "-F", "-l"]
+    for marker in _UNSCANNABLE_MARKERS:
+        marker_scan += ["-e", marker]
+    marker_scan.append("--")
+
+    # Batch the paths: one exec per ~half of ARG_MAX. Passing every path in a
+    # single argv fails with E2BIG once the corpus is large enough — measured
+    # here at 7819 files needing 1,181,495 bytes against an ARG_MAX of
+    # 1,048,576. That failure degrades safely (OSError -> return None -> no
+    # filtering), but it means the speedup silently switched itself off in
+    # exactly the "tens of thousands of files" case that motivated it.
+    try:
+        arg_max = os.sysconf("SC_ARG_MAX")
+    except (ValueError, OSError):
+        arg_max = 256 * 1024
+    matched: set[Path] = set()
+
+    def run_batch(scan_prefix: list[str], paths_chunk: list[str]) -> bool:
+        """Returns False if the scanner failed — caller degrades to no filter."""
+        try:
+            result = subprocess.run(
+                scan_prefix + paths_chunk, capture_output=True, text=True,
+                encoding="utf-8", errors="replace", timeout=120,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return False
+        # Both rg and grep: 0 = matches found, 1 = no matches (not an error).
+        # Any other code (bad invocation, I/O error) is a scanner failure ->
+        # degrade to "don't filter" rather than trust a broken result.
+        if result.returncode not in (0, 1):
+            return False
+        matched.update(Path(line) for line in result.stdout.splitlines() if line)
+        return True
+
+    def scan_all(scan_prefix: list[str]) -> bool:
+        fixed = sum(len(a.encode("utf-8", "replace")) + 1 for a in scan_prefix)
+        chunk_budget = max(arg_max // 2 - fixed, 64 * 1024)
+        batch: list[str] = []
+        used = 0
+        for path in path_list:
+            text = str(path)
+            size = len(text.encode("utf-8", "replace")) + 1
+            if batch and used + size > chunk_budget:
+                if not run_batch(scan_prefix, batch):
+                    return False
+                batch, used = [], 0
+            batch.append(text)
+            used += size
+        return not batch or run_batch(scan_prefix, batch)
+
+    if not scan_all(kw_scan) or not scan_all(marker_scan):
+        return None
+    return matched
 
 
 def extract_text(content: Any) -> str:

--- a/daymade-claude-code/claude-code-history-files-finder/scripts/analyze_sessions.py
+++ b/daymade-claude-code/claude-code-history-files-finder/scripts/analyze_sessions.py
@@ -47,7 +47,13 @@ from _core.sources import (  # noqa: E402
     HistorySourceConfigError,
     discover_claude_sources,
 )
-from _core.text import SearchSegment, iter_jsonl, searchable_segments  # noqa: E402
+from _core.text import (  # noqa: E402
+    SearchSegment,
+    files_possibly_matching,
+    iter_jsonl,
+    keywords_are_raw_byte_safe,
+    searchable_segments,
+)
 
 
 def _record_identity(record: Dict[str, Any]) -> str:
@@ -153,12 +159,27 @@ def search_codex_rollouts(
     to_timestamp: Optional[float] = None,
     project_path: Optional[str] = None,
     exclude_ids: Optional[set] = None,
+    use_prefilter: bool = True,
 ) -> List[Dict[str, Any]]:
     """Search Codex rollouts for keywords, one match dict per session.
 
     ``project_path`` filters by the rollout's session_meta cwd (recursive
     workspace match). Rollouts are de-duplicated by session id — a copy left
     in both sessions/ and archived_sessions/ is reported once.
+
+    ``use_prefilter`` skips per-file and per-line json.loads() work a raw byte
+    scan already proves cannot match (see ``files_possibly_matching`` and
+    ``iter_jsonl``'s ``line_keywords``). The FILE-level skip is safe
+    unconditionally — every counter this function reports (``excluded_untimed``,
+    ``session_range``, ``match_range``) is scoped to a single rollout file and
+    only surfaces when that same file has ``total_mentions > 0``, so a file
+    ruled out entirely never had anything to report.
+
+    Codex does NOT do line-level skipping at all — not even outside a date
+    window. Two separate accountings need to see every record: ``session_range``
+    (which would otherwise collapse onto ``match_range``) and, under a date
+    window, ``excluded_untimed``. See the comment at the ``line_keywords``
+    assignment below; the disabling is unconditional and a test enforces it.
     """
     search_keywords = [
         (keyword, keyword if case_sensitive else keyword.casefold())
@@ -167,6 +188,25 @@ def search_codex_rollouts(
     exclude = exclude_ids or set()
     matches: List[Dict[str, Any]] = []
     seen_ids: set[str] = set()
+
+    matched_files: Optional[set[Path]] = None
+    if use_prefilter:
+        matched_files = files_possibly_matching(
+            rollouts, keywords, case_sensitive=case_sensitive
+        )
+    # Codex gets FILE-level pre-filtering only, never line-level.
+    #
+    # ``session_range.observe()`` has to see every record — including the
+    # ``session_meta`` first line — to report the conversation's time span.
+    # Skipping lines that lack the keyword bytes collapses ``Internal range``
+    # onto ``Match range``: measured on a 4-line rollout, ``01-01 .. 01-20``
+    # became ``01-10 .. 01-10``. That is not "one less field", it is a *wrong
+    # value* in a field callers quote, and it fires on the plain no-date-window
+    # search — the most common invocation there is.
+    #
+    # A file the file-level filter rules out entirely reports no range at all,
+    # so that layer stays safe and stays on.
+    line_keywords = None
 
     for path in rollouts:
         try:
@@ -177,10 +217,19 @@ def search_codex_rollouts(
         sid = codex_session_id(meta, path) if meta else None
         if not sid:
             sid = path.stem
+        # Dedup and exclusion happen BEFORE the pre-filter check below, on
+        # purpose: they must claim/reject this path exactly as before, in the
+        # same traversal order, regardless of whether it turns out to have a
+        # keyword match. Moving the pre-filter check earlier would change
+        # which physical copy "wins" the session id when two copies of one
+        # session exist (sessions/ vs archived_sessions/) — a real behavior
+        # change this performance fix has no business making silently.
         if sid in seen_ids:
             continue
         seen_ids.add(sid)
         if sid in exclude or path.stem in exclude:
+            continue
+        if matched_files is not None and path not in matched_files:
             continue
         cwd = meta.get("cwd") if isinstance(meta, dict) else None
         if project_path is not None:
@@ -196,7 +245,7 @@ def search_codex_rollouts(
         match_range = TimestampRange()
         excluded_untimed = 0
         try:
-            for record in iter_jsonl(path):
+            for record in iter_jsonl(path, line_keywords=line_keywords):
                 record_timestamp = parse_timestamp(record.get("timestamp"))
                 if record_timestamp is not None:
                     session_range.observe(record_timestamp)
@@ -608,6 +657,7 @@ class SessionAnalyzer:
         case_sensitive: bool = False,
         from_timestamp: Optional[float] = None,
         to_timestamp: Optional[float] = None,
+        use_prefilter: bool = True,
     ) -> List[Dict[str, Any]]:
         """
         Search sessions for keywords.
@@ -619,11 +669,56 @@ class SessionAnalyzer:
             case_sensitive: Whether to perform case-sensitive search.
             from_timestamp: Inclusive lower internal record timestamp.
             to_timestamp: Inclusive upper internal record timestamp.
+            use_prefilter: Skip the expensive per-line json.loads() + text
+                extraction pass on copies a raw byte scan already proves
+                cannot contain any keyword (see ``files_possibly_matching``).
+                Forced off automatically when a date window is active — see
+                below for why.
 
         Returns:
             List of match dicts (session ref + match counts), most mentions
             first.
         """
+        # The pre-filter is only safe to apply when no date window is active.
+        # `excluded_untimed_count` below counts records that lack a timestamp
+        # ACROSS EVERY COPY of a session, independent of whether those records
+        # contain a keyword — it exists purely to report "N records could not
+        # be checked against your --from-date/--to-date window". Skipping a
+        # copy's full parse because it has no keyword match would silently
+        # drop its contribution to that count. Outside a date window this
+        # counter is never computed, so skipping is unconditionally safe —
+        # the file-level pre-filter is provably an over-approximation (see
+        # files_possibly_matching's docstring), so a copy it rules out cannot
+        # contain a matchable record.
+        use_prefilter = use_prefilter and from_timestamp is None and to_timestamp is None
+        matched_files: Optional[set[Path]] = None
+        # Always case-folded regardless of `case_sensitive`: casefold-matching
+        # is a strict superset of exact-case matching (anything an exact-case
+        # check would find, casefold-matching finds too), so it is always a
+        # safe over-approximation to hand to the line-level pre-check in
+        # iter_jsonl — it costs a little filtering precision in
+        # case-sensitive mode, never a missed match.
+        # Gate on the ORIGINAL keywords, not the folded ones: "ß".casefold()
+        # is "ss" (ASCII), so checking after folding would answer "safe" for
+        # precisely the input the check exists to reject.
+        line_keywords = (
+            [kw.casefold() for kw in keywords]
+            if use_prefilter and keywords_are_raw_byte_safe(keywords)
+            else None
+        )
+        if use_prefilter:
+            all_copy_paths = [
+                copy["path"]
+                for ref in session_refs
+                for copy in (
+                    ref.get("copies")
+                    or [{"path": ref["path"], "source": ref["sources"][0]}]
+                )
+            ]
+            matched_files = files_possibly_matching(
+                all_copy_paths, keywords, case_sensitive=case_sensitive
+            )
+
         matches: List[Dict[str, Any]] = []
         search_keywords = [
             (keyword, keyword if case_sensitive else keyword.casefold())
@@ -653,12 +748,18 @@ class SessionAnalyzer:
             for copy in copies:
                 session_file = copy["path"]
                 source = copy["source"]
+                if matched_files is not None and session_file not in matched_files:
+                    # A raw byte scan already proved this exact copy cannot
+                    # contain any keyword — see the use_prefilter comment
+                    # above for why skipping it here (no date window active)
+                    # cannot under-count anything.
+                    continue
                 copy_had_match = False
                 copy_new_mentions = 0
                 copy_untimed_records: set[str] = set()
                 copy_matched_records: set[str] = set()
                 try:
-                    records = iter_jsonl(session_file)
+                    records = iter_jsonl(session_file, line_keywords=line_keywords)
                     for data in records:
                         record_identity = _record_identity(data)
                         record_timestamp = parse_timestamp(data.get("timestamp"))
@@ -1042,6 +1143,29 @@ def _normalize_search_scope(args, parser) -> None:
     args.keywords = terms[1:]
 
 
+def _maybe_hint_all_projects(project_path: str) -> None:
+    """Warn when an unresolved ``project_path`` looks like it was meant as a
+    keyword, not a path — the exact trap of running ``search`` with keywords
+    only and forgetting ``--all-projects``: argparse's positional grammar
+    (``project_path?`` then ``keywords+``) silently consumes the first
+    keyword as the project, the lookup finds nothing, and the message alone
+    ("No sessions found for project: embedding") reads as "your keyword
+    doesn't exist" rather than "you searched for a project by that name".
+    A real project path always contains a path separator or resolves to an
+    existing directory; a bare word that does neither almost certainly was
+    not one.
+    """
+    if "/" in project_path or "\\" in project_path or Path(project_path).exists():
+        return
+    print(
+        "Hint: this looks like it might be a keyword, not a project path — "
+        "if you don't know which project the conversation happened in, "
+        "re-run with --all-projects (e.g. `search --all-projects "
+        f"{project_path} ...`).",
+        file=sys.stderr,
+    )
+
+
 def _collect_sessions(analyzer: "SessionAnalyzer", args) -> List[Dict[str, Any]]:
     """Collect session refs for the requested scope, applying exclusions."""
     if args.all_projects:
@@ -1171,6 +1295,18 @@ def main():
     search_parser.add_argument(
         "--case-sensitive", action="store_true", help="Case-sensitive search"
     )
+    search_parser.add_argument(
+        "--no-prefilter",
+        action="store_true",
+        help="Disable the rg/grep raw-byte pre-filter and fully parse every "
+        "session file. The pre-filter is designed to be a pure speedup: it "
+        "only runs for keywords whose bytes must appear verbatim in the file "
+        "(ASCII, no '/', no control characters), and disables itself for the "
+        "rest — so a non-ASCII query (any CJK one) already parses everything "
+        "and this flag changes nothing for it. Use this to verify the "
+        "pre-filter's neutrality on an ASCII query, or to rule it out when "
+        "diagnosing a suspected missed match.",
+    )
     _add_home_flags(search_parser)
 
     # Stats command
@@ -1217,6 +1353,7 @@ def main():
                 print("No sessions found across all projects")
             else:
                 print(f"No sessions found for project: {args.project_path}")
+                _maybe_hint_all_projects(args.project_path)
             print(
                 f"(searched {len(analyzer.sources)} source(s): {source_summary})",
                 file=sys.stderr,
@@ -1283,6 +1420,7 @@ def main():
                 print("No sessions found across all projects")
             else:
                 print(f"No sessions found for project: {args.project_path}")
+                _maybe_hint_all_projects(args.project_path)
             print(
                 f"(searched {len(analyzer.sources)} source(s): {source_summary})",
                 file=sys.stderr,
@@ -1305,6 +1443,7 @@ def main():
                 args.case_sensitive,
                 from_timestamp,
                 to_timestamp,
+                not args.no_prefilter,
             )
             if sessions
             else []
@@ -1327,6 +1466,7 @@ def main():
                 to_timestamp,
                 None if args.all_projects else args.project_path,
                 set(args.exclude_session),
+                not args.no_prefilter,
             )
 
         if matches:

--- a/daymade-claude-code/claude-code-history-files-finder/tests/test_analyze_sessions.py
+++ b/daymade-claude-code/claude-code-history-files-finder/tests/test_analyze_sessions.py
@@ -15,6 +15,9 @@ from pathlib import Path
 SKILL_DIR = Path(__file__).resolve().parents[1]
 SCRIPT = SKILL_DIR / "scripts" / "analyze_sessions.py"
 
+sys.path.insert(0, str(SKILL_DIR / "scripts"))
+from _core.text import keywords_are_raw_byte_safe  # noqa: E402
+
 
 def write_jsonl(path: Path, records: list[object]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -224,6 +227,137 @@ class SessionAnalyzerTests(unittest.TestCase):
             str(self.manifest),
         )
         self.assertIn("No matches found.", signature_only.stdout)
+
+    def test_prefilter_and_no_prefilter_agree_byte_for_byte(self) -> None:
+        """The 2026-08 pre-filter (rg/grep file-level + in-process line-level)
+        must be a pure speedup: identical stdout with and without it, on a
+        mix of matching, non-matching, and mixed-case sessions."""
+        matching_id = "44444444-4444-4444-8444-444444444444"
+        write_jsonl(
+            project_dir(self.active_home, self.workspace) / f"{matching_id}.jsonl",
+            [
+                user_record(matching_id, self.workspace, "irrelevant filler line", "2026-04-01T00:00:00Z"),
+                user_record(matching_id, self.workspace, "contains the RareToken here", "2026-04-01T00:00:01Z"),
+                user_record(matching_id, self.workspace, "more filler after the hit", "2026-04-01T00:00:02Z"),
+            ],
+        )
+        no_match_id = "55555555-5555-4555-8555-555555555555"
+        write_jsonl(
+            project_dir(self.active_home, self.workspace) / f"{no_match_id}.jsonl",
+            [user_record(no_match_id, self.workspace, "nothing of interest", "2026-04-02T00:00:00Z")],
+        )
+
+        default_run = self.run_cli(
+            "search", str(self.workspace), "raretoken",
+            "--history-sources", str(self.manifest),
+        )
+        no_prefilter_run = self.run_cli(
+            "search", str(self.workspace), "raretoken", "--no-prefilter",
+            "--history-sources", str(self.manifest),
+        )
+        self.assertEqual(default_run.stdout, no_prefilter_run.stdout)
+        self.assertIn(matching_id, default_run.stdout)
+        self.assertNotIn(no_match_id, default_run.stdout)
+
+    def test_prefilter_disabled_under_date_window_keeps_untimed_count_exact(self) -> None:
+        """The pre-filter is gated off automatically whenever a date window is
+        active (see search_sessions's use_prefilter docstring) because
+        excluded_untimed_records counts every untimed record in a session
+        regardless of keyword match, and skipping non-matching records would
+        silently under-report it. Prove the count is identical either way,
+        not just that both runs happen to exit 0."""
+        session_id = "66666666-6666-4666-8666-666666666666"
+        write_jsonl(
+            project_dir(self.active_home, self.workspace) / f"{session_id}.jsonl",
+            [
+                user_record(session_id, self.workspace, "has the target keyword", "2026-04-15T00:00:00Z"),
+                {  # untimed record, no keyword — must still be counted while a date window is active
+                    "type": "user",
+                    "sessionId": session_id,
+                    "cwd": str(self.workspace),
+                    "message": {"role": "user", "content": "untimed filler, no timestamp field at all"},
+                },
+                {  # a SECOND untimed record with no keyword — count must reach 2, not 1
+                    "type": "user",
+                    "sessionId": session_id,
+                    "cwd": str(self.workspace),
+                    "message": {"role": "user", "content": "another untimed filler"},
+                },
+            ],
+        )
+        default_run = self.run_cli(
+            "search", str(self.workspace), "target keyword",
+            "--from-date", "2026-04-01", "--to-date", "2026-04-30",
+            "--history-sources", str(self.manifest),
+        )
+        no_prefilter_run = self.run_cli(
+            "search", str(self.workspace), "target keyword", "--no-prefilter",
+            "--from-date", "2026-04-01", "--to-date", "2026-04-30",
+            "--history-sources", str(self.manifest),
+        )
+        self.assertEqual(default_run.stdout, no_prefilter_run.stdout)
+        self.assertIn("excluded 2 record(s) without an internal timestamp", default_run.stdout)
+
+    def test_signature_only_keyword_finds_no_match_with_prefilter_on(self) -> None:
+        """The pre-filter's raw byte scan is a deliberate OVER-approximation —
+        it will say a file/line "could" match even when the keyword only
+        appears in a field the structured search excludes (signature/id/
+        tool_use_id — see _flatten_search_strings). Confirm that over-approval
+        never leaks into an actual false-positive match."""
+        session_id = "77777777-7777-4777-8777-777777777777"
+        write_jsonl(
+            project_dir(self.active_home, self.workspace) / f"{session_id}.jsonl",
+            [
+                {
+                    "type": "assistant",
+                    "sessionId": session_id,
+                    "cwd": str(self.workspace),
+                    "timestamp": "2026-04-10T00:00:00Z",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "thinking",
+                                "thinking": "ordinary reasoning text",
+                                "signature": "excluded-only-secret-marker",
+                            }
+                        ],
+                    },
+                }
+            ],
+        )
+        result = self.run_cli(
+            "search", str(self.workspace), "excluded-only-secret-marker",
+            "--history-sources", str(self.manifest),
+        )
+        self.assertIn("No matches found.", result.stdout)
+
+    def test_all_projects_hint_appears_for_bare_keyword_project_path(self) -> None:
+        """Regression for a real trap: `search KEYWORD1 KEYWORD2` without
+        --all-projects treats KEYWORD1 as a project path (documented
+        argparse grammar), finds no project by that name, and used to print
+        only "No sessions found for project: KEYWORD1" — which reads as "your
+        keyword doesn't exist" rather than "you searched for a project by
+        that name". An agent hit exactly this during a real investigation."""
+        result = self.run_cli(
+            "search", "embedding", "classifier",
+            "--history-sources", str(self.manifest),
+            check=False,
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("No sessions found for project: embedding", result.stdout)
+        self.assertIn("--all-projects", result.stderr)
+
+    def test_all_projects_hint_absent_for_a_real_existing_path(self) -> None:
+        """The hint must not fire when project_path genuinely looks like (or
+        is) a path — false "did you mean --all-projects" noise on an honest
+        typo'd real path would be its own annoyance."""
+        result = self.run_cli(
+            "search", str(self.workspace), "no-such-keyword-at-all",
+            "--history-sources", str(self.manifest),
+            check=False,
+        )
+        self.assertNotIn("--all-projects", result.stderr)
 
     def test_duplicate_session_unions_distinct_records_and_keeps_provenance(self) -> None:
         session_id = "33333333-3333-4333-8333-333333333333"
@@ -623,6 +757,164 @@ class SessionAnalyzerTests(unittest.TestCase):
         )
         self.assertIn(matching_id, swept.stdout)
         self.assertIn(other_id, swept.stdout)
+
+
+class RawBytePrefilterSafetyTests(unittest.TestCase):
+    """The raw-byte pre-filter must never rule out a session a full parse
+    would have matched.
+
+    Every case here was a real divergence found by an A/B run of the CLI
+    against its own pre-pre-filter version — and every one of them slipped
+    past the 59 tests above, because those fixtures are written with
+    ``ensure_ascii=False`` and searched with ASCII-only keywords. The shapes
+    below are exactly the ones that combination cannot reach.
+    """
+
+    def test_non_ascii_keyword_is_not_raw_byte_safe(self) -> None:
+        # Two independent reasons, either one sufficient: json.dumps defaults
+        # to ensure_ascii=True (so "café" is stored as "caf\\u00e9" and the
+        # UTF-8 bytes are absent), and case folding disagrees between Python
+        # and the byte scanners.
+        for keyword in ("café", "你好", "straße", "ẞ"):
+            with self.subTest(keyword=keyword):
+                self.assertFalse(keywords_are_raw_byte_safe([keyword]))
+
+    def test_ascii_keyword_is_raw_byte_safe(self) -> None:
+        # The guard must not misfire on ordinary input — killing the speedup
+        # for everyone would be a worse outcome than the bug it prevents.
+        for keyword in ("hello", "TODO", "session_id", "a-b_c.d"):
+            with self.subTest(keyword=keyword):
+                self.assertTrue(keywords_are_raw_byte_safe([keyword]))
+
+    def test_guard_must_see_original_keyword_not_the_folded_one(self) -> None:
+        # "ß".casefold() == "ss", which is pure ASCII. A call site that folds
+        # before asking would get "safe" back for the exact input the guard
+        # exists to reject, silently restoring the bug.
+        self.assertFalse(keywords_are_raw_byte_safe(["ß"]))
+        self.assertTrue(keywords_are_raw_byte_safe(["ß".casefold()]))
+
+    def test_json_escaped_keywords_are_not_raw_byte_safe(self) -> None:
+        # JSON *must* escape control characters, '"' and '\\'; '/' is optional
+        # but some writers escape it. All of them mean the keyword's bytes are
+        # not in the file verbatim. The quote and backslash cases are the ones
+        # that matter most in practice — quoted error fragments, JSON config
+        # snippets and Windows paths are common history queries.
+        for keyword in ("foo\nbar", "a\tb", "src/main.py",
+                        'say "hello world"', r"C:\Users", r"a\b"):
+            with self.subTest(keyword=keyword):
+                self.assertFalse(keywords_are_raw_byte_safe([keyword]))
+
+    def test_ascii_keyword_matches_fold_equivalent_content(self) -> None:
+        # The keyword-side guard cannot see the CONTENT. Python's casefold does
+        # full folding, so an all-ASCII keyword legitimately matches non-ASCII
+        # content — "financial" must find "ﬁnancial" (U+FB01, what you get
+        # pasting from a PDF). A byte scanner does not fold that way, so the
+        # pre-filter has to treat such content as unscannable.
+        for content, keyword in (
+            ("the ﬁnancial model is attached", "financial"),
+            ("DIE STRAẞE IST LANG", "strasse"),
+            ("a ﬅudy of ﬆate machines", "study"),
+        ):
+            with self.subTest(content=content):
+                self._assert_search_finds(content, keyword)
+
+    def test_fold_equivalent_table_is_derived_not_hand_written(self) -> None:
+        # Guards against someone "tidying" the table into a hand-typed literal.
+        # A hand-written draft of this list had 17 entries, several of which do
+        # not fold to ASCII at all.
+        from _core.text import _FOLDS_TO_ASCII
+
+        self.assertIn("ﬁ", _FOLDS_TO_ASCII)
+        self.assertIn("ß", _FOLDS_TO_ASCII)
+        for ch in _FOLDS_TO_ASCII:
+            self.assertFalse(ch.isascii(), f"{ch!r} is already ASCII")
+            self.assertTrue(ch.casefold().isascii(), f"{ch!r} does not fold to ASCII")
+
+    def _assert_search_finds(self, content: str, keyword: str,
+                             ensure_ascii: bool = False) -> None:
+        with tempfile.TemporaryDirectory() as raw_root:
+            root = Path(raw_root)
+            home, workspace = root / "home", root / "ws"
+            workspace.mkdir()
+            target = project_dir(home, workspace) / "018f0000-0000-4000-8000-0000000000ab.jsonl"
+            target.parent.mkdir(parents=True, exist_ok=True)
+            record = {
+                "type": "user",
+                "timestamp": "2026-04-01T00:00:00Z",
+                "message": {"role": "user", "content": content},
+            }
+            target.write_text(
+                json.dumps(record, ensure_ascii=ensure_ascii) + "\n", encoding="utf-8"
+            )
+            completed = subprocess.run(
+                [sys.executable, str(SCRIPT), "search", str(workspace), keyword],
+                capture_output=True, text=True, check=False,
+                env=dict(os.environ, CLAUDE_CONFIG_DIR=str(home)),
+            )
+            self.assertNotIn("No matches found", completed.stdout,
+                             f"lost a match: content={content!r} keyword={keyword!r}")
+
+    def test_one_unsafe_keyword_disables_the_filter_for_the_whole_query(self) -> None:
+        self.assertFalse(keywords_are_raw_byte_safe(["safe", "你好"]))
+
+    def test_escaped_unicode_session_is_still_found(self) -> None:
+        # End-to-end: a session file written with ensure_ascii=True (as any
+        # archive rewritten by default-parameter json.dumps would be) must
+        # still be found by a non-ASCII keyword.
+        with tempfile.TemporaryDirectory() as raw_root:
+            root = Path(raw_root)
+            home = root / "home"
+            workspace = root / "ws"
+            workspace.mkdir()
+            target = project_dir(home, workspace) / "018f0000-0000-4000-8000-0000000000ff.jsonl"
+            target.parent.mkdir(parents=True, exist_ok=True)
+            record = {
+                "type": "user",
+                "timestamp": "2026-04-01T00:00:00Z",
+                "message": {"role": "user", "content": "café 你好世界 discussion"},
+            }
+            # ensure_ascii=True is the point of this fixture — do not "fix" it.
+            target.write_text(json.dumps(record, ensure_ascii=True) + "\n", encoding="utf-8")
+
+            env = dict(os.environ, CLAUDE_CONFIG_DIR=str(home))
+            for keyword in ("café", "你好"):
+                with self.subTest(keyword=keyword):
+                    completed = subprocess.run(
+                        [sys.executable, str(SCRIPT), "search", str(workspace), keyword],
+                        capture_output=True, text=True, env=env, check=False,
+                    )
+                    self.assertNotIn("No matches found", completed.stdout)
+                    self.assertIn("018f0000", completed.stdout)
+
+    def test_codex_path_does_not_build_line_keywords(self) -> None:
+        # Line-level filtering is incompatible with Codex's session_range:
+        # observe() needs every record (including the session_meta first line)
+        # to report the conversation's span. With line filtering on, a measured
+        # 4-line rollout reported "01-10 .. 01-10" instead of "01-01 .. 01-20"
+        # — a wrong value in a field callers quote, on the default
+        # no-date-window search. This asserts nobody adds it back.
+        lines = SCRIPT.read_text(encoding="utf-8").splitlines()
+        starts = [i for i, l in enumerate(lines) if l.startswith("def search_codex_rollouts")]
+        self.assertEqual(len(starts), 1, "anchor is no longer unique")
+        start = starts[0]
+        # The next top-level construct is a `class`, not a `def` — searching
+        # only for "\ndef " runs past it and swallows SessionAnalyzer's own
+        # (legitimate) line_keywords, failing this test on correct code.
+        end = next(
+            (i for i, l in enumerate(lines)
+             if i > start and (l.startswith("def ") or l.startswith("class "))),
+            len(lines),
+        )
+        codex_body = "\n".join(lines[start:end])
+        self.assertIn(
+            "line_keywords = None", codex_body,
+            "sliced the wrong region — Codex body should contain the disabling line",
+        )
+        self.assertNotIn(
+            "[kw.casefold() for kw in keywords]",
+            codex_body,
+            "Codex must not build line_keywords — it collapses Internal range",
+        )
 
 
 if __name__ == "__main__":

--- a/daymade-claude-code/claude-code-history-files-finder/tests/test_core_text.py
+++ b/daymade-claude-code/claude-code-history-files-finder/tests/test_core_text.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Unit tests for the search pre-filter primitives in ``_core.text``.
+
+These are the new, reusable building blocks a 2026-08 performance fix added
+after a real search on this machine failed to complete in over three minutes
+against a single 1.6GB/294-file project: brute-force ``json.loads()`` of
+every line of every file, with no cheap way to rule out files/lines that
+plainly cannot contain any of the search keywords. ``files_possibly_matching``
+(file-level) and ``iter_jsonl``'s ``line_keywords`` (line-level) are both
+deliberate OVER-approximations — see their docstrings for why that direction
+is the only safe one for a completeness-first tool. These tests exist to hold
+that safety property, not just the happy path.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SKILL_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SKILL_DIR / "scripts"))
+
+from _core.text import files_possibly_matching, iter_jsonl  # noqa: E402
+
+
+class FilesPossiblyMatchingTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def _write(self, name: str, text: str) -> Path:
+        path = self.root / name
+        path.write_text(text, encoding="utf-8")
+        return path
+
+    def test_rules_out_a_file_with_no_keyword_anywhere(self) -> None:
+        hay = self._write("no-match.jsonl", '{"message": "totally unrelated content"}\n')
+        result = files_possibly_matching([hay], ["needle"])
+        self.assertIsNotNone(result)
+        self.assertNotIn(hay, result)
+
+    def test_keeps_a_file_that_contains_the_keyword(self) -> None:
+        hit = self._write("match.jsonl", '{"message": "found the needle here"}\n')
+        result = files_possibly_matching([hit], ["needle"])
+        self.assertIsNotNone(result)
+        self.assertIn(hit, result)
+
+    def test_case_insensitive_by_default(self) -> None:
+        hit = self._write("match.jsonl", '{"message": "Found the NEEDLE here"}\n')
+        result = files_possibly_matching([hit], ["needle"], case_sensitive=False)
+        self.assertIsNotNone(result)
+        self.assertIn(hit, result)
+
+    def test_case_sensitive_mode_rules_out_a_wrong_case_only_file(self) -> None:
+        wrong_case = self._write("wrong-case.jsonl", '{"message": "NEEDLE only in caps"}\n')
+        result = files_possibly_matching([wrong_case], ["needle"], case_sensitive=True)
+        self.assertIsNotNone(result)
+        self.assertNotIn(wrong_case, result)
+
+    def test_or_semantics_across_multiple_keywords(self) -> None:
+        only_second = self._write("second.jsonl", '{"message": "contains haystack only"}\n')
+        result = files_possibly_matching([only_second], ["needle", "haystack"])
+        self.assertIsNotNone(result)
+        self.assertIn(only_second, result, "OR semantics: matching ANY keyword must keep the file")
+
+    def test_batches_many_files_in_one_call(self) -> None:
+        paths = [
+            self._write(
+                f"f{i}.jsonl",
+                json.dumps({"message": "needle" if i % 3 == 0 else "noise"}) + "\n",
+            )
+            for i in range(10)
+        ]
+        result = files_possibly_matching(paths, ["needle"])
+        self.assertIsNotNone(result)
+        expected = {paths[i] for i in range(10) if i % 3 == 0}
+        self.assertEqual(result, expected)
+
+    def test_degrades_to_none_on_empty_keywords(self) -> None:
+        hay = self._write("f.jsonl", '{"message": "anything"}\n')
+        self.assertIsNone(files_possibly_matching([hay], []))
+
+    def test_degrades_to_none_on_empty_paths(self) -> None:
+        self.assertIsNone(files_possibly_matching([], ["needle"]))
+
+    def test_degrades_to_none_on_control_character_keyword(self) -> None:
+        """A keyword containing a raw newline can't be raw-byte-matched against
+        a JSONL file, because json encodes an embedded newline as the two
+        bytes ``\\n`` — the literal 0x0A byte never appears in the file. The
+        safe response is to skip filtering entirely for this keyword, not to
+        guess at the escaped form."""
+        hay = self._write("f.jsonl", '{"message": "line one\\nline two"}\n')
+        self.assertIsNone(files_possibly_matching([hay], ["line one\nline two"]))
+
+    def test_nonexistent_file_does_not_crash_and_is_excluded(self) -> None:
+        missing = self.root / "does-not-exist.jsonl"
+        result = files_possibly_matching([missing], ["needle"])
+        # rg/grep report a missing path as an error for that path but still
+        # succeed overall when other paths are given; alone, treat it as "no
+        # scanner result available" and degrade to not-filtering rather than
+        # crash the caller.
+        if result is not None:
+            self.assertNotIn(missing, result)
+
+
+class IterJsonlLineKeywordsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def _write_lines(self, records: list[dict]) -> Path:
+        path = self.root / "session.jsonl"
+        with path.open("w", encoding="utf-8") as handle:
+            for record in records:
+                handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+        return path
+
+    def test_without_line_keywords_yields_every_record(self) -> None:
+        path = self._write_lines([{"a": 1}, {"a": 2}, {"a": 3}])
+        self.assertEqual(len(list(iter_jsonl(path))), 3)
+
+    def test_line_keywords_filters_out_non_matching_lines(self) -> None:
+        path = self._write_lines(
+            [
+                {"message": "irrelevant one"},
+                {"message": "contains the needle"},
+                {"message": "irrelevant two"},
+            ]
+        )
+        results = list(iter_jsonl(path, line_keywords=["needle"]))
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["message"], "contains the needle")
+
+    def test_line_keywords_is_an_over_approximation_not_exact(self) -> None:
+        """The pre-check matches the RAW line, including JSON structural
+        bytes / keys the real search deliberately excludes (see
+        _flatten_search_strings). A keyword appearing only in an excluded
+        key name still passes this cheap check — that is fine, it costs a
+        wasted json.loads() on one line, not a correctness bug, and the
+        real (structured) search downstream is what enforces the field
+        exclusion."""
+        path = self._write_lines([{"tool_use_id": "needle-shaped-id", "message": "hi"}])
+        results = list(iter_jsonl(path, line_keywords=["needle"]))
+        self.assertEqual(len(results), 1, "over-approximation must still parse the line")
+
+    def test_line_keywords_never_produces_a_false_negative(self) -> None:
+        """Cross-check against the no-filter path on a larger synthetic file:
+        every record containing the keyword in an ORDINARY field must survive
+        filtering — this is the actual safety property, checked mechanically
+        rather than by eyeballing one example."""
+        records = [
+            {"message": f"record {i}" + (" needle" if i % 7 == 0 else "")}
+            for i in range(50)
+        ]
+        path = self._write_lines(records)
+        unfiltered = {r["message"] for r in iter_jsonl(path)}
+        filtered = {r["message"] for r in iter_jsonl(path, line_keywords=["needle"])}
+        expected = {r["message"] for r in records if "needle" in r["message"]}
+        self.assertTrue(expected.issubset(filtered))
+        self.assertTrue(filtered.issubset(unfiltered))
+
+    def test_line_keywords_case_insensitive_via_casefold(self) -> None:
+        path = self._write_lines([{"message": "Found NEEDLE here"}])
+        results = list(iter_jsonl(path, line_keywords=["needle"]))
+        self.assertEqual(len(results), 1)
+
+    def test_bounded_mode_still_respects_line_keywords(self) -> None:
+        records = [{"message": "noise"} for _ in range(5)]
+        records.append({"message": "has needle"})
+        path = self._write_lines(records)
+        results = list(iter_jsonl(path, bounded=True, line_keywords=["needle"]))
+        self.assertEqual([r["message"] for r in results], ["has needle"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/daymade-claude-code/continue-claude-work/scripts/_core/text.py
+++ b/daymade-claude-code/continue-claude-work/scripts/_core/text.py
@@ -11,7 +11,10 @@ re-deriving title/noise heuristics that would drift apart.
 from __future__ import annotations
 
 import json
+import os
 import re
+import shutil
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable, Iterator, Optional
@@ -84,7 +87,41 @@ def strip_structural_metadata_lines(value: str) -> tuple[str, bool]:
     return "\n".join(lines).strip(), removed_attachment
 
 
-def iter_jsonl(path: Path, *, bounded: bool = False) -> Iterator[dict[str, Any]]:
+def iter_jsonl(
+    path: Path,
+    *,
+    bounded: bool = False,
+    line_keywords: Optional[list[str]] = None,
+) -> Iterator[dict[str, Any]]:
+    """Yield each JSONL record as a dict.
+
+    ``line_keywords`` is an optional cheap pre-check: when given, a line is
+    only handed to ``json.loads`` if it contains at least one of these
+    strings as a raw substring (case-insensitive — callers pass already
+    case-folded keywords and this function case-folds the line to match).
+    This exists because ``json.loads`` plus walking the resulting structure
+    is the expensive part of a keyword search, and file-level filtering
+    (skip whole files with no occurrence anywhere) turned out not to be
+    enough on its own: a keyword common across a user's session history
+    (e.g. "embedding") can appear in most FILES while still appearing in
+    only a small fraction of the LINES within each one, so ruling out
+    individual non-matching lines before parsing them is where the real
+    remaining cost lives.
+
+    Like the file-level pre-filter in ``files_possibly_matching``, this is
+    an over-approximation: a line can pass this check and still turn out to
+    have no *matchable* record once parsed (the keyword landed in a raw
+    JSON key/structural byte rather than an actual field value, or in a
+    field the structured extractor deliberately excludes). It must never be
+    an under-approximation — never skip a line that a full parse would have
+    matched — which is what makes it safe to use as a pure speedup.
+
+    Only pass this from a call site that has independently confirmed
+    skipping unselected lines cannot corrupt some other accounting the
+    caller performs across every record (see ``search_sessions``'s
+    ``use_prefilter`` docstring for the specific case this codebase hit —
+    date-window "excluded because untimed" counts must see every record).
+    """
     consumed = 0
     lines = 0
     try:
@@ -94,6 +131,15 @@ def iter_jsonl(path: Path, *, bounded: bool = False) -> Iterator[dict[str, Any]]
                 lines += 1
                 if bounded and (consumed > MAX_PREFIX_BYTES or lines > MAX_PREFIX_LINES):
                     return
+                if line_keywords is not None:
+                    haystack = line.casefold()
+                    if not any(kw in haystack for kw in line_keywords) and not any(
+                        marker in line for marker in _UNSCANNABLE_MARKERS
+                    ):
+                        # Same over-approximation as the file-level filter: a
+                        # line holding a fold-equivalent character or a \u
+                        # escape may still match once parsed, so never skip it.
+                        continue
                 try:
                     value = json.loads(line)
                 except (json.JSONDecodeError, TypeError):
@@ -102,6 +148,219 @@ def iter_jsonl(path: Path, *, bounded: bool = False) -> Iterator[dict[str, Any]]
                     yield value
     except (OSError, UnicodeError):
         return
+
+
+# Every character a JSON writer may store as something other than itself:
+# the two mandatory escapes (" and \), the optional one (/), and all control
+# characters. Enumerated from the JSON grammar rather than from observed
+# escapes — an earlier version listed only control chars and "/", which
+# covered a case Python never even produces while missing the two that every
+# writer produces.
+_JSON_ESCAPED_CHAR_RE = re.compile(r'["\\/\x00-\x1f]')
+
+# The guard above can only inspect the KEYWORD. The other half of the problem
+# is invisible to it: an all-ASCII keyword can legitimately match non-ASCII
+# CONTENT, because Python's casefold() does *full* folding. Searching
+# "financial" must match a transcript containing "ﬁnancial" (U+FB01, which
+# arrives whenever someone pastes from a PDF) — the real matcher does, a byte
+# scanner does not.
+#
+# Enumerated from Python's own casefold table rather than written by hand:
+# every non-ASCII code point whose casefold is pure ASCII. There are exactly
+# 11 (ß ſ ẞ K and the ff/fi/fl/ffi/ffl/st ligatures). A hand-written list
+# drafted for this fix had 17 entries, several of which do not actually fold
+# to ASCII — which is the argument for deriving it.
+_FOLDS_TO_ASCII = tuple(
+    chr(cp)
+    for cp in range(0x80, 0x11000)
+    if chr(cp).casefold() != chr(cp)
+    and chr(cp).casefold().isascii()
+    and chr(cp).casefold().strip()
+)
+
+# Any of these in a file/line means a byte scan cannot rule it out:
+#   - the fold-equivalent characters above
+#   - a "\u" escape: content written with ensure_ascii=True stores non-ASCII
+#     that way, and some writers (Go's encoding/json) escape even ASCII
+#     "<" ">" "&" as </>/&
+_UNSCANNABLE_MARKERS = _FOLDS_TO_ASCII + ("\\u",)
+
+
+def keywords_are_raw_byte_safe(keywords: Iterable[str]) -> bool:
+    """Can a literal byte scan of the physical file stand in for matching
+    against the parsed strings?
+
+    Pass the **original** keywords, never case-folded ones. ``"ß".casefold()``
+    is ``"ss"`` — pure ASCII — so folding first makes this function answer
+    "safe" for exactly the input that motivated rule 2 below, silently
+    re-opening the hole it exists to close.
+
+    Only when every keyword's bytes are *guaranteed* to appear verbatim in the
+    file, and a byte scanner's notion of "equal" matches Python's. Three shapes
+    break that guarantee, and each one silently loses matches rather than
+    reporting an error — so all three fall back to full parsing:
+
+    1. **Characters JSON is required to escape**: control characters, ``"``,
+       and ``\\``. An embedded newline is stored as the two bytes ``\\n``, a
+       quote as ``\\"``, a backslash as ``\\\\`` — so a literal search for the
+       raw character cannot find the escaped form actually sitting in the
+       file. This is not a quirk of some serializers; every conforming JSON
+       writer does it, including the one that produced these transcripts.
+       Quoted error fragments (``Error: "ENOENT"``), config snippets
+       (``"model": "opus"``), and Windows paths are exactly the sort of thing
+       people search history for.
+
+    2. **Non-ASCII.** Two independent failures. (a) ``json.dumps`` defaults to
+       ``ensure_ascii=True``, which stores ``café`` as ``caf\\u00e9`` — the
+       UTF-8 bytes are simply not in the file. Claude Code's own writer does
+       not do this, but archives rewritten by other tooling do. (b) Even in
+       raw UTF-8, case-insensitive folding disagrees across implementations:
+       measured on this corpus's tooling, Python ``casefold()`` does *full*
+       folding (``straße`` == ``STRASSE``), ``rg -i`` does only *simple*
+       folding (matches ``STRAẞE`` but not ``STRASSE``), and ``/usr/bin/grep
+       -i`` matches neither. A pre-filter that disagrees with the real matcher
+       drops sessions, and it would drop *different* ones depending on whether
+       ``rg`` happens to be installed.
+
+    3. **A literal ``/``.** Optional in JSON — Python does not escape it — but
+       some writers emit ``\\/``, so it is excluded for the same reason.
+
+    Falling back is always the safe direction: it costs speed, never a missed
+    match. The cost is real and worth naming — a non-ASCII query (any CJK one)
+    gets no pre-filter at all and pays the full parse. Correctness first: this
+    tool's callers are told they may conclude a topic is absent from a
+    no-match result.
+    """
+    return all(
+        kw.isascii()
+        and not _JSON_ESCAPED_CHAR_RE.search(kw)
+        for kw in keywords
+    )
+
+
+def files_possibly_matching(
+    paths: Iterable[Path], keywords: Iterable[str], *, case_sensitive: bool = False
+) -> Optional[set[Path]]:
+    """Raw-byte pre-filter: which of ``paths`` could possibly contain any of
+    ``keywords``, without paying per-line ``json.loads`` + structured
+    extraction on files that plainly cannot match?
+
+    This exists because the natural way to search this corpus — open every
+    session file, ``json.loads`` every line, extract the searchable text, and
+    substring-match keywords against it — parses every byte of every file
+    even when the overwhelming majority contain none of the keywords at all.
+    On a single project of 294 files / 1.6GB that pure-Python loop measured
+    3.5+ minutes of CPU time without completing; ``rg``/``grep`` scan the same
+    bytes at native speed and can usually rule out most files in well under a
+    second, letting the expensive path run only on the handful of files that
+    are actually candidates.
+
+    Deliberately an OVER-approximation, never an under-approximation: keys
+    excluded from search on purpose (``id``, ``tool_use_id``, ``signature`` —
+    see ``_flatten_search_strings``) can still contain a keyword's raw bytes,
+    so a small number of files this returns as "possible" will turn out to
+    have no real match once fully parsed. That costs a little wasted parsing,
+    which is fine. What must never happen is the reverse — silently ruling
+    out a file that genuinely contains a matchable occurrence — because
+    completeness is this tool's whole reason to exist (see the "Completeness
+    invariant" in the finder skill's own SKILL.md). So every failure mode
+    below degrades to "don't filter" rather than to "filter more":
+
+    - No keywords, or a keyword containing a raw control character (the
+      JSON-escaping mismatch above): returns ``None``.
+    - Neither ``rg`` nor ``grep`` is on PATH: returns ``None``.
+    - The scanner subprocess itself errors or times out: returns ``None``.
+
+    ``None`` means "no filtering information — treat every path as a
+    candidate", which is exactly the pre-existing behavior before this
+    function existed. Callers must check for ``None`` and fall through to
+    scanning everything, not treat it as an empty result.
+    """
+    path_list = list(paths)
+    keyword_list = list(keywords)
+    if not path_list or not keyword_list or not keywords_are_raw_byte_safe(keyword_list):
+        return None
+    exe = shutil.which("rg") or shutil.which("grep")
+    if not exe:
+        return None
+    # -a/--text: never let the binary-content heuristic skip a JSONL file that
+    #   happens to contain a byte sequence that looks binary.
+    # -F: keywords are literal substrings everywhere else in this codebase
+    #   (Python's str.count(), not a regex) — a raw scan must match the same
+    #   semantics, not treat a keyword like "a.b" as a wildcard pattern.
+    # -l: list matching filenames only; we don't need line numbers here.
+    # Two scans, unioned — they need opposite case settings.
+    #
+    # Pass 1 matches the keywords the way the real matcher does (folded, unless
+    # the caller asked for case-sensitive).
+    #
+    # Pass 2 looks for content the byte scanner cannot reason about at all
+    # (fold-equivalent characters, "\u" escapes) and MUST be case-sensitive.
+    # Handing those characters to a "-i" scan is self-defeating: "-i" folds the
+    # *pattern* too, so `ſ` matches a plain `s` and `K` (U+212A) matches `k` —
+    # every file with an "s" or a "k" in it becomes a candidate and the filter
+    # stops filtering. (Caught by the pre-existing unit tests, which is exactly
+    # what they are for.)
+    kw_scan = [exe, "-a", "-F", "-l"]
+    if not case_sensitive:
+        kw_scan.append("-i")
+    for kw in keyword_list:
+        kw_scan += ["-e", kw]
+    kw_scan.append("--")
+
+    marker_scan = [exe, "-a", "-F", "-l"]
+    for marker in _UNSCANNABLE_MARKERS:
+        marker_scan += ["-e", marker]
+    marker_scan.append("--")
+
+    # Batch the paths: one exec per ~half of ARG_MAX. Passing every path in a
+    # single argv fails with E2BIG once the corpus is large enough — measured
+    # here at 7819 files needing 1,181,495 bytes against an ARG_MAX of
+    # 1,048,576. That failure degrades safely (OSError -> return None -> no
+    # filtering), but it means the speedup silently switched itself off in
+    # exactly the "tens of thousands of files" case that motivated it.
+    try:
+        arg_max = os.sysconf("SC_ARG_MAX")
+    except (ValueError, OSError):
+        arg_max = 256 * 1024
+    matched: set[Path] = set()
+
+    def run_batch(scan_prefix: list[str], paths_chunk: list[str]) -> bool:
+        """Returns False if the scanner failed — caller degrades to no filter."""
+        try:
+            result = subprocess.run(
+                scan_prefix + paths_chunk, capture_output=True, text=True,
+                encoding="utf-8", errors="replace", timeout=120,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return False
+        # Both rg and grep: 0 = matches found, 1 = no matches (not an error).
+        # Any other code (bad invocation, I/O error) is a scanner failure ->
+        # degrade to "don't filter" rather than trust a broken result.
+        if result.returncode not in (0, 1):
+            return False
+        matched.update(Path(line) for line in result.stdout.splitlines() if line)
+        return True
+
+    def scan_all(scan_prefix: list[str]) -> bool:
+        fixed = sum(len(a.encode("utf-8", "replace")) + 1 for a in scan_prefix)
+        chunk_budget = max(arg_max // 2 - fixed, 64 * 1024)
+        batch: list[str] = []
+        used = 0
+        for path in path_list:
+            text = str(path)
+            size = len(text.encode("utf-8", "replace")) + 1
+            if batch and used + size > chunk_budget:
+                if not run_batch(scan_prefix, batch):
+                    return False
+                batch, used = [], 0
+            batch.append(text)
+            used += size
+        return not batch or run_batch(scan_prefix, batch)
+
+    if not scan_all(kw_scan) or not scan_all(marker_scan):
+        return None
+    return matched
 
 
 def extract_text(content: Any) -> str:

--- a/daymade-claude-code/continue-codex-work/scripts/_core/text.py
+++ b/daymade-claude-code/continue-codex-work/scripts/_core/text.py
@@ -11,7 +11,10 @@ re-deriving title/noise heuristics that would drift apart.
 from __future__ import annotations
 
 import json
+import os
 import re
+import shutil
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable, Iterator, Optional
@@ -84,7 +87,41 @@ def strip_structural_metadata_lines(value: str) -> tuple[str, bool]:
     return "\n".join(lines).strip(), removed_attachment
 
 
-def iter_jsonl(path: Path, *, bounded: bool = False) -> Iterator[dict[str, Any]]:
+def iter_jsonl(
+    path: Path,
+    *,
+    bounded: bool = False,
+    line_keywords: Optional[list[str]] = None,
+) -> Iterator[dict[str, Any]]:
+    """Yield each JSONL record as a dict.
+
+    ``line_keywords`` is an optional cheap pre-check: when given, a line is
+    only handed to ``json.loads`` if it contains at least one of these
+    strings as a raw substring (case-insensitive — callers pass already
+    case-folded keywords and this function case-folds the line to match).
+    This exists because ``json.loads`` plus walking the resulting structure
+    is the expensive part of a keyword search, and file-level filtering
+    (skip whole files with no occurrence anywhere) turned out not to be
+    enough on its own: a keyword common across a user's session history
+    (e.g. "embedding") can appear in most FILES while still appearing in
+    only a small fraction of the LINES within each one, so ruling out
+    individual non-matching lines before parsing them is where the real
+    remaining cost lives.
+
+    Like the file-level pre-filter in ``files_possibly_matching``, this is
+    an over-approximation: a line can pass this check and still turn out to
+    have no *matchable* record once parsed (the keyword landed in a raw
+    JSON key/structural byte rather than an actual field value, or in a
+    field the structured extractor deliberately excludes). It must never be
+    an under-approximation — never skip a line that a full parse would have
+    matched — which is what makes it safe to use as a pure speedup.
+
+    Only pass this from a call site that has independently confirmed
+    skipping unselected lines cannot corrupt some other accounting the
+    caller performs across every record (see ``search_sessions``'s
+    ``use_prefilter`` docstring for the specific case this codebase hit —
+    date-window "excluded because untimed" counts must see every record).
+    """
     consumed = 0
     lines = 0
     try:
@@ -94,6 +131,15 @@ def iter_jsonl(path: Path, *, bounded: bool = False) -> Iterator[dict[str, Any]]
                 lines += 1
                 if bounded and (consumed > MAX_PREFIX_BYTES or lines > MAX_PREFIX_LINES):
                     return
+                if line_keywords is not None:
+                    haystack = line.casefold()
+                    if not any(kw in haystack for kw in line_keywords) and not any(
+                        marker in line for marker in _UNSCANNABLE_MARKERS
+                    ):
+                        # Same over-approximation as the file-level filter: a
+                        # line holding a fold-equivalent character or a \u
+                        # escape may still match once parsed, so never skip it.
+                        continue
                 try:
                     value = json.loads(line)
                 except (json.JSONDecodeError, TypeError):
@@ -102,6 +148,219 @@ def iter_jsonl(path: Path, *, bounded: bool = False) -> Iterator[dict[str, Any]]
                     yield value
     except (OSError, UnicodeError):
         return
+
+
+# Every character a JSON writer may store as something other than itself:
+# the two mandatory escapes (" and \), the optional one (/), and all control
+# characters. Enumerated from the JSON grammar rather than from observed
+# escapes — an earlier version listed only control chars and "/", which
+# covered a case Python never even produces while missing the two that every
+# writer produces.
+_JSON_ESCAPED_CHAR_RE = re.compile(r'["\\/\x00-\x1f]')
+
+# The guard above can only inspect the KEYWORD. The other half of the problem
+# is invisible to it: an all-ASCII keyword can legitimately match non-ASCII
+# CONTENT, because Python's casefold() does *full* folding. Searching
+# "financial" must match a transcript containing "ﬁnancial" (U+FB01, which
+# arrives whenever someone pastes from a PDF) — the real matcher does, a byte
+# scanner does not.
+#
+# Enumerated from Python's own casefold table rather than written by hand:
+# every non-ASCII code point whose casefold is pure ASCII. There are exactly
+# 11 (ß ſ ẞ K and the ff/fi/fl/ffi/ffl/st ligatures). A hand-written list
+# drafted for this fix had 17 entries, several of which do not actually fold
+# to ASCII — which is the argument for deriving it.
+_FOLDS_TO_ASCII = tuple(
+    chr(cp)
+    for cp in range(0x80, 0x11000)
+    if chr(cp).casefold() != chr(cp)
+    and chr(cp).casefold().isascii()
+    and chr(cp).casefold().strip()
+)
+
+# Any of these in a file/line means a byte scan cannot rule it out:
+#   - the fold-equivalent characters above
+#   - a "\u" escape: content written with ensure_ascii=True stores non-ASCII
+#     that way, and some writers (Go's encoding/json) escape even ASCII
+#     "<" ">" "&" as </>/&
+_UNSCANNABLE_MARKERS = _FOLDS_TO_ASCII + ("\\u",)
+
+
+def keywords_are_raw_byte_safe(keywords: Iterable[str]) -> bool:
+    """Can a literal byte scan of the physical file stand in for matching
+    against the parsed strings?
+
+    Pass the **original** keywords, never case-folded ones. ``"ß".casefold()``
+    is ``"ss"`` — pure ASCII — so folding first makes this function answer
+    "safe" for exactly the input that motivated rule 2 below, silently
+    re-opening the hole it exists to close.
+
+    Only when every keyword's bytes are *guaranteed* to appear verbatim in the
+    file, and a byte scanner's notion of "equal" matches Python's. Three shapes
+    break that guarantee, and each one silently loses matches rather than
+    reporting an error — so all three fall back to full parsing:
+
+    1. **Characters JSON is required to escape**: control characters, ``"``,
+       and ``\\``. An embedded newline is stored as the two bytes ``\\n``, a
+       quote as ``\\"``, a backslash as ``\\\\`` — so a literal search for the
+       raw character cannot find the escaped form actually sitting in the
+       file. This is not a quirk of some serializers; every conforming JSON
+       writer does it, including the one that produced these transcripts.
+       Quoted error fragments (``Error: "ENOENT"``), config snippets
+       (``"model": "opus"``), and Windows paths are exactly the sort of thing
+       people search history for.
+
+    2. **Non-ASCII.** Two independent failures. (a) ``json.dumps`` defaults to
+       ``ensure_ascii=True``, which stores ``café`` as ``caf\\u00e9`` — the
+       UTF-8 bytes are simply not in the file. Claude Code's own writer does
+       not do this, but archives rewritten by other tooling do. (b) Even in
+       raw UTF-8, case-insensitive folding disagrees across implementations:
+       measured on this corpus's tooling, Python ``casefold()`` does *full*
+       folding (``straße`` == ``STRASSE``), ``rg -i`` does only *simple*
+       folding (matches ``STRAẞE`` but not ``STRASSE``), and ``/usr/bin/grep
+       -i`` matches neither. A pre-filter that disagrees with the real matcher
+       drops sessions, and it would drop *different* ones depending on whether
+       ``rg`` happens to be installed.
+
+    3. **A literal ``/``.** Optional in JSON — Python does not escape it — but
+       some writers emit ``\\/``, so it is excluded for the same reason.
+
+    Falling back is always the safe direction: it costs speed, never a missed
+    match. The cost is real and worth naming — a non-ASCII query (any CJK one)
+    gets no pre-filter at all and pays the full parse. Correctness first: this
+    tool's callers are told they may conclude a topic is absent from a
+    no-match result.
+    """
+    return all(
+        kw.isascii()
+        and not _JSON_ESCAPED_CHAR_RE.search(kw)
+        for kw in keywords
+    )
+
+
+def files_possibly_matching(
+    paths: Iterable[Path], keywords: Iterable[str], *, case_sensitive: bool = False
+) -> Optional[set[Path]]:
+    """Raw-byte pre-filter: which of ``paths`` could possibly contain any of
+    ``keywords``, without paying per-line ``json.loads`` + structured
+    extraction on files that plainly cannot match?
+
+    This exists because the natural way to search this corpus — open every
+    session file, ``json.loads`` every line, extract the searchable text, and
+    substring-match keywords against it — parses every byte of every file
+    even when the overwhelming majority contain none of the keywords at all.
+    On a single project of 294 files / 1.6GB that pure-Python loop measured
+    3.5+ minutes of CPU time without completing; ``rg``/``grep`` scan the same
+    bytes at native speed and can usually rule out most files in well under a
+    second, letting the expensive path run only on the handful of files that
+    are actually candidates.
+
+    Deliberately an OVER-approximation, never an under-approximation: keys
+    excluded from search on purpose (``id``, ``tool_use_id``, ``signature`` —
+    see ``_flatten_search_strings``) can still contain a keyword's raw bytes,
+    so a small number of files this returns as "possible" will turn out to
+    have no real match once fully parsed. That costs a little wasted parsing,
+    which is fine. What must never happen is the reverse — silently ruling
+    out a file that genuinely contains a matchable occurrence — because
+    completeness is this tool's whole reason to exist (see the "Completeness
+    invariant" in the finder skill's own SKILL.md). So every failure mode
+    below degrades to "don't filter" rather than to "filter more":
+
+    - No keywords, or a keyword containing a raw control character (the
+      JSON-escaping mismatch above): returns ``None``.
+    - Neither ``rg`` nor ``grep`` is on PATH: returns ``None``.
+    - The scanner subprocess itself errors or times out: returns ``None``.
+
+    ``None`` means "no filtering information — treat every path as a
+    candidate", which is exactly the pre-existing behavior before this
+    function existed. Callers must check for ``None`` and fall through to
+    scanning everything, not treat it as an empty result.
+    """
+    path_list = list(paths)
+    keyword_list = list(keywords)
+    if not path_list or not keyword_list or not keywords_are_raw_byte_safe(keyword_list):
+        return None
+    exe = shutil.which("rg") or shutil.which("grep")
+    if not exe:
+        return None
+    # -a/--text: never let the binary-content heuristic skip a JSONL file that
+    #   happens to contain a byte sequence that looks binary.
+    # -F: keywords are literal substrings everywhere else in this codebase
+    #   (Python's str.count(), not a regex) — a raw scan must match the same
+    #   semantics, not treat a keyword like "a.b" as a wildcard pattern.
+    # -l: list matching filenames only; we don't need line numbers here.
+    # Two scans, unioned — they need opposite case settings.
+    #
+    # Pass 1 matches the keywords the way the real matcher does (folded, unless
+    # the caller asked for case-sensitive).
+    #
+    # Pass 2 looks for content the byte scanner cannot reason about at all
+    # (fold-equivalent characters, "\u" escapes) and MUST be case-sensitive.
+    # Handing those characters to a "-i" scan is self-defeating: "-i" folds the
+    # *pattern* too, so `ſ` matches a plain `s` and `K` (U+212A) matches `k` —
+    # every file with an "s" or a "k" in it becomes a candidate and the filter
+    # stops filtering. (Caught by the pre-existing unit tests, which is exactly
+    # what they are for.)
+    kw_scan = [exe, "-a", "-F", "-l"]
+    if not case_sensitive:
+        kw_scan.append("-i")
+    for kw in keyword_list:
+        kw_scan += ["-e", kw]
+    kw_scan.append("--")
+
+    marker_scan = [exe, "-a", "-F", "-l"]
+    for marker in _UNSCANNABLE_MARKERS:
+        marker_scan += ["-e", marker]
+    marker_scan.append("--")
+
+    # Batch the paths: one exec per ~half of ARG_MAX. Passing every path in a
+    # single argv fails with E2BIG once the corpus is large enough — measured
+    # here at 7819 files needing 1,181,495 bytes against an ARG_MAX of
+    # 1,048,576. That failure degrades safely (OSError -> return None -> no
+    # filtering), but it means the speedup silently switched itself off in
+    # exactly the "tens of thousands of files" case that motivated it.
+    try:
+        arg_max = os.sysconf("SC_ARG_MAX")
+    except (ValueError, OSError):
+        arg_max = 256 * 1024
+    matched: set[Path] = set()
+
+    def run_batch(scan_prefix: list[str], paths_chunk: list[str]) -> bool:
+        """Returns False if the scanner failed — caller degrades to no filter."""
+        try:
+            result = subprocess.run(
+                scan_prefix + paths_chunk, capture_output=True, text=True,
+                encoding="utf-8", errors="replace", timeout=120,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return False
+        # Both rg and grep: 0 = matches found, 1 = no matches (not an error).
+        # Any other code (bad invocation, I/O error) is a scanner failure ->
+        # degrade to "don't filter" rather than trust a broken result.
+        if result.returncode not in (0, 1):
+            return False
+        matched.update(Path(line) for line in result.stdout.splitlines() if line)
+        return True
+
+    def scan_all(scan_prefix: list[str]) -> bool:
+        fixed = sum(len(a.encode("utf-8", "replace")) + 1 for a in scan_prefix)
+        chunk_budget = max(arg_max // 2 - fixed, 64 * 1024)
+        batch: list[str] = []
+        used = 0
+        for path in path_list:
+            text = str(path)
+            size = len(text.encode("utf-8", "replace")) + 1
+            if batch and used + size > chunk_budget:
+                if not run_batch(scan_prefix, batch):
+                    return False
+                batch, used = [], 0
+            batch.append(text)
+            used += size
+        return not batch or run_batch(scan_prefix, batch)
+
+    if not scan_all(kw_scan) or not scan_all(marker_scan):
+        return None
+    return matched
 
 
 def extract_text(content: Any) -> str:

--- a/daymade-claude-code/local-conversation-history/scripts/_core/text.py
+++ b/daymade-claude-code/local-conversation-history/scripts/_core/text.py
@@ -11,7 +11,10 @@ re-deriving title/noise heuristics that would drift apart.
 from __future__ import annotations
 
 import json
+import os
 import re
+import shutil
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable, Iterator, Optional
@@ -84,7 +87,41 @@ def strip_structural_metadata_lines(value: str) -> tuple[str, bool]:
     return "\n".join(lines).strip(), removed_attachment
 
 
-def iter_jsonl(path: Path, *, bounded: bool = False) -> Iterator[dict[str, Any]]:
+def iter_jsonl(
+    path: Path,
+    *,
+    bounded: bool = False,
+    line_keywords: Optional[list[str]] = None,
+) -> Iterator[dict[str, Any]]:
+    """Yield each JSONL record as a dict.
+
+    ``line_keywords`` is an optional cheap pre-check: when given, a line is
+    only handed to ``json.loads`` if it contains at least one of these
+    strings as a raw substring (case-insensitive — callers pass already
+    case-folded keywords and this function case-folds the line to match).
+    This exists because ``json.loads`` plus walking the resulting structure
+    is the expensive part of a keyword search, and file-level filtering
+    (skip whole files with no occurrence anywhere) turned out not to be
+    enough on its own: a keyword common across a user's session history
+    (e.g. "embedding") can appear in most FILES while still appearing in
+    only a small fraction of the LINES within each one, so ruling out
+    individual non-matching lines before parsing them is where the real
+    remaining cost lives.
+
+    Like the file-level pre-filter in ``files_possibly_matching``, this is
+    an over-approximation: a line can pass this check and still turn out to
+    have no *matchable* record once parsed (the keyword landed in a raw
+    JSON key/structural byte rather than an actual field value, or in a
+    field the structured extractor deliberately excludes). It must never be
+    an under-approximation — never skip a line that a full parse would have
+    matched — which is what makes it safe to use as a pure speedup.
+
+    Only pass this from a call site that has independently confirmed
+    skipping unselected lines cannot corrupt some other accounting the
+    caller performs across every record (see ``search_sessions``'s
+    ``use_prefilter`` docstring for the specific case this codebase hit —
+    date-window "excluded because untimed" counts must see every record).
+    """
     consumed = 0
     lines = 0
     try:
@@ -94,6 +131,15 @@ def iter_jsonl(path: Path, *, bounded: bool = False) -> Iterator[dict[str, Any]]
                 lines += 1
                 if bounded and (consumed > MAX_PREFIX_BYTES or lines > MAX_PREFIX_LINES):
                     return
+                if line_keywords is not None:
+                    haystack = line.casefold()
+                    if not any(kw in haystack for kw in line_keywords) and not any(
+                        marker in line for marker in _UNSCANNABLE_MARKERS
+                    ):
+                        # Same over-approximation as the file-level filter: a
+                        # line holding a fold-equivalent character or a \u
+                        # escape may still match once parsed, so never skip it.
+                        continue
                 try:
                     value = json.loads(line)
                 except (json.JSONDecodeError, TypeError):
@@ -102,6 +148,219 @@ def iter_jsonl(path: Path, *, bounded: bool = False) -> Iterator[dict[str, Any]]
                     yield value
     except (OSError, UnicodeError):
         return
+
+
+# Every character a JSON writer may store as something other than itself:
+# the two mandatory escapes (" and \), the optional one (/), and all control
+# characters. Enumerated from the JSON grammar rather than from observed
+# escapes — an earlier version listed only control chars and "/", which
+# covered a case Python never even produces while missing the two that every
+# writer produces.
+_JSON_ESCAPED_CHAR_RE = re.compile(r'["\\/\x00-\x1f]')
+
+# The guard above can only inspect the KEYWORD. The other half of the problem
+# is invisible to it: an all-ASCII keyword can legitimately match non-ASCII
+# CONTENT, because Python's casefold() does *full* folding. Searching
+# "financial" must match a transcript containing "ﬁnancial" (U+FB01, which
+# arrives whenever someone pastes from a PDF) — the real matcher does, a byte
+# scanner does not.
+#
+# Enumerated from Python's own casefold table rather than written by hand:
+# every non-ASCII code point whose casefold is pure ASCII. There are exactly
+# 11 (ß ſ ẞ K and the ff/fi/fl/ffi/ffl/st ligatures). A hand-written list
+# drafted for this fix had 17 entries, several of which do not actually fold
+# to ASCII — which is the argument for deriving it.
+_FOLDS_TO_ASCII = tuple(
+    chr(cp)
+    for cp in range(0x80, 0x11000)
+    if chr(cp).casefold() != chr(cp)
+    and chr(cp).casefold().isascii()
+    and chr(cp).casefold().strip()
+)
+
+# Any of these in a file/line means a byte scan cannot rule it out:
+#   - the fold-equivalent characters above
+#   - a "\u" escape: content written with ensure_ascii=True stores non-ASCII
+#     that way, and some writers (Go's encoding/json) escape even ASCII
+#     "<" ">" "&" as </>/&
+_UNSCANNABLE_MARKERS = _FOLDS_TO_ASCII + ("\\u",)
+
+
+def keywords_are_raw_byte_safe(keywords: Iterable[str]) -> bool:
+    """Can a literal byte scan of the physical file stand in for matching
+    against the parsed strings?
+
+    Pass the **original** keywords, never case-folded ones. ``"ß".casefold()``
+    is ``"ss"`` — pure ASCII — so folding first makes this function answer
+    "safe" for exactly the input that motivated rule 2 below, silently
+    re-opening the hole it exists to close.
+
+    Only when every keyword's bytes are *guaranteed* to appear verbatim in the
+    file, and a byte scanner's notion of "equal" matches Python's. Three shapes
+    break that guarantee, and each one silently loses matches rather than
+    reporting an error — so all three fall back to full parsing:
+
+    1. **Characters JSON is required to escape**: control characters, ``"``,
+       and ``\\``. An embedded newline is stored as the two bytes ``\\n``, a
+       quote as ``\\"``, a backslash as ``\\\\`` — so a literal search for the
+       raw character cannot find the escaped form actually sitting in the
+       file. This is not a quirk of some serializers; every conforming JSON
+       writer does it, including the one that produced these transcripts.
+       Quoted error fragments (``Error: "ENOENT"``), config snippets
+       (``"model": "opus"``), and Windows paths are exactly the sort of thing
+       people search history for.
+
+    2. **Non-ASCII.** Two independent failures. (a) ``json.dumps`` defaults to
+       ``ensure_ascii=True``, which stores ``café`` as ``caf\\u00e9`` — the
+       UTF-8 bytes are simply not in the file. Claude Code's own writer does
+       not do this, but archives rewritten by other tooling do. (b) Even in
+       raw UTF-8, case-insensitive folding disagrees across implementations:
+       measured on this corpus's tooling, Python ``casefold()`` does *full*
+       folding (``straße`` == ``STRASSE``), ``rg -i`` does only *simple*
+       folding (matches ``STRAẞE`` but not ``STRASSE``), and ``/usr/bin/grep
+       -i`` matches neither. A pre-filter that disagrees with the real matcher
+       drops sessions, and it would drop *different* ones depending on whether
+       ``rg`` happens to be installed.
+
+    3. **A literal ``/``.** Optional in JSON — Python does not escape it — but
+       some writers emit ``\\/``, so it is excluded for the same reason.
+
+    Falling back is always the safe direction: it costs speed, never a missed
+    match. The cost is real and worth naming — a non-ASCII query (any CJK one)
+    gets no pre-filter at all and pays the full parse. Correctness first: this
+    tool's callers are told they may conclude a topic is absent from a
+    no-match result.
+    """
+    return all(
+        kw.isascii()
+        and not _JSON_ESCAPED_CHAR_RE.search(kw)
+        for kw in keywords
+    )
+
+
+def files_possibly_matching(
+    paths: Iterable[Path], keywords: Iterable[str], *, case_sensitive: bool = False
+) -> Optional[set[Path]]:
+    """Raw-byte pre-filter: which of ``paths`` could possibly contain any of
+    ``keywords``, without paying per-line ``json.loads`` + structured
+    extraction on files that plainly cannot match?
+
+    This exists because the natural way to search this corpus — open every
+    session file, ``json.loads`` every line, extract the searchable text, and
+    substring-match keywords against it — parses every byte of every file
+    even when the overwhelming majority contain none of the keywords at all.
+    On a single project of 294 files / 1.6GB that pure-Python loop measured
+    3.5+ minutes of CPU time without completing; ``rg``/``grep`` scan the same
+    bytes at native speed and can usually rule out most files in well under a
+    second, letting the expensive path run only on the handful of files that
+    are actually candidates.
+
+    Deliberately an OVER-approximation, never an under-approximation: keys
+    excluded from search on purpose (``id``, ``tool_use_id``, ``signature`` —
+    see ``_flatten_search_strings``) can still contain a keyword's raw bytes,
+    so a small number of files this returns as "possible" will turn out to
+    have no real match once fully parsed. That costs a little wasted parsing,
+    which is fine. What must never happen is the reverse — silently ruling
+    out a file that genuinely contains a matchable occurrence — because
+    completeness is this tool's whole reason to exist (see the "Completeness
+    invariant" in the finder skill's own SKILL.md). So every failure mode
+    below degrades to "don't filter" rather than to "filter more":
+
+    - No keywords, or a keyword containing a raw control character (the
+      JSON-escaping mismatch above): returns ``None``.
+    - Neither ``rg`` nor ``grep`` is on PATH: returns ``None``.
+    - The scanner subprocess itself errors or times out: returns ``None``.
+
+    ``None`` means "no filtering information — treat every path as a
+    candidate", which is exactly the pre-existing behavior before this
+    function existed. Callers must check for ``None`` and fall through to
+    scanning everything, not treat it as an empty result.
+    """
+    path_list = list(paths)
+    keyword_list = list(keywords)
+    if not path_list or not keyword_list or not keywords_are_raw_byte_safe(keyword_list):
+        return None
+    exe = shutil.which("rg") or shutil.which("grep")
+    if not exe:
+        return None
+    # -a/--text: never let the binary-content heuristic skip a JSONL file that
+    #   happens to contain a byte sequence that looks binary.
+    # -F: keywords are literal substrings everywhere else in this codebase
+    #   (Python's str.count(), not a regex) — a raw scan must match the same
+    #   semantics, not treat a keyword like "a.b" as a wildcard pattern.
+    # -l: list matching filenames only; we don't need line numbers here.
+    # Two scans, unioned — they need opposite case settings.
+    #
+    # Pass 1 matches the keywords the way the real matcher does (folded, unless
+    # the caller asked for case-sensitive).
+    #
+    # Pass 2 looks for content the byte scanner cannot reason about at all
+    # (fold-equivalent characters, "\u" escapes) and MUST be case-sensitive.
+    # Handing those characters to a "-i" scan is self-defeating: "-i" folds the
+    # *pattern* too, so `ſ` matches a plain `s` and `K` (U+212A) matches `k` —
+    # every file with an "s" or a "k" in it becomes a candidate and the filter
+    # stops filtering. (Caught by the pre-existing unit tests, which is exactly
+    # what they are for.)
+    kw_scan = [exe, "-a", "-F", "-l"]
+    if not case_sensitive:
+        kw_scan.append("-i")
+    for kw in keyword_list:
+        kw_scan += ["-e", kw]
+    kw_scan.append("--")
+
+    marker_scan = [exe, "-a", "-F", "-l"]
+    for marker in _UNSCANNABLE_MARKERS:
+        marker_scan += ["-e", marker]
+    marker_scan.append("--")
+
+    # Batch the paths: one exec per ~half of ARG_MAX. Passing every path in a
+    # single argv fails with E2BIG once the corpus is large enough — measured
+    # here at 7819 files needing 1,181,495 bytes against an ARG_MAX of
+    # 1,048,576. That failure degrades safely (OSError -> return None -> no
+    # filtering), but it means the speedup silently switched itself off in
+    # exactly the "tens of thousands of files" case that motivated it.
+    try:
+        arg_max = os.sysconf("SC_ARG_MAX")
+    except (ValueError, OSError):
+        arg_max = 256 * 1024
+    matched: set[Path] = set()
+
+    def run_batch(scan_prefix: list[str], paths_chunk: list[str]) -> bool:
+        """Returns False if the scanner failed — caller degrades to no filter."""
+        try:
+            result = subprocess.run(
+                scan_prefix + paths_chunk, capture_output=True, text=True,
+                encoding="utf-8", errors="replace", timeout=120,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return False
+        # Both rg and grep: 0 = matches found, 1 = no matches (not an error).
+        # Any other code (bad invocation, I/O error) is a scanner failure ->
+        # degrade to "don't filter" rather than trust a broken result.
+        if result.returncode not in (0, 1):
+            return False
+        matched.update(Path(line) for line in result.stdout.splitlines() if line)
+        return True
+
+    def scan_all(scan_prefix: list[str]) -> bool:
+        fixed = sum(len(a.encode("utf-8", "replace")) + 1 for a in scan_prefix)
+        chunk_budget = max(arg_max // 2 - fixed, 64 * 1024)
+        batch: list[str] = []
+        used = 0
+        for path in path_list:
+            text = str(path)
+            size = len(text.encode("utf-8", "replace")) + 1
+            if batch and used + size > chunk_budget:
+                if not run_batch(scan_prefix, batch):
+                    return False
+                batch, used = [], 0
+            batch.append(text)
+            used += size
+        return not batch or run_batch(scan_prefix, batch)
+
+    if not scan_all(kw_scan) or not scan_all(marker_scan):
+        return None
+    return matched
 
 
 def extract_text(content: Any) -> str:


### PR DESCRIPTION
## What

Searching this corpus brute-forced `json.loads()` over every line of every file. A real search across one 1.6GB / 294-file project did not finish in 3.5 minutes. This adds a two-level pre-filter — `rg`/`grep` over whole files, then a per-line byte check — so only plausible candidates get parsed.

**Measured on 7831 real session files: 326.1s → 164.1s (2.0×).**

## Why this needed two rounds of adversarial review

A pre-filter is only sound while a keyword's bytes are guaranteed to appear verbatim in the file **and** the byte scanner agrees with Python about what "equal" means. Neither held in eight places, and every failure was **silent** — the worst possible mode for a tool whose callers are explicitly told they may conclude a topic is absent from a no-match result.

| Hole | Effect |
|---|---|
| JSON's mandatory escapes (`"` → `\"`, `\` → `\\`) | Quoted error fragments and Windows paths never found |
| Python `casefold()` (full) vs `rg -i` (simple) vs `grep -i` | Results differed by whether `rg` was installed |
| ASCII keyword vs non-ASCII content | `financial` missed `ﬁnancial` (U+FB01 — pasting from a PDF) |
| `ensure_ascii=True` archives | `café` stored as `café`; CJK search dead on such archives |
| Codex line-level filtering | `Internal range` collapsed onto `Match range` (measured `01-01..01-20` → `01-10..01-10`) on the **default** no-window search |
| argv > `ARG_MAX` at 7819 files (1,181,495 > 1,048,576) | Pre-filter silently switched itself off in exactly the large-corpus case that motivated it |

## Fixes

- Derive the unsafe-keyword rule from the **JSON grammar**, not from observed escapes
- Derive the fold-equivalent character table from **Python's own casefold table** — 11 entries, not the 17 a hand-written draft contained (several of which do not fold to ASCII)
- Scan for those markers **case-sensitively in a second pass**: `-i` folds the *pattern* too, so `ſ` would match every `s` and the filter would stop filtering
- Batch paths under `ARG_MAX`
- Disable line-level filtering for Codex entirely — `session_range` needs every record

## Verification

- **7 A/B cases × 5 configurations** (default, `--no-prefilter`, pre-change build, no scanner installed, grep-only) now agree on every one
- Tests **59 → 68**, including a **mutation check**: reverting each fix makes the new assertions fail (8 and 1 respectively), and restoring returns them to green
- `sync_core check` green across all four bundles; regression audit passed; gitleaks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XTEHpchL4co3YJnis6se8n