### PR TITLE
fix(transcript-fixer): protect ordinary words from false positives

### DIFF
--- a/daymade-audio/transcript-fixer/scripts/tests/test_common_words_safety.py
+++ b/daymade-audio/transcript-fixer/scripts/tests/test_common_words_safety.py
@@ -762,6 +762,21 @@ class TestProductionFalsePositives2026_06(unittest.TestCase):
         self.assertEqual(changes[0].risk, "medium")
 
 
+class TestProductionFalsePositives2026_08(unittest.TestCase):
+    """Regression tests for ordinary words seen in a 2026-08 corpus."""
+
+    def test_production_common_words_are_protected(self):
+        for source, target in (("买买", "卖卖"), ("争论", "蒸馏"), ("冲锋", "聪聪")):
+            with self.subTest(source=source):
+                self.assertIn(source, ALL_COMMON_WORDS)
+                errors = [
+                    warning
+                    for warning in check_correction_safety(source, target, strict=True)
+                    if warning.level == "error"
+                ]
+                self.assertTrue(errors, f"'{source}' must be blocked at --add time")
+
+
 class TestValidPhraseAuditHeuristic(unittest.TestCase):
     """
     jieba-based heuristic (is_likely_valid_phrase) for the 4+ char real-word

--- a/daymade-audio/transcript-fixer/scripts/utils/common_words.py
+++ b/daymade-audio/transcript-fixer/scripts/utils/common_words.py
@@ -103,6 +103,9 @@ COMMON_WORDS_2CHAR: Set[str] = {
     # here makes --add block the bad rule, _assess_risk flag it high, and
     # --audit surface it — the three guards that all read ALL_COMMON_WORDS.
     "龙虾", "多深", "早生",
+    # 2026-08 production corpus: all three appeared with their ordinary
+    # meanings and were proposed/replaced as person or domain terms.
+    "买买", "争论", "冲锋",
 }
 
 # Common 3+ character words that should also be protected.


### PR DESCRIPTION
## Summary
- protect three ordinary two-character words from automatic correction
- add production regression coverage for all three source/target pairs
- keep the public test context generic and non-identifying

## Verification
- full transcript-fixer common-word safety suite: 86 passed, 8 skipped
- mutation check: all three new subtests fail when the words are removed from the common-word SSOT
- skill quick validation passed
- independent fresh-context review: APPROVE