### PR TITLE
fix(github-sensitive-data-cleanup): GBK 解码崩溃修复 + --yes/--replace-message 文档补全

### DIFF
--- a/github-sensitive-data-cleanup/SKILL.md
+++ b/github-sensitive-data-cleanup/SKILL.md
@@ -171,13 +171,15 @@ Save this file outside the repo, e.g. `/tmp/sensitive-replacements.txt`.
 ```bash
 uv run scripts/rewrite_history.py --repo /path/to/repo \
   --replacements /tmp/sensitive-replacements.txt \
-  --backup /tmp/repo-backup.bundle
+  --backup /tmp/repo-backup.bundle \
+  --yes
 
 # Entity leaks live in commit MESSAGES too, not just file content. Cover both:
 uv run scripts/rewrite_history.py --repo /path/to/repo \
   --replacements /tmp/sensitive-replacements.txt \
   --message-replacements /tmp/sensitive-replacements.txt \
-  --backup /tmp/repo-backup.bundle
+  --backup /tmp/repo-backup.bundle \
+  --yes
 ```
 
 This script:
@@ -255,7 +257,8 @@ uv run --with gitpython scripts/rewrite_history.py \
   --repo /path/to/repo \
   --replacements /tmp/sensitive-replacements.txt \
   --message-replacements /tmp/sensitive-replacements.txt \
-  --backup /tmp/repo-backup.bundle
+  --backup /tmp/repo-backup.bundle \
+  --yes
 ```
 
 ### `scripts/verify_cleanup.py`

--- a/github-sensitive-data-cleanup/scripts/rewrite_history.py
+++ b/github-sensitive-data-cleanup/scripts/rewrite_history.py
@@ -57,8 +57,10 @@ def create_backup(repo_path: Path, backup_path: Path) -> None:
     ]
     subprocess.run(cmd, check=True)
 
+    # 与 create 一样带 -C：从非 git 目录调用时 bundle verify 会因找不到
+    # 仓库而失败（错误信息指错方向），且 RuntimeError 要能被调用点接住
     verify = subprocess.run(
-        ["git", "bundle", "verify", str(backup_path)],
+        ["git", "-C", str(repo_path), "bundle", "verify", str(backup_path)],
         capture_output=True,
         text=True,
         check=False,
@@ -166,7 +168,7 @@ def main():
     print("Creating backup bundle...")
     try:
         create_backup(repo_path, backup_path)
-    except subprocess.CalledProcessError as e:
+    except (subprocess.CalledProcessError, RuntimeError) as e:
         print(f"Backup failed: {e}", file=sys.stderr)
         sys.exit(1)
     print(f"Backup created: {backup_path}")

--- a/github-sensitive-data-cleanup/scripts/verify_cleanup.py
+++ b/github-sensitive-data-cleanup/scripts/verify_cleanup.py
@@ -84,25 +84,44 @@ def check_pattern_in_history(
 
 def check_pattern_in_messages(
     repo_path: Path, pattern: str, is_regex: bool
-) -> tuple[int, str | None]:
-    """Return the count of commit MESSAGES still containing the pattern.
+) -> tuple[list[str], int, str | None]:
+    """Return (commit hashes, hit count, error) for commit MESSAGES.
 
     `git grep <commits>` only searches blob content; a rewrite that covered
     file content but missed --replace-message would pass blob checks while
     the entity still named itself in a commit message.
+
+    Decoding uses errors="replace": repos with GBK/legacy-encoded commit
+    messages must not crash verification (a repo being cleaned is by
+    definition a repo with hygiene problems — old encodings included).
+    Hashes are returned so a FAILED report locates the offending commits
+    instead of just counting hits.
     """
     log = subprocess.run(
-        ["git", "-C", str(repo_path), "log", "--all", "--format=%B", "--no-color"],
+        ["git", "-C", str(repo_path), "log", "--all",
+         "--format=%H%x1f%B%x1e", "--no-color"],
         capture_output=True,
         text=True,
+        errors="replace",
         check=False,
     )
     if log.returncode != 0:
-        return 0, f"git log failed: {log.stderr}"
-    if is_regex:
-        hits = re.findall(pattern, log.stdout)
-        return len(hits), None
-    return log.stdout.count(pattern), None
+        return [], 0, f"git log failed: {log.stderr}"
+    rx = re.compile(pattern) if is_regex else None
+    hashes: list[str] = []
+    hits = 0
+    for record in log.stdout.split("\x1e"):
+        sha, sep, msg = record.partition("\x1f")
+        if not sep:
+            continue
+        sha = sha.strip()
+        matched = bool(rx.search(msg)) if rx else pattern in msg
+        if not matched:
+            continue
+        hits += len(rx.findall(msg)) if rx else msg.count(pattern)
+        if sha and sha not in hashes:
+            hashes.append(sha)
+    return hashes, hits, None
 
 
 def run_gitleaks(repo_path: Path) -> list[dict]:
@@ -189,7 +208,7 @@ def main():
                 {"pattern": item["pattern"], "is_regex": item["is_regex"], "error": error}
             )
             continue
-        msg_hits, msg_error = check_pattern_in_messages(
+        msg_hashes, msg_hits, msg_error = check_pattern_in_messages(
             repo_path, item["pattern"], item["is_regex"]
         )
         if msg_error:
@@ -203,6 +222,7 @@ def main():
                 entry["commits"] = commits[:10]
             if msg_hits:
                 entry["commit_message_hits"] = msg_hits
+                entry["commit_message_commits"] = msg_hashes[:10]
             remaining.append(entry)
 
     report = {


### PR DESCRIPTION
## 背景
PR #326 补 commit-message 重写通道后，独立审阅（fresh-context subagent）发现 4 项问题，本 PR 全部修复。

## 修复内容
1. **HIGH — verify_cleanup.py GBK 崩溃**：`check_pattern_in_messages` 用 `text=True` 严格 UTF-8 解码，GBK/旧编码 commit message 直接 `UnicodeDecodeError` traceback（要清理的仓恰好最可能有旧编码）。改 `errors="replace"` + `%H%x1f%B%x1e` 记录式解析。
2. **LOW — message 命中不可定位**：FAILED 时只给计数不给位置。报告新增 `commit_message_commits`（hash 列表，前 10 条）。
3. **MEDIUM — SKILL.md 命令缺 `--yes`**：Step 4 两个命令块 + 脚本说明一个命令块照文档原样跑会 exit=1（连 backup 都不建）。全部补上。
4. **MEDIUM — rewrite_history.py `bundle verify` 缺 `-C`**：从非 git cwd 调用时 verify 因找不到仓库 traceback；同时 `create_backup` 的 `RuntimeError` 之前不在捕获范围。

## 验证（端到端标定，真实仓）
- GBK 编码 commit message + 含实体的仓 → `VERIFICATION FAILED`，`commit_message_hits: 1` + hash 列表，无崩溃
- GBK 干净仓 → `VERIFICATION PASSED`
- 非 git cwd 跑 rewrite_history.py → 正常产出 bundle + verify 通过

## 影响面
仅 `github-sensitive-data-cleanup/` 内 3 个文件，+39/-14。