### PR TITLE
fix(read-codex-history): preserve oversized evidence briefings

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -104,7 +104,7 @@
       "description": "Claude Code operations suite that bundles cross-project prior-work retrieval across code, docs, Skills, meetings, WeChat archives, and conversation history; provider-separated Claude Code and Codex history readers; identity- and lineage-gated continuation workflows; plugin/skill troubleshooting; CLAUDE.md progressive disclosure optimization; version-synced Lark CLI routing; statusline configuration; exported .txt repair; full claude.ai conversation extraction with tool-call rendering and file download; plugin marketplace development and suite consolidation; writing/testing/debugging Claude Code hooks; multi-provider profile isolation; personal-memory migration into tool-agnostic AGENTS.md reference docs; one-shot local timers that ping Claude right after subscription quota reset to start a fresh 5-hour usage window; and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
       "source": "./daymade-claude-code",
       "strict": false,
-      "version": "3.7.0",
+      "version": "3.7.1",
       "category": "suite",
       "keywords": [
         "suite",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **read-codex-history** (`daymade-claude-code` v3.7.1): define “one chronological
+  evidence briefing” as one immutable local artifact rather than one oversized model
+  payload. Large briefings are materialized once, hash- and line-count-bound, then read
+  through bounded non-overlapping ranges; unread ranges remain explicit gaps instead of
+  being hidden by rerunning and fusing differently truncated outputs. The compatibility
+  section now distinguishes the restored cross-provider router from its historical
+  combined-command reference while keeping Codex evidence ownership here.
 - **tunnel-doctor** (v1.11.0): correct a false negative in Step 2K that sent the reader to the
   wrong side of the fork. The step inferred "zero `sshd` journal entries → the packets never
   arrived → suspect your tunnel," but a host-local packet filter produces exactly that reading

--- a/daymade-claude-code/read-codex-history/.security-scan-passed
+++ b/daymade-claude-code/read-codex-history/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-08-26T20:39:55.139690+00:00
+Scanned at: 2026-08-30T00:02:01.467953+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 5b1cc430daa2acbf7aa97a2e2676ceee7cdcf5e6e90cf6097553f5b8143491b8
+Content hash: 6da13cbc051aa0188d275582b94a58b154d4443568753d0fdca7d1991c387b2d

--- a/daymade-claude-code/read-codex-history/SKILL.md
+++ b/daymade-claude-code/read-codex-history/SKILL.md
@@ -100,6 +100,14 @@ an ID, the reader accepts byte-identical copies or a strict append-only superset
 otherwise fails as ambiguous. Every selected and inherited JSONL record is parsed
 strictly; malformed lines cannot become a complete-looking receipt.
 
+If the complete briefing is too large for one model context, materialize it once to a
+private temporary file and record its SHA-256 plus line count before reading. That one
+immutable file is still the single briefing; “one briefing” does not mean one stdout
+payload or one monolithic context load. Read bounded, non-overlapping ranges using its
+existing headings or exact record coordinates, keep coverage against the recorded line
+count, and report every unread range as a gap. Do not rerun the reader with different
+truncation and fuse the outputs into a complete-looking chronology.
+
 ### Bounded full-event search
 
 ```text
@@ -150,10 +158,11 @@ negative result.
 - Do not infer Session state or ownership from process names, cwd, or writer-lock absence.
 - Keep raw history local unless the user explicitly asks to share it.
 
-## Legacy compatibility
+## Router and legacy compatibility
 
-The former `local-conversation-history` combined Claude, Codex, and Kimi inventory.
-Its complete instructions remain in
+The current `local-conversation-history` is a cross-provider router; it sends a
+provider-specific Codex read here and does not replace this Skill's identity,
+lineage, or evidence contract. The older combined command contract remains in
 [references/legacy_multi_provider_inventory.md](references/legacy_multi_provider_inventory.md)
-so the Kimi branch and old command contract are not silently erased. New Claude
-requests route to `daymade-claude-code:read-claude-code-history`.
+so its Kimi branch and historical flags are not silently erased. Provider-specific
+Claude requests route to `daymade-claude-code:read-claude-code-history`.


### PR DESCRIPTION
# Pull Request

## Description

Prevents complete Codex session briefings from being truncated when they exceed one model context.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement to existing skill

## Changes Made

- Define one briefing as one immutable private local artifact, not one stdout payload.
- Bind oversized briefings by SHA-256 and line count before bounded reads.
- Require non-overlapping range coverage and explicit unread gaps; forbid fusing differently truncated reruns.
- Bump the `daymade-claude-code` suite and record the change.

## Affected Skills

- `daymade-claude-code:read-codex-history`

## Testing Done

- [x] Validated with Skill Creator `quick_validate`.
- [x] Passed Skill Creator security scan and existing-Skill regression audit.
- [x] Passed strict marketplace validation and README/manifest drift checks.
- [x] Passed one commit-pinned fresh-context fidelity/actionability review with no BLOCKER or MAJOR.

## Quality Checklist

- [x] Documentation and marketplace version are synchronized.
- [x] No old capability was removed.
- [x] No sensitive project material or private path was added.
- [x] Changes remain read-only and do not resume old work.
