### PR TITLE
docs(github-sensitive-data-cleanup): Lesson 9 两处措辞残留（复验轮收尾）

### DIFF
--- a/github-sensitive-data-cleanup/references/incident-lessons.md
+++ b/github-sensitive-data-cleanup/references/incident-lessons.md
@@ -141,8 +141,9 @@ files to satisfy the check.
 tooling itself broke on realistic inputs: `verify_cleanup.py` decoded
 `git log` output with strict UTF-8, so one GBK/legacy-encoded commit message
 crashed verification with an uncaught `UnicodeDecodeError` — no report at
-all. The SKILL.md Step 4 command blocks omitted `--yes`, so following the
-documentation verbatim exited before the backup was even created.
+all. The SKILL.md rewrite command blocks (Step 4 and the script-reference
+section) omitted `--yes`, so following the documentation verbatim exited
+before the backup was even created.
 `rewrite_history.py` ran `git bundle verify` without `-C <repo>`, crashing
 when invoked from a non-git directory, and the resulting `RuntimeError`
 escaped the `except` clause. A FAILED message check reported only a hit
@@ -167,7 +168,7 @@ get silently skipped.
 **Prevention:**
 
 - Decode git output with `errors="replace"` when the goal is detection, not
-  fidelity — this now holds for every subprocess call in all four scripts,
+  fidelity — this now holds for every subprocess decode in all four scripts,
   both channels. Report `commit_message_commits` hashes (first 10) so a
   FAILED check locates commits instead of just counting hits. Boundary:
   `errors="replace"` prevents the crash but cannot make a UTF-8 pattern


### PR DESCRIPTION
复验轮（#330 的窄范围 re-review）确认 4 条 finding 中 3 条闭环，INFO 项残留一半 + 1 条新 nit，本 PR 收尾：

1. **INFO 残留**：Lesson 9 what-happened 仍写「Step 4 command blocks」——#330 只改了 CHANGELOG 里的同一事实，Lesson 9 这处副本漏改（同事实两副本只改一个）。修为「Step 4 and the script-reference section」与 CHANGELOG 对齐。
2. **nit**：prevention 写「every subprocess **call**」比实际宽——4 脚本 16 处 `subprocess.run` 中 2 处是 bytes-mode（不解码、无需 `errors=`），复验者按字面 grep 会发现「不一致」。修为「every subprocess **decode**」，与 CHANGELOG 及同课补记段表述一致。

纯措辞，无行为变化。