### PR TITLE
fix(skill-creator): audit_skill_regression compare can't survive a rename

### DIFF
--- a/daymade-skill/skill-creator/SKILL.md
+++ b/daymade-skill/skill-creator/SKILL.md
@@ -1280,6 +1280,16 @@ When editing, remember that the skill is being created for another instance of C
    `--baseline-origin git-ref:<ref>`. The tool resolves the ref to an immutable
    commit and verifies every included file and executable bit against that tree.
 
+   **Renaming or moving the skill directory itself** (not just editing its
+   contents) changes `--after`'s path, which both baseline modes use for
+   identity — `compare` rejects that by default (on the assumption `--before`/
+   `--after` were mismatched by accident) with `pre-edit snapshot source
+   identity does not match the edited skill`. Add `--renamed-from <old-path>`
+   (the path `--source` pointed at for `snapshot`, or the skill's old relative
+   path for `git-ref:`) to declare the rename explicitly; the identity check
+   then verifies that path instead of `--after`, while the content/tree-hash
+   check is untouched, so an actually-mismatched pairing still fails.
+
 4. Review every candidate. Use exactly one disposition and record concrete
    evidence/reason: `preserved_or_moved`, `intentional_sanitization`,
    `intentional_boundary`, `removed_by_explicit_user_request`, `not_reusable`,

--- a/daymade-skill/skill-creator/SKILL.md
+++ b/daymade-skill/skill-creator/SKILL.md
@@ -1258,9 +1258,26 @@ When editing, remember that the skill is being created for another instance of C
      --output <workspace>/skill-before
    ```
 
-   For a clean Git-tracked source, materialize the directory from the chosen ref.
+   For a clean Git-tracked source, materialize the directory from the chosen ref:
+
+   ```bash
+   mkdir -p <workspace>/skill-before   # tar -C requires the target to already exist
+   git -C <repo-containing-the-skill> archive <ref> <skill-dir-relative-to-repo-root> \
+     | tar -x -C <workspace>/skill-before
+   # lands at <workspace>/skill-before/<skill-dir>/SKILL.md — one level deeper than
+   # the snapshot subcommand's output, because `git archive` preserves the path
+   # prefix; --before in step 3 is <workspace>/skill-before/<skill-dir>, not
+   # <workspace>/skill-before itself.
+   ```
+
    Include SKILL.md, references, scripts, assets, workflows, and existing evals—not
    just the main prompt. Never copy the already-edited tree and label it "before".
+   **Use a directory nothing has extracted into before** — reusing one that already
+   has content from an earlier run lets `tar -x` silently overwrite same-named files
+   while leaving stale files the new archive doesn't contain untouched, producing a
+   mixed snapshot with zero signal at extract time (`compare` only catches it later,
+   indirectly, as a tree-hash mismatch). See "Concurrent sessions on the same skill
+   repo" below for the fuller version of this trap, including the `mv`-based variant.
 2. Inventory the old skill's actor/jobs, trigger contexts, runtime contracts,
    commands/flags, failure and recovery cases, page/domain variants, bundled
    resources, and eval coverage. Add preservation cases for important old edge
@@ -1285,10 +1302,20 @@ When editing, remember that the skill is being created for another instance of C
    identity — `compare` rejects that by default (on the assumption `--before`/
    `--after` were mismatched by accident) with `pre-edit snapshot source
    identity does not match the edited skill`. Add `--renamed-from <old-path>`
-   (the path `--source` pointed at for `snapshot`, or the skill's old relative
-   path for `git-ref:`) to declare the rename explicitly; the identity check
-   then verifies that path instead of `--after`, while the content/tree-hash
-   check is untouched, so an actually-mismatched pairing still fails.
+   (the path `--source` pointed at for `snapshot`, or the skill's old path
+   relative to its repo root for `git-ref:`) to declare the rename explicitly;
+   the identity check then verifies that path instead of `--after`, while the
+   content/tree-hash check is untouched, so an actually-mismatched pairing
+   still fails. **Pass `--renamed-from` as an absolute path.** Every path this
+   command takes resolves relative to the current working directory when given
+   as relative — not relative to `--after`, and not relative to each other —
+   and `--renamed-from` typically names a directory that no longer exists (it
+   was renamed away), so there's no existence check to catch a wrong
+   resolution the way there is for `--before`/`--after`; it just fails deeper,
+   confusingly. This bites skill-creator's own edits in particular: `cd
+   <skill-creator-path>` above is skill-creator's own repo, which is usually a
+   *different* repo from the skill being audited, so a relative
+   `--renamed-from` silently resolves against the wrong one.
 
 4. Review every candidate. Use exactly one disposition and record concrete
    evidence/reason: `preserved_or_moved`, `intentional_sanitization`,

--- a/daymade-skill/skill-creator/scripts/audit_skill_regression.py
+++ b/daymade-skill/skill-creator/scripts/audit_skill_regression.py
@@ -20,6 +20,11 @@ For a Git-tracked skill, reconstruct the old directory from Git and use
 ``--baseline-origin git-ref:<ref>``. The command resolves the ref to an immutable
 commit and rejects a ``before`` tree that does not match that exact Git tree.
 
+If the skill was renamed or moved (so ``--after`` is not at the same path the
+baseline was captured from), pass ``--renamed-from <old-path>`` to ``compare``
+to declare it explicitly; without it, a path change is rejected as an identity
+mismatch, on the assumption that ``--before``/``--after`` were paired by mistake.
+
     # Review every candidate in the JSON, then:
     python -m scripts.audit_skill_regression verify \
       --before /tmp/skill-before --after ./my-skill \
@@ -219,7 +224,19 @@ def _resolve_baseline_provenance(
     before: Path,
     after: Path,
     baseline_origin: str,
+    *,
+    renamed_from: Path | None = None,
 ) -> dict[str, Any]:
+    # Both provenance modes below identify the baseline by the SOURCE PATH the
+    # skill lived at when the baseline was captured, not by directory content.
+    # A skill rename changes that path on purpose while leaving the skill's
+    # identity and content otherwise intact, so a bare path match is too strict
+    # for that (legitimate, documented) operation. `renamed_from` is an explicit,
+    # narrow escape hatch — same shape as `--allow-identical-baseline` — that
+    # substitutes the declared old path for identity purposes ONLY; it does not
+    # touch either branch's content/tree-hash check, so a genuinely mismatched
+    # pairing (wrong skill entirely) still fails exactly as before.
+    identity_source = renamed_from.resolve() if renamed_from is not None else after.resolve()
     if baseline_origin == "test-fixture":
         return {"origin": "test-fixture"}
     if baseline_origin == "pre-edit-snapshot":
@@ -236,9 +253,14 @@ def _resolve_baseline_provenance(
             raise ValueError("pre-edit snapshot provenance uses an obsolete schema")
         if manifest.get("kind") != "skill-regression-pre-edit-snapshot":
             raise ValueError("pre-edit snapshot provenance has an invalid kind")
-        expected_source_hash = hashlib.sha256(str(after.resolve()).encode("utf-8")).hexdigest()
+        expected_source_hash = hashlib.sha256(str(identity_source).encode("utf-8")).hexdigest()
         if manifest.get("source_path_hash") != expected_source_hash:
-            raise ValueError("pre-edit snapshot source identity does not match the edited skill")
+            hint = (
+                " (pass --renamed-from <the path --source pointed at during snapshot> if the skill was renamed/moved)"
+                if renamed_from is None
+                else ""
+            )
+            raise ValueError(f"pre-edit snapshot source identity does not match the edited skill{hint}")
         if manifest.get("tree_hash") != tree_hash(before):
             raise ValueError("pre-edit snapshot content does not match its provenance manifest")
         created_at = manifest.get("created_at")
@@ -248,11 +270,14 @@ def _resolve_baseline_provenance(
             raise ValueError("pre-edit snapshot provenance timestamp is invalid") from error
         if parsed.tzinfo is None:
             raise ValueError("pre-edit snapshot provenance timestamp must include a timezone")
-        return {
+        provenance = {
             "origin": "pre-edit-snapshot",
             "created_at": created_at,
             "source_path_hash": manifest["source_path_hash"],
         }
+        if renamed_from is not None:
+            provenance["renamed_from"] = str(identity_source)
+        return provenance
     if baseline_origin.startswith("git-ref:"):
         requested_ref = baseline_origin.partition(":")[2].strip()
         if not requested_ref:
@@ -261,7 +286,7 @@ def _resolve_baseline_provenance(
             repo_value = _git_output(after, "rev-parse", "--show-toplevel")
             assert isinstance(repo_value, str)
             repo = Path(repo_value.strip()).resolve()
-            skill_rel = after.resolve().relative_to(repo)
+            skill_rel = identity_source.relative_to(repo)
             commit_value = _git_output(repo, "rev-parse", "--verify", f"{requested_ref}^{{commit}}")
             assert isinstance(commit_value, str)
             commit = commit_value.strip()
@@ -275,12 +300,15 @@ def _resolve_baseline_provenance(
             raise ValueError(
                 f"before tree does not match {requested_ref} for {skill_rel.as_posix()}"
             )
-        return {
+        provenance = {
             "origin": f"git-ref:{commit}",
             "requested_ref": requested_ref,
             "resolved_commit": commit,
             "skill_path": skill_rel.as_posix(),
         }
+        if renamed_from is not None:
+            provenance["renamed_from"] = str(identity_source)
+        return provenance
     raise ValueError("baseline origin must be pre-edit-snapshot or git-ref:<ref>")
 
 
@@ -661,13 +689,14 @@ def build_report(
     after: Path,
     *,
     baseline_origin: str = "test-fixture",
+    renamed_from: Path | None = None,
 ) -> dict[str, Any]:
     before = before.resolve()
     after = after.resolve()
     for label, root in (("before", before), ("after", after)):
         if not root.is_dir() or not (root / "SKILL.md").is_file():
             raise ValueError(f"{label} skill directory must contain SKILL.md: {root}")
-    provenance = _resolve_baseline_provenance(before, after, baseline_origin)
+    provenance = _resolve_baseline_provenance(before, after, baseline_origin, renamed_from=renamed_from)
 
     before_files = {str(rel).replace("\\", "/"): path for rel, path in _iter_files(before)}
     after_files = {str(rel).replace("\\", "/"): path for rel, path in _iter_files(after)}
@@ -1214,6 +1243,18 @@ def _parser() -> argparse.ArgumentParser:
         action="store_true",
         help="explicit bootstrap only: allow before and after to have the same tree hash",
     )
+    compare.add_argument(
+        "--renamed-from",
+        type=Path,
+        default=None,
+        help=(
+            "explicit rename declaration: the path --source pointed at when the baseline "
+            "was captured (snapshot) or the skill's old path in the baseline ref (git-ref). "
+            "Use when --after is at a different path than the baseline because the skill "
+            "was renamed or moved; the identity check verifies this path instead of --after, "
+            "so an undeclared path mismatch still fails exactly as before."
+        ),
+    )
     compare.add_argument("--json", action="store_true", help="also print the report JSON")
     verify = subparsers.add_parser("verify", help="verify a completed regression review")
     verify.add_argument("--before", required=True, type=Path)
@@ -1259,6 +1300,7 @@ def main(argv: list[str] | None = None) -> int:
                 args.before,
                 args.after,
                 baseline_origin=args.baseline_origin,
+                renamed_from=args.renamed_from,
             )
             if (
                 report["before"]["tree_hash"] == report["after"]["tree_hash"]

--- a/daymade-skill/skill-creator/scripts/audit_skill_regression.py
+++ b/daymade-skill/skill-creator/scripts/audit_skill_regression.py
@@ -255,11 +255,14 @@ def _resolve_baseline_provenance(
             raise ValueError("pre-edit snapshot provenance has an invalid kind")
         expected_source_hash = hashlib.sha256(str(identity_source).encode("utf-8")).hexdigest()
         if manifest.get("source_path_hash") != expected_source_hash:
-            hint = (
-                " (pass --renamed-from <the path --source pointed at during snapshot> if the skill was renamed/moved)"
-                if renamed_from is None
-                else ""
-            )
+            if renamed_from is None:
+                hint = " (pass --renamed-from <the path --source pointed at during snapshot> if the skill was renamed/moved)"
+            else:
+                hint = (
+                    f" (--renamed-from resolved to {identity_source} — verify this is exactly "
+                    "the absolute path --source pointed at during snapshot; a relative value "
+                    "resolves against the current working directory, not against --after)"
+                )
             raise ValueError(f"pre-edit snapshot source identity does not match the edited skill{hint}")
         if manifest.get("tree_hash") != tree_hash(before):
             raise ValueError("pre-edit snapshot content does not match its provenance manifest")
@@ -286,14 +289,35 @@ def _resolve_baseline_provenance(
             repo_value = _git_output(after, "rev-parse", "--show-toplevel")
             assert isinstance(repo_value, str)
             repo = Path(repo_value.strip()).resolve()
+        except subprocess.CalledProcessError as error:
+            raise ValueError(
+                "git-ref baseline requires --after to be inside a Git worktree"
+            ) from error
+        try:
             skill_rel = identity_source.relative_to(repo)
+        except ValueError as error:
+            # Distinct from the two except blocks around it: this is neither
+            # "not a Git worktree" nor "the ref doesn't resolve" — the path
+            # that failed here is whichever one identity now points at, and
+            # it isn't inside the same repo as --after. The likeliest cause,
+            # given both --before/--after/--renamed-from resolve relative to
+            # the CURRENT WORKING DIRECTORY when given as relative paths (not
+            # relative to each other), is that this ran from a different
+            # repo's directory than the skill being audited — a common shape
+            # for skill-creator itself, which normally lives in its own repo.
+            where = "--renamed-from" if renamed_from is not None else "--after"
+            raise ValueError(
+                f"{where} ({identity_source}) is not inside the Git repository containing "
+                f"--after ({repo}). If this path was given as relative, it resolved against "
+                "the current working directory, not against --after's location — pass an "
+                "absolute path to avoid the ambiguity."
+            ) from error
+        try:
             commit_value = _git_output(repo, "rev-parse", "--verify", f"{requested_ref}^{{commit}}")
             assert isinstance(commit_value, str)
             commit = commit_value.strip()
         except (subprocess.CalledProcessError, ValueError) as error:
-            raise ValueError(
-                "git-ref baseline requires the edited skill to be inside a Git worktree and the ref to resolve"
-            ) from error
+            raise ValueError(f"could not resolve ref {requested_ref!r} in {repo}") from error
         expected_hash = _git_tree_hash(repo, commit, skill_rel)
         actual_hash = tree_hash(before)
         if actual_hash != expected_hash:

--- a/daymade-skill/skill-creator/tests/test_audit_skill_regression.py
+++ b/daymade-skill/skill-creator/tests/test_audit_skill_regression.py
@@ -632,6 +632,88 @@ def test_pre_edit_snapshot_requires_tool_created_provenance(tmp_path):
     assert report["before"]["provenance"]["origin"] == "pre-edit-snapshot"
 
 
+def test_pre_edit_snapshot_rejects_undeclared_rename(tmp_path):
+    skill = _make_skill(tmp_path / "old-name", "- Keep offline recovery available.")
+    before = tmp_path / "before"
+    create_baseline_snapshot(skill, before)
+    renamed = tmp_path / "new-name"
+    skill.rename(renamed)
+
+    with pytest.raises(ValueError, match="does not match the edited skill"):
+        build_report(before, renamed, baseline_origin="pre-edit-snapshot")
+
+
+def test_pre_edit_snapshot_accepts_declared_rename(tmp_path):
+    skill = _make_skill(tmp_path / "old-name", "- Keep offline recovery available.")
+    before = tmp_path / "before"
+    create_baseline_snapshot(skill, before)
+    renamed = tmp_path / "new-name"
+    skill.rename(renamed)
+    (renamed / "SKILL.md").write_text(
+        (renamed / "SKILL.md").read_text(encoding="utf-8").replace(
+            "Keep offline recovery available", "Use the online workflow"
+        ),
+        encoding="utf-8",
+    )
+
+    report = build_report(
+        before, renamed, baseline_origin="pre-edit-snapshot", renamed_from=skill
+    )
+
+    assert report["before"]["provenance"]["origin"] == "pre-edit-snapshot"
+    assert report["before"]["provenance"]["renamed_from"] == str(skill.resolve())
+    assert any("offline recovery" in item["text"] for item in report["candidates"])
+
+    # A renamed_from pointing at the wrong old path must still fail — the
+    # override is a narrow substitution, not a way to skip identity checking.
+    with pytest.raises(ValueError, match="does not match the edited skill"):
+        build_report(
+            before, renamed, baseline_origin="pre-edit-snapshot", renamed_from=tmp_path / "wrong-old-name"
+        )
+
+
+def test_git_ref_baseline_accepts_declared_rename(tmp_path):
+    repo = tmp_path / "repo"
+    skill = _make_skill(repo / "old-name", "- Keep offline recovery available.")
+    before = tmp_path / "before"
+    subprocess.run(["git", "init", str(repo)], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.email", "user@example.com"], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.name", "Test User"], check=True)
+    subprocess.run(["git", "-C", str(repo), "add", "old-name"], check=True)
+    tree = subprocess.run(
+        ["git", "-C", str(repo), "write-tree"], check=True, capture_output=True, text=True
+    ).stdout.strip()
+    commit = subprocess.run(
+        ["git", "-C", str(repo), "commit-tree", tree, "-m", "baseline"],
+        check=True, capture_output=True, text=True,
+    ).stdout.strip()
+    subprocess.run(["git", "-C", str(repo), "symbolic-ref", "HEAD", "refs/heads/main"], check=True)
+    subprocess.run(["git", "-C", str(repo), "update-ref", "refs/heads/main", commit], check=True)
+    create_baseline_snapshot(skill, before)
+    renamed = repo / "new-name"
+    skill.rename(renamed)
+    (renamed / "SKILL.md").write_text(
+        (renamed / "SKILL.md").read_text(encoding="utf-8").replace(
+            "Keep offline recovery available", "Use the online workflow"
+        ),
+        encoding="utf-8",
+    )
+
+    # Undeclared: after moved out from under the ref-relative lookup path, so
+    # the tree lookup for the (now nonexistent) new-name path fails.
+    with pytest.raises(ValueError):
+        build_report(before, renamed, baseline_origin="git-ref:HEAD")
+
+    report = build_report(
+        before, renamed, baseline_origin="git-ref:HEAD", renamed_from=skill
+    )
+
+    assert report["before"]["provenance"]["origin"] == f"git-ref:{commit}"
+    assert report["before"]["provenance"]["skill_path"] == "old-name"
+    assert report["before"]["provenance"]["renamed_from"] == str(skill.resolve())
+    assert any("offline recovery" in item["text"] for item in report["candidates"])
+
+
 def test_compare_cli_rejects_identical_current_to_current_baseline(tmp_path, capsys):
     skill = _make_skill(tmp_path / "skill", "- Keep offline recovery available.")
     before = tmp_path / "before"

--- a/daymade-skill/skill-creator/tests/test_audit_skill_regression.py
+++ b/daymade-skill/skill-creator/tests/test_audit_skill_regression.py
@@ -672,6 +672,26 @@ def test_pre_edit_snapshot_accepts_declared_rename(tmp_path):
         )
 
 
+def test_pre_edit_snapshot_wrong_renamed_from_names_the_resolved_path(tmp_path):
+    # A wrong --renamed-from value used to produce the exact same bare error
+    # as no --renamed-from at all, with no way to tell "you forgot the flag"
+    # apart from "you passed the flag but got the value wrong" (independent
+    # review, 2026-08-15). The hint must now show what path renamed_from
+    # actually resolved to, so a wrong value is diagnosable from the error
+    # alone.
+    skill = _make_skill(tmp_path / "old-name", "- Keep offline recovery available.")
+    before = tmp_path / "before"
+    create_baseline_snapshot(skill, before)
+    renamed = tmp_path / "new-name"
+    skill.rename(renamed)
+    wrong_old_path = tmp_path / "wrong-old-name"
+
+    with pytest.raises(ValueError, match=r"--renamed-from resolved to .*wrong-old-name"):
+        build_report(
+            before, renamed, baseline_origin="pre-edit-snapshot", renamed_from=wrong_old_path
+        )
+
+
 def test_git_ref_baseline_accepts_declared_rename(tmp_path):
     repo = tmp_path / "repo"
     skill = _make_skill(repo / "old-name", "- Keep offline recovery available.")
@@ -712,6 +732,19 @@ def test_git_ref_baseline_accepts_declared_rename(tmp_path):
     assert report["before"]["provenance"]["skill_path"] == "old-name"
     assert report["before"]["provenance"]["renamed_from"] == str(skill.resolve())
     assert any("offline recovery" in item["text"] for item in report["candidates"])
+
+    # renamed_from resolving outside --after's repo (e.g. a relative path that
+    # resolved against the wrong cwd — the exact shape independent review hit
+    # running this from skill-creator's own, separate repo) must get a specific
+    # "not inside the Git repository containing --after" error, not the bare
+    # "requires the edited skill to be inside a Git worktree" message that used
+    # to also fire here and made this failure indistinguishable from --after
+    # genuinely not being in a worktree at all.
+    outside_repo_path = tmp_path / "not-in-repo-at-all"
+    with pytest.raises(ValueError, match="not inside the Git repository containing"):
+        build_report(
+            before, renamed, baseline_origin="git-ref:HEAD", renamed_from=outside_repo_path
+        )
 
 
 def test_compare_cli_rejects_identical_current_to_current_baseline(tmp_path, capsys):


### PR DESCRIPTION
## What broke

The existing-skill migration gate's `compare` command verifies identity between
`--before` (the pre-edit snapshot) and `--after` (the edited skill) before
producing a regression review. For `--baseline-origin pre-edit-snapshot`, it
hashes `--after`'s **absolute path** and compares it against the path recorded
when `snapshot --source` was run. For `--baseline-origin git-ref:<ref>`, it
looks up `--after`'s **relative path** inside the historical git tree.

Both checks assume the skill's path is unchanged between snapshot-time and
compare-time. That assumption breaks for the one operation this exact tool's
own SKILL.md documents extensively elsewhere: **renaming a skill**. Any
legitimate rename hits a hard `pre-edit snapshot source identity does not
match the edited skill` (or an equivalent git-ref lookup failure), with no
documented way to proceed short of hand-editing the provenance manifest —
which the tool's own docs explicitly warn against (`.skill-regression-*`
markers are described as things you should never hand-edit).

## The fix

Add an explicit `--renamed-from <old-path>` flag to `compare`. When given, the
identity check verifies *that* declared path instead of `--after`'s current
path/relative-path — for both baseline-origin modes. The content/tree-hash
checks (`tree_hash(before)` vs the manifest, and `before`'s tree vs the
historical git ref) are **untouched**, so an undeclared path change, or a
`--renamed-from` pointing at the wrong old path, still fails exactly as
before. Same design as the existing `--allow-identical-baseline` flag: a
narrow, explicit, opt-in override for one named legitimate scenario, not a
general relaxation.

The provenance recorded in the report now includes `renamed_from` when the
flag is used, so a reviewer can see a rename was declared and what the old
path was.

Also documented the flag in SKILL.md's migration-gate walkthrough, right next
to the existing `compare` example, so the next rename doesn't rediscover this
the same way.

## How this was found

Renaming a skill (`transcript-research-brief` → `fact-check-pro`) in a
private sibling skill repo today, following this exact skill's own
"existing-skill migration gate" procedure. `snapshot` succeeded; `compare`
failed with the identity error above. Read the source
(`_resolve_baseline_provenance`, lines ~218–256 before this change) and
confirmed the root cause is the absolute-path hash. Verified via `git diff`
that the rename itself preserved 100% of content (git's rename detection
made this exact and complete) and used that as the regression check for that
specific rename, since this tool structurally couldn't run.

## Testing

- All 35 existing tests in `tests/test_audit_skill_regression.py` still pass
  unchanged (ran before and after the fix).
- 3 new tests added, covering both baseline-origin modes:
  - `test_pre_edit_snapshot_rejects_undeclared_rename` — confirms the
    **default (no flag) behavior is unchanged**: an undeclared rename still
    fails with the same error as before.
  - `test_pre_edit_snapshot_accepts_declared_rename` — confirms a declared
    rename succeeds, the report records `renamed_from`, and a
    `--renamed-from` pointing at the *wrong* old path still fails (the
    override doesn't degrade into "skip identity checking").
  - `test_git_ref_baseline_accepts_declared_rename` — same shape for the
    `git-ref:` baseline-origin mode, including an undeclared-rename negative
    case.
  - 38/38 green in a fully isolated fresh clone (not just the working copy
    the fix was written in).
- End-to-end CLI smoke test (not just the Python API): snapshot → rename the
  directory → `compare` without the flag (reproduces the original failure,
  now with an improved error message pointing at `--renamed-from`) →
  `compare` with the flag (succeeds, `report.json` provenance shows
  `renamed_from`).

## Scope

Touches only `daymade-skill/skill-creator/{SKILL.md, scripts/audit_skill_regression.py, tests/test_audit_skill_regression.py}`. No other files. No new dependencies, no new capability beyond making an already-documented, already-supported operation (skill rename) actually work with the migration-gate tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DcR3tHN3tKMy9WnYRJJZKk