### PR TITLE
feat(history): restore local-conversation-history as the cross-provider entry point

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional Claude Code and Codex skills marketplace — production-ready skills spanning GitHub and git operations (including current-base contributor PR review), document conversion and generation (Markdown, PDF, PPTX, DOCX), diagram and UI-design extraction, the full audio pipeline (ASR transcription, TTS, transcript correction, meeting minutes), financial and investment-research data, web scraping and content capture, security/PII tooling and secure repomix packaging, macOS and iOS development, CLI demo and terminal automation, prompt and skill engineering, deep research and fact-checking, QA and LLM-evaluation infrastructure, internationalization, network/Tailscale and remote-desktop diagnostics, Claude Code operations, and model-aware Codex workstation setup. Suite plugins bundle related skills under shared namespaces, including the StepFun StepAudio 2.5 audio family. See the Available Skills list in the README for the authoritative per-skill breakdown.",
-    "version": "3.4.1"
+    "version": "3.5.0"
   },
   "plugins": [
     {
@@ -104,7 +104,7 @@
       "description": "Claude Code operations suite that bundles cross-project prior-work retrieval across code, docs, Skills, meetings, WeChat archives, and conversation history; provider-separated Claude Code and Codex history readers; identity- and lineage-gated continuation workflows; plugin/skill troubleshooting; CLAUDE.md progressive disclosure optimization; version-synced Lark CLI routing; statusline configuration; exported .txt repair; full claude.ai conversation extraction with tool-call rendering and file download; plugin marketplace development and suite consolidation; writing/testing/debugging Claude Code hooks; multi-provider profile isolation; personal-memory migration into tool-agnostic AGENTS.md reference docs; one-shot local timers that ping Claude right after subscription quota reset to start a fresh 5-hour usage window; and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
       "source": "./daymade-claude-code",
       "strict": false,
-      "version": "3.6.2",
+      "version": "3.7.0",
       "category": "suite",
       "keywords": [
         "suite",
@@ -129,6 +129,7 @@
         "memory-migration"
       ],
       "skills": [
+        "./local-conversation-history",
         "./read-claude-code-history",
         "./read-codex-history",
         "./continue-claude-code-work",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   disk and memory fine — with the packet filter never inspected.
 
 ### Added
+- **local-conversation-history** (`daymade-claude-code` v3.7.0; marketplace v3.5.0): restore the
+  cross-provider entry point above the four provider-and-action-specific history skills. PR #357
+  converged local history into `read-claude-code-history`, `read-codex-history`,
+  `continue-claude-code-work` and `continue-codex-work`, and moved the old entry point's SKILL.md
+  into `read-codex-history` as a legacy reference; the router that was meant to sit above them was
+  specified the same day and never written — no branch, no commit, no PR. This adds it.
+
+  It routes by platform (Claude Code / Codex / Kimi CLI) x action (read evidence vs continue
+  interrupted work), and owns the one job none of the four own alone: a single inventory across all
+  three providers. Both readers already ship `list_local_history.py` and its `--source` defaults to
+  `all`, but each reader's task table pins it to that reader's own provider, so a cross-provider
+  listing never happened unless someone asked for it by name. Kimi CLI, which has no dedicated skill,
+  had no entry anywhere.
+
+  Deliberately thin: no parsing, no provider-specific flags beyond `--source`, and no copy of an
+  executor's commands, so it cannot drift into teaching a stale invocation. It does carry forward
+  three invariants the retired skill had established — the Claude source set is indivisible (active
+  homes plus every archive in `~/.claude/history-sources.json`), the current session self-matches and
+  must be excluded before a hit counts as historical evidence, and zero results are not absence.
 - **github-ops** (v1.2.0): replace command-success GitHub automation with a verified-state
   operating contract. Every mutation now binds the account, host, fully qualified target,
   authorized consequence, recovery path, supported input schema, and an independent readback;

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ claude plugin install daymade-claude-code@daymade-skills
 This suite bundles the skills that extend Claude Code itself — cross-project prior-work retrieval across code, docs, Skills, meetings, WeChat archives, and conversation history; fast local conversation discovery across Claude Code and Codex; session recovery; CLAUDE.md tuning; version-synced Lark CLI routing; troubleshooting; statusline configuration; export repair; marketplace development and suite consolidation; terminal screenshot rendering; usage analysis; and multi-provider model switching:
 
 ```text
+/daymade-claude-code:local-conversation-history
 /daymade-claude-code:read-claude-code-history
 /daymade-claude-code:read-codex-history
 /daymade-claude-code:continue-claude-code-work
@@ -896,6 +897,31 @@ Transform vague prompts into precise, well-structured specifications using EARS 
 - `examples.md` - Full transformation examples with before/after comparisons
 
 **💡 Innovation**: EARS methodology eliminates ambiguity by forcing explicit conditions, triggers, and measurable criteria. Combined with domain theory grounding (GTD, BJ Fogg, Gestalt, etc.), it transforms "build a todo app" into a complete specification with behavioral psychology principles, UX best practices, and concrete test cases - enabling test-driven development from day one.
+
+---
+
+### **local-conversation-history** - Cross-Provider History Entry Point
+
+> **Install**: `claude plugin install daymade-claude-code@daymade-skills` (suite-only — invoked as `daymade-claude-code:local-conversation-history`)
+
+The entry point above the four provider-and-action-specific history skills. It
+routes a request to whichever one owns it — by platform (Claude Code, OpenAI
+Codex, Kimi CLI) and action (read evidence vs continue interrupted work) — and
+owns the one job none of them own alone: a single inventory spanning all three
+providers.
+
+**When to use:**
+- The provider is unknown or plural — "our history", "what have I been working on"
+- Listing Kimi CLI sessions, which has no dedicated skill of its own
+- It is unclear whether the need is evidence or resumption
+- You remember this entry point by name
+
+**When not to use:** the platform *and* the action are both already clear. Load
+that executor skill directly instead — this router adds a hop, not information.
+
+**Design**: a thin routing layer. It carries no parsing, no provider-specific
+flags beyond `--source`, and no copies of the executors' commands, so it cannot
+drift into teaching a stale invocation.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -217,6 +217,7 @@ claude plugin install daymade-claude-code@daymade-skills
 一次安装即可获得扩展 Claude Code 本体的全部 power-user 技能——跨代码、项目文档、Skill/SOP、会议、微信归档与对话历史的已有工作检索；跨 Claude Code/Codex 的快速本地对话发现；会话恢复；CLAUDE.md 调优；随 lark-cli 版本同步的飞书路由；故障诊断；statusline 配置；导出修复；marketplace 开发与 suite 收敛；终端截图渲染；用量分析；以及多 Provider 模型切换：
 
 ```text
+/daymade-claude-code:local-conversation-history
 /daymade-claude-code:read-claude-code-history
 /daymade-claude-code:read-codex-history
 /daymade-claude-code:continue-claude-code-work
@@ -929,6 +930,28 @@ python3 scripts/calculate_metrics.py tests/TEST-EXECUTION-TRACKING.csv
 - `examples.md` - 包含前后对比的完整转换示例
 
 **💡 创新**：EARS 方法论通过强制明确条件、触发器和可测量标准来消除歧义。结合领域理论基础（GTD、BJ Fogg、格式塔等），它将"构建一个待办事项应用"转换为包含行为心理学原则、UX 最佳实践和具体测试用例的完整规范 - 从第一天起就支持测试驱动开发。
+
+---
+
+### **local-conversation-history** - 跨 provider 历史统一入口
+
+> **安装**：`claude plugin install daymade-claude-code@daymade-skills`（仅作为套件成员发布，调用方式 `daymade-claude-code:local-conversation-history`）
+
+四个「平台 × 动作」历史 Skill 之上的入口层。它按平台（Claude Code / OpenAI Codex /
+Kimi CLI）和动作（取证 vs 续做）把请求分流给真正拥有它的那一个，并独占一件谁都不单独
+拥有的事：**一次列出全部三家 provider 的会话清单**。
+
+**使用场景：**
+- provider 未知或不止一个——「我们的历史」「我最近都在忙什么」
+- 列 Kimi CLI 会话，它没有专属 Skill
+- 分不清要的是取证还是续做
+- 你记得的就是这个入口名
+
+**不适用**：平台和动作**都**已经明确时，直接加载对应的执行 Skill——此时路由只多一跳，
+不提供额外信息。
+
+**设计**：薄路由层。不含解析逻辑、不含 `--source` 以外的 provider 专属参数、不复制执行
+Skill 的命令，因此不会漂移成教一条过期的调用方式。
 
 ---
 

--- a/daymade-claude-code/local-conversation-history/.security-scan-passed
+++ b/daymade-claude-code/local-conversation-history/.security-scan-passed
@@ -1,0 +1,4 @@
+Security scan passed
+Scanned at: 2026-08-29T23:37:03.382473+00:00
+Tool: gitleaks + pattern-based validation
+Content hash: 85344ff9a1a78cba8b6be7903e9b872de5c8a07eba8ea64d09e046022bc2ff47

--- a/daymade-claude-code/local-conversation-history/.security-scan-passed
+++ b/daymade-claude-code/local-conversation-history/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-08-29T23:37:03.382473+00:00
+Scanned at: 2026-08-29T23:55:55.781697+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 85344ff9a1a78cba8b6be7903e9b872de5c8a07eba8ea64d09e046022bc2ff47
+Content hash: 9d6545fdc026507734b08bec95d8f7154d923f62e560fd45c6eb7daa3c49098a

--- a/daymade-claude-code/local-conversation-history/SKILL.md
+++ b/daymade-claude-code/local-conversation-history/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: local-conversation-history
+description: >-
+  Entry point for local AI conversation history across providers. Routes a
+  request to the one skill that owns it, by platform (Claude Code, OpenAI Codex,
+  Kimi CLI) and action (read evidence vs continue interrupted work), and owns the
+  one job none of them own alone: a single inventory spanning all three
+  providers. Use when the provider is unknown or plural ("our history", "what
+  have I been working on", "which chats did I have"), when the user wants Kimi
+  CLI sessions, when it is unclear whether they need evidence or resumption, or
+  when they ask for this skill by name. When the platform and the action are
+  both already clear, load that executor skill directly instead.
+argument-hint: "[keywords | session-id | workspace-path]"
+---
+
+# Local Conversation History — router
+
+This skill decides **which** skill runs. It does not parse history itself, does
+not own commands for a single provider, and never re-implements what an executor
+already does. If you find yourself explaining flags for one provider, you are in
+the wrong skill — hand off and stop.
+
+## Route by platform × action
+
+Establish two things before routing: **which platform** the conversation lived
+on, and whether the user wants **evidence** (what was said/done) or
+**resumption** (take the work forward).
+
+| Platform | Read evidence | Continue the work |
+|---|---|---|
+| Claude Code | `daymade-claude-code:read-claude-code-history` | `daymade-claude-code:continue-claude-code-work` |
+| OpenAI Codex | `daymade-claude-code:read-codex-history` | `daymade-claude-code:continue-codex-work` |
+| Kimi CLI | see **Cross-provider inventory** below | no continuation skill exists |
+
+Resumption always follows a read. The continuation skills require a verified
+read receipt; routing straight to them without one is a defect, not a shortcut.
+
+## Cross-provider inventory — the job only this entry point routes
+
+"What have I been working on", "list my recent chats", an unknown provider, or
+Kimi CLI all need **one inventory across all three providers**. Both readers ship
+the same bundled inventory command, and its `--source` already defaults to `all`
+— but each reader's own task table pins it to that reader's provider
+(`--source claude`, `--source codex`). So a cross-provider inventory does not
+happen unless someone asks for it.
+
+Route it to `read-claude-code-history` and state the scope explicitly: run that
+skill's bundled inventory with `--source all` (or `--source kimi` for Kimi
+alone). Let it resolve its own command; this skill names the scope, not the
+path. **Kimi CLI has no other entry anywhere** — no dedicated skill exists, and
+its home resolves `--kimi-home` > `KIMI_HOME` > `~/.kimi-code`.
+
+Let the executor own every flag beyond `--source`: scope (`--all-projects`,
+`--recursive`), date bounds, `--include-archived`, `--include-subagents`,
+`--include-automated`, and output format. This skill names the provider scope
+and nothing else.
+
+## Intent decides the route — the word "history" does not
+
+| The user's requested result | Route |
+|---|---|
+| A list of conversations: titles, dates, session IDs | Cross-provider inventory above, or the matching reader when one platform is named |
+| The conversation where a topic, quote, file, or tool result appeared — "find that old chat", "did we ever discuss X" | The matching reader's **search**, not an inventory. When the provider is unknown, the search must cover all three; a Claude-only result cannot support an absence claim |
+| Their own raw inputs in chronological order, verbatim | The matching reader's verbatim-input path. Preserve duplicates and session boundaries; duplicates are part of the ledger, not noise |
+| Picking work back up from an identified session | The matching continuation skill, after a read |
+
+The requested output wins over the background motivation. If someone explains a
+problem and then asks for a window of their own raw inputs, return that window —
+the explanation's topic clues do not convert the request into a content search.
+
+## Invariants that survive routing
+
+- **Completeness.** A Claude inventory's source set is indivisible: the
+  auto-discovered active homes (`~/.claude`, profile homes, the current
+  `CLAUDE_CONFIG_DIR`) **plus** every archive registered in
+  `~/.claude/history-sources.json`. Never call a conversation absent unless the
+  output shows the registered archives were covered. An unavailable required
+  archive is a configuration error, not permission to return a partial answer.
+  `--claude-home` is a diagnostic override and can never back a completeness
+  claim.
+- **Self-match.** The current session records the user's question and this
+  agent's own commands, so it matches almost any query about itself. Exclude the
+  current session ID before treating a hit as historical evidence.
+- **Zero results are not absence.** Ranked recall and a bounded search both
+  return nothing for wording that exists under different words. Widen, or say
+  what was searched — do not convert an empty result into "it never happened".
+
+## Do not
+
+- Do not run provider-specific parsing, SQLite, `rg`, `jq`, or JSONL pipelines
+  here. Every one of those belongs to an executor that already handles its
+  store's schema, archives, and failure modes.
+- Do not copy an executor's flags into this file beyond `--source`. They change;
+  this file would drift silently and then teach the wrong command.
+- Do not route to a continuation skill to answer a question about the past.
+  Reading is evidence; continuing changes the world.

--- a/daymade-claude-code/local-conversation-history/SKILL.md
+++ b/daymade-claude-code/local-conversation-history/SKILL.md
@@ -7,9 +7,14 @@ description: >-
   one job none of them own alone: a single inventory spanning all three
   providers. Use when the provider is unknown or plural ("our history", "what
   have I been working on", "which chats did I have"), when the user wants Kimi
-  CLI sessions, when it is unclear whether they need evidence or resumption, or
-  when they ask for this skill by name. When the platform and the action are
-  both already clear, load that executor skill directly instead.
+  CLI history at all, when it is unclear whether they need evidence or
+  resumption, or when they ask for this skill by name. Vague recall that names
+  no platform ("we discussed this once, when was it?") belongs here rather than
+  to a single-provider reader, because a Claude-only answer to an unscoped
+  question cannot support an absence claim. When the platform and the action are
+  both already clear, load that executor skill directly instead — except Kimi
+  CLI, which has no reader or continuation skill of its own and always routes
+  through here.
 argument-hint: "[keywords | session-id | workspace-path]"
 ---
 
@@ -30,37 +35,49 @@ on, and whether the user wants **evidence** (what was said/done) or
 |---|---|---|
 | Claude Code | `daymade-claude-code:read-claude-code-history` | `daymade-claude-code:continue-claude-code-work` |
 | OpenAI Codex | `daymade-claude-code:read-codex-history` | `daymade-claude-code:continue-codex-work` |
-| Kimi CLI | see **Cross-provider inventory** below | no continuation skill exists |
+| Kimi CLI | `read-claude-code-history`, with the Kimi scope named — see **Provider scope** | no continuation skill exists |
 
 Resumption always follows a read. The continuation skills require a verified
 read receipt; routing straight to them without one is a defect, not a shortcut.
 
-## Cross-provider inventory — the job only this entry point routes
+**When the platform is not stated** — a bare session ID, "pick up where we left
+off" — do not guess it. Identify it first: try the Claude Code exact-session
+lookup in `read-claude-code-history`, then the Codex rollout locator in
+`read-codex-history`. Only a lookup that returns a verified identity decides
+which continuation skill runs; a plausible-looking ID prefix does not.
 
-"What have I been working on", "list my recent chats", an unknown provider, or
-Kimi CLI all need **one inventory across all three providers**. Both readers ship
-the same bundled inventory command, and its `--source` already defaults to `all`
-— but each reader's own task table pins it to that reader's provider
-(`--source claude`, `--source codex`). So a cross-provider inventory does not
-happen unless someone asks for it.
+## Provider scope — the job only this entry point routes
 
-Route it to `read-claude-code-history` and state the scope explicitly: run that
-skill's bundled inventory with `--source all` (or `--source kimi` for Kimi
-alone). Let it resolve its own command; this skill names the scope, not the
-path. **Kimi CLI has no other entry anywhere** — no dedicated skill exists, and
-its home resolves `--kimi-home` > `KIMI_HOME` > `~/.kimi-code`.
+Each executor defaults to its own provider, so a request that spans providers
+never widens by itself. **Naming the scope is this skill's whole job.** It has
+two axes, and they use different flags — conflating them is the failure this
+section exists to prevent.
 
-Let the executor own every flag beyond `--source`: scope (`--all-projects`,
-`--recursive`), date bounds, `--include-archived`, `--include-subagents`,
-`--include-automated`, and output format. This skill names the provider scope
-and nothing else.
+| Cross-provider need | Route to | Name this scope |
+|---|---|---|
+| **Inventory** — "what have I been working on", "list my recent chats", session titles/dates/IDs | `read-claude-code-history`, its bundled inventory | `--source all`, or `--source kimi` for Kimi alone |
+| **Content search** — "did we ever discuss X", find the conversation containing a quote, file, or tool result | `read-claude-code-history`, its bundled full-event search | add `--codex` and `--kimi` to the Claude search; each is a separate store the Claude registry never covers |
+
+Both readers ship the same inventory command and its `--source` already defaults
+to `all` — but each reader's own task table pins it to that reader's provider
+(`--source claude`, `--source codex`), so the default never fires on its own.
+Search is the mirror image: it is Claude-only unless the other two stores are
+added explicitly.
+
+**Kimi CLI has no other entry anywhere** — no dedicated skill exists for either
+axis. Its home resolves `--kimi-home` > `KIMI_HOME` > `~/.kimi-code`.
+
+Let the executor own every flag beyond provider scope: `--all-projects`,
+`--recursive`, date bounds, `--include-archived`, `--include-subagents`,
+`--include-automated`, output format, and every detail of how each store is
+parsed. This skill names which providers are in scope and nothing else.
 
 ## Intent decides the route — the word "history" does not
 
 | The user's requested result | Route |
 |---|---|
-| A list of conversations: titles, dates, session IDs | Cross-provider inventory above, or the matching reader when one platform is named |
-| The conversation where a topic, quote, file, or tool result appeared — "find that old chat", "did we ever discuss X" | The matching reader's **search**, not an inventory. When the provider is unknown, the search must cover all three; a Claude-only result cannot support an absence claim |
+| A list of conversations: titles, dates, session IDs | The inventory row under **Provider scope**, or the matching reader when one platform is named |
+| The conversation where a topic, quote, file, or tool result appeared — "find that old chat", "did we ever discuss X" | The **search** row under **Provider scope**, never an inventory. Listing titles is not searching content, and a title match is not evidence the content exists |
 | Their own raw inputs in chronological order, verbatim | The matching reader's verbatim-input path. Preserve duplicates and session boundaries; duplicates are part of the ledger, not noise |
 | Picking work back up from an identified session | The matching continuation skill, after a read |
 


### PR DESCRIPTION
## Outcome

Restores the entry point above the four provider-and-action-specific history skills.

PR #357 converged local history into `read-claude-code-history`, `read-codex-history`, `continue-claude-code-work` and `continue-codex-work`, and retired `local-conversation-history` by moving its SKILL.md into `read-codex-history` as a legacy reference. The router that was meant to sit above those four was specified the same day and accepted, then never written — no branch, no commit, no PR. This adds it.

## What it owns

- **Routing** by platform (Claude Code / Codex / Kimi CLI) × action (read evidence vs continue interrupted work).
- **The one job none of the four own alone**: a single inventory across all three providers. Both readers ship the same bundled inventory and its `--source` already defaults to `all`, but each reader's task table pins it to that reader's own provider (`--source claude`, `--source codex`) — so a cross-provider listing never happens unless someone asks for it by name.
- **Kimi CLI**, which has no dedicated skill and had no entry anywhere.

## What it deliberately does not own

Parsing, provider-specific flags beyond `--source`, and any copy of an executor's commands. `quick_validate` flagged an earlier draft's bare `scripts/…` reference as ambiguous about which bundle owns it; the fix was to drop the path entirely and let the executor resolve its own command. A thin layer cannot drift into teaching a stale invocation.

## Invariants carried forward from the retired skill

- The Claude source set is indivisible — active homes **plus** every archive in `~/.claude/history-sources.json`; a partial view cannot back an absence claim.
- The current session self-matches almost any query about itself and must be excluded before a hit counts as historical evidence.
- Zero results are not absence.

## Verification

- `quick_validate`: **Skill is valid!**
- `check_marketplace.py`: 54 plugins, every source resolves, no unregistered directories.
- `check_version_progression.py`: no regression; only the changed plugin bumped (`daymade-claude-code` 3.6.2 → 3.7.0, marketplace 3.4.1 → 3.5.0).
- `check_doc_skill_lists.py`: both README catalogs 102/102, no drift.
- `security_scan.py`: gitleaks clean. Its own warning says a green scan is not a clean bill for a public repo, so the file was also read by hand for private paths, names and CJK — clean, the only non-ASCII character is an em-dash.