### PR TITLE
docs(claude-code-hooks): three gaps found by actually building a guard with this skill

### DIFF
--- a/daymade-claude-code/claude-code-hooks/SKILL.md
+++ b/daymade-claude-code/claude-code-hooks/SKILL.md
@@ -147,6 +147,19 @@ a guard people must bypass gets bypassed reflexively, and then it protects
 nothing (the core discipline: *误杀健康输入比漏报更糟*). The recurring cause of
 false-blocks is matching on the raw command string.
 
+**Corollary — the escape hatch should be the correct usage, not a bypass flag.**
+Every guard needs a way out for the legitimate case it cannot distinguish; the
+question is what you make that way out *be*. A `SKIP=1` / `--force` / env-var
+escape trains the exact reflex the paragraph above warns about, and it is
+indistinguishable from a bypass when someone reaches for it under deadline. Prefer
+an escape that is **the thing you wanted them to do anyway**, so taking it improves
+the command instead of disarming the guard: `pipe-fallback-guard` exits 0 the moment
+the command mentions `pipefail` / `PIPESTATUS` / `pipestatus`, because an author who
+wrote any of those has already demonstrated they understand pipeline exit codes —
+the guard has nothing left to teach them. The test to apply: *if someone takes my
+escape hatch, is the resulting command better or merely unblocked?* If the honest
+answer is "merely unblocked", the guard has a bypass flag with a nicer name.
+
 - **Wrong**: `awk '{gsub(/&&|\|\||;|\|/,"\n")}'` to split into segments — awk
   doesn't understand shell quoting, so `grep -E "a|TRIGGER|b"` gets split at the
   `|` *inside the quoted regex*, `TRIGGER` becomes a phantom command, and the
@@ -766,7 +779,42 @@ wall time.
 2. Write the script in the SSOT dir; `chmod +x`.
 3. **Detection** with shlex token-level matching (rule 1), keyed on a fact the
    world can answer rather than your own rendering or a naming convention (rule 6).
+   - **First check whether ShellCheck already decides it — then record the answer,
+     because the next author will ask the same question.** It is the de-facto standard
+     for shell anti-patterns, so "why didn't you just use shellcheck" is the first
+     thing a reviewer asks. Measured 2026-08-15 on **0.11.0** against
+     `find . -name x | head -5 || echo "no"` — a fallback that provably can never fire,
+     because `||` binds to the pipeline's **last** stage and `head` exits 0 on empty
+     input: **default config reports nothing, exit 0**. `--enable=all` surfaces
+     **SC2312** (`check-extra-masked-returns`), but it fires on `cmd | jq . || echo bad`
+     too, where the last stage genuinely can fail and the fallback is meaningful.
+     Three reasons that disqualifies it as *the gate* — each one generalizes:
+     it is **off by default** (so it is not protecting anyone today), it cannot
+     distinguish a dead fallback from a live one (blanket firing = the rule-1
+     false-block spiral), and its own suggested remedy is "use `|| true` to ignore",
+     the opposite of the intent. It also lints **files**, not tool-call events.
+     The general shape of the answer: the standard linter is the right thing to
+     **check** and usually the wrong thing to **delegate a blocking gate to**, because
+     linters are tuned for advisory breadth and a gate needs precision. Your hook's
+     contribution is that precision. Shipped example: `pipe-fallback-guard`, whose
+     precision lives in a small list of last-stage commands that actually swallow the
+     upstream code (`head`/`tail`/`wc`/`cat`/`sort`/…) and which deliberately excludes
+     `grep`/`jq`/`awk`/`sed` because those fail for real.
 4. **`bash -n` + `test_hook.sh`** with trigger AND healthy-lookalike cases (rule 2) — do not register until green. Include the shapes that carry an unexpanded path (`cd ~/elsewhere && …`, rule 5); if the hook has a human gate, a forced-decline row (Pattern B, "Make the gate testable"); and if it demands remediation, the **after-remediation row pair** — fires without the receipt, quiet with it (template in `scripts/test_hook.sh`; rule 7 — point-in-time fixtures structurally cannot see non-termination).
+   - **Give the hook a `--selftest` mode, and make it bidirectional.** Then have the
+     SessionStart guard-rail health check (see "Hook types" above — the one whose whole
+     job is checking the guards themselves) invoke `<hook> --selftest` for every
+     installed hook that offers one. This is the only automatic check that catches the
+     failure `bash -n` and the registration check both structurally miss: a hook that has
+     **degraded into a permanent no-op**. That failure is invisible by construction —
+     a guard that never fires produces output identical to a session with nothing to
+     report, which is why it can persist for weeks. Feed it **two** fixtures, never
+     one: a must-block sample *and* a must-pass sample, so it catches "stopped firing"
+     and "started false-blocking" alike. Then calibrate it the way you calibrate the
+     suite — break the detector on purpose and confirm `--selftest` exits non-zero;
+     a selftest that has never been seen to fail is indistinguishable from `exit 0`.
+     Keep it to two probes: it runs at every session start, so its cost is paid
+     constantly while its job is only to prove the hook is still alive.
 5. **Replay a real command corpus and hand-check every block** (rule 9) — this measures the
    false-block surface, which the fixture table in step 4 structurally cannot. Slice the
    shipped detector out verbatim to pre-filter; feed each candidate **to** the real hook

--- a/daymade-claude-code/claude-code-hooks/SKILL.md
+++ b/daymade-claude-code/claude-code-hooks/SKILL.md
@@ -147,18 +147,6 @@ a guard people must bypass gets bypassed reflexively, and then it protects
 nothing (the core discipline: *误杀健康输入比漏报更糟*). The recurring cause of
 false-blocks is matching on the raw command string.
 
-**Corollary — the escape hatch should be the correct usage, not a bypass flag.**
-Every guard needs a way out for the legitimate case it cannot distinguish; the
-question is what you make that way out *be*. A `SKIP=1` / `--force` / env-var
-escape trains the exact reflex the paragraph above warns about, and it is
-indistinguishable from a bypass when someone reaches for it under deadline. Prefer
-an escape that is **the thing you wanted them to do anyway**, so taking it improves
-the command instead of disarming the guard: `pipe-fallback-guard` exits 0 the moment
-the command mentions `pipefail` / `PIPESTATUS` / `pipestatus`, because an author who
-wrote any of those has already demonstrated they understand pipeline exit codes —
-the guard has nothing left to teach them. The test to apply: *if someone takes my
-escape hatch, is the resulting command better or merely unblocked?* If the honest
-answer is "merely unblocked", the guard has a bypass flag with a nicer name.
 
 - **Wrong**: `awk '{gsub(/&&|\|\||;|\|/,"\n")}'` to split into segments — awk
   doesn't understand shell quoting, so `grep -E "a|TRIGGER|b"` gets split at the
@@ -289,6 +277,23 @@ skeleton: Pattern C in [references/hook_patterns.md](references/hook_patterns.md
   and/or a typed `YES` on `/dev/tty` (model can't type into the user's terminal);
   refuse/cancel/timeout = hard NO; log every prompt/bypass to an audit file.
   Pattern in [references/hook_patterns.md](references/hook_patterns.md).
+  - **Below Tier-0, where a model-serviceable escape *is* allowed, make it the
+    correct usage rather than a bypass flag.** The rule above is absolute for Tier-0
+    and does not bend here — this is about the correctness guards that fall short of
+    it, which still need a way out for the legitimate case the detector cannot
+    distinguish. The question is what you make that way out *be*. A `SKIP=1` /
+    `--force` env escape trains exactly the reflex rule 1 warns about, and under
+    deadline it is indistinguishable from a bypass. Prefer an escape that is **the
+    thing you wanted them to do anyway**, so taking it improves the command instead of
+    disarming the guard: `pipe-fallback-guard` exits 0 the moment the command mentions
+    `pipefail` / `PIPESTATUS` / `pipestatus`, because an author who wrote any of those
+    has already demonstrated they understand pipeline exit codes — the guard has
+    nothing left to teach them. The test to apply: *if someone takes my escape hatch,
+    is the resulting command better, or merely unblocked?* If the honest answer is
+    "merely unblocked", you have a bypass flag with a nicer name. Sibling principle
+    for the Tier-0 case, where the override exists only so the gate can be tested:
+    **the escape hatch may only make the gate stricter** — see the `GIT_GUARD_TEST`
+    discussion in [references/hook_patterns.md](references/hook_patterns.md).
 
 ### 5. Decide the failure **direction**, and test *that* — not just the happy path
 
@@ -788,7 +793,7 @@ wall time.
      input: **default config reports nothing, exit 0**. `--enable=all` surfaces
      **SC2312** (`check-extra-masked-returns`), but it fires on `cmd | jq . || echo bad`
      too, where the last stage genuinely can fail and the fallback is meaningful.
-     Three reasons that disqualifies it as *the gate* — each one generalizes:
+     Three reasons that disqualify it as *the gate* — each one generalizes:
      it is **off by default** (so it is not protecting anyone today), it cannot
      distinguish a dead fallback from a live one (blanket firing = the rule-1
      false-block spiral), and its own suggested remedy is "use `|| true` to ignore",
@@ -805,16 +810,26 @@ wall time.
      SessionStart guard-rail health check (see "Hook types" above — the one whose whole
      job is checking the guards themselves) invoke `<hook> --selftest` for every
      installed hook that offers one. This is the only automatic check that catches the
-     failure `bash -n` and the registration check both structurally miss: a hook that has
+     failure `bash -n` and steps 4-7 below both structurally miss: a hook that has
      **degraded into a permanent no-op**. That failure is invisible by construction —
      a guard that never fires produces output identical to a session with nothing to
-     report, which is why it can persist for weeks. Feed it **two** fixtures, never
-     one: a must-block sample *and* a must-pass sample, so it catches "stopped firing"
-     and "started false-blocking" alike. Then calibrate it the way you calibrate the
-     suite — break the detector on purpose and confirm `--selftest` exits non-zero;
-     a selftest that has never been seen to fail is indistinguishable from `exit 0`.
-     Keep it to two probes: it runs at every session start, so its cost is paid
-     constantly while its job is only to prove the hook is still alive.
+     report, which is why it can persist for weeks. Two fixtures is the *floor*, not
+     the target: a must-block sample **and** a must-pass sample, so it catches "stopped
+     firing" and "started false-blocking" alike — one of either kind alone cannot.
+     **Size it by mutants killed, not by a fixture count**, and calibrate the way you
+     calibrate the suite: break the detector on purpose and confirm `--selftest` exits
+     non-zero. A selftest never seen to fail is indistinguishable from `exit 0`.
+     Measured on the shipped `compounding-edit-review`: its **first version's two
+     fixtures killed only 4 of 14 mutants** — every behavior its own comments declared
+     load-bearing had zero coverage, including a mutation that short-circuits the
+     anti-loop check while the selftest still printed OK. It now runs 58 cases.
+     The real constraint is not fixture count but **wall-clock at session start**,
+     where this is paid on every session: those 58 cases measure **~5.3 s**, against
+     **~140 ms** for a two-probe liveness check. When killing the mutants pushes you
+     past that budget, **split** rather than shrink — a cheap fixed-size liveness probe
+     on `--selftest`, the full regression battery in `test_hook.sh` at build time.
+     Shrinking below the mutant-kill line just buys back a selftest that passes
+     while the guard is dead.
 5. **Replay a real command corpus and hand-check every block** (rule 9) — this measures the
    false-block surface, which the fixture table in step 4 structurally cannot. Slice the
    shipped detector out verbatim to pre-filter; feed each candidate **to** the real hook


### PR DESCRIPTION
Built a real PreToolUse guard using this skill, and hit three things it doesn't cover — each of which every hook author will hit. 63 lines added, **0 removed**.

## ⚠️ Merge-order note — read before merging

`perf/history-search-date-prefilter` (pushed at `e9c8235`, no PR yet) carries two rounds of independent-review work on **this same file**, and one of its hunks edits the exact bullet this PR attaches to — *"If the guard needs a release valve, make it a human gate, not an env var"* — appending its own nested `⚠️ /dev/tty` sub-bullet there.

**This PR will conflict with that branch at that anchor.** The resolution is trivial and non-semantic: both sub-bullets belong under the same parent and neither contradicts the other. Keep both, `⚠️ /dev/tty` first, then `Below Tier-0`. Merging that branch first and rebasing this one is the cleaner order, since it is the more mature work on this file.

## 1. Check ShellCheck first — and record the answer (build order, step 3)

It is the de-facto standard for shell anti-patterns, so *"why didn't you just use shellcheck"* is the first thing a reviewer asks. Without the answer written down, every author re-derives it.

Measured on **0.11.0** against `find . -name x | head -5 || echo "no"` — a fallback that provably cannot fire, since `||` binds to the pipeline's **last** stage and `head` exits 0 on empty input:

| | Result |
|---|---|
| default config | **nothing reported, exit 0** |
| `--enable=all` | `SC2312` (`check-extra-masked-returns`) fires |
| same rule on `cmd \| jq . \|\| echo bad` (a **live** fallback) | **fires identically** |

Three reasons that disqualifies it as *the gate*, each generalizing beyond this case: it is **off by default** (protecting nobody today), it **cannot distinguish a dead fallback from a live one** (blanket firing is the rule-1 false-block spiral), and its own suggested remedy is *"use `|| true` to ignore"* — the opposite of the intent. It also lints **files**, not tool-call events.

General shape: **the standard linter is the right thing to check and usually the wrong thing to delegate a blocking gate to** — linters are tuned for advisory breadth, a gate needs precision.

## 2. Give the hook a `--selftest`, sized by mutants killed (build order, step 4)

The pattern existed informally in `hook_pitfalls.md` but was never in the build-order checklist. It is the only automatic check for the one failure `bash -n` and registration both structurally miss: **a hook degraded into a permanent no-op** — invisible by construction, because a guard that never fires produces output identical to a session with nothing to report.

The sizing rule is the part worth having, and it came from being wrong first. An earlier draft of this PR said *"keep it to two probes"*. That is refuted by the shipped `compounding-edit-review`, whose own header records: **its first version's two fixtures killed only 4 of 14 mutants** — every behavior its comments declared load-bearing had zero coverage, including a mutation short-circuiting the anti-loop check while the selftest still printed OK. It now runs 58 cases.

So: two fixtures is the **floor** (one must-block + one must-pass; either kind alone is blind in one direction), and you size up by **mutants killed**. The real constraint is session-start wall-clock — measured **~5.3 s** for those 58 cases vs **~140 ms** for a two-probe liveness check. When killing the mutants exceeds that budget, **split** rather than shrink: cheap liveness probe on `--selftest`, full battery in `test_hook.sh` at build time.

## 3. Below Tier-0, make the escape hatch the correct usage (nested under rule 4)

Rule 4 is absolute for Tier-0 and this does not bend it — it addresses the correctness guards that fall short of Tier-0, which still need a way out for the legitimate case the detector cannot distinguish.

A `SKIP=1` / `--force` escape trains exactly the reflex rule 1 warns about. Prefer an escape that is **the thing you wanted them to do anyway**, so taking it improves the command instead of disarming the guard. The test: *if someone takes my escape hatch, is the resulting command better, or merely unblocked?* Cross-referenced to the sibling Tier-0 principle already in `hook_patterns.md` (*"the escape hatch may only make the gate stricter"*), which points the other way mechanically and reads as tension until you work it out.

Placed as a **nested** bullet under rule 4's human-gate rule specifically so the Tier-0 scoping is structural rather than a qualifier someone can read past.

## Verification

- `quick_validate` → valid
- Existing-skill migration gate (`audit_skill_regression compare`) → **0 candidates, 716 exact preservations**. It earned its keep: it caught a real defect this PR introduced — a sub-bullet insertion had pushed the back half of step 4 to the end of the new text, where it read as part of the selftest advice. Fixed, re-run clean.
- One fresh-context independent review, which re-ran shellcheck itself and reproduced every measured claim; all three of its substantive findings were verified and applied (they are what produced §2's refutation and §3's placement).
- No step renumbering: `step 4` is cross-referenced elsewhere in the file, so both additions extend existing steps in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)