### PR TITLE
fix(claude-code-hooks): pitfall #36 — a formal acceptance gate is not immune

### DIFF
--- a/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
+++ b/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
@@ -1803,6 +1803,25 @@ this list and describe defects you reach by asking a different question):
   surface across those rounds — the review was not worthless — so the missing
   check was never “is this finding real,” it was “does clearing it still
   justify a fresh pass over everything else.”
+- **A formal "ready to ship" gate is not immune either — the lineage can reopen
+  after passing it.** A different fact-check report, also meant to inform a
+  real personal decision: 19 independent-review rounds, **three** of which
+  also triggered a separate formal acceptance pass — a workflow's own
+  designated "0 open findings, ready to ship" checkpoint, not merely another
+  review — at round 10, round 15, and round 19, spanning three calendar days.
+  The first acceptance passed the
+  same day as round 10. The lineage still reopened roughly two days later and
+  ran five more rounds before a second acceptance (round 15) — which *also*
+  did not end the task; four more rounds followed before the third acceptance
+  actually shipped it. Termination held every time (each acceptance genuinely
+  found the artifact ready when it ran); every new finding across those rounds
+  was real and on a different axis, so no single round was the "same-axis
+  BLOCKER" this pitfall's Fix already says should stop a reopen. The signal
+  that would have caught it is a different one: **a lineage that has already
+  cleared its own ready-to-ship gate once and is still running is itself the
+  thing to surface** — independent of whether the new round's finding is
+  same-axis or genuinely fresh — which is the trip condition the Fix below
+  adds.
 - **Fix:** write the Loop Contract from SKILL.md rule 7 before round 1. Key it on
   one immutable lineage plus one failure axis; predeclare the budget and both
   exits. Repair commits and new reviewer names remain in that lineage. For
@@ -1811,6 +1830,12 @@ this list and describe defects you reach by asking a different question):
   backlog item / new task; it does not reset the budget. If the re-review still
   reproduces a same-axis BLOCKER or MAJOR, stop with the artifact unregistered
   or unshipped and report `blocked` — do not silently dispatch a third reviewer.
+  **A same-axis recurrence is not the only trip condition worth coding for**:
+  if the lineage has already passed one formal acceptance/ready-to-ship check
+  and a new round is about to run anyway, that crossing — by itself, before
+  judging whether the new finding is real — is the signal to stop and put the
+  question to the human, not to reason "this one's a genuinely new finding, so
+  it's fine." A second "ready to ship" should not be quieter than the first.
 - **Restart authority:** only an explicitly user-authorized new task can open
   another review budget after the cap. The agent must then declare that budget,
   the concrete safety or business failure caused by stopping, and the new


### PR DESCRIPTION
## Summary
- Adds a third real case to pitfall #36 (*A self-applied review rule can loop without any hook*): a review lineage that passed its own "ready to ship" acceptance gate **twice** (round 10, round 15) before a third acceptance (round 19) actually shipped it — 19 rounds across three calendar days, every finding real and on a different axis, so nothing in the existing same-axis-BLOCKER trip condition would have caught it.
- Extends the Fix with the missing signal: a lineage that already cleared its own ready-to-ship gate once and is still running is itself the thing to surface, independent of whether the new finding is same-axis or fresh.

## Provenance
This session's own live-conversation history is the source: a real independent-review lineage (a fact-check report informing a real personal decision) ran 19 rounds / 3 formal acceptance passes before shipping, in this exact shape. Round-count, acceptance-round numbers (10/15/19), and calendar-day span were verified against file mtimes rather than recalled from memory before writing.

## Review
Independently reviewed by a fresh-context agent against: technical consistency with rule 7 and the rest of pitfall #36, actionability, redundancy against the two existing cases, arithmetic, and register/style fit. One MAJOR finding (a self-contradiction — the new bullet claimed something was "missing from the Fix as written" while the same edit added it to the Fix three lines later) was fixed by rewording to forward-reference the addition instead of claiming an ongoing gap. Two MINOR findings (rule 7's filled Loop Contract example not showcasing this new trigger shape; "19 rounds plus three passes" briefly reading as 22 events before its clarifying clause) were judged out of scope / low-value and left as-is — see reasoning in the review transcript.

## Test plan
- [x] `quick_validate` passes
- [x] `audit_skill_regression compare` → 846 exact preservations, 1 candidate (a text run split by the insertion, not a deletion) → classified `preserved_or_moved` → `verify` passes, `.skill-regression-reviewed` attestation current
- [x] Independent fresh-context review completed, findings addressed
- [x] Diff scoped to exactly one file, one addition — confirmed via `git diff --cached --stat` before commit

Note: this repo had a concurrent, unrelated PR (#323, already merged as `a700b45`) land in the same file while this branch was being prepared — this PR is rebased on top of that merge, not in conflict with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)