### PR TITLE
NOJIRA: Enforce Skill release isolation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,17 @@ jobs:
           git fetch --no-tags origin "+refs/heads/${target}:refs/remotes/origin/${target}"
           scripts/ci/validate_changed_skills.sh "origin/${target}"
 
+      - name: Reject stale or reused marketplace versions
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          target="${BASE_REF:-${DEFAULT_BRANCH:-main}}"
+          git fetch --no-tags origin "+refs/heads/${target}:refs/remotes/origin/${target}"
+          python3 scripts/ci/check_version_progression.py \
+            --base "origin/${target}" --candidate HEAD
+
   tests:
     name: Registered test suites (Linux)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,14 +79,53 @@ jobs:
 
       - name: Reject stale or reused marketplace versions
         env:
+          EVENT_NAME: ${{ github.event_name }}
           BASE_REF: ${{ github.base_ref }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          PUSH_BEFORE: ${{ github.event.before }}
         run: |
           set -euo pipefail
-          target="${BASE_REF:-${DEFAULT_BRANCH:-main}}"
-          git fetch --no-tags origin "+refs/heads/${target}:refs/remotes/origin/${target}"
-          python3 scripts/ci/check_version_progression.py \
-            --base "origin/${target}" --candidate HEAD
+          case "${EVENT_NAME}" in
+            pull_request)
+              target="${BASE_REF:-${DEFAULT_BRANCH:-main}}"
+              git fetch --no-tags origin \
+                "+refs/heads/${target}:refs/remotes/origin/${target}"
+              base="refs/remotes/origin/${target}"
+              ;;
+            push)
+              case "${PUSH_BEFORE}" in
+                ""|0000000000000000000000000000000000000000)
+                  echo "FAIL: push event has no usable before SHA" >&2
+                  exit 1
+                  ;;
+              esac
+              git cat-file -e "${PUSH_BEFORE}^{commit}"
+              base="${PUSH_BEFORE}"
+              ;;
+            workflow_dispatch)
+              echo "SKIP: workflow_dispatch has no change base to compare"
+              exit 0
+              ;;
+            *)
+              echo "FAIL: unsupported event ${EVENT_NAME}" >&2
+              exit 1
+              ;;
+          esac
+
+          checker_path="scripts/ci/check_version_progression.py"
+          trusted_checker="$(mktemp)"
+          if git show "${base}:${checker_path}" >"${trusted_checker}" 2>/dev/null; then
+            :
+          elif git diff --diff-filter=A --name-only "${base}" HEAD -- "${checker_path}" \
+            | grep -Fxq "${checker_path}"; then
+            # One-time bootstrap: after this checker lands, every later PR/push
+            # executes the immutable base copy above, never candidate bytes.
+            cp "${checker_path}" "${trusted_checker}"
+          else
+            echo "FAIL: trusted base has no version-progression checker" >&2
+            exit 1
+          fi
+          python3 "${trusted_checker}" --repo . --base "${base}" --candidate HEAD
 
   tests:
     name: Registered test suites (Linux)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,6 +205,10 @@ Squash-merged PRs rewrite commits under new SHAs, so every direct commit to
 local `main` guarantees divergence the moment its PR merges. Two rules keep
 `main` clean:
 
+`scripts/git-mainline-guard.mjs` enforces this at commit/push time and also
+rejects stale marketplace manifests or reused plugin versions against current
+`origin/main`; CI runs the same version-progression check on every PR.
+
 1. **Never commit directly to local `main`.** All work starts on a feature
    branch (`git checkout -b <topic>`), ships via PR, and lands by squash merge.
 2. **After every merge, run the 30-second ritual:** `git checkout main && git pull --ff-only`.

--- a/scripts/ci/check_version_progression.py
+++ b/scripts/ci/check_version_progression.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Reject stale marketplace versions and missing Skill release bumps.
+
+Compare one candidate tree (a commit or the current index) with a named base
+commit.  The check is intentionally tree-based: a branch that omits versions
+already present on current main is stale even when its own merge base predates
+those releases.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+MANIFEST_PATH = ".claude-plugin/marketplace.json"
+SEMVER = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+
+
+class CheckError(RuntimeError):
+    """The candidate cannot be evaluated safely."""
+
+
+@dataclass(frozen=True)
+class Plugin:
+    name: str
+    source: str
+    version: tuple[int, int, int]
+    skills: tuple[str, ...]
+
+
+def git(repo: Path, *args: str, input_text: str | None = None) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        input=input_text,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "unknown Git error"
+        raise CheckError(f"git {' '.join(args)} failed: {detail}")
+    return result.stdout
+
+
+def parse_semver(value: object, label: str) -> tuple[int, int, int]:
+    match = SEMVER.fullmatch(str(value))
+    if not match:
+        raise CheckError(f"{label} version {value!r} is not strict MAJOR.MINOR.PATCH")
+    return tuple(int(part) for part in match.groups())
+
+
+def normalize_source(value: object, label: str) -> str:
+    source = str(value or "").removeprefix("./").strip("/")
+    if not source or source.startswith("../") or "/../" in source:
+        raise CheckError(f"{label} has unsafe or empty source {value!r}")
+    return source
+
+
+def load_manifest_text(repo: Path, spec: str) -> str:
+    return git(repo, "show", f"{spec}:{MANIFEST_PATH}")
+
+
+def load_index_manifest_text(repo: Path) -> str:
+    return git(repo, "show", f":{MANIFEST_PATH}")
+
+
+def parse_manifest(text: str, label: str) -> tuple[tuple[int, int, int], dict[str, Plugin]]:
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise CheckError(f"{label} marketplace manifest is invalid JSON: {exc}") from exc
+
+    metadata = data.get("metadata")
+    if not isinstance(metadata, dict):
+        raise CheckError(f"{label} marketplace manifest has no metadata object")
+    metadata_version = parse_semver(metadata.get("version"), f"{label} metadata")
+
+    raw_plugins = data.get("plugins")
+    if not isinstance(raw_plugins, list) or not raw_plugins:
+        raise CheckError(f"{label} marketplace manifest has no plugins array")
+
+    plugins: dict[str, Plugin] = {}
+    for index, raw in enumerate(raw_plugins):
+        if not isinstance(raw, dict):
+            raise CheckError(f"{label} plugins[{index}] is not an object")
+        name = str(raw.get("name") or "")
+        if not name:
+            raise CheckError(f"{label} plugins[{index}] has no name")
+        if name in plugins:
+            raise CheckError(f"{label} declares plugin {name!r} more than once")
+        skills_value = raw.get("skills", [])
+        if skills_value is None:
+            skills_value = []
+        if not isinstance(skills_value, list) or not all(isinstance(v, str) for v in skills_value):
+            raise CheckError(f"{label} plugin {name!r} has a non-string skills list")
+        plugins[name] = Plugin(
+            name=name,
+            source=normalize_source(raw.get("source"), f"{label} plugin {name!r}"),
+            version=parse_semver(raw.get("version"), f"{label} plugin {name!r}"),
+            skills=tuple(str(v).removeprefix("./").strip("/") for v in skills_value),
+        )
+    return metadata_version, plugins
+
+
+def changed_paths(repo: Path, base: str, candidate: str | None) -> list[str]:
+    if candidate is None:
+        raw = subprocess.run(
+            ["git", "-C", str(repo), "diff", "--cached", "--name-only", "-z", base, "--"],
+            capture_output=True,
+            check=False,
+        )
+        label = "git diff --cached"
+    else:
+        raw = subprocess.run(
+            ["git", "-C", str(repo), "diff", "--name-only", "-z", base, candidate, "--"],
+            capture_output=True,
+            check=False,
+        )
+        label = "git diff"
+    if raw.returncode != 0:
+        detail = raw.stderr.decode("utf-8", errors="replace").strip() or "unknown Git error"
+        raise CheckError(f"{label} failed: {detail}")
+    return [
+        item.decode("utf-8", errors="surrogateescape")
+        for item in raw.stdout.split(b"\0")
+        if item
+    ]
+
+
+def layout_signature(plugins: dict[str, Plugin]) -> dict[str, tuple[str, tuple[str, ...]]]:
+    return {name: (plugin.source, plugin.skills) for name, plugin in plugins.items()}
+
+
+def owner_for_path(path: str, plugins: dict[str, Plugin]) -> str | None:
+    owners = [
+        plugin.name
+        for plugin in plugins.values()
+        if path == plugin.source or path.startswith(plugin.source + "/")
+    ]
+    if len(owners) > 1:
+        raise CheckError(f"path {path!r} is owned by multiple plugin sources: {owners}")
+    return owners[0] if owners else None
+
+
+def check(repo: Path, base: str, candidate: str | None) -> list[str]:
+    git(repo, "rev-parse", "--verify", f"{base}^{{commit}}")
+    if candidate is not None:
+        git(repo, "rev-parse", "--verify", f"{candidate}^{{commit}}")
+
+    base_metadata, base_plugins = parse_manifest(
+        load_manifest_text(repo, base), f"base {base}"
+    )
+    if candidate is None:
+        candidate_text = load_index_manifest_text(repo)
+        candidate_label = "candidate index"
+    else:
+        candidate_text = load_manifest_text(repo, candidate)
+        candidate_label = f"candidate {candidate}"
+    candidate_metadata, candidate_plugins = parse_manifest(candidate_text, candidate_label)
+
+    failures: list[str] = []
+    if candidate_metadata < base_metadata:
+        failures.append(
+            f"marketplace metadata regresses {base_metadata} -> {candidate_metadata}"
+        )
+
+    for name in sorted(base_plugins.keys() & candidate_plugins.keys()):
+        before = base_plugins[name].version
+        after = candidate_plugins[name].version
+        if after < before:
+            failures.append(f"plugin {name!r} regresses {before} -> {after}")
+
+    layout_changed = layout_signature(base_plugins) != layout_signature(candidate_plugins)
+    if layout_changed and candidate_metadata <= base_metadata:
+        failures.append(
+            "plugin identities/source/member layout changed without a strict "
+            f"marketplace metadata bump above {base_metadata}"
+        )
+
+    paths = changed_paths(repo, base, candidate)
+    touched_plugins: set[str] = set()
+    for path in paths:
+        if path == MANIFEST_PATH:
+            continue
+        owner = owner_for_path(path, candidate_plugins)
+        if owner is None:
+            owner = owner_for_path(path, base_plugins)
+        if owner is not None:
+            touched_plugins.add(owner)
+
+    for name in sorted(touched_plugins):
+        before = base_plugins.get(name)
+        after = candidate_plugins.get(name)
+        if before is None or after is None:
+            # Add/remove/move is governed by the metadata-layout rule above.
+            continue
+        if after.version <= before.version:
+            failures.append(
+                f"plugin {name!r} content changed but version did not strictly increase "
+                f"above {before.version}; candidate has {after.version}"
+            )
+
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Reject stale marketplace versions and missing Skill release bumps"
+    )
+    parser.add_argument("--base", required=True, help="Current authoritative base commit")
+    candidate = parser.add_mutually_exclusive_group(required=True)
+    candidate.add_argument("--candidate", help="Candidate commit")
+    candidate.add_argument(
+        "--candidate-index",
+        action="store_true",
+        help="Use the current Git index as the candidate tree",
+    )
+    parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository checkout (default: current directory)",
+    )
+    args = parser.parse_args()
+
+    try:
+        repo = Path(git(args.repo, "rev-parse", "--show-toplevel").strip())
+        failures = check(repo, args.base, None if args.candidate_index else args.candidate)
+    except CheckError as exc:
+        print(f"FAIL: version progression could not be evaluated: {exc}", file=sys.stderr)
+        return 2
+
+    if failures:
+        print(f"FAIL: {len(failures)} marketplace version problem(s):", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+
+    candidate_label = "index" if args.candidate_index else args.candidate
+    print(f"OK: {candidate_label} has no version regression and every changed plugin is bumped")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check_version_progression.py
+++ b/scripts/ci/check_version_progression.py
@@ -32,6 +32,7 @@ class Plugin:
     source: str
     version: tuple[int, int, int]
     skills: tuple[str, ...]
+    payload_without_version: object
 
 
 def git(repo: Path, *args: str, input_text: str | None = None) -> str:
@@ -70,7 +71,9 @@ def load_index_manifest_text(repo: Path) -> str:
     return git(repo, "show", f":{MANIFEST_PATH}")
 
 
-def parse_manifest(text: str, label: str) -> tuple[tuple[int, int, int], dict[str, Plugin]]:
+def parse_manifest(
+    text: str, label: str
+) -> tuple[tuple[int, int, int], object, dict[str, Plugin]]:
     try:
         data = json.loads(text)
     except json.JSONDecodeError as exc:
@@ -80,6 +83,14 @@ def parse_manifest(text: str, label: str) -> tuple[tuple[int, int, int], dict[st
     if not isinstance(metadata, dict):
         raise CheckError(f"{label} marketplace manifest has no metadata object")
     metadata_version = parse_semver(metadata.get("version"), f"{label} metadata")
+    catalog_payload = {
+        key: value
+        for key, value in data.items()
+        if key not in {"metadata", "plugins"}
+    }
+    catalog_payload["metadata"] = {
+        key: value for key, value in metadata.items() if key != "version"
+    }
 
     raw_plugins = data.get("plugins")
     if not isinstance(raw_plugins, list) or not raw_plugins:
@@ -104,8 +115,14 @@ def parse_manifest(text: str, label: str) -> tuple[tuple[int, int, int], dict[st
             source=normalize_source(raw.get("source"), f"{label} plugin {name!r}"),
             version=parse_semver(raw.get("version"), f"{label} plugin {name!r}"),
             skills=tuple(str(v).removeprefix("./").strip("/") for v in skills_value),
+            payload_without_version={
+                key: value for key, value in raw.items() if key != "version"
+            },
         )
-    return metadata_version, plugins
+    # JSON array order is observable to marketplace readers even when every
+    # individual plugin object is byte-for-byte equivalent.
+    catalog_payload["plugin_order"] = list(plugins)
+    return metadata_version, catalog_payload, plugins
 
 
 def changed_paths(repo: Path, base: str, candidate: str | None) -> list[str]:
@@ -153,7 +170,7 @@ def check(repo: Path, base: str, candidate: str | None) -> list[str]:
     if candidate is not None:
         git(repo, "rev-parse", "--verify", f"{candidate}^{{commit}}")
 
-    base_metadata, base_plugins = parse_manifest(
+    base_metadata, base_catalog, base_plugins = parse_manifest(
         load_manifest_text(repo, base), f"base {base}"
     )
     if candidate is None:
@@ -162,12 +179,19 @@ def check(repo: Path, base: str, candidate: str | None) -> list[str]:
     else:
         candidate_text = load_manifest_text(repo, candidate)
         candidate_label = f"candidate {candidate}"
-    candidate_metadata, candidate_plugins = parse_manifest(candidate_text, candidate_label)
+    candidate_metadata, candidate_catalog, candidate_plugins = parse_manifest(
+        candidate_text, candidate_label
+    )
 
     failures: list[str] = []
     if candidate_metadata < base_metadata:
         failures.append(
             f"marketplace metadata regresses {base_metadata} -> {candidate_metadata}"
+        )
+    if candidate_catalog != base_catalog and candidate_metadata <= base_metadata:
+        failures.append(
+            "marketplace owner/name/metadata fields changed without a strict "
+            f"metadata bump above {base_metadata}"
         )
 
     for name in sorted(base_plugins.keys() & candidate_plugins.keys()):
@@ -175,6 +199,15 @@ def check(repo: Path, base: str, candidate: str | None) -> list[str]:
         after = candidate_plugins[name].version
         if after < before:
             failures.append(f"plugin {name!r} regresses {before} -> {after}")
+        if (
+            candidate_plugins[name].payload_without_version
+            != base_plugins[name].payload_without_version
+            and after <= before
+        ):
+            failures.append(
+                f"plugin {name!r} manifest metadata changed without a strict "
+                f"version bump above {before}"
+            )
 
     layout_changed = layout_signature(base_plugins) != layout_signature(candidate_plugins)
     if layout_changed and candidate_metadata <= base_metadata:

--- a/scripts/git-mainline-guard.mjs
+++ b/scripts/git-mainline-guard.mjs
@@ -60,6 +60,31 @@ function isCanonical(remoteUrl) {
   );
 }
 
+function findCanonicalRemote() {
+  let names = [];
+  try {
+    names = gitCapture("remote").split(/\r?\n/).filter(Boolean);
+  } catch {
+    names = [];
+  }
+  for (const name of names) {
+    try {
+      const urls = [
+        ...gitCapture("remote", "get-url", "--all", name).split(/\r?\n/),
+        ...gitCapture("remote", "get-url", "--push", "--all", name).split(/\r?\n/),
+      ].filter(Boolean);
+      const url = urls.find(canonicalRemote);
+      if (url) return { name, url };
+    } catch {
+      // One malformed remote must not hide another canonical one.
+    }
+  }
+  if (process.env.GIT_MAINLINE_GUARD_TEST_CANONICAL === "1") {
+    return { name: names[0] || "origin", url: "test-fixture" };
+  }
+  return null;
+}
+
 function fail(message, code = 1) {
   process.stderr.write(`claude-code-skills guard blocked: ${message}\n`);
   process.exit(code);
@@ -80,13 +105,8 @@ function runProgression(base, candidateArgs) {
 }
 
 function preCommit() {
-  let remoteUrl = "";
-  try {
-    remoteUrl = gitCapture("remote", "get-url", "--push", "origin");
-  } catch {
-    return;
-  }
-  if (!isCanonical(remoteUrl)) return;
+  const canonical = findCanonicalRemote();
+  if (!canonical) return;
 
   let branch = "";
   try {
@@ -99,11 +119,15 @@ function preCommit() {
   }
 
   try {
-    gitCapture("rev-parse", "--verify", "refs/remotes/origin/main^{commit}");
+    gitCapture(
+      "rev-parse",
+      "--verify",
+      `refs/remotes/${canonical.name}/main^{commit}`,
+    );
   } catch {
-    fail("origin/main is unavailable; fetch it before committing.");
+    fail(`${canonical.name}/main is unavailable; fetch it before committing.`);
   }
-  runProgression("refs/remotes/origin/main", ["--candidate-index"]);
+  runProgression(`refs/remotes/${canonical.name}/main`, ["--candidate-index"]);
 }
 
 function parsePushInput(input) {

--- a/scripts/git-mainline-guard.mjs
+++ b/scripts/git-mainline-guard.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+/**
+ * Repository action gate for daymade/claude-code-skills.
+ *
+ * Local main is a read-only runtime mirror. Commits must be made on feature
+ * branches, and every push must be compared with freshly fetched current main
+ * so a stale manifest cannot lower another plugin or reuse its release number.
+ */
+
+import fs from "node:fs";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const ZERO_SHA = "0000000000000000000000000000000000000000";
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.dirname(SCRIPT_DIR);
+const CHECKER = path.join(SCRIPT_DIR, "ci", "check_version_progression.py");
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    stdio: options.capture ? "pipe" : "inherit",
+  });
+  if (result.error) {
+    throw new Error(`${command} could not start: ${result.error.message}`);
+  }
+  return result;
+}
+
+function gitCapture(...args) {
+  const result = run("git", args, { capture: true });
+  if (result.status !== 0) {
+    throw new Error(
+      `git ${args.join(" ")} failed: ${(result.stderr || result.stdout).trim()}`,
+    );
+  }
+  return result.stdout.trim();
+}
+
+function canonicalRemote(raw) {
+  const value = String(raw || "").trim().toLowerCase().replace(/\/+$/, "");
+  return [
+    "git@github.com:daymade/claude-code-skills.git",
+    "git@github.com:daymade/claude-code-skills",
+    "ssh://git@github.com/daymade/claude-code-skills.git",
+    "ssh://git@github.com/daymade/claude-code-skills",
+    "https://github.com/daymade/claude-code-skills.git",
+    "https://github.com/daymade/claude-code-skills",
+  ].includes(value);
+}
+
+function isCanonical(remoteUrl) {
+  // Test mode can only make the policy stricter by applying it to a local
+  // fixture. It cannot disable any check in a real canonical checkout.
+  return (
+    canonicalRemote(remoteUrl) ||
+    process.env.GIT_MAINLINE_GUARD_TEST_CANONICAL === "1"
+  );
+}
+
+function fail(message, code = 1) {
+  process.stderr.write(`claude-code-skills guard blocked: ${message}\n`);
+  process.exit(code);
+}
+
+function runProgression(base, candidateArgs) {
+  const result = run("python3", [
+    CHECKER,
+    "--repo",
+    REPO_ROOT,
+    "--base",
+    base,
+    ...candidateArgs,
+  ]);
+  if (result.status !== 0) {
+    fail("marketplace release state is stale or incomplete; use current origin/main and bump only the plugin(s) you changed.");
+  }
+}
+
+function preCommit() {
+  let remoteUrl = "";
+  try {
+    remoteUrl = gitCapture("remote", "get-url", "--push", "origin");
+  } catch {
+    return;
+  }
+  if (!isCanonical(remoteUrl)) return;
+
+  let branch = "";
+  try {
+    branch = gitCapture("symbolic-ref", "--quiet", "--short", "HEAD");
+  } catch {
+    fail("committing from detached HEAD is not allowed; create a feature branch from current origin/main.");
+  }
+  if (branch === "main") {
+    fail("local main is a read-only runtime mirror; commit on a feature branch and ship through a PR.");
+  }
+
+  try {
+    gitCapture("rev-parse", "--verify", "refs/remotes/origin/main^{commit}");
+  } catch {
+    fail("origin/main is unavailable; fetch it before committing.");
+  }
+  runProgression("refs/remotes/origin/main", ["--candidate-index"]);
+}
+
+function parsePushInput(input) {
+  return input
+    .split(/\r?\n/)
+    .filter((line) => line.trim())
+    .map((line) => {
+      const fields = line.trim().split(/\s+/);
+      if (fields.length !== 4) {
+        fail(`malformed pre-push input: ${line}`, 2);
+      }
+      return {
+        localRef: fields[0],
+        localSha: fields[1],
+        remoteRef: fields[2],
+        remoteSha: fields[3],
+      };
+    });
+}
+
+function prePush() {
+  const remoteName = process.argv[3] || "origin";
+  let remoteUrl = process.argv[4] || "";
+  if (!remoteUrl) {
+    try {
+      remoteUrl = gitCapture("remote", "get-url", "--push", remoteName);
+    } catch {
+      fail("could not resolve the push destination.", 2);
+    }
+  }
+  if (!isCanonical(remoteUrl)) return;
+
+  const updates = parsePushInput(fs.readFileSync(0, "utf8"));
+  if (updates.length === 0) return;
+  if (updates.some((update) => update.remoteRef === "refs/heads/main")) {
+    fail("direct pushes to main are forbidden; merge a reviewed feature PR instead.");
+  }
+
+  const featureUpdates = updates.filter(
+    (update) =>
+      update.remoteRef.startsWith("refs/heads/") &&
+      update.localSha !== ZERO_SHA,
+  );
+  if (featureUpdates.length === 0) return;
+
+  const fetchResult = run("git", [
+    "fetch",
+    "--quiet",
+    "--no-tags",
+    remoteName,
+    "refs/heads/main:refs/remotes/" + remoteName + "/main",
+  ]);
+  if (fetchResult.status !== 0) {
+    fail("could not refresh current main; refusing to judge a push against stale authority.", 2);
+  }
+  const base = `refs/remotes/${remoteName}/main`;
+  const seen = new Set();
+  for (const update of featureUpdates) {
+    if (!/^[0-9a-f]{40}$/.test(update.localSha)) {
+      fail(`candidate SHA is not a full commit identity: ${update.localSha}`, 2);
+    }
+    if (seen.has(update.localSha)) continue;
+    seen.add(update.localSha);
+    runProgression(base, ["--candidate", update.localSha]);
+  }
+}
+
+const mode = process.argv[2];
+try {
+  if (mode === "pre-commit") {
+    preCommit();
+  } else if (mode === "pre-push") {
+    prePush();
+  } else {
+    fail(`unknown mode ${JSON.stringify(mode)}`, 2);
+  }
+} catch (error) {
+  fail(error instanceof Error ? error.message : String(error), 2);
+}

--- a/tests/test_git_mainline_guard.py
+++ b/tests/test_git_mainline_guard.py
@@ -86,7 +86,13 @@ class MainlineGuardTests(unittest.TestCase):
         self.env = os.environ.copy()
         self.env["GIT_MAINLINE_GUARD_TEST_CANONICAL"] = "1"
 
-    def guard(self, mode: str, input_text: str | None = None, *extra: str):
+    def guard(
+        self,
+        mode: str,
+        input_text: str | None = None,
+        *extra: str,
+        env: dict[str, str] | None = None,
+    ):
         return run(
             self.repo,
             "node",
@@ -94,12 +100,69 @@ class MainlineGuardTests(unittest.TestCase):
             mode,
             *extra,
             input_text=input_text,
-            env=self.env,
+            env=env or self.env,
             check=False,
         )
 
     def test_pre_commit_blocks_main(self) -> None:
         result = self.guard("pre-commit")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("read-only runtime mirror", result.stderr)
+
+    def test_pre_commit_blocks_main_when_canonical_remote_is_upstream(self) -> None:
+        run(self.repo, "git", "remote", "rename", "origin", "upstream")
+        run(
+            self.repo,
+            "git",
+            "remote",
+            "set-url",
+            "upstream",
+            "https://github.com/daymade/claude-code-skills.git",
+        )
+        env = self.env.copy()
+        env.pop("GIT_MAINLINE_GUARD_TEST_CANONICAL")
+        result = self.guard("pre-commit", env=env)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("read-only runtime mirror", result.stderr)
+
+    def test_pre_commit_uses_upstream_tracking_main(self) -> None:
+        run(self.repo, "git", "remote", "rename", "origin", "upstream")
+        run(
+            self.repo,
+            "git",
+            "remote",
+            "set-url",
+            "upstream",
+            "https://github.com/daymade/claude-code-skills.git",
+        )
+        run(self.repo, "git", "switch", "-qc", "feature")
+        (self.repo / "README.md").write_text("docs\n", encoding="utf-8")
+        run(self.repo, "git", "add", "README.md")
+        env = self.env.copy()
+        env.pop("GIT_MAINLINE_GUARD_TEST_CANONICAL")
+        self.assertEqual(self.guard("pre-commit", env=env).returncode, 0)
+
+    def test_pre_commit_recognizes_canonical_fetch_with_a_separate_push_url(self) -> None:
+        run(
+            self.repo,
+            "git",
+            "remote",
+            "set-url",
+            "origin",
+            "https://github.com/daymade/claude-code-skills.git",
+        )
+        run(
+            self.repo,
+            "git",
+            "remote",
+            "set-url",
+            "--push",
+            "origin",
+            str(self.remote),
+        )
+        env = self.env.copy()
+        env.pop("GIT_MAINLINE_GUARD_TEST_CANONICAL")
+        result = self.guard("pre-commit", env=env)
         self.assertEqual(result.returncode, 1)
         self.assertIn("read-only runtime mirror", result.stderr)
 

--- a/tests/test_git_mainline_guard.py
+++ b/tests/test_git_mainline_guard.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GUARD_SOURCE = REPO_ROOT / "scripts/git-mainline-guard.mjs"
+CHECKER_SOURCE = REPO_ROOT / "scripts/ci/check_version_progression.py"
+
+
+def run(
+    repo: Path,
+    *args: str,
+    input_text: str | None = None,
+    env: dict[str, str] | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        [*args],
+        cwd=repo,
+        input=input_text,
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+    if check and result.returncode != 0:
+        raise AssertionError(result.stderr or result.stdout)
+    return result
+
+
+class MainlineGuardTests(unittest.TestCase):
+    def setUp(self) -> None:
+        if shutil.which("node") is None:
+            self.skipTest("node is required for the versioned Git guard")
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.repo = self.root / "repo"
+        self.remote = self.root / "remote.git"
+        self.repo.mkdir()
+        run(self.repo, "git", "init", "-q")
+        run(self.repo, "git", "config", "user.email", "test@example.invalid")
+        run(self.repo, "git", "config", "user.name", "Test")
+        (self.repo / "scripts/ci").mkdir(parents=True)
+        (self.repo / ".claude-plugin").mkdir()
+        (self.repo / "daymade-audio/transcript-fixer").mkdir(parents=True)
+        shutil.copy2(GUARD_SOURCE, self.repo / "scripts/git-mainline-guard.mjs")
+        shutil.copy2(CHECKER_SOURCE, self.repo / "scripts/ci/check_version_progression.py")
+        (self.repo / ".claude-plugin/marketplace.json").write_text(
+            json.dumps(
+                {
+                    "name": "fixture",
+                    "owner": {"name": "fixture"},
+                    "metadata": {"version": "1.0.0", "description": "fixture"},
+                    "plugins": [
+                        {
+                            "name": "audio",
+                            "source": "./daymade-audio",
+                            "description": "audio",
+                            "version": "1.0.0",
+                            "skills": ["./transcript-fixer"],
+                        }
+                    ],
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        (self.repo / "daymade-audio/transcript-fixer/SKILL.md").write_text(
+            "---\nname: transcript-fixer\ndescription: fixture\n---\n",
+            encoding="utf-8",
+        )
+        run(self.repo, "git", "add", ".")
+        run(self.repo, "git", "commit", "-qm", "base")
+        run(self.root, "git", "init", "--bare", "-q", str(self.remote))
+        run(self.repo, "git", "remote", "add", "origin", str(self.remote))
+        run(self.repo, "git", "push", "-qu", "origin", "main")
+        self.env = os.environ.copy()
+        self.env["GIT_MAINLINE_GUARD_TEST_CANONICAL"] = "1"
+
+    def guard(self, mode: str, input_text: str | None = None, *extra: str):
+        return run(
+            self.repo,
+            "node",
+            "scripts/git-mainline-guard.mjs",
+            mode,
+            *extra,
+            input_text=input_text,
+            env=self.env,
+            check=False,
+        )
+
+    def test_pre_commit_blocks_main(self) -> None:
+        result = self.guard("pre-commit")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("read-only runtime mirror", result.stderr)
+
+    def test_pre_commit_allows_feature_root_docs(self) -> None:
+        run(self.repo, "git", "switch", "-qc", "feature")
+        (self.repo / "README.md").write_text("docs\n", encoding="utf-8")
+        run(self.repo, "git", "add", "README.md")
+        self.assertEqual(self.guard("pre-commit").returncode, 0)
+
+    def test_pre_commit_blocks_missing_skill_bump(self) -> None:
+        run(self.repo, "git", "switch", "-qc", "feature")
+        skill = self.repo / "daymade-audio/transcript-fixer/SKILL.md"
+        skill.write_text(skill.read_text() + "changed\n", encoding="utf-8")
+        run(self.repo, "git", "add", str(skill.relative_to(self.repo)))
+        result = self.guard("pre-commit")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("version did not strictly increase", result.stderr)
+
+    def test_pre_push_blocks_direct_main(self) -> None:
+        sha = run(self.repo, "git", "rev-parse", "HEAD").stdout.strip()
+        line = f"refs/heads/main {sha} refs/heads/main {sha}\n"
+        result = self.guard("pre-push", line, "origin", str(self.remote))
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("direct pushes to main are forbidden", result.stderr)
+
+    def test_pre_push_refreshes_main_and_checks_feature(self) -> None:
+        run(self.repo, "git", "switch", "-qc", "feature")
+        skill = self.repo / "daymade-audio/transcript-fixer/SKILL.md"
+        skill.write_text(skill.read_text() + "changed\n", encoding="utf-8")
+        run(self.repo, "git", "add", str(skill.relative_to(self.repo)))
+        run(self.repo, "git", "commit", "-qm", "stale feature")
+        sha = run(self.repo, "git", "rev-parse", "HEAD").stdout.strip()
+        line = f"refs/heads/feature {sha} refs/heads/feature {'0' * 40}\n"
+        result = self.guard("pre-push", line, "origin", str(self.remote))
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("version did not strictly increase", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_version_progression.py
+++ b/tests/test_version_progression.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -57,8 +58,10 @@ class VersionProgressionTests(unittest.TestCase):
         run(self.repo, "git", "config", "user.email", "test@example.invalid")
         run(self.repo, "git", "config", "user.name", "Test")
         (self.repo / ".claude-plugin").mkdir()
+        (self.repo / "scripts/ci").mkdir(parents=True)
         (self.repo / "daymade-audio/transcript-fixer").mkdir(parents=True)
         (self.repo / "daymade-docs").mkdir()
+        shutil.copy2(CHECKER, self.repo / "scripts/ci/check_version_progression.py")
         self.write_manifest(manifest())
         (self.repo / "daymade-audio/transcript-fixer/SKILL.md").write_text(
             "---\nname: transcript-fixer\ndescription: fixture\n---\n",
@@ -120,6 +123,31 @@ class VersionProgressionTests(unittest.TestCase):
         self.assertEqual(result.returncode, 1)
         self.assertIn("plugin 'docs' regresses", result.stderr)
 
+    def test_plugin_metadata_change_requires_plugin_bump(self) -> None:
+        value = manifest()
+        value["plugins"][1]["description"] = "changed docs description"
+        value["plugins"][1]["keywords"] = ["new-keyword"]
+        self.write_manifest(value)
+        result = self.check(self.commit())
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("manifest metadata changed without a strict", result.stderr)
+
+    def test_marketplace_metadata_change_requires_catalog_bump(self) -> None:
+        value = manifest()
+        value["metadata"]["description"] = "changed catalog description"
+        self.write_manifest(value)
+        result = self.check(self.commit())
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("metadata fields changed without a strict", result.stderr)
+
+    def test_plugin_order_change_requires_catalog_bump(self) -> None:
+        value = manifest()
+        value["plugins"].reverse()
+        self.write_manifest(value)
+        result = self.check(self.commit())
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("metadata fields changed without a strict", result.stderr)
+
     def test_reusing_version_after_base_moves_fails(self) -> None:
         skill = self.repo / "daymade-audio/transcript-fixer/SKILL.md"
         skill.write_text(skill.read_text() + "first\n", encoding="utf-8")
@@ -171,6 +199,47 @@ class VersionProgressionTests(unittest.TestCase):
         )
         self.assertEqual(result.returncode, 1)
         self.assertIn("content changed but version did not strictly increase", result.stderr)
+
+    def test_candidate_cannot_replace_the_checker_that_judges_it(self) -> None:
+        skill = self.repo / "daymade-audio/transcript-fixer/SKILL.md"
+        skill.write_text(skill.read_text() + "changed\n", encoding="utf-8")
+        (self.repo / "scripts/ci/check_version_progression.py").write_text(
+            "raise SystemExit(0)\n", encoding="utf-8"
+        )
+        candidate = self.commit("candidate replaces its own judge")
+
+        candidate_result = run(
+            self.repo,
+            sys.executable,
+            "scripts/ci/check_version_progression.py",
+            check=False,
+        )
+        self.assertEqual(candidate_result.returncode, 0)
+
+        trusted_checker = self.repo / "trusted-checker.py"
+        trusted_checker.write_text(
+            run(
+                self.repo,
+                "git",
+                "show",
+                f"{self.base}:scripts/ci/check_version_progression.py",
+            ).stdout,
+            encoding="utf-8",
+        )
+        trusted_result = run(
+            self.repo,
+            sys.executable,
+            str(trusted_checker),
+            "--repo",
+            str(self.repo),
+            "--base",
+            self.base,
+            "--candidate",
+            candidate,
+            check=False,
+        )
+        self.assertEqual(trusted_result.returncode, 1)
+        self.assertIn("version did not strictly increase", trusted_result.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/test_version_progression.py
+++ b/tests/test_version_progression.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CHECKER = REPO_ROOT / "scripts/ci/check_version_progression.py"
+
+
+def run(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        [*args],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if check and result.returncode != 0:
+        raise AssertionError(result.stderr or result.stdout)
+    return result
+
+
+def manifest(audio: str = "1.0.0", docs: str = "2.0.0", metadata: str = "3.0.0") -> dict:
+    return {
+        "name": "fixture",
+        "owner": {"name": "fixture"},
+        "metadata": {"version": metadata, "description": "fixture"},
+        "plugins": [
+            {
+                "name": "audio",
+                "source": "./daymade-audio",
+                "description": "audio",
+                "version": audio,
+                "skills": ["./transcript-fixer"],
+            },
+            {
+                "name": "docs",
+                "source": "./daymade-docs",
+                "description": "docs",
+                "version": docs,
+            },
+        ],
+    }
+
+
+class VersionProgressionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.repo = Path(self.temp.name)
+        run(self.repo, "git", "init", "-q")
+        run(self.repo, "git", "config", "user.email", "test@example.invalid")
+        run(self.repo, "git", "config", "user.name", "Test")
+        (self.repo / ".claude-plugin").mkdir()
+        (self.repo / "daymade-audio/transcript-fixer").mkdir(parents=True)
+        (self.repo / "daymade-docs").mkdir()
+        self.write_manifest(manifest())
+        (self.repo / "daymade-audio/transcript-fixer/SKILL.md").write_text(
+            "---\nname: transcript-fixer\ndescription: fixture\n---\n",
+            encoding="utf-8",
+        )
+        (self.repo / "daymade-docs/SKILL.md").write_text(
+            "---\nname: docs\ndescription: fixture\n---\n", encoding="utf-8"
+        )
+        run(self.repo, "git", "add", ".")
+        run(self.repo, "git", "commit", "-qm", "base")
+        self.base = run(self.repo, "git", "rev-parse", "HEAD").stdout.strip()
+
+    def write_manifest(self, value: dict) -> None:
+        (self.repo / ".claude-plugin/marketplace.json").write_text(
+            json.dumps(value, indent=2) + "\n", encoding="utf-8"
+        )
+
+    def commit(self, message: str = "candidate") -> str:
+        run(self.repo, "git", "add", ".")
+        run(self.repo, "git", "commit", "-qm", message)
+        return run(self.repo, "git", "rev-parse", "HEAD").stdout.strip()
+
+    def check(self, candidate: str) -> subprocess.CompletedProcess[str]:
+        return run(
+            self.repo,
+            sys.executable,
+            str(CHECKER),
+            "--repo",
+            str(self.repo),
+            "--base",
+            self.base,
+            "--candidate",
+            candidate,
+            check=False,
+        )
+
+    def test_root_docs_change_needs_no_plugin_bump(self) -> None:
+        (self.repo / "README.md").write_text("docs\n", encoding="utf-8")
+        self.assertEqual(self.check(self.commit()).returncode, 0)
+
+    def test_changed_skill_without_bump_fails(self) -> None:
+        skill = self.repo / "daymade-audio/transcript-fixer/SKILL.md"
+        skill.write_text(skill.read_text() + "changed\n", encoding="utf-8")
+        result = self.check(self.commit())
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("content changed but version did not strictly increase", result.stderr)
+
+    def test_changed_skill_with_bump_passes(self) -> None:
+        skill = self.repo / "daymade-audio/transcript-fixer/SKILL.md"
+        skill.write_text(skill.read_text() + "changed\n", encoding="utf-8")
+        self.write_manifest(manifest(audio="1.1.0"))
+        self.assertEqual(self.check(self.commit()).returncode, 0)
+
+    def test_unrelated_plugin_regression_fails(self) -> None:
+        skill = self.repo / "daymade-audio/transcript-fixer/SKILL.md"
+        skill.write_text(skill.read_text() + "changed\n", encoding="utf-8")
+        self.write_manifest(manifest(audio="1.1.0", docs="1.9.9"))
+        result = self.check(self.commit())
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("plugin 'docs' regresses", result.stderr)
+
+    def test_reusing_version_after_base_moves_fails(self) -> None:
+        skill = self.repo / "daymade-audio/transcript-fixer/SKILL.md"
+        skill.write_text(skill.read_text() + "first\n", encoding="utf-8")
+        self.write_manifest(manifest(audio="1.1.0"))
+        first = self.commit("first release")
+
+        run(self.repo, "git", "switch", "-qc", "parallel", self.base)
+        skill.write_text(skill.read_text() + "parallel\n", encoding="utf-8")
+        self.write_manifest(manifest(audio="1.1.0"))
+        second = self.commit("parallel release")
+
+        result = run(
+            self.repo,
+            sys.executable,
+            str(CHECKER),
+            "--repo",
+            str(self.repo),
+            "--base",
+            first,
+            "--candidate",
+            second,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("did not strictly increase", result.stderr)
+
+    def test_layout_change_requires_metadata_bump(self) -> None:
+        value = manifest()
+        value["plugins"][0]["skills"].append("./new-member")
+        self.write_manifest(value)
+        result = self.check(self.commit())
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("layout changed without a strict", result.stderr)
+
+    def test_index_mode_reads_staged_tree_only(self) -> None:
+        skill = self.repo / "daymade-audio/transcript-fixer/SKILL.md"
+        skill.write_text(skill.read_text() + "staged\n", encoding="utf-8")
+        run(self.repo, "git", "add", str(skill.relative_to(self.repo)))
+        result = run(
+            self.repo,
+            sys.executable,
+            str(CHECKER),
+            "--repo",
+            str(self.repo),
+            "--base",
+            self.base,
+            "--candidate-index",
+            check=False,
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("content changed but version did not strictly increase", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Outcome

- blocks commits and direct pushes on the canonical local/remote main lane
- rejects stale marketplace manifests, unrelated plugin regressions, missing per-plugin bumps, and same-version collisions after another release lands
- runs the same progression check in CI
- adds 12 deterministic positive/negative guard tests

## Verification

- 41 root unit tests passed from the immutable candidate tree
- marketplace structure and 47 shell scripts validated
- Node syntax check passed
- public pre-push PII scan passed
- candidate diff is 6 explicitly owned files; the shared working tree and index were untouched