### PR TITLE
tunnel-doctor: Step 2K mistook a host firewall for a dead network path

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -748,7 +748,7 @@
       "description": "Diagnoses concrete tunnel and proxy-path failures across macOS and Windows/WSL: Tailscale routing, proxy env/system bypass, SSH double tunneling, VM/container propagation, stalled DNS, TUN DIRECT split-brain, Windows-host TUN cascades, and single-hop or chained proxy node/exit throughput. Use when Tailscale ping works but SSH/HTTP fails, browser returns 503 while curl works, Git SSH closes through the proxy, Docker pull/build fails behind TUN, getaddrinfo stalls while nslookup is fast, raw probes report physically impossible results, domestic DIRECT-routed sites fail while proxied sites work, a blocked port could be your tunnel or the destination's firewall, or the proxy is reachable but real downloads and full Git clones crawl. Also use when Git reports \"failed to begin relaying via HTTP\", ssh -vvv freezes at \"debug2: resolving\", ping works but dig times out, or setting up Tailscale SSH to WSL. Use debugging-network-issues only when the root cause remains unknown or belongs to an application/protocol layer.",
       "source": "./tunnel-doctor",
       "strict": false,
-      "version": "1.10.0",
+      "version": "1.11.0",
       "category": "developer-tools",
       "keywords": [
         "tailscale",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **tunnel-doctor** (v1.11.0): correct a false negative in Step 2K that sent the reader to the
+  wrong side of the fork. The step inferred "zero `sshd` journal entries → the packets never
+  arrived → suspect your tunnel," but a host-local packet filter produces exactly that reading
+  while the packets are in fact arriving. Verified against a live case: `tcpdump` on the
+  destination showed the client's SYNs landing on the NIC and being retransmitted, while
+  `ss` showed only `LISTEN` and no `SYN-RECV` — a default `-P INPUT DROP` with explicit accepts
+  for 80/443 was dropping them before the socket layer. Step 2K now requires `tcpdump` + `ss`
+  to separate "never arrived" from "arrived and dropped locally" before anyone blames a tunnel.
+
+  Two related corrections in the same step. A cloud host enforces an inbound port **twice** —
+  provider security group *and* host firewall (`ufw`/`firewalld`/`nftables`) — so the step now
+  checks both and states that satisfying one leaves the other blocking with no signal. And the
+  old bullet "it is in the allowlist and packets still never arrive → the blocker is local" is
+  replaced, because that is precisely the case where the blocker is the host firewall. Also adds
+  the cheapest control for "is it me or is it them": run the same probe from another host that
+  shares your egress but not your network stack — the one instrument a TUN cannot corrupt,
+  since it never traverses it. If that host succeeds, `ssh -J` through it is a working path
+  that keeps your key on your own machine.
+
+  Context for the correction: the earlier text let a blocked host be certified "completely
+  healthy" — `sshd` active and listening, config valid, no `fail2ban`, empty `hosts.deny`,
+  disk and memory fine — with the packet filter never inspected.
+
 ### Added
 - **github-ops** (v1.2.0): replace command-success GitHub automation with a verified-state
   operating contract. Every mutation now binds the account, host, fully qualified target,

--- a/tunnel-doctor/SKILL.md
+++ b/tunnel-doctor/SKILL.md
@@ -83,7 +83,8 @@ Determine which scenario applies:
 - If connections to fake-IP-resolved domains die but the same host works via `curl --resolve <host>:443:<real-ip>` (real IP from `dig @<public-resolver>`) → the TUN tool's DIRECT forwarding state is broken, not your network and not the destination (Step 2J).
 - If `nc -z` succeeds on port 22 but SSH gets no banner (`kex_exchange_identification`) → Tailscale SSH proxy intercept (Step 5A). Confirm with `tcpdump -i any port 22` on the remote — 0 packets means Tailscale intercepts above the kernel.
 - If `nc -z` also succeeds on a port the destination does **not** serve (probe 65001) → under a TUN the local stack answers for the destination, so **no `nc -z` result on that host means anything**. Never read a port probe you have not calibrated this way. This supersedes the plain `nc -z` reading in the bullet above whenever a TUN — not just Tailscale — is in the path (Step 2K).
-- If the destination's own `journalctl -u ssh` shows **zero** entries for your attempts → the packets never arrived; the blocker is its firewall allowlist or your TUN, never its `sshd`. Reach the machine through the cloud provider's guest-agent channel to ask, since that path does not use the port you cannot reach. Check the journal, not `auth.log`: on Ubuntu 24.04 `sshd` writes nothing to `auth.log`, so an empty file there is not evidence (Step 2K).
+- If the destination's own `journalctl -u ssh` shows **zero** entries for your attempts → something before `sshd` is eating them, but **not necessarily the network**: a host-local packet filter drops them just as silently. `tcpdump` on the host separates "never arrived" from "arrived and was dropped locally"; only the first implicates your TUN. Reach the machine through the cloud provider's guest-agent channel to ask, since that path does not use the port you cannot reach. Check the journal, not `auth.log`: on Ubuntu 24.04 `sshd` writes nothing to `auth.log`, so an empty file there is not evidence (Step 2K).
+- A cloud host enforces an inbound port **twice** — provider security group *and* host firewall (`ufw`/`firewalld`/`nftables`). Adding your IP to one leaves the other blocking, with no signal that you only did half the job (Step 2K).
 - If `tailscale ssh` fails with "not available on App Store builds" → install Standalone Tailscale (Step 5B).
 - If `nslookup <host>` is fast (<0.1s) but `dscacheutil -q host -a name <host>` takes 60s+ → a supplemental resolver in `scutil --dns` is dead (Step 2I).
 - If `ping <resolver-ip>` succeeds but `dig @<resolver-ip>` times out → daemon dead, `utun` interface zombied. ICMP is answered by the interface; the actual port-53 service is gone (Step 2I).
@@ -799,7 +800,7 @@ curl -x http://127.0.0.1:<proxy-port> -sS -o /dev/null -w 'overseas via proxy: %
 
 **Symptom**: SSH to a public host fails with `kex_exchange_identification: Connection closed by <ip>` — or `Connection closed by UNKNOWN port 65535` — while HTTPS to the *same* host keeps working. `nc -z <ip> 22` reports the port open. The method below is written for SSH; for another blocked service substitute its own port, log path and service unit throughout.
 
-**Why this needs its own step**: it looks exactly like Step 2H, and Step 2H's fix (restart the TUN, flush DNS) will not help, because the cause may not be local at all. It also looks exactly like Step 5A — but 5A is specifically Tailscale-on-WSL, while this step is for a TUN with no Tailscale in the path. The third mechanism neither of those covers is the destination's own firewall allowlist (a cloud security group) silently dropping you. From the client, a dropped-by-allowlist connection and a TUN forwarding failure are **indistinguishable**: both show "the connection opens, then dies before the protocol banner." Under a TUN, every additional local probe produces more misleading evidence rather than less.
+**Why this needs its own step**: it looks exactly like Step 2H, and Step 2H's fix (restart the TUN, flush DNS) will not help, because the cause may not be local at all. It also looks exactly like Step 5A — but 5A is specifically Tailscale-on-WSL, while this step is for a TUN with no Tailscale in the path. The third mechanism neither of those covers is the destination's own firewall silently dropping you — at **either** of the two layers a cloud host enforces (the provider's security group outside the machine, and `ufw`/`firewalld`/`nftables` inside it). From the client, a dropped-by-allowlist connection and a TUN forwarding failure are **indistinguishable**: both show "the connection opens, then dies before the protocol banner." Under a TUN, every additional local probe produces more misleading evidence rather than less.
 
 **First: stop trusting `nc -z`.** Under a TUN the local stack completes the TCP handshake on the destination's behalf, so `nc -z` succeeds for **every** port, including ports the destination has closed. Calibrate before reading any port probe:
 
@@ -839,8 +840,19 @@ To see an attempt land in real time, run this on the host **while you retry the 
 ss -tn | grep ':22 '
 ```
 
-- **No entries for your attempts** → your packets never arrived. The blocker sits before the destination: its firewall allowlist, or your own TUN. Continue below.
 - **Entries present** → packets arrive and `sshd` is closing you. That is a server-side problem (`MaxStartups` exhaustion, `AllowUsers`/`DenyUsers`, `hosts.deny`, full disk, fork failure) — not a tunnel problem, and outside this skill.
+- **No entries for your attempts** → **do not conclude "the packets never arrived."** Zero journal entries only proves nothing reached `sshd`, which a host-local packet filter produces just as reliably as a network that never delivered anything. The two have opposite fixes and are separated by one command:
+
+```bash
+# on the host, while the client retries; needs root
+timeout 20 tcpdump -nni any "tcp port 22 and host <your-egress-ip>" -c 10
+ss -tan '( sport = :22 )'          # look for SYN-RECV, not just LISTEN
+```
+
+- **SYNs appear in `tcpdump`, but `ss` shows only `LISTEN` and no `SYN-RECV`** → the packets **did** arrive and a **host-local firewall** dropped them before the socket layer. The network path is fine; stop looking at your tunnel. Go to the host-firewall check below.
+- **No SYNs in `tcpdump` at all** → now you have earned "never arrived." The blocker sits before the host: its cloud firewall / network ACL, or your own TUN. Continue below.
+
+⚠️ Retransmitted SYNs (the same sequence number every second) are the giveaway for a silent drop; a *rejected* connection produces an RST instead, and a *closed* port produces one immediately.
 
 **If nothing arrived, check the allowlist against your *real* egress IP.** Under a TUN, `curl ifconfig.me` returns the proxy exit, not the address the destination's firewall sees. The authoritative value is the source IP the provider recorded for **your own API calls**:
 
@@ -855,10 +867,28 @@ The IP filter is load-bearing: internal service-to-service events carry a **host
 
 ⚠️ This is authoritative **only if your provider-API traffic and your blocked connection take the same forwarding plane** (both DIRECT, or both proxied). Step 2J is the reason: a TUN routes by rule, so the provider's API domain and your destination host can sit on different planes with different exits — in which case the recorded IP is not the IP the destination's firewall sees. Confirm the two match a common rule before trusting the comparison.
 
-Compare that address with the security group's inbound rules for the port:
+**There are usually two allowlists, and fixing one is not fixing the problem.** A cloud host typically enforces the port twice: at the provider's security group (outside the machine) and again at the host's own firewall (`ufw`, `firewalld`, raw `iptables`/`nftables`). They are edited by different tools, drift independently, and a rule added to one is invisible in the other. Check **both**, always:
 
-- **Your current egress IP is not in the allowlist** → that is the fix. Have the security-group owner add it (on Alibaba Cloud, `aliyun ecs AuthorizeSecurityGroup`; the reverse is `RevokeSecurityGroup`). Allowlists pinned to a dynamic residential or mobile address rot silently: the rule still reads as correct, and nothing logs the day your address changes.
-- **It is in the allowlist and packets still never arrive** → the blocker is local; continue below.
+```bash
+# outside the machine — provider security group (Alibaba Cloud shown)
+aliyun ecs DescribeSecurityGroupAttribute --RegionId <region> --SecurityGroupId <sg-id>
+
+# inside the machine, via the out-of-band channel — host firewall
+ufw status verbose 2>/dev/null            # Debian/Ubuntu, if ufw is in use
+firewall-cmd --list-all 2>/dev/null       # RHEL family
+iptables -S 2>/dev/null | head -30        # raw rules, and the INPUT policy
+nft list ruleset 2>/dev/null | head -60
+```
+
+- **Your current egress IP is missing from *either* list** → that is the fix. Add it to that layer (security group: `aliyun ecs AuthorizeSecurityGroup`, reverse `RevokeSecurityGroup`; `ufw allow from <ip> to any port <n> proto tcp`, reverse `ufw delete allow ...`). Allowlists pinned to a dynamic residential or mobile address rot silently: the rule still reads as correct, and nothing logs the day your address changes.
+- **It is present in the security group but packets still never reach `sshd`** → this is the case the previous bullet's older wording got wrong. It does **not** mean the blocker is local. Run the `tcpdump` + `ss` pair above first: arriving SYNs with no `SYN-RECV` mean the *host* firewall is dropping you, and no amount of work on your own machine will change it. Only after `tcpdump` shows nothing arriving is the blocker local; continue below.
+
+⚠️ **`iptables -S` first, not just the service-level tools.** A default `-P INPUT DROP` with explicit accepts for 80/443 looks like a healthy machine from every angle this skill checks elsewhere — `sshd` active and listening on `0.0.0.0:22`, config valid, no `fail2ban`, empty `hosts.deny`, disk and memory fine — and still drops every SSH packet. Checking `fail2ban` and `hosts.deny` while skipping the packet filter is the single easiest way to certify a blocked host as "completely healthy."
+
+**Borrow a second vantage point before blaming your own machine.** If any other host shares your egress (another machine on the same LAN, a phone hotspot, a colleague's laptop) but *not* your network stack, run the same probe from there. It is the cheapest control that exists for "is it me or is it them," and it is the one instrument a TUN cannot corrupt, because it does not traverse the TUN. Two readings, two meanings:
+
+- **The clean host fails too, and its egress IP matches yours** → the destination is refusing you; your tunnel was never the problem.
+- **The clean host succeeds** → the blocker really is local, and you now also have a working path (`ssh -J <clean-host> <destination>` relays TCP while your key stays on your own machine).
 
 **Confirm a local blocker** by asking the proxy to relay explicitly instead of letting the TUN intercept:
 


### PR DESCRIPTION
## What was wrong

Step 2K told the reader:

> **No entries for your attempts** → your packets never arrived. The blocker sits before the destination: its firewall allowlist, or your own TUN.

That inference does not hold. Zero `sshd` journal entries only proves nothing reached `sshd` — and a **host-local packet filter** produces exactly that reading while the packets are in fact arriving. The two causes have opposite fixes, and the step routed every reader to the wrong one.

A second bullet compounded it:

> **It is in the allowlist and packets still never arrive** → the blocker is local

That names the precise case where the blocker is *not* local: the IP satisfied the cloud security group, and the host firewall was still dropping it.

## Evidence

Measured on a live host while a client retried:

- `tcpdump` on the destination: the client's SYNs **arriving on the NIC** and being retransmitted once per second.
- `ss -tan '( sport = :22 )'` at the same moment: **only `LISTEN`**, no `SYN-RECV` — the kernel received the packets and never created a socket.
- Cause: `-P INPUT DROP` with explicit accepts for the web ports only.

Every other health signal this skill checks elsewhere was green at that moment: `sshd` active and listening on all interfaces, `sshd -t` passing, no `fail2ban`, empty `hosts.deny`, disk and memory fine. **The old text let a blocked host be certified "completely healthy."**

## Changes

- **Require `tcpdump` + `ss` before blaming a tunnel.** Retransmitted SYNs with no `SYN-RECV` = host firewall; no SYNs at all = you have earned "never arrived."
- **Check both allowlists.** A cloud host enforces an inbound port twice — provider security group *and* host firewall (`ufw`/`firewalld`/`nftables`). They drift independently and satisfying one leaves the other blocking with no signal. Commands added for all four.
- **`iptables -S` first, not just the service-level tools** — a default-DROP policy is invisible to every other check in this skill.
- **Borrowed-vantage-host control.** Run the same probe from a machine that shares your egress but not your network stack. It is the one instrument a TUN cannot corrupt, because it never traverses it. If that host succeeds, `ssh -J <clean-host> <destination>` is a working path that keeps your key on your own machine.
- Two same-inference sites in the Key-distinctions list and the "why this needs its own step" rationale corrected to match.

## Verification

- `check_marketplace.py` — OK, 54 plugins
- `check_version_progression.py` — OK, no regression, plugin bumped 1.10.0 → 1.11.0
- `check_shell_syntax.sh` — OK, 94 scripts
- `validate_changed_skills.sh` — `ok tunnel-doctor`, 0 pre-existing issues carried
- Diff scanned for identifiers, addresses and hostnames from the originating incident: zero matches (checker calibrated against a string known to be present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
