### PR TITLE
fix(github-sensitive-data-cleanup): commit-message 通道重写与校验补全

### DIFF
--- a/github-sensitive-data-cleanup/SKILL.md
+++ b/github-sensitive-data-cleanup/SKILL.md
@@ -172,6 +172,12 @@ Save this file outside the repo, e.g. `/tmp/sensitive-replacements.txt`.
 uv run scripts/rewrite_history.py --repo /path/to/repo \
   --replacements /tmp/sensitive-replacements.txt \
   --backup /tmp/repo-backup.bundle
+
+# Entity leaks live in commit MESSAGES too, not just file content. Cover both:
+uv run scripts/rewrite_history.py --repo /path/to/repo \
+  --replacements /tmp/sensitive-replacements.txt \
+  --message-replacements /tmp/sensitive-replacements.txt \
+  --backup /tmp/repo-backup.bundle
 ```
 
 This script:
@@ -181,7 +187,10 @@ This script:
    files). If not, aborts.
 3. Creates a `git bundle` backup of the current state.
 4. Verifies the backup bundle with `git bundle verify`.
-5. Runs `git filter-repo --replace-text`.
+5. Runs `git filter-repo --replace-text`. When `--message-replacements` is
+   given, it also runs `--replace-message` so commit messages are rewritten,
+   not just file blobs — a cleanup that only covers blobs can leave the
+   entity naming itself in a commit message.
 6. Reports the old and new commit hashes.
 
 **If the backup or verification step fails, the script stops.** Do not proceed
@@ -237,18 +246,24 @@ uv run --with gitpython scripts/scan_repo.py --repo /path/to/repo --output /tmp/
 
 ### `scripts/rewrite_history.py`
 
-Creates a backup bundle and runs `git filter-repo --replace-text`.
+Creates a backup bundle and runs `git filter-repo --replace-text`. Pass
+`--message-replacements <file>` to also rewrite commit messages via
+`--replace-message` (the same replacements file usually covers both).
 
 ```bash
 uv run --with gitpython scripts/rewrite_history.py \
   --repo /path/to/repo \
   --replacements /tmp/sensitive-replacements.txt \
+  --message-replacements /tmp/sensitive-replacements.txt \
   --backup /tmp/repo-backup.bundle
 ```
 
 ### `scripts/verify_cleanup.py`
 
-Re-runs the scanner and greps all commits for the original sensitive strings.
+Re-runs the scanner and greps all commits for the original sensitive strings,
+covering both blob content (`git grep` over every commit) and commit messages
+(`git log --format=%B`), so a rewrite that missed `--replace-message` still
+fails verification.
 
 ```bash
 uv run --with gitpython scripts/verify_cleanup.py \

--- a/github-sensitive-data-cleanup/references/incident-lessons.md
+++ b/github-sensitive-data-cleanup/references/incident-lessons.md
@@ -96,6 +96,44 @@ seen. History cleanup does not invalidate the secret.
 - The skill instructions make this explicit: "Live secrets must be rotated
   before history cleanup."
 
+## Lesson 7: Commit Messages Leak Too — Blob-Only Rewrite and Verify Both Missed Them
+
+**What happened:** A cleanup replaced leaked entities in file content across
+history, but the commit messages kept naming the same entities — including
+the squash-merge message on `main` itself. `rewrite_history.py` only ran
+`--replace-text` (blob content), and `verify_cleanup.py` only ran
+`git grep` over commit trees, which also covers blobs only. Both layers
+agreed the repo was clean while the entity sat in `git log` output.
+
+**Why it matters:** Two checks that share a blind spot read as independent
+confirmation. A rewrite is only as complete as its narrowest channel, and
+commit messages are a first-class leak channel — search engines index them.
+
+**Prevention:**
+
+- `rewrite_history.py --message-replacements <file>` runs
+  `git filter-repo --replace-message` in the same pass; the same replacements
+  file usually covers both channels.
+- `verify_cleanup.py` now greps `git log --all --format=%B` in addition to
+  blob content, so a message-only leak fails verification.
+
+## Lesson 8: The Clean-Working-Tree Check Blocks Rewrites on Shared Checkouts
+
+**What happened:** A rewrite had to run while untracked directories owned by
+other active sessions sat in the working tree. `rewrite_history.py` aborts on
+any `git status --short` output, and the foreign files could neither be
+committed (not the rewriter's work) nor moved (active writers).
+
+**Why it matters:** The check protects against losing uncommitted tracked
+changes during the post-rewrite checkout, but untracked files are not touched
+by a ref rewrite or by the final `reset --hard` — blocking on them conflates
+two different risks and can stall an urgent cleanup.
+
+**Prevention:** If the tree is clean except foreign-owned untracked paths,
+run the script's exact steps manually (backup bundle, `git filter-repo`,
+verify) and document the deviation — never delete or stash another session's
+files to satisfy the check.
+
 ## When to Escalate to a Human
 
 Stop and ask the user before proceeding if:

--- a/github-sensitive-data-cleanup/scripts/rewrite_history.py
+++ b/github-sensitive-data-cleanup/scripts/rewrite_history.py
@@ -9,6 +9,14 @@ Usage:
       --repo /path/to/repo \
       --replacements /tmp/sensitive-replacements.txt \
       --backup /tmp/repo-backup.bundle
+
+    # also rewrite commit MESSAGES (entity leaks live there too — file content
+    # can be clean while the commit message still names the private entity):
+    uv run --with gitpython scripts/rewrite_history.py \
+      --repo /path/to/repo \
+      --replacements /tmp/sensitive-replacements.txt \
+      --message-replacements /tmp/sensitive-replacements.txt \
+      --backup /tmp/repo-backup.bundle
 """
 
 import argparse
@@ -81,6 +89,13 @@ def main():
     parser = argparse.ArgumentParser(description="Rewrite repo history to remove sensitive strings.")
     parser.add_argument("--repo", required=True, help="Path to the git repository.")
     parser.add_argument("--replacements", required=True, help="Path to git-filter-repo replacements file.")
+    parser.add_argument(
+        "--message-replacements",
+        default=None,
+        help="Optional replacements file for commit MESSAGES "
+             "(git filter-repo --replace-message). File content and commit "
+             "messages leak differently; pass the same file to cover both.",
+    )
     parser.add_argument("--backup", required=True, help="Path for the output git bundle backup.")
     parser.add_argument(
         "--yes",
@@ -91,6 +106,9 @@ def main():
 
     repo_path = Path(args.repo).resolve()
     replacements_path = Path(args.replacements).resolve()
+    message_replacements_path = (
+        Path(args.message_replacements).resolve() if args.message_replacements else None
+    )
     backup_path = Path(args.backup).resolve()
 
     if not (repo_path / ".git").is_dir():
@@ -99,6 +117,13 @@ def main():
 
     if not replacements_path.is_file():
         print(f"Replacements file not found: {replacements_path}", file=sys.stderr)
+        sys.exit(1)
+
+    if message_replacements_path is not None and not message_replacements_path.is_file():
+        print(
+            f"Message replacements file not found: {message_replacements_path}",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     filter_repo_bin = shutil.which("git-filter-repo")
@@ -153,6 +178,8 @@ def main():
         "--replace-text",
         str(replacements_path),
     ]
+    if message_replacements_path is not None:
+        cmd += ["--replace-message", str(message_replacements_path)]
     try:
         subprocess.run(cmd, cwd=str(repo_path), check=True)
     except subprocess.CalledProcessError as e:

--- a/github-sensitive-data-cleanup/scripts/verify_cleanup.py
+++ b/github-sensitive-data-cleanup/scripts/verify_cleanup.py
@@ -82,6 +82,29 @@ def check_pattern_in_history(
     return list(matched), None
 
 
+def check_pattern_in_messages(
+    repo_path: Path, pattern: str, is_regex: bool
+) -> tuple[int, str | None]:
+    """Return the count of commit MESSAGES still containing the pattern.
+
+    `git grep <commits>` only searches blob content; a rewrite that covered
+    file content but missed --replace-message would pass blob checks while
+    the entity still named itself in a commit message.
+    """
+    log = subprocess.run(
+        ["git", "-C", str(repo_path), "log", "--all", "--format=%B", "--no-color"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if log.returncode != 0:
+        return 0, f"git log failed: {log.stderr}"
+    if is_regex:
+        hits = re.findall(pattern, log.stdout)
+        return len(hits), None
+    return log.stdout.count(pattern), None
+
+
 def run_gitleaks(repo_path: Path) -> list[dict]:
     gitleaks_bin = shutil.which("gitleaks")
     if not gitleaks_bin:
@@ -166,10 +189,21 @@ def main():
                 {"pattern": item["pattern"], "is_regex": item["is_regex"], "error": error}
             )
             continue
-        if commits:
-            remaining.append(
-                {"pattern": item["pattern"], "is_regex": item["is_regex"], "commits": commits[:10]}
+        msg_hits, msg_error = check_pattern_in_messages(
+            repo_path, item["pattern"], item["is_regex"]
+        )
+        if msg_error:
+            check_errors.append(
+                {"pattern": item["pattern"], "is_regex": item["is_regex"], "error": msg_error}
             )
+            continue
+        if commits or msg_hits:
+            entry = {"pattern": item["pattern"], "is_regex": item["is_regex"]}
+            if commits:
+                entry["commits"] = commits[:10]
+            if msg_hits:
+                entry["commit_message_hits"] = msg_hits
+            remaining.append(entry)
 
     report = {
         "repo": str(repo_path),


### PR DESCRIPTION
## 问题（真实 incident 暴露）

一次实体脱敏历史重写中发现两个同通道盲区：

1. **`rewrite_history.py` 只跑 `--replace-text`（blob 内容）**——commit message 里的实体原样保留（含 main 上的 squash merge message），只能手工偏离脚本补 `--replace-message`
2. **`verify_cleanup.py` 的 `git grep` 只覆盖 blob**——message-only 泄漏在验证层同样不可见，双层「干净」假象

## 修复

- `rewrite_history.py` 新增 `--message-replacements <file>`：同一 pass 追加 `git filter-repo --replace-message`（同一 replacements 文件通常可复用）
- `verify_cleanup.py` 校验补 message 层（`git log --all --format=%B`），报告新增 `commit_message_hits` 字段
- `SKILL.md` 两处用法同步；`incident-lessons.md` 补 Lesson 7（message 通道双盲区）与 Lesson 8（共享 checkout 外人 untracked 文件阻塞重写的处置）

## 端到端标定

- scratch 仓 commit message 藏实体：`verify_cleanup` 重写前 **FAILED**（`commit_message_hits: 1`），`git filter-repo` 双 flag 重写后 **PASSED**
- `rewrite_history.py --message-replacements` 内容与 message 同步改写（backup bundle 正常产出）

🤖 Generated with [Claude Code](https://claude.com/claude-code)