### PR TITLE
docs(hook-pitfalls): 订正 #32 第 1 条修法——我推荐的 assert 实测是 fail-OPEN 的

### DIFF
--- a/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
+++ b/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
@@ -1476,11 +1476,26 @@ this list and describe defects you reach by asking a different question):
 
 **Fixes, in the order they buy the most:**
 
-1. **Make the invariant executable, not documentary.** `assert len(qmask)
-   == len(out)` immediately after the loop costs nothing and converts a
-   silent misalignment into a loud failure. A comment saying "these must
-   stay equal" is not enforcement; the next person appending a branch will
-   not read it. Better still, remove the invariant's ability to break:
+1. **Make the invariant executable, not documentary — but check which way
+   your "loud failure" actually falls.** A comment saying "these must stay
+   equal" is not enforcement; the next person appending a branch will not
+   read it. The reflex is `assert len(qmask) == len(out)` — and in this
+   guard that reflex was **measured to be wrong, in the dangerous
+   direction**. This block returns its verdict on **stdout** (the shell does
+   `FORM=$(python3 …)`) and always `sys.exit(0)` itself, so an uncaught
+   `AssertionError` prints nothing to stdout, leaves `FORM` empty, reads as
+   "no violation found", and exits the hook **1** — and PreToolUse treats
+   any nonzero-but-not-2 as a non-blocking error, so the tool runs anyway.
+   Forcing the assertion to fire measured exactly that: `git commit -a -m x`
+   → exit 1 → allowed. Replacing it with an explicit `if len(qmask) !=
+   len(out): report_violation()` measured exit 2 for both the dangerous and
+   the healthy command — conservative, which is the correct direction for a
+   Tier-0 gate. **Generalize: whether a tripwire is fail-open or fail-closed
+   is a property of how *the call site consumes the result*, not of the
+   language construct.** The same `assert` is fail-closed in a hook whose
+   exit code is the verdict and fail-open in a block whose stdout is the
+   verdict. Determine this by forcing the failure and reading the exit code,
+   not by intuition. Better still, remove the invariant's ability to break:
    append `(char, in_quote)` **tuples** to one array so no branch *can*
    update one without the other. Two arrays that must stay in lockstep are
    a data-structure choice you can simply decline to make.


### PR DESCRIPTION
接 #297。那个 PR 把 `assert len(qmask) == len(out)` 当作首选修法推荐；
把它落地到守卫本体时**实测发现方向正好是反的**，这里订正。

## 为什么 assert 在那个调用点是 fail-OPEN

该 python 块的判定结果**不靠退出码、靠 stdout** 回传给 shell
（`FORM=$(python3 …)`），且它自己一律 `sys.exit(0)` 收尾。所以：

未捕获 `AssertionError` → stdout 空 → `FORM` 空 → 被读成「没有违规」
→ hook 退出 **1**；而 PreToolUse **只认 exit 2 为 block**，非 2 的非零是
「非阻断错误、工具照常执行」。

| 变体 | `git commit -a -m x` | `git commit -m x` |
|---|---|---|
| 强制触发 assert | **exit=1 → 放行** ❌ | exit=1 |
| 改成显式失配分支 | exit=2 ✅ | exit=2 ✅（保守方向） |

## 沉淀下来的判据

> **一个绊线是 fail-open 还是 fail-closed，是「调用点怎么消费结果」的属性，
> 不是语言构造的属性。**

同一个 `assert`，放在「退出码即判定」的 hook 里是 fail-closed，放在
「stdout 即判定」的块里就是 fail-open。**判定方法是强制触发一次、读退出码**，
不是靠直觉——我就是靠直觉写下那条推荐的。

「不如改存元组、从结构上消灭断裂可能」那半句保留，它本来就是更好的答案。

守卫本体的对应修复在私有仓（`daymade/scripts` 93b9b9b）；套件仍 74-0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)