### PR TITLE
fix(marketplace): register sector research in suite

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -196,6 +196,7 @@
         "./financial-data-collector",
         "./gangtise-copilot",
         "./ashare-news-fetcher",
+        "./daymade-sector-research",
         "./pharma-daily-report"
       ]
     },


### PR DESCRIPTION
## Summary
- register the newly added sector-research skill in the daymade-financial suite
- restore the marketplace manifest invariant required by CI

## Verification
- `uv run python scripts/ci/check_marketplace.py`
- `git diff --check`