### PR TITLE
test(prior-work): pin independent-review adversarial corpus

### DIFF
--- a/daymade-claude-code/prior-work-retrieval/tests/test_prior_work_hook.py
+++ b/daymade-claude-code/prior-work-retrieval/tests/test_prior_work_hook.py
@@ -429,6 +429,49 @@ class PriorWorkHookTests(unittest.TestCase):
         substantial, reason = hook.substantial_tool_use(event)
         self.assertFalse(substantial, reason)
 
+    def test_independent_review_adversarial_corpus(self) -> None:
+        # Pins shapes from the 2026-08-27 two-round independent review that the
+        # dedicated tests above do not cover (archive: PKM
+        # next/_meta/skill-reviews/prior-work-retrieval/independent-review.md).
+        # Every shape was verified behaviorally against this hook before pinning.
+        gated = [
+            # F3 literals: an inner shell re-parses the wrapper string.
+            'bash -c "prior_work.py check; git push"',
+            'eval "prior_work.py check && git push"',
+            "printf '%s' 'prior_work.py check; git push' | xargs -I{} sh -c {}",
+            # F4: a backslash-escaped quote outside quotes must not enter quote state.
+            'prior_work.py check \\"& git push',
+            # F5: a substring of a different filename is not the route.
+            "python my_prior_work.py check & git push",
+            # F-new-1: bare &- is a zsh async separator (only >&- is fd close).
+            "prior_work.py check &- git push",
+            # F-new-2: wrapper prefixes beyond the naive five-name list.
+            'env FOO=1 bash -c "prior_work.py check; git push"',
+            'command bash -c "prior_work.py check; git push"',
+            '(bash -c "prior_work.py check; git push")',
+            'ssh host "prior_work.py check; git push"',
+            # F-new-3: $'…' ANSI-C quoting desyncs a naive quote state machine.
+            "prior_work.py check $'x\\'y'; git push",
+        ]
+        for command in gated:
+            with self.subTest(command=command):
+                event = {"tool_name": "Bash", "tool_input": {"command": command}}
+                substantial, reason = hook.substantial_tool_use(event)
+                self.assertTrue(substantial, reason)
+        allowed = [
+            # Backgrounding the route command itself is benign.
+            "uv run python scripts/prior_work.py check --session-id S &",
+            # A wrapped route call without any write token stays allowed.
+            'bash -c "prior_work.py check"',
+            # >&- is fd close, not a separator.
+            "uv run python scripts/prior_work.py check 2>&- --session-id S",
+        ]
+        for command in allowed:
+            with self.subTest(command=command):
+                event = {"tool_name": "Bash", "tool_input": {"command": command}}
+                substantial, reason = hook.substantial_tool_use(event)
+                self.assertFalse(substantial, reason)
+
     def test_pretool_never_invents_requirement_for_ordinary_write(self) -> None:
         event = {
             "hook_event_name": "PreToolUse",


### PR DESCRIPTION
Pins the 2026-08-27 two-round independent-review adversarial shapes not already covered by dedicated tests (archive: PKM `next/_meta/skill-reviews/prior-work-retrieval/independent-review.md`).

**Gated shapes pinned**: F3 wrapper literals (`bash -c` / `eval` / `xargs`), F4 escaped-quote desync, F5 filename substring (`my_prior_work.py`), F-new-1 bare `&-` async separator (zsh), F-new-2 wrapper prefixes (`env`/`command`/parens/`ssh`), F-new-3 ANSI-C `$'…'` quoting.

**Healthy calibration pinned**: backgrounded route command, wrapped route call without write tokens, `>&-` fd close.

Every shape verified behaviorally against current main (21/21 corpus match) before pinning; suite 62/62 green in a clean clone of origin/main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)