### PR TITLE
docs(git-ops): close-unmerged PR → 同动作删除 head 分支

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,14 @@ git commit -m "message"
 git push
 ```
 
+**Closing a PR unmerged (declined, or superseded by another PR) → delete its head
+branch in the same action.** `gh pr merge --delete-branch` only covers merged PRs;
+a closed-unmerged PR keeps `refs/pull/<N>/head` pointing at the branch tip, so its
+commits stay publicly addressable — including anything later found to need
+sanitizing (2026-08-17: a closed-superseded PR's branch carried an unsanitized
+fixture for 13 days after the fix was written). A weekly launchd job
+(`stale-branch-watch`) reports stragglers, but deleting at close time is the norm.
+
 ### Local `main` Is a Read-Only Mirror
 
 Squash-merged PRs rewrite commits under new SHAs, so every direct commit to


### PR DESCRIPTION
2026-08-17 战例: 被取代后 closed-unmerged 的 PR #253, 其 head 分支携带未脱敏 fixture 在公开仓挂了 13 天——`--delete-branch` 只覆盖 merged PR, `refs/pull/<N>/head` 让 commit 持续可公开寻址。周检(stale-branch-watch)兜底, 但 close 当场删才是规范。

🤖 Generated with [Claude Code](https://claude.com/claude-code)