### PR TITLE
prior-work-retrieval: stop arming on questions about the current session

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -104,7 +104,7 @@
       "description": "Claude Code operations suite that bundles cross-project prior-work retrieval across code, docs, Skills, meetings, WeChat archives, and conversation history; provider-separated Claude Code and Codex history readers; identity- and lineage-gated continuation workflows; plugin/skill troubleshooting; CLAUDE.md progressive disclosure optimization; version-synced Lark CLI routing; statusline configuration; exported .txt repair; full claude.ai conversation extraction with tool-call rendering and file download; plugin marketplace development and suite consolidation; writing/testing/debugging Claude Code hooks; multi-provider profile isolation; personal-memory migration into tool-agnostic AGENTS.md reference docs; one-shot local timers that ping Claude right after subscription quota reset to start a fresh 5-hour usage window; and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
       "source": "./daymade-claude-code",
       "strict": false,
-      "version": "3.7.2",
+      "version": "3.7.3",
       "category": "suite",
       "keywords": [
         "suite",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **daymade-claude-code / prior-work-retrieval** (v3.7.3): stop arming the retrieval gate on
+  questions about the *current* session. `什么来着` sits in the strong-signal tier, so it armed
+  with no distal-referent requirement — and the gate's own `audit` command shows it firing twice
+  on prompts whose referent is the conversation already in front of the executor
+  (「我们这个对话最开始是想要干什么来着」,「我们的主线任务是什么来着」). Those have no carrier
+  to search, no candidate to verify, and produce no artifact, so the gate could only add
+  friction, and a gate that misfires on healthy input is how an operator learns to bypass it
+  reflexively.
+
+  Fixed by excising the proximal construct before signal matching, alongside the existing
+  negation and stale-age excisions. Demoting `什么来着` to the weak tier was the wrong fix:
+  「上次做的方案叫什么来着？」 is a genuine recall and carries no distal determiner, so it would
+  have stopped arming. The excised span must include the recall idiom itself — removing only
+  `这个对话` leaves `什么来着` behind and the strong tier still matches it. Calibrated in both
+  directions (4 proximal prompts no longer arm; 6 genuine-recall prompts still do) with
+  regression tests for each half; suite 66/66.
+
 - **read-claude-code-history** (`daymade-claude-code` v3.7.2): the Skill claimed Kimi
   CLI was reachable "only through that reference until a dedicated Kimi reader is
   justified," while its own bundled scripts ship a live `search --kimi`

--- a/daymade-claude-code/prior-work-retrieval/scripts/prior_work_hook.py
+++ b/daymade-claude-code/prior-work-retrieval/scripts/prior_work_hook.py
@@ -107,6 +107,27 @@ NEGATED_PRIOR_SIGNAL = re.compile(
 # "这些 Skill 也是很久之前写的" dates something to argue it is stale — the
 # opposite of asking to go find it. Excised like a negation.
 STALE_AGE_IDIOM = re.compile(r"(?:很久|太久|好久|老早|早就)\s*(?:以前|之前)")
+# 「我们这个对话最开始是想要干什么来着」/「我们的主线任务是什么来着」ask what the
+# CURRENT session is about. The answer is the conversation already in front of the
+# executor: no carrier to search, no candidate to verify, and no artifact produced —
+# so the gate can only add friction, and a gate that misfires on healthy input is
+# how an operator learns to bypass it reflexively.
+#
+# This is the same distinction the weak tier already draws with 这个脚本 (the script
+# in front of you) vs 那个脚本 (one being recalled), but 什么来着 sits in the strong
+# tier and so arms with no distal requirement. Demoting it to the weak tier is the
+# wrong fix: 「上次做的方案叫什么来着？」 is a genuine recall and carries no distal
+# determiner, so it would stop arming. Excising the proximal construct instead
+# leaves every distal phrasing untouched.
+#
+# The excised span MUST include the recall idiom itself — excising only 这个对话
+# leaves 什么来着 behind and the strong tier still matches it.
+CURRENT_SESSION_RECALL = re.compile(
+    r"(?:这个|这次|本次|当前|我们这)\s*(?:对话|会话|session)[^\n。；;，,]{0,30}"
+    r"(?:什么来着|想(?:要)?干什么|要干什么|是要做什么)"
+    r"|(?:主线|当前|本次)\s*(?:任务|目标)\s*(?:是)?\s*什么来着",
+    re.IGNORECASE,
+)
 HOOK_GUIDANCE_MARKER = "Prior Work Retrieval is required before substantial production"
 USER_OPTOUT = re.compile(
     r"(?:不用|不要|无需|跳过).{0,12}(?:查历史|检索历史|已有工作检索|prior work|历史检索)"
@@ -185,7 +206,9 @@ def classify_prompt(prompt: str, receipt_valid: bool = False) -> str:
         return "none"
     if USER_OPTOUT.search(text):
         return "opt_out"
-    scannable = STALE_AGE_IDIOM.sub(" ", NEGATED_PRIOR_SIGNAL.sub(" ", text))
+    scannable = CURRENT_SESSION_RECALL.sub(
+        " ", STALE_AGE_IDIOM.sub(" ", NEGATED_PRIOR_SIGNAL.sub(" ", text))
+    )
     if PRIOR_WORK_STRONG_SIGNAL.search(scannable):
         return "required_prior_signal"
     if PRIOR_WORK_WEAK_SIGNAL.search(scannable) and DISTAL_WORK_NOUN.search(scannable):

--- a/daymade-claude-code/prior-work-retrieval/tests/test_prior_work_hook.py
+++ b/daymade-claude-code/prior-work-retrieval/tests/test_prior_work_hook.py
@@ -79,6 +79,41 @@ class PriorWorkHookTests(unittest.TestCase):
                     hook.classify_prompt(prompt, False), "required_prior_signal"
                 )
 
+    def test_recall_about_the_current_session_does_not_arm(self) -> None:
+        # Observed twice in the audit log: 什么来着 sits in the strong tier, so it
+        # armed on questions whose referent is the conversation already in front of
+        # the executor. There is no carrier to search and no artifact produced, so
+        # the gate could only add friction — and a gate that misfires on healthy
+        # input is how an operator learns to bypass it reflexively.
+        prompts = [
+            "我们这个对话最开始是想要干什么来着",
+            "我们的主线任务是什么来着",
+            "本次会话最开始是要干什么来着",
+            "当前对话的主线任务是什么来着",
+        ]
+        for prompt in prompts:
+            with self.subTest(prompt=prompt):
+                self.assertNotEqual(
+                    hook.classify_prompt(prompt, False), "required_prior_signal"
+                )
+
+    def test_current_session_excision_does_not_swallow_distal_recall(self) -> None:
+        # The narrow half of the same fix: excising the proximal construct must not
+        # cost any genuine recall. 上次做的方案叫什么来着 carries no distal
+        # determiner, which is why demoting 什么来着 to the weak tier was the wrong
+        # fix and excision was the right one.
+        prompts = [
+            "之前用的那个框架是什么来着？",
+            "上次做的方案叫什么来着？",
+            "上次那个脚本叫什么",
+            "复用 Flowzero 长音频 checkpoint 与本地 ASR 实现",
+        ]
+        for prompt in prompts:
+            with self.subTest(prompt=prompt):
+                self.assertEqual(
+                    hook.classify_prompt(prompt, False), "required_prior_signal"
+                )
+
     def test_ordinary_production_prompt_does_not_create_requirement(self) -> None:
         event = {
             "hook_event_name": "UserPromptSubmit",


### PR DESCRIPTION
## The misfire

The gate's own `audit` command reports the same false positive twice:

```
matched='什么来着'  '我们这个对话最开始是想要干什么来着'
matched='什么来着'  '我们的主线任务是什么来着'
```

Both ask what the **current** session is about. The answer is the conversation already in front of the executor — no carrier to search, no candidate to open, no artifact produced. The gate can only add friction there, and a gate that misfires on healthy input is how an operator learns to reach for the bypass reflexively.

## Cause

`什么来着` sits in `PRIOR_WORK_STRONG_SIGNAL`, which arms unconditionally. The weak tier already draws exactly the distinction this needs — `这个脚本` is the script in front of you, `那个脚本` is one being recalled — but the strong tier never consults it.

## Why not just demote it to the weak tier

Because 「上次做的方案叫什么来着？」 is a genuine recall and carries **no** distal determiner, so it would stop arming. That prompt is already in the suite. Excising the proximal construct instead — alongside the existing negation and stale-age excisions — leaves every distal phrasing untouched.

One detail worth keeping: **the excised span has to include the recall idiom itself.** Removing only `这个对话` leaves `什么来着` behind and the strong tier matches it anyway.

## Calibration

Run before the suite, because false positives are the expensive side here:

**No longer arm** (2 observed in the audit log + 2 variants)
- 我们这个对话最开始是想要干什么来着
- 我们的主线任务是什么来着
- 本次会话最开始是要干什么来着
- 当前对话的主线任务是什么来着

**Still arm** (genuine recall — a miss here costs duplicated work)
- 之前用的那个框架是什么来着？ *(already in the suite)*
- 上次做的方案叫什么来着？ *(already in the suite)*
- 上次那个脚本叫什么
- 复用 … 与本地 ASR 实现
- 但是我不希望你重新造轮子
- 按照路 A 做吧，我们之前 … 就是这么做的

10/10. Regression tests added for both halves.

## Verification

- `python -m unittest discover -s tests` — 66 tests, OK; both new cases confirmed executing via `-v` (the default output prints no case names, so a bare `OK` would not have proven they ran)
- `scripts/prior-work-retrieval.sh --selftest` — OK
- `check_marketplace.py` — OK, 54 plugins
- `check_version_progression.py` — OK, plugin bumped 3.7.2 → 3.7.3
- `check_shell_syntax.sh` — OK, 94 scripts
- `validate_changed_skills.sh` — `ok daymade-claude-code/prior-work-retrieval`, 0 pre-existing issues carried
- PII guard clean; diff scanned for identifiers from the originating session (checker calibrated against a string known to be present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
