### PR TITLE
docs(history): Kimi is a live surface of read-claude-code-history, not a legacy reference

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -104,7 +104,7 @@
       "description": "Claude Code operations suite that bundles cross-project prior-work retrieval across code, docs, Skills, meetings, WeChat archives, and conversation history; provider-separated Claude Code and Codex history readers; identity- and lineage-gated continuation workflows; plugin/skill troubleshooting; CLAUDE.md progressive disclosure optimization; version-synced Lark CLI routing; statusline configuration; exported .txt repair; full claude.ai conversation extraction with tool-call rendering and file download; plugin marketplace development and suite consolidation; writing/testing/debugging Claude Code hooks; multi-provider profile isolation; personal-memory migration into tool-agnostic AGENTS.md reference docs; one-shot local timers that ping Claude right after subscription quota reset to start a fresh 5-hour usage window; and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
       "source": "./daymade-claude-code",
       "strict": false,
-      "version": "3.7.1",
+      "version": "3.7.2",
       "category": "suite",
       "keywords": [
         "suite",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **read-claude-code-history** (`daymade-claude-code` v3.7.2): the Skill claimed Kimi
+  CLI was reachable "only through that reference until a dedicated Kimi reader is
+  justified," while its own bundled scripts ship a live `search --kimi`
+  (`search_kimi_wires`) and `list_local_history.py --source kimi`. With the
+  cross-provider router now sending every Kimi request here, that stale sentence was
+  the last hop of a chain that answers a Kimi question from Claude data and reports a
+  false "never happened". Kimi is now a task-table row and a stated live surface, the
+  legacy section documents the router, and the two frozen PR #357 snapshots carry a
+  banner saying they describe retired contracts — one of them shares its `name:` with
+  a skill that has since been rebuilt around a different contract. The router drops
+  its duplicate copy of the Kimi home-resolution order, which belongs to the executor
+  that owns the surface, and widens its own "no executor flags here" rule to admit the
+  three flags that name provider scope, which it was already using.
 - **read-codex-history** (`daymade-claude-code` v3.7.1): define “one chronological
   evidence briefing” as one immutable local artifact rather than one oversized model
   payload. Large briefings are materialized once, hash- and line-count-bound, then read

--- a/daymade-claude-code/local-conversation-history/SKILL.md
+++ b/daymade-claude-code/local-conversation-history/SKILL.md
@@ -65,7 +65,8 @@ Search is the mirror image: it is Claude-only unless the other two stores are
 added explicitly.
 
 **Kimi CLI has no other entry anywhere** — no dedicated skill exists for either
-axis. Its home resolves `--kimi-home` > `KIMI_HOME` > `~/.kimi-code`.
+axis, so both routes above land in `read-claude-code-history`, which documents
+its own Kimi home resolution.
 
 Let the executor own every flag beyond provider scope: `--all-projects`,
 `--recursive`, date bounds, `--include-archived`, `--include-subagents`,
@@ -107,7 +108,9 @@ the explanation's topic clues do not convert the request into a content search.
 - Do not run provider-specific parsing, SQLite, `rg`, `jq`, or JSONL pipelines
   here. Every one of those belongs to an executor that already handles its
   store's schema, archives, and failure modes.
-- Do not copy an executor's flags into this file beyond `--source`. They change;
-  this file would drift silently and then teach the wrong command.
+- Do not copy an executor's flags into this file beyond the three that name
+  provider scope (`--source`, `--codex`, `--kimi`) — those are this skill's own
+  subject. Every other flag changes on the executor's schedule; copying one here
+  makes this file drift silently and then teach the wrong command.
 - Do not route to a continuation skill to answer a question about the past.
   Reading is evidence; continuing changes the world.

--- a/daymade-claude-code/read-claude-code-history/SKILL.md
+++ b/daymade-claude-code/read-claude-code-history/SKILL.md
@@ -8,7 +8,10 @@ description: >-
   Claude homes plus registered archives. Use whenever the user asks what they or
   Claude said, wants a Claude Code session ID or original context, remembers prior
   work vaguely, needs an old file from a transcript, or must prove what a Claude
-  session contained before continuing it. For Codex history use read-codex-history.
+  session contained before continuing it. Also owns the only Kimi CLI surface, via
+  its Kimi inventory and search flags. For Codex history use read-codex-history;
+  when the request names no platform at all or spans providers, start at
+  local-conversation-history.
 argument-hint: "[session-id | keywords | workspace-path]"
 ---
 
@@ -29,6 +32,7 @@ hand the verified evidence to `daymade-claude-code:continue-claude-code-work`.
 | Prior work whose wording may have changed | `scripts/history_index.py recall` after checking index status |
 | How sessions in a time window ended | `scripts/analyze_sessions.py triage` |
 | A deleted/overwritten file preserved in Claude file-history records | `scripts/recover_content.py` |
+| Kimi CLI sessions — this Skill owns the only live Kimi surface | inventory: `scripts/list_local_history.py --source kimi`; full-text: `scripts/analyze_sessions.py search --kimi` |
 | Continue a verified Claude session | Stop reading and invoke `daymade-claude-code:continue-claude-code-work` |
 
 The requested output wins over the background story. If the user asks for a
@@ -145,11 +149,20 @@ be checked against raw records and the current workspace for load-bearing claims
   it can contain credentials and private business context.
 - Do not report a search as complete after a timeout or malformed source.
 
-## Legacy compatibility
+## Router and legacy compatibility
+
+`daymade-claude-code:local-conversation-history` is the cross-provider router. It
+sends Claude reads and every Kimi CLI request here, and does not replace this
+Skill's identity or evidence contract. New Codex requests route to
+`daymade-claude-code:read-codex-history`.
+
+**Kimi CLI is a live surface of this Skill, not a legacy one.** It has no reader
+of its own, so the two commands in the task table above are the only way to reach
+it; a Kimi question answered from Claude data alone produces a false "never
+happened". Home resolution order is `--kimi-home` > `KIMI_HOME` > `~/.kimi-code`.
 
 The former `claude-code-history-files-finder` also exposed optional Codex and Kimi
-branches. Their original instructions are retained in
+branches. Its original instructions are retained in
 [references/legacy_cross_provider_workflow.md](references/legacy_cross_provider_workflow.md)
-for migration and regression evidence. New Codex requests must route to
-`daymade-claude-code:read-codex-history`; legacy Kimi commands remain available only
-through that reference until a dedicated Kimi reader is justified by real use.
+as a frozen snapshot for migration and regression evidence only — read it for what
+the old contract said, never as a description of what ships today.

--- a/daymade-claude-code/read-claude-code-history/references/legacy_cross_provider_workflow.md
+++ b/daymade-claude-code/read-claude-code-history/references/legacy_cross_provider_workflow.md
@@ -17,7 +17,14 @@ description: >-
   inventory, use local-conversation-history.
 ---
 
-# Claude Code History Files Finder
+# Claude Code History Files Finder — frozen snapshot, not a live contract
+
+> ⚠️ **`claude-code-history-files-finder` no longer exists.** This is its retired
+> PR #357 snapshot, kept for migration and regression evidence. Its Codex branch
+> now lives in `daymade-claude-code:read-codex-history`, and its Kimi branch is a
+> live surface of `daymade-claude-code:read-claude-code-history` — not, as the
+> frontmatter above implies, something reachable only through this file. Read this
+> for what the old contract said; read those skills for what ships today.
 
 Search and recover content from Claude Code session history stored in active
 homes and explicitly registered long-term archives.

--- a/daymade-claude-code/read-codex-history/references/legacy_multi_provider_inventory.md
+++ b/daymade-claude-code/read-codex-history/references/legacy_multi_provider_inventory.md
@@ -15,7 +15,14 @@ description: >-
 argument-hint: "[workspace-path]"
 ---
 
-# Local Conversation History
+# Local Conversation History — frozen snapshot, not a live contract
+
+> ⚠️ **This is the retired PR #357 snapshot of a skill that has since been rebuilt
+> under the same name.** The frontmatter above describes an executor that listed
+> three providers itself; the live `daymade-claude-code:local-conversation-history`
+> is a thin router that owns no parsing at all. Read this file only for what the
+> old contract said. For what ships today, read that skill and the executors it
+> routes to — never quote the description above as current.
 
 List project-scoped histories or exact Codex prompt-ledger rows without
 reconstructing ad hoc `rg`, `stat`, `jq`, SQLite, or JSONL pipelines. The two


### PR DESCRIPTION
## The defect

`read-claude-code-history/SKILL.md` said:

> legacy Kimi commands remain available only through that reference until a dedicated Kimi reader is justified by real use

Its own bundled scripts disagree:

- `scripts/analyze_sessions.py` — `--kimi` flag (line 2137), `search_kimi_wires()` (line 836), called at line 2527
- `scripts/list_local_history.py` — `--source` accepts `kimi` (line 603)

The task table had **zero** Kimi rows; every row pinned `--source claude` or a Claude-only script.

## Why it became load-bearing now

While `local-conversation-history` was a dead name (#357 → #403), that sentence was inert. #403 restored the router, and the router sends **every** Kimi request here — Kimi has no reader of its own. So the chain now reads:

> router: "Kimi always routes to read-claude-code-history"
> → read-claude-code-history: "Kimi is legacy-only, see the reference"
> → agent answers from Claude data → reports a false "never happened"

That is the same failure shape the router's own invariants forbid, arriving through the door #403 opened.

## Changes

**`read-claude-code-history/SKILL.md`**
- Task table gains a Kimi row naming both live commands.
- `## Legacy compatibility` → `## Router and legacy compatibility`, symmetric to what #404 added to `read-codex-history`. States that Kimi is a live surface, and that the legacy reference is a frozen snapshot rather than a description of what ships.
- Description names the Kimi surface and defers platform-unknown / cross-provider requests to the router (a trigger collision an independent review flagged against #403; the anchor side is fixed here).

**Two frozen PR #357 snapshots** — banner at the top of each. One of them carries `name: local-conversation-history` in its frontmatter, which now collides with a live skill rebuilt around a completely different contract (executor → thin router); a reader grepping that name hits the retired description first.

**`local-conversation-history/SKILL.md`** — SSOT hygiene inside a file already being touched:
- Drops its duplicate copy of the Kimi home-resolution order (`--kimi-home` > `KIMI_HOME` > `~/.kimi-code`), which now lives once, with the executor that owns the surface.
- Its own "do not copy executor flags into this file beyond `--source`" rule was already being violated by the table's `--codex` / `--kimi`. Widened to admit exactly the three flags that name provider scope — those are this skill's subject; everything else still belongs to the executor.

## Verification

| Check | Result |
|---|---|
| `check_marketplace.py` | OK — 54 plugins |
| `check_version_progression.py --base origin/main` | OK |
| `check_doc_skill_lists.py` | OK — catalogs match, CLAUDE.md carries only the authority pointer |
| `quick_validate` × 3 changed skills | Skill is valid! |
| `validate_changed_skills.sh origin/main` | OK — 3 touched, 0 pre-existing carried |
| `run_registered_tests.sh` | OK — 15 registered suites |
| PII Guard (pre-commit) | clean |

No README change: their router sections already say Kimi has no dedicated skill, which stays true. No `CLAUDE.md` change: `check_doc_skill_lists.py` enforces that it carry only the authority pointer, and history routing is not one of its standing rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)