### PR TITLE
docs(prior-work-retrieval): route unscoped conversation evidence to the router

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -104,7 +104,7 @@
       "description": "Claude Code operations suite that bundles cross-project prior-work retrieval across code, docs, Skills, meetings, WeChat archives, and conversation history; provider-separated Claude Code and Codex history readers; identity- and lineage-gated continuation workflows; plugin/skill troubleshooting; CLAUDE.md progressive disclosure optimization; version-synced Lark CLI routing; statusline configuration; exported .txt repair; full claude.ai conversation extraction with tool-call rendering and file download; plugin marketplace development and suite consolidation; writing/testing/debugging Claude Code hooks; multi-provider profile isolation; personal-memory migration into tool-agnostic AGENTS.md reference docs; one-shot local timers that ping Claude right after subscription quota reset to start a fresh 5-hour usage window; and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
       "source": "./daymade-claude-code",
       "strict": false,
-      "version": "3.7.3",
+      "version": "3.7.4",
       "category": "suite",
       "keywords": [
         "suite",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **prior-work-retrieval** (`daymade-claude-code` v3.7.4): the Search routing table was
+  provider-blind in one row and short one row. "Meaning remembered, wording changed" carried no
+  platform qualifier while its adapter is a Claude-only index, and no row covered prior
+  conversation evidence whose platform is unknown, plural, or simply not Claude — so a
+  cross-provider retrieval could satisfy the table, search Claude alone, and write "no prior work
+  found" into a receipt. The recall row now states its Claude scope and a new row routes
+  unscoped/non-Claude conversation evidence to `local-conversation-history`. The description was
+  audited for a trigger collision with that router and does not have one: it is limited to reuse
+  before substantial new production, which the router never claims.
 - **daymade-claude-code / prior-work-retrieval** (v3.7.3): stop arming the retrieval gate on
   questions about the *current* session. `什么来着` sits in the strong-signal tier, so it armed
   with no distal-referent requirement — and the gate's own `audit` command shows it firing twice

--- a/daymade-claude-code/prior-work-retrieval/SKILL.md
+++ b/daymade-claude-code/prior-work-retrieval/SKILL.md
@@ -227,8 +227,9 @@ path remain possible so the agent can repair the gate without bypassing it.
 | Need | Route |
 |---|---|
 | Known exact string, symbol, path | Filesystem carrier (`rg`) |
-| Meaning remembered, wording changed | Declared semantic adapter (gbrain or Claude-history hybrid recall) |
+| Meaning remembered, wording changed | Declared semantic adapter (gbrain, or Claude-history hybrid recall — that index covers Claude sessions only) |
 | Exact prior Claude tool/thinking/file-history evidence | `read-claude-code-history search` |
+| Prior conversation evidence whose platform is unknown, plural, or not Claude | `local-conversation-history`; each provider is a separate store, so a Claude-only answer cannot support "we never discussed it" |
 | Meeting decision or speaker claim | Project transcript carrier; open raw speaker turn |
 | Archived WeChat text/voice transcription | Declared WeChat archive carrier |
 | Live/latest WeChat | `read-wechat-messages`; record manual coverage |


### PR DESCRIPTION
Follow-up to #405, closing the last item its review archive listed as *not checked*.

## Audited, not a defect

`prior-work-retrieval`'s **description** was flagged as a possible trigger collision with the restored `local-conversation-history` router. It is not one. The description is limited to *reuse before substantial new production* ("Finds and verifies existing successful work before substantial new production when reuse is materially plausible"), plus explicit anti-triggers for inspection, bug fixes, and reports. The router never claims that job. **No change.**

## The actual defect, one level down

Its `## Search routing` table was provider-blind in one row and short one row:

| Row | Problem |
|---|---|
| `Meaning remembered, wording changed → …Claude-history hybrid recall` | Need side carries **no platform qualifier**, but the adapter is a Claude-only index. A cross-provider need matches this row and gets a Claude-only answer. |
| — | **No row at all** for prior conversation evidence whose platform is unknown, plural, or not Claude. |

`Exact prior **Claude** tool/thinking/file-history evidence` is fine as written — its Need side is self-limiting, so a Codex need never matches it. That row is untouched.

Consequence: a cross-provider retrieval could satisfy the table, search Claude alone, and write "no prior work found" into a receipt — the zero-hits-prove-absence failure this skill's own description explicitly forbids ("zero hits never prove absence").

## Change

- Recall row states its Claude scope.
- New row: unscoped / non-Claude conversation evidence → `local-conversation-history`, with the reason (each provider is a separate store).

Two lines of table, no logic, no scripts.

## Verification

| Check | Result |
|---|---|
| `check_marketplace.py` | OK — 54 plugins |
| `check_version_progression.py --base origin/main` | OK |
| `check_doc_skill_lists.py` | OK |
| `quick_validate` | Skill is valid! |
| `validate_changed_skills.sh origin/main` | OK — 1 touched, 0 pre-existing carried |
| `run_registered_tests.sh` | OK — 15 registered suites |
| PII Guard (pre-commit) | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)