### PR TITLE
ci(validate_changed_skills): say what the "no skill directory" OK examined

### DIFF
--- a/scripts/ci/validate_changed_skills.sh
+++ b/scripts/ci/validate_changed_skills.sh
@@ -58,7 +58,27 @@ skills="$(
 )"
 
 if [ -z "$skills" ]; then
+  # This OK must say WHAT IT LOOKED AT, for the same reason as the PREFLIGHT above: the
+  # walk reads the COMMITTED diff ($MERGE_BASE...HEAD), so staged-but-uncommitted edits are
+  # invisible to it. "you genuinely touched no skill" and "you touched three skills and have
+  # not committed them yet" then print the identical green line.
+  #
+  # Measured 2026-08-30: run locally right after `git add` on a change that edited three
+  # skills, this printed "OK: this change touches no skill directory". Read as a pass, it
+  # certifies work the run never examined.
+  #
+  # Deliberately NOT a failure: on CI, and for any genuinely skill-free commit, zero touched
+  # skills is the correct and common answer — failing there would kill healthy input and
+  # teach people to skip the check. Naming the scope is enough to make the vacuous case
+  # visible without arming a gate that misfires.
+  examined="$(git diff --name-only "$MERGE_BASE"...HEAD | wc -l | tr -d ' ')"
   echo "OK: this change touches no skill directory"
+  echo "    scope: the committed diff $MERGE_BASE...HEAD ($examined file(s) examined)"
+  uncommitted="$(git status --porcelain | wc -l | tr -d ' ')"
+  if [ "$uncommitted" != "0" ]; then
+    echo "    NOTE: $uncommitted uncommitted path(s) were NOT examined. If your skill edits are"
+    echo "          still staged or unstaged, this OK says nothing about them — commit and re-run."
+  fi
   exit 0
 fi
 


### PR DESCRIPTION
## The hole

`validate_changed_skills.sh` walks `git diff --name-only $MERGE_BASE...HEAD` — the **committed** diff. When that yields nothing it prints:

```
OK: this change touches no skill directory
```

Two very different situations print that identical line:

1. You genuinely touched no skill directory. (Correct, common, fine.)
2. You edited three skills and haven't committed them yet. The run examined **zero** of your files and still printed OK.

**Measured 2026-08-30**: run locally right after `git add` on a change that edited three skills, it printed `OK: this change touches no skill directory`. Read as a pass, that green certifies work the run never looked at.

This is the same class the file's own `PREFLIGHT` block already guards against ("a gate reporting success exactly when it is broken — worse than no gate, because the green tick is now evidence of nothing"), one hole further down.

## Change

The OK now names its scope, and counts what it did not look at:

```
OK: this change touches no skill directory
    scope: the committed diff 6a91781...HEAD (0 file(s) examined)
    NOTE: 2 uncommitted path(s) were NOT examined. If your skill edits are
          still staged or unstaged, this OK says nothing about them — commit and re-run.
```

**Deliberately not a failure.** Zero touched skills is the correct and common answer on CI and for any skill-free commit; failing there would kill healthy input and train people to skip the check. Naming the scope makes the vacuous case visible without arming a gate that misfires.

## Calibration — both directions, and the first probe was broken

| Input | Result |
|---|---|
| **Dangerous** — committed diff empty, 2 uncommitted paths present | `0 file(s) examined` + NOTE naming 2 unexamined paths ✅ |
| **Healthy** — clean tree, one committed non-skill file | `1 file(s) examined`, **no NOTE** ✅ |

Worth recording: the first dangerous-direction probe was a `.tmp` file, which `.gitignore:48` (`*.tmp`) swallowed. It never appeared in `git status`, so the NOTE that fired was triggered by the script's own uncommitted edit, not by the probe — the test passed while measuring something else. Re-run with a non-ignored `.md` probe, after first asserting the probe was actually visible to git.

No behavior change to any pass/fail verdict; only the zero-touched message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)