### PR TITLE
chore(ci): upgrade GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -29,10 +29,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -57,7 +57,7 @@ jobs:
           npx vitest run tests/benchmark/scrape-benchmark.ts --reporter=verbose 2>&1 | tee scrape-benchmark.log
 
       - name: Upload benchmark results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: scrape-benchmark-results
@@ -92,10 +92,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -111,7 +111,7 @@ jobs:
           npx vitest run tests/benchmark/annotation-accuracy.ts --reporter=verbose 2>&1 | tee annotation-accuracy.log
 
       - name: Upload benchmark results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: annotation-accuracy-results
@@ -147,10 +147,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
 
       - name: Generate combined report
         run: |
@@ -171,14 +171,14 @@ jobs:
           fi
 
       - name: Upload combined report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: full-benchmark-report
           path: benchmark-report.md
 
       - name: Create GitHub Issue on failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             github.rest.issues.create({

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # The manifest every `/plugin marketplace add` reads. A source that no longer
       # resolves breaks installation for everyone, and no skill imports this file, so
@@ -47,14 +47,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # The check compares against the merge base; a shallow clone has no such base,
           # and comparing against a base you do not actually have is how you get a
           # confident wrong answer.
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 
@@ -82,9 +82,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # Pinned to the same version .pre-commit-config.yaml uses, so local and CI agree.
       # A pinned binary rather than a third-party action: one less thing in the supply

--- a/daymade-audio/transcript-fixer/references/team_collaboration.md
+++ b/daymade-audio/transcript-fixer/references/team_collaboration.md
@@ -271,7 +271,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Validate JSON is well-formed
         run: |
           for f in *.json; do python -m json.tool "$f" > /dev/null; done

--- a/iOS-APP-developer/references/apple-codesign-notarize.md
+++ b/iOS-APP-developer/references/apple-codesign-notarize.md
@@ -140,7 +140,7 @@ const CODESIGN_IDENTITY = process.env.CODESIGN_IDENTITY || 'Developer ID Applica
       if (/\.(so|dylib|node)$/.test(filePath)) return false;
       return true;
     },
-    // CI: apple-actions/import-codesign-certs@v3 imports to signing_temp.keychain,
+    // CI: apple-actions/import-codesign-certs@v7 imports to signing_temp.keychain,
     // but @electron/osx-sign searches system keychain by default.
     ...(process.env.MACOS_SIGNING_KEYCHAIN
       ? { keychain: process.env.MACOS_SIGNING_KEYCHAIN }
@@ -243,7 +243,7 @@ if (SHOULD_CODESIGN && process.platform === 'darwin') {
 ```yaml
 - name: Import Apple certificates
   if: ${{ env.HAS_CERT == 'true' }}
-  uses: apple-actions/import-codesign-certs@v3
+  uses: apple-actions/import-codesign-certs@v7
   with:
     p12-file-base64: ${{ secrets.MACOS_CERT_P12 }}
     p12-password: ${{ secrets.MACOS_CERT_PASSWORD }}
@@ -325,7 +325,7 @@ gh api repos/OWNER/REPO/dispatches -f event_type=release -f 'client_payload[ref]
 | App signed as adhoc despite certificate configured | `@electron/packager` defaults `continueOnError: true` in `createSignOpts()` (mac.js line 402-404). Signing error was silently swallowed. | Set `continueOnError: false` in osxSign config |
 | "Cannot use password credentials, API key credentials and keychain credentials at once" | `@electron/notarize` v2.5.0 `isNotaryToolPasswordCredentials()` checks `teamId !== undefined`. Passing `teamId` with API key = credential conflict. | Remove `teamId` from osxNotarize config. `notarytool` infers team from API key. |
 | EMFILE: too many open files | `@electron/osx-sign` `walkAsync()` traverses ALL files in .app. Large embedded runtimes (Python: 51k+ files) exhaust file descriptors. | Add `ignore` filter to skip non-binary files + `ulimit -n 65536` in CI |
-| CI signing: cert not found | `apple-actions/import-codesign-certs@v3` imports to `signing_temp.keychain`, but osx-sign searches system keychain. | Pass `keychain: process.env.MACOS_SIGNING_KEYCHAIN` in osxSign |
+| CI signing: cert not found | `apple-actions/import-codesign-certs@v7` imports to `signing_temp.keychain`, but osx-sign searches system keychain. | Pass `keychain: process.env.MACOS_SIGNING_KEYCHAIN` in osxSign |
 | Install .cer: Error -25294 | Certificate imported to wrong keychain (iCloud/System). Private key from CSR is in `login` keychain. | Re-import `.cer` choosing `login` keychain |
 | `security find-identity` shows nothing | Private key and certificate in different keychains | Ensure CSR private key and imported cert are both in `login` keychain |
 | CI step `if:` with secrets → HTTP 422 | `secrets.*` context not available in step `if:` conditions | Use `env:` intermediate variable pattern (see workflow section) |


### PR DESCRIPTION
## Summary

- Upgrade GitHub-maintained JavaScript Actions to Node 24-compatible majors.
- Update the directly affected active documentation examples.
- Keep project runtimes and workflow behavior unchanged.

## Validation

- actionlint passed for the migrated workflows.
- Every referenced remote action manifest was checked for a non-legacy runtime.
- Documentation consistency search and git diff --check passed.
