### PR TITLE
docs(hook-pitfalls): #33 基于 shlex 的守卫看见的是你打的字，不是 bash 构造的 argv

### DIFF
--- a/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
+++ b/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
@@ -1527,3 +1527,86 @@ this list and describe defects you reach by asking a different question):
    triggers it is trivially constructible and entirely ordinary (a comment
    above a commit). Frequency data tells you whether you were lucky, not
    whether the gate holds.
+
+## 33. A shlex-based guard sees the text you typed, not the argv bash builds — every shell expansion is a hole in it
+
+> Worked example: `git-commit-form-guard.sh` (a private hooks repo, not
+> shipped here), 2026-08-16, found by an independent fresh-context reviewer
+> after the author had already declared the guard sound. Three separate,
+> zero-setup, everyday-syntax ways to make the guard's own target form
+> (`git commit -a`) invisible to it, all present since the guard's earliest
+> commit, one of them pushed all the way through to a real `git commit` that
+> genuinely swept uncommitted work into the tree.
+
+- **Symptom:** the guard blocks `git commit -a -m x` (exit 2) and allows all
+  of these (exit 0), each of which bash executes as *exactly that command*:
+
+  | typed | bash's real argv |
+  |---|---|
+  | `git commit {-a,-m} x` | `commit` `-a` `-m` `x` (brace expansion) |
+  | `git commit $'-a' -m x` | `commit` `-a` `-m` `x` (ANSI-C quoting) |
+  | `git${IFS:0:1}commit${IFS:0:1}-a` | `git` `commit` `-a` (IFS as separator) |
+
+- **Cause — a category error about what the tokenizer is for.** `shlex` is a
+  *lexer*: it splits text into words and handles quoting. Bash, before it
+  ever has an argv, additionally performs brace expansion, tilde expansion,
+  parameter/variable expansion, command substitution, arithmetic expansion,
+  word splitting, and pathname expansion. `shlex` does **none** of these and
+  never claims to. So `{-a,-m}` arrives as one literal token beginning with
+  `{`, which never reaches a flag scanner that only fires on tokens
+  beginning with `-`. The guard is not buggy in its own terms; it is
+  answering a different question than the one that matters ("what did the
+  user type" vs "what will actually run").
+
+- **Why this outranks the disclaimer the guard already had.** This guard
+  already declared variable indirection (`G=git; $G commit -am`) an accepted
+  false negative. That disclaimer does not cover these: `$G` requires the
+  user to have written an assignment first, whereas all three above are
+  zero-setup and are ordinary syntax people type for non-evasive reasons
+  (`cp file.{txt,bak}` is completely normal). "We accept some
+  under-detection" is a budget, and it silently overran — the accepted case
+  was narrow and these are broad.
+
+- **Why the author didn't find it and the reviewer did.** The author's own
+  adversarial sweep (26 dangerous forms) was built from *the mechanism he
+  had just fixed* — comments, redirects, line continuations, quoting. Not
+  one case used a shell expansion, because expansions were not part of the
+  bug he had in mind. A fresh-context reviewer, given only "find any
+  remaining bypass," had no such anchor. **Generalize: your own bypass
+  hunt is shaped by the bug you just fixed, and is therefore blindest
+  exactly where the next bug lives.**
+
+**Fixes, in the order they buy the most:**
+
+1. **Decide explicitly whether you are guarding text or argv, and write it
+   down.** If argv, a lexer alone cannot get you there and every expansion
+   is an open hole. If text (a reasonable choice for a cheap PreToolUse
+   guard), then the accepted-under-detection list must name the expansion
+   classes, not just the one you happened to think of.
+2. **Normalize the expansions you can, on raw text, outside quotes, before
+   tokenizing.** You do not need to *implement* bash expansion — you need
+   only to stop the expansion from *hiding a flag*. Rewriting `{a,b}` to
+   ` a b `, `$'x'` to `x`, and `${IFS…}` to a space is a few dozen lines and
+   restores the flags as independent tokens the existing logic already
+   understands. Constrain the brace rule to groups that contain a comma and
+   no whitespace, or you will eat `find -exec {} \;` and `awk '{print $1}'`.
+3. **Prove the exploit against real bash before you fix, and against real
+   bash after.** A guard-parser disagreement is not automatically a
+   vulnerability — the reviewer here correctly discarded one candidate
+   (`{-a,} -m x`) after finding that real `git` rejects it with `fatal:
+   paths … with -a does not make sense`. Dump argv with a probe script that
+   just prints `"$@"`; that is the ground truth, not your reading of the
+   man page.
+4. **Measure the fix against a real corpus, in both directions.** Here:
+   27,641 real commands containing `commit` / brace-with-comma / `IFS` /
+   `$'`, run through pre-fix and post-fix binaries, **zero exit-code
+   differences** — three complete bypasses closed with provably no
+   real-world behavior change. Without that number, "I added a normalizer to
+   a Tier-0 gate" is an unbounded false-positive risk, and false positives
+   on a gate are worse than the gap you closed.
+5. **Keep the positive controls that pass in BOTH versions.** The
+   calibration run against the pre-fix binary should redden *only* the
+   bug-specific cases (here 11 of them: 8 bypasses + 3 false blocks), while
+   `cp file.{txt,bak}` and "braces appearing inside a commit message as
+   data" stay green on both. A positive control that only passes after the
+   fix is not a control — it is another regression test riding along.


### PR DESCRIPTION
接 #297 / #298。fresh-context 独立审阅在我**已宣布守卫可靠之后**，找出三条
零设置、日常语法的完全绕过——都让守卫的目标形态 `git commit -a` 对它隐形。

## 三条绕过（均已用 probe 脚本核过真实 argv）

| 打的字 | bash 真实 argv |
|---|---|
| `git commit {-a,-m} x` | `commit` `-a` `-m` `x`（花括号展开） |
| `git commit $'-a' -m x` | `commit` `-a` `-m` `x`（ANSI-C 引用） |
| `git${IFS:0:1}commit${IFS:0:1}-a` | `git` `commit` `-a`（IFS 当分隔符） |

其中 `{-a,-m}` 被审阅者推到**真 git 执行**，真把未提交改动卷进了工作树。
三条都可回溯到守卫最早的提交，不是新引入的。

## 根因是范畴错误

`shlex` 是**词法器**：切词 + 处理引号。而 bash 在拿到 argv 之前还要做
花括号/波浪号/参数/命令替换/算术展开、词分割、路径名展开——`shlex` 一个都不做，
也从没声称要做。所以 `{-a,-m}` 作为一个以 `{` 开头的字面 token 到达，
永远进不了只对 `-` 开头 token 生效的旗标扫描器。

守卫按自己的口径没 bug，它只是在回答**另一个问题**：
「用户打了什么」而不是「实际会跑什么」。

## 两条元教训（条目正文里的重点）

1. **自己的绕过排查会被"刚修的那个 bug"塑形，因而恰好在下一个 bug 所在处最盲。**
   我那轮对抗测试 26 条危险形态，全部围绕注释/重定向/续行/引号——
   零条用到 shell 展开，因为展开不在我当时脑子里的那个 bug 里。
2. **「我们接受一部分漏报」是预算，会悄悄超支。** 该守卫早已声明放弃变量间接
   （`$G commit -am`），但那要求先写一条赋值语句；这三条零设置，
   且是人们出于非规避理由天天在打的语法（`cp file.{txt,bak}` 完全日常）。

## 附带修掉的一条误杀（Finding C）

`N>&word` 只有 word **整个是数字**时才是 fd dup，否则是**到文件的重定向**
（实测 `2>&1x` 真在磁盘建出名为 `1x` 的文件）。原正则只写了纯数字那支，
于是 `git commit -- 2>&1x` 被误杀。

## 数字

- 守卫套件 77 → 97 全绿
- 双向标定（指向修复前版本）：86 pass / 11 fail，红的**恰好**是 8 条绕过 + 3 条误杀，
  无一旁落；正控（`cp file.{txt,bak}` / `awk '{print $1}'` / `find -exec {} \;` /
  message 里写花括号是数据）在**两版都绿**——证明它们不是靠修复才通过的
- 真实语料 A/B：27,641 条相关命令跑前后两版，**退出码差异 0 条**

给 Tier-0 闸门加归一化器却不给最后这个数字，就是无界的误杀风险——
而闸门上的误杀比刚补的那个洞更糟。

守卫本体修复在私有仓（`daymade/scripts` f0ff4a3）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)