### PR TITLE
fix(doc-to-markdown): PDF 后处理三件套 + heavy 退化大声警告（v1.12.0）

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -283,7 +283,7 @@
       "description": "Audio processing suite covering the full speech pipeline: ASR transcription (Qwen3, StepFun) with batch-mode guards against music-only repetition-loop hallucinations, speaker diarization and CAM++ voiceprint identification for multi-speaker recordings, transcript error correction, structured meeting minutes generation, and TTS voice synthesis (StepFun). Install once for the complete audio workflow.",
       "source": "./daymade-audio",
       "strict": false,
-      "version": "1.32.2",
+      "version": "1.32.3",
       "category": "suite",
       "keywords": [
         "suite",
@@ -309,7 +309,7 @@
       "description": "Daymade skills core suite. Bundles skill creation, quality review, real Claude/Codex Skill-surface governance, suite-migration reconciliation, and marketplace development tooling under one shared namespace. Skill governance separates canonical source, installed inventory, discovery policy, the fresh model-visible catalog, and router-resolved cold resources instead of optimizing cache counts; it preserves Claude's official versioned-cache lifecycle and verifies selected entries in the real host prompt. Skill verification separates risk classification from evaluation spend: bounded fixes use targeted checks, narrow behavior changes use sampled replays, and paired baselines, graders, benchmarks, or a viewer run only after explicit user authorization or a decision-bearing evidence plan plus opt-in; that authorization does not change the risk tier. Existing-skill edits retain an old-vs-new capability audit and content-bound packaging attestation so prompt compression cannot silently delete runtime contracts. When the official skill-creator plugin is also installed, skill-creator detects the coexistence and offers a consent-based, reversible SessionStart routing hook so the daymade edition wins deterministically; on machines without the official plugin nothing is ever installed.",
       "source": "./daymade-skill",
       "strict": false,
-      "version": "1.32.0",
+      "version": "1.32.1",
       "category": "suite",
       "keywords": [
         "suite",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -104,7 +104,7 @@
       "description": "Claude Code operations suite that bundles cross-project prior-work retrieval across code, docs, Skills, meetings, WeChat archives, and conversation history; provider-separated Claude Code and Codex history readers; identity- and lineage-gated continuation workflows; plugin/skill troubleshooting; CLAUDE.md progressive disclosure optimization; version-synced Lark CLI routing; statusline configuration; exported .txt repair; full claude.ai conversation extraction with tool-call rendering and file download; plugin marketplace development and suite consolidation; writing/testing/debugging Claude Code hooks; multi-provider profile isolation; personal-memory migration into tool-agnostic AGENTS.md reference docs; one-shot local timers that ping Claude right after subscription quota reset to start a fresh 5-hour usage window; and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
       "source": "./daymade-claude-code",
       "strict": false,
-      "version": "3.7.4",
+      "version": "3.7.5",
       "category": "suite",
       "keywords": [
         "suite",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -185,7 +185,7 @@
       "description": "Documentation suite plugin that exposes document conversion, Mermaid diagram generation, PDF/PPT/DOCX creation, Excel workbook creation/parsing/control, and documentation cleanup, and docx review-comment/track-changes extraction skills under one shared namespace",
       "source": "./daymade-docs",
       "strict": false,
-      "version": "1.11.0",
+      "version": "1.12.0",
       "category": "suite",
       "keywords": [
         "suite",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **read-claude-code-history / read-codex-history** (`daymade-claude-code` v3.7.5):
+  stop scanning the same multi-gigabyte Claude history tree once per profile label.
+  Multi-model profiles commonly expose distinct config homes whose `projects/` paths are
+  symlinks to one physical tree; the inventory previously parsed that tree again for every
+  alias and only de-duplicated sessions after paying the full I/O cost. It now groups sources
+  by the resolved physical `projects/` path, scans each tree once, and attaches every nominal
+  active/archive label to the resulting conversations before the existing cross-tree merge;
+  the original-word exporter now applies the same grouping to each of its two logical passes.
+  A deterministic main + aliased-profile + distinct-archive regression proves two physical
+  parses instead of three, full provenance retention, and non-inflated subagent exclusion
+  counts, while a second regression proves two exporter reads instead of four; both complete
+  reader suites remain green.
 - **prior-work-retrieval** (`daymade-claude-code` v3.7.4): the Search routing table was
   provider-blind in one row and short one row. "Meaning remembered, wording changed" carried no
   platform qualifier while its adapter is a Claude-only index, and no row covered prior

--- a/daymade-claude-code/_conversation_core/sources.py
+++ b/daymade-claude-code/_conversation_core/sources.py
@@ -72,6 +72,24 @@ def _active_sources(
     ]
 
 
+def group_claude_sources_by_projects(
+    sources: Sequence[HistorySource],
+) -> list[list[HistorySource]]:
+    """Group source labels that expose the same physical ``projects/`` tree.
+
+    Multi-model Claude profiles commonly symlink their ``projects/`` directory
+    to the main profile.  Inventory callers must scan that physical tree once,
+    while retaining every nominal source label as provenance.  Group order and
+    source order remain stable so representative-path selection stays
+    deterministic.  Distinct archive trees remain distinct groups.
+    """
+    groups: dict[str, list[HistorySource]] = {}
+    for source in sources:
+        key = _resolved_key(source.home / "projects")
+        groups.setdefault(key, []).append(source)
+    return list(groups.values())
+
+
 def _read_manifest(path: Path) -> dict:
     try:
         raw = path.read_text(encoding="utf-8")

--- a/daymade-claude-code/read-claude-code-history/scripts/_core/sources.py
+++ b/daymade-claude-code/read-claude-code-history/scripts/_core/sources.py
@@ -72,6 +72,24 @@ def _active_sources(
     ]
 
 
+def group_claude_sources_by_projects(
+    sources: Sequence[HistorySource],
+) -> list[list[HistorySource]]:
+    """Group source labels that expose the same physical ``projects/`` tree.
+
+    Multi-model Claude profiles commonly symlink their ``projects/`` directory
+    to the main profile.  Inventory callers must scan that physical tree once,
+    while retaining every nominal source label as provenance.  Group order and
+    source order remain stable so representative-path selection stays
+    deterministic.  Distinct archive trees remain distinct groups.
+    """
+    groups: dict[str, list[HistorySource]] = {}
+    for source in sources:
+        key = _resolved_key(source.home / "projects")
+        groups.setdefault(key, []).append(source)
+    return list(groups.values())
+
+
 def _read_manifest(path: Path) -> dict:
     try:
         raw = path.read_text(encoding="utf-8")

--- a/daymade-claude-code/read-claude-code-history/scripts/extract_user_messages.py
+++ b/daymade-claude-code/read-claude-code-history/scripts/extract_user_messages.py
@@ -47,7 +47,10 @@ from pathlib import Path
 
 # Multi-home discovery lives in the bundled `_core` package (see analyze_sessions.py).
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _core.sources import discover_claude_sources  # noqa: E402
+from _core.sources import (  # noqa: E402
+    discover_claude_sources,
+    group_claude_sources_by_projects,
+)
 from _core.text import iter_jsonl  # noqa: E402
 
 CST = timezone(timedelta(hours=8))
@@ -118,7 +121,8 @@ def _iter_session_files(sources, cutoff: datetime):
     """Yield (source_label, Path) for session JSONL files. mtime is only a coarse
     prefilter with a 2-day grace band; the real window is applied per record."""
     grace = cutoff.timestamp() - 2 * 86400
-    for src in sources:
+    for group in group_claude_sources_by_projects(sources):
+        src = group[0]
         projects = src.home / 'projects'
         if not projects.is_dir():
             continue

--- a/daymade-claude-code/read-claude-code-history/scripts/list_local_history.py
+++ b/daymade-claude-code/read-claude-code-history/scripts/list_local_history.py
@@ -32,6 +32,7 @@ from _core.sources import (  # noqa: E402
     HistorySource,
     HistorySourceConfigError,
     discover_claude_sources,
+    group_claude_sources_by_projects,
 )
 from _core.text import (  # noqa: E402
     is_automated_title,
@@ -726,6 +727,36 @@ def merge_claude_results(results: list[ProviderResult]) -> ProviderResult:
     )
 
 
+def collect_claude_sources(
+    args: argparse.Namespace, sources: list[HistorySource]
+) -> ProviderResult:
+    """Collect Claude inventory once per physical projects tree.
+
+    Profile homes can be distinct configuration roots while their ``projects/``
+    paths are symlinks to the same history tree.  Scanning once per source label
+    multiplies multi-gigabyte JSONL reads without adding evidence.  Collapse
+    only physical aliases here, attach every label to each conversation, then
+    retain the existing cross-tree/session merge for genuinely distinct copies.
+    """
+    grouped_results: list[ProviderResult] = []
+    for group in group_claude_sources_by_projects(sources):
+        primary = next(
+            (source for source in group if source.kind == "active"),
+            group[0],
+        )
+        result = collect_claude(args, primary)
+        labels = [source.display_label for source in group]
+        result.home = ", ".join(labels)
+        selected_kind = (
+            "active" if any(source.kind == "active" for source in group) else primary.kind
+        )
+        for conversation in result.conversations:
+            conversation.source_kind = selected_kind
+            conversation.source_labels = list(labels)
+        grouped_results.append(result)
+    return merge_claude_results(grouped_results)
+
+
 def apply_date_filter(
     result: ProviderResult,
     from_timestamp: Optional[float],
@@ -823,9 +854,7 @@ def main(argv: Optional[list[str]] = None) -> int:
                     ]
         except HistorySourceConfigError as error:
             parser.error(str(error))
-        claude_result = merge_claude_results(
-            [collect_claude(args, source) for source in claude_sources]
-        )
+        claude_result = collect_claude_sources(args, claude_sources)
         claude_result.warnings = source_warnings + claude_result.warnings
         results.append(
             apply_date_filter(claude_result, from_timestamp, to_timestamp)

--- a/daymade-claude-code/read-claude-code-history/tests/test_extract_user_messages.py
+++ b/daymade-claude-code/read-claude-code-history/tests/test_extract_user_messages.py
@@ -9,6 +9,7 @@ import tempfile
 import unittest
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from unittest import mock
 
 SKILL_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(SKILL_DIR / "scripts"))
@@ -60,6 +61,29 @@ def run_extract(home: Path, records: list) -> ex.Extraction:
 
 
 class ExtractUserMessagesTest(unittest.TestCase):
+    def test_aliased_profile_tree_is_read_once_per_logical_pass(self):
+        main = self.home
+        profile = self.home / 'profile'
+        records = [user('u1', '同一棵物理历史只读一次')]
+        write_jsonl(main / 'projects' / '-tmp-proj' / 's1.jsonl', records)
+        profile.mkdir(parents=True)
+        (profile / 'projects').symlink_to(
+            main / 'projects', target_is_directory=True
+        )
+        sources, _ = discover_claude_sources(
+            explicit_homes=[str(main), str(profile)]
+        )
+        cutoff = NOW - timedelta(days=1)
+
+        with mock.patch.object(ex, 'iter_jsonl', wraps=ex.iter_jsonl) as iterator:
+            ext = ex.extract(sources, cutoff)
+
+        self.assertEqual(iterator.call_count, 2)
+        self.assertEqual(
+            [entry.text for entry in ext.entries],
+            ['同一棵物理历史只读一次'],
+        )
+
     def test_typed_message_is_kept(self):
         ext = run_extract(self.home, [user('u1', '今天把这个修一下')])
         self.assertEqual([e.text for e in ext.entries], ['今天把这个修一下'])

--- a/daymade-claude-code/read-claude-code-history/tests/test_list_local_history.py
+++ b/daymade-claude-code/read-claude-code-history/tests/test_list_local_history.py
@@ -1189,6 +1189,93 @@ with path.open("r+b") as handle:
         self.assertEqual(archive_only["source_kind"], "archive")
         self.assertEqual(archive_only["source_labels"], ["archive:full-backup"])
 
+    def test_aliased_profile_projects_are_scanned_once_with_all_provenance(self) -> None:
+        user_home = self.root / "user-home"
+        active_home = user_home / ".claude"
+        profile_home = user_home / ".claude-profiles" / "kimi"
+        archive_home = self.root / "conversation-archive"
+        active_project = claude_project_dir(active_home, self.workspace)
+        archive_project = claude_project_dir(archive_home, self.workspace)
+        profile_home.mkdir(parents=True)
+        (profile_home / "projects").symlink_to(
+            active_home / "projects", target_is_directory=True
+        )
+        session_id = "abababab-abab-4bab-8bab-abababababab"
+        active_path = active_project / f"{session_id}.jsonl"
+        archive_path = archive_project / f"{session_id}.jsonl"
+        write_jsonl(
+            active_path,
+            [
+                claude_user_record(
+                    session_id,
+                    self.workspace,
+                    "Active aliased profile conversation",
+                    "2026-08-30T01:00:00Z",
+                )
+            ],
+        )
+        write_jsonl(
+            archive_path,
+            [
+                claude_user_record(
+                    session_id,
+                    self.workspace,
+                    "Older archive copy",
+                    "2026-08-29T01:00:00Z",
+                )
+            ],
+        )
+        write_jsonl(
+            active_project / "agent-worker.jsonl",
+            [
+                claude_user_record(
+                    "cdcdcdcd-cdcd-4dcd-8dcd-cdcdcdcdcdcd",
+                    self.workspace,
+                    "Internal worker",
+                    "2026-08-30T01:05:00Z",
+                )
+            ],
+        )
+
+        spec = importlib.util.spec_from_file_location(
+            f"local_history_alias_under_test_{id(self)}",
+            SCRIPT,
+        )
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        args = module.argparse.Namespace(
+            cwd=str(self.workspace),
+            recursive=False,
+            all_projects=False,
+            include_subagents=False,
+            include_automated=True,
+            max_title_chars=120,
+        )
+        sources = [
+            module.HistorySource("claude", "active", "main", active_home),
+            module.HistorySource("claude", "active", "kimi", profile_home),
+            module.HistorySource("claude", "archive", "full-backup", archive_home),
+        ]
+
+        with mock.patch.object(
+            module,
+            "parse_claude_session",
+            wraps=module.parse_claude_session,
+        ) as parse_session:
+            result = module.collect_claude_sources(args, sources)
+
+        self.assertEqual(parse_session.call_count, 2)
+        self.assertEqual(result.excluded_subagents, 1)
+        self.assertEqual(len(result.conversations), 1)
+        conversation = result.conversations[0]
+        self.assertEqual(conversation.path, str(active_path))
+        self.assertEqual(conversation.title, "Active aliased profile conversation")
+        self.assertEqual(
+            conversation.source_labels,
+            ["active:main", "active:kimi", "archive:full-backup"],
+        )
+
     def test_date_filter_uses_session_overlap_and_excludes_unknown_time(self) -> None:
         project_dir = claude_project_dir(self.claude_home, self.workspace)
         spanning_id = "40404040-4040-4040-8040-404040404040"

--- a/daymade-claude-code/read-codex-history/scripts/_core/sources.py
+++ b/daymade-claude-code/read-codex-history/scripts/_core/sources.py
@@ -72,6 +72,24 @@ def _active_sources(
     ]
 
 
+def group_claude_sources_by_projects(
+    sources: Sequence[HistorySource],
+) -> list[list[HistorySource]]:
+    """Group source labels that expose the same physical ``projects/`` tree.
+
+    Multi-model Claude profiles commonly symlink their ``projects/`` directory
+    to the main profile.  Inventory callers must scan that physical tree once,
+    while retaining every nominal source label as provenance.  Group order and
+    source order remain stable so representative-path selection stays
+    deterministic.  Distinct archive trees remain distinct groups.
+    """
+    groups: dict[str, list[HistorySource]] = {}
+    for source in sources:
+        key = _resolved_key(source.home / "projects")
+        groups.setdefault(key, []).append(source)
+    return list(groups.values())
+
+
 def _read_manifest(path: Path) -> dict:
     try:
         raw = path.read_text(encoding="utf-8")

--- a/daymade-claude-code/read-codex-history/scripts/list_local_history.py
+++ b/daymade-claude-code/read-codex-history/scripts/list_local_history.py
@@ -32,6 +32,7 @@ from _core.sources import (  # noqa: E402
     HistorySource,
     HistorySourceConfigError,
     discover_claude_sources,
+    group_claude_sources_by_projects,
 )
 from _core.text import (  # noqa: E402
     is_automated_title,
@@ -726,6 +727,36 @@ def merge_claude_results(results: list[ProviderResult]) -> ProviderResult:
     )
 
 
+def collect_claude_sources(
+    args: argparse.Namespace, sources: list[HistorySource]
+) -> ProviderResult:
+    """Collect Claude inventory once per physical projects tree.
+
+    Profile homes can be distinct configuration roots while their ``projects/``
+    paths are symlinks to the same history tree.  Scanning once per source label
+    multiplies multi-gigabyte JSONL reads without adding evidence.  Collapse
+    only physical aliases here, attach every label to each conversation, then
+    retain the existing cross-tree/session merge for genuinely distinct copies.
+    """
+    grouped_results: list[ProviderResult] = []
+    for group in group_claude_sources_by_projects(sources):
+        primary = next(
+            (source for source in group if source.kind == "active"),
+            group[0],
+        )
+        result = collect_claude(args, primary)
+        labels = [source.display_label for source in group]
+        result.home = ", ".join(labels)
+        selected_kind = (
+            "active" if any(source.kind == "active" for source in group) else primary.kind
+        )
+        for conversation in result.conversations:
+            conversation.source_kind = selected_kind
+            conversation.source_labels = list(labels)
+        grouped_results.append(result)
+    return merge_claude_results(grouped_results)
+
+
 def apply_date_filter(
     result: ProviderResult,
     from_timestamp: Optional[float],
@@ -823,9 +854,7 @@ def main(argv: Optional[list[str]] = None) -> int:
                     ]
         except HistorySourceConfigError as error:
             parser.error(str(error))
-        claude_result = merge_claude_results(
-            [collect_claude(args, source) for source in claude_sources]
-        )
+        claude_result = collect_claude_sources(args, claude_sources)
         claude_result.warnings = source_warnings + claude_result.warnings
         results.append(
             apply_date_filter(claude_result, from_timestamp, to_timestamp)

--- a/daymade-claude-code/read-codex-history/tests/test_list_local_history.py
+++ b/daymade-claude-code/read-codex-history/tests/test_list_local_history.py
@@ -1261,6 +1261,93 @@ with path.open("r+b") as handle:
         self.assertEqual(archive_only["source_kind"], "archive")
         self.assertEqual(archive_only["source_labels"], ["archive:full-backup"])
 
+    def test_aliased_profile_projects_are_scanned_once_with_all_provenance(self) -> None:
+        user_home = self.root / "user-home"
+        active_home = user_home / ".claude"
+        profile_home = user_home / ".claude-profiles" / "kimi"
+        archive_home = self.root / "conversation-archive"
+        active_project = claude_project_dir(active_home, self.workspace)
+        archive_project = claude_project_dir(archive_home, self.workspace)
+        profile_home.mkdir(parents=True)
+        (profile_home / "projects").symlink_to(
+            active_home / "projects", target_is_directory=True
+        )
+        session_id = "abababab-abab-4bab-8bab-abababababab"
+        active_path = active_project / f"{session_id}.jsonl"
+        archive_path = archive_project / f"{session_id}.jsonl"
+        write_jsonl(
+            active_path,
+            [
+                claude_user_record(
+                    session_id,
+                    self.workspace,
+                    "Active aliased profile conversation",
+                    "2026-08-30T01:00:00Z",
+                )
+            ],
+        )
+        write_jsonl(
+            archive_path,
+            [
+                claude_user_record(
+                    session_id,
+                    self.workspace,
+                    "Older archive copy",
+                    "2026-08-29T01:00:00Z",
+                )
+            ],
+        )
+        write_jsonl(
+            active_project / "agent-worker.jsonl",
+            [
+                claude_user_record(
+                    "cdcdcdcd-cdcd-4dcd-8dcd-cdcdcdcdcdcd",
+                    self.workspace,
+                    "Internal worker",
+                    "2026-08-30T01:05:00Z",
+                )
+            ],
+        )
+
+        spec = importlib.util.spec_from_file_location(
+            f"local_history_alias_under_test_{id(self)}",
+            SCRIPT,
+        )
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        args = module.argparse.Namespace(
+            cwd=str(self.workspace),
+            recursive=False,
+            all_projects=False,
+            include_subagents=False,
+            include_automated=True,
+            max_title_chars=120,
+        )
+        sources = [
+            module.HistorySource("claude", "active", "main", active_home),
+            module.HistorySource("claude", "active", "kimi", profile_home),
+            module.HistorySource("claude", "archive", "full-backup", archive_home),
+        ]
+
+        with mock.patch.object(
+            module,
+            "parse_claude_session",
+            wraps=module.parse_claude_session,
+        ) as parse_session:
+            result = module.collect_claude_sources(args, sources)
+
+        self.assertEqual(parse_session.call_count, 2)
+        self.assertEqual(result.excluded_subagents, 1)
+        self.assertEqual(len(result.conversations), 1)
+        conversation = result.conversations[0]
+        self.assertEqual(conversation.path, str(active_path))
+        self.assertEqual(conversation.title, "Active aliased profile conversation")
+        self.assertEqual(
+            conversation.source_labels,
+            ["active:main", "active:kimi", "archive:full-backup"],
+        )
+
     def test_date_filter_uses_session_overlap_and_excludes_unknown_time(self) -> None:
         project_dir = claude_project_dir(self.claude_home, self.workspace)
         spanning_id = "40404040-4040-4040-8040-404040404040"

--- a/daymade-docs/doc-to-markdown/SKILL.md
+++ b/daymade-docs/doc-to-markdown/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: doc-to-markdown
-description: Converts DOCX/PDF/PPTX to high-quality Markdown with automatic post-processing. Fixes pandoc grid tables, simple tables, image paths, CJK bold spacing, attribute noise, and code blocks. Benchmarked best-in-class (7.6/10) against Docling, MarkItDown, Pandoc raw, and Mammoth. Trigger on "convert document", "docx to markdown", "parse word", "doc to markdown", "解析word", "转换文档".
+description: Converts DOCX/PDF/PPTX to high-quality Markdown with automatic post-processing. Fixes pandoc grid tables, simple tables, image paths, CJK bold spacing, attribute noise, and code blocks; for PDFs also strips OCR garbage blocks, repeated headers/footers/watermarks, and absolute image paths from pymupdf4llm output. Benchmarked best-in-class (7.6/10) against Docling, MarkItDown, Pandoc raw, and Mammoth. Trigger on "convert document", "docx to markdown", "parse word", "doc to markdown", "解析word", "转换文档".
 ---
 
 # Doc to Markdown
@@ -52,6 +52,25 @@ When converting DOCX via pandoc, 8 cleanups are applied automatically:
 | Indented dashed code blocks | → fenced ``` with language detection | `test_code_block_with_language` |
 | Escaped brackets (`\[...\]`) | → `[...]` | `test_escaped_brackets_fixed` |
 | Double-bracket links (`[[text]](url)`) | → `[text](url)` | `test_double_bracket_links_fixed` |
+
+## PDF Post-Processing (automatic, 2026-08-30 起)
+
+When converting PDF via pymupdf4llm, 3 cleanups are applied automatically (skip with `--no-postprocess`):
+
+| Problem | Fix | Test coverage |
+|---------|-----|---------------|
+| Tesseract OCR garbage on image regions (`<!-- Start of picture text -->...`) | Block removed; images themselves kept | `TestStripOcrPictureText` |
+| Repeated header/footer/watermark lines (same normalized line on ≥60% of pages, incl. diagonal watermarks) | Detected via pymupdf cross-page scan, removed from markdown; bold-wrapped and merged-with-page-number variants also caught | `TestRepeatingLines` |
+| Absolute image paths (`![](/abs/tmp/assets/...)`) | Rewritten relative to the output markdown file (portable output) | `TestImagePathsRelative` |
+
+Heavy mode additionally prints a loud `⚠️ HEAVY MODE DEGRADED` warning on stderr when one engine fails and the merge would otherwise silently degrade to single-engine output.
+
+**Known limits (learned from a 62-page Chinese research-report conversion, 2026-08-30):**
+- pymupdf4llm may emit duplicated paragraphs (source text layer has only one copy) — not auto-fixed; spot-check.
+- Dotted TOC pages get detected as tables — rewrite the TOC manually if it matters.
+- Cross-page tables are NOT merged (each page's fragment keeps its own header row) — merge manually.
+- Table cells overlapped by diagonal watermarks can contain watermark character shards (`dn`, `uFE`, ...); the repeating-line stripper removes full lines only, not intra-cell shards. Watermark-heavy PDFs need cell-level rebuild (collect non-watermark spans per cell bbox).
+- Complex infographics (dense in-image text) come out as images only; transcribing in-image text needs a VLM pass, not this tool.
 
 ### CJK Bold Spacing — why and how
 

--- a/daymade-docs/doc-to-markdown/scripts/convert.py
+++ b/daymade-docs/doc-to-markdown/scripts/convert.py
@@ -27,6 +27,7 @@ Dependencies:
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
@@ -58,6 +59,8 @@ class PostProcessStats:
     code_blocks_fixed: int = 0
     escaped_brackets_fixed: int = 0
     double_brackets_fixed: int = 0
+    pdf_ocr_blocks_removed: int = 0
+    pdf_header_footer_lines_removed: int = 0
 
     def any_fixes(self) -> bool:
         return any(
@@ -79,6 +82,10 @@ class PostProcessStats:
             parts.append(f"escaped brackets: {self.escaped_brackets_fixed}")
         if self.double_brackets_fixed:
             parts.append(f"double brackets: {self.double_brackets_fixed}")
+        if self.pdf_ocr_blocks_removed:
+            parts.append(f"OCR picture-text blocks: {self.pdf_ocr_blocks_removed}")
+        if self.pdf_header_footer_lines_removed:
+            parts.append(f"header/footer lines: {self.pdf_header_footer_lines_removed}")
         return ", ".join(parts) if parts else "no fixes needed"
 
 
@@ -606,6 +613,139 @@ def postprocess_docx_markdown(
     text = _cleanup_excessive_blank_lines(text)
 
     return text, stats
+
+
+# ── PDF post-processing (pymupdf4llm output) ─────────────────────────────────
+
+_RE_OCR_PICTURE_TEXT = re.compile(
+    r"<!--\s*Start of picture text\s*-->.*?<!--\s*End of picture text\s*-->",
+    re.S,
+)
+
+
+def _strip_ocr_picture_text(text: str, stats: PostProcessStats) -> str:
+    """Remove pymupdf4llm's Tesseract OCR blocks on image regions.
+
+    For text-layer PDFs these blocks are garbage injected into the markdown
+    (e.g. `foxes Soa ON<br>ABMS x RBA...`). The images themselves stay;
+    only the OCR'd pseudo-text between the comment markers is removed.
+    """
+    def _sub(_m: re.Match) -> str:
+        stats.pdf_ocr_blocks_removed += 1
+        return ""
+
+    return _RE_OCR_PICTURE_TEXT.sub(_sub, text)
+
+
+def _normalize_repeat_line(line: str) -> str:
+    """Normalize a line for cross-page repetition matching:
+    collapse whitespace, digits → #, strip markdown heading/bold shells."""
+    norm = re.sub(r"\s+", " ", line).strip()
+    norm = norm.replace("**", "")  # bold shells may sit mid-line, not only at edges
+    norm = norm.strip("#*| ").strip()
+    return re.sub(r"\d+", "#", norm)
+
+
+def _detect_repeating_lines(
+    pdf_path: Path, threshold: float = 0.6, max_len: int = 60
+) -> set[str]:
+    """Detect header/footer/watermark lines: same normalized text line
+    appearing on >= threshold fraction of pages. Watermarks (diagonal text
+    repeated every page) are caught by the same rule."""
+    import pymupdf  # already a transitive dep of pymupdf4llm
+
+    try:
+        doc = pymupdf.open(str(pdf_path))
+    except Exception:
+        return set()
+    if len(doc) < 3:
+        return set()
+
+    from collections import Counter
+
+    cnt: Counter = Counter()
+    for page in doc:
+        seen_on_page = set()
+        for ln in page.get_text().split("\n"):
+            norm = _normalize_repeat_line(ln)
+            if norm and len(norm) <= max_len:
+                seen_on_page.add(norm)
+        for ln in seen_on_page:
+            cnt[ln] += 1
+
+    thresh = max(3, int(len(doc) * threshold))
+    return {ln for ln, c in cnt.items() if c >= thresh}
+
+
+def _strip_repeating_lines(
+    text: str, patterns: set[str], stats: PostProcessStats
+) -> str:
+    if not patterns:
+        return text
+    # Patterns long enough to safely act as coverage parts (short ones only
+    # participate in exact full-line matches, to avoid false positives)
+    cover_parts = {p for p in patterns if len(p) >= 4}
+
+    def covered_by_patterns(bare: str) -> bool:
+        """True if the line is fully covered by 1+ pattern substrings
+        (handles converters that merge e.g. footer + page number into one line)."""
+        rest, iterations = bare, 0
+        while rest.strip() and iterations < 4:
+            iterations += 1
+            for p in cover_parts:
+                if p in rest:
+                    rest = rest.replace(p, " ", 1)
+                    break
+            else:
+                break
+        return not rest.strip()
+
+    out = []
+    for ln in text.split("\n"):
+        bare = _normalize_repeat_line(ln)
+        if bare and (bare in patterns or covered_by_patterns(bare)):
+            stats.pdf_header_footer_lines_removed += 1
+            continue
+        out.append(ln)
+    return "\n".join(out)
+
+
+def _make_image_paths_relative(
+    text: str, assets_dir: Path, output_dir: Path, stats: PostProcessStats
+) -> str:
+    """Rewrite absolute asset paths in image references to paths relative
+    to the output markdown file, so the output is portable."""
+    prefix = str(assets_dir.resolve()) + "/"
+    if prefix not in text:
+        return text
+    rel = Path(os.path.relpath(assets_dir.resolve(), output_dir.resolve()))
+
+    def fix_path(m: re.Match) -> str:
+        alt, path = m.group(1), m.group(2)
+        if path.startswith(prefix):
+            stats.image_paths_fixed += 1
+            return f"![{alt}]({rel / path[len(prefix):]})"
+        return m.group(0)
+
+    return re.sub(r"!\[([^\]]*)\]\(([^)]+)\)", fix_path, text)
+
+
+def postprocess_pdf_markdown(
+    text: str,
+    pdf_path: Path,
+    assets_dir: Optional[Path],
+    output_dir: Optional[Path],
+    stats: PostProcessStats,
+) -> str:
+    """Post-process pymupdf4llm markdown output: strip OCR garbage blocks,
+    cross-page header/footer/watermark lines, absolutize-portable image paths."""
+    text = _strip_ocr_picture_text(text, stats)
+    patterns = _detect_repeating_lines(pdf_path)
+    text = _strip_repeating_lines(text, patterns, stats)
+    if assets_dir and output_dir:
+        text = _make_image_paths_relative(text, assets_dir, output_dir, stats)
+    text = re.sub(r"\n{4,}", "\n\n\n", text)
+    return text
 
 
 # ── DOCX deep parsing (python-docx) ──────────────────────────────────────────
@@ -1138,6 +1278,13 @@ Examples:
             print(f"FAIL ({result.error[:50]}...)")
 
     # Merge results if heavy mode
+    failed_tools = [r.tool for r in results if not r.success]
+    if mode == "heavy" and failed_tools and any(r.success for r in results):
+        print(
+            f"  ⚠️ HEAVY MODE DEGRADED: {', '.join(failed_tools)} failed — "
+            f"merging with remaining tool(s) only; output is NOT multi-tool verified",
+            file=sys.stderr,
+        )
     if mode == "heavy" and len(results) > 1:
         print("  Merging results...", end=" ", flush=True)
         final = merge_results(results)
@@ -1154,6 +1301,16 @@ Examples:
         print("  Post-processing DOCX output...", end=" ", flush=True)
         final.markdown, pp_stats = postprocess_docx_markdown(
             final.markdown, assets_dir
+        )
+        print(f"ok ({pp_stats.summary()})")
+
+    # Apply PDF post-processing
+    is_pdf = args.input.suffix.lower() == ".pdf"
+    if is_pdf and not args.no_postprocess and "pymupdf4llm" in final.tool:
+        print("  Post-processing PDF output...", end=" ", flush=True)
+        pp_stats = PostProcessStats()
+        final.markdown = postprocess_pdf_markdown(
+            final.markdown, args.input, assets_dir, output_path.parent, pp_stats
         )
         print(f"ok ({pp_stats.summary()})")
 

--- a/daymade-docs/doc-to-markdown/scripts/test_convert.py
+++ b/daymade-docs/doc-to-markdown/scripts/test_convert.py
@@ -240,3 +240,105 @@ class TestSimpleTable:
   ---------- ---------- ---------- ----------"""
         out, stats = postprocess_docx_markdown(inp)
         assert "| ![](a.png) | ![](b.png) | ![](c.png) | ![](d.png) |" in out
+
+
+# ── PDF post-processing (pymupdf4llm output) ────────────────────────────────
+
+from convert import (
+    _strip_ocr_picture_text,
+    _strip_repeating_lines,
+    _normalize_repeat_line,
+    _make_image_paths_relative,
+)
+
+
+class TestStripOcrPictureText:
+    """Tesseract OCR blocks on image regions must be removed (text-layer PDFs)."""
+
+    def test_ocr_block_removed(self):
+        inp = "正文段落\n<!-- Start of picture text -->foxes Soa ON<br>ABMS x RBA<br><!-- End of picture text -->\n下一段"
+        stats = PostProcessStats()
+        out = _strip_ocr_picture_text(inp, stats)
+        assert "foxes" not in out
+        assert "Start of picture" not in out
+        assert "正文段落" in out and "下一段" in out
+        assert stats.pdf_ocr_blocks_removed == 1
+
+    def test_multiline_ocr_block(self):
+        inp = "A\n<!-- Start of picture text -->\n乱码一行\n乱码二行<br>\n<!-- End of picture text -->\nB"
+        stats = PostProcessStats()
+        out = _strip_ocr_picture_text(inp, stats)
+        assert "乱码" not in out
+        assert stats.pdf_ocr_blocks_removed == 1
+
+    def test_no_block_untouched(self):
+        inp = "没有 OCR 块的普通文本"
+        stats = PostProcessStats()
+        assert _strip_ocr_picture_text(inp, stats) == inp
+        assert stats.pdf_ocr_blocks_removed == 0
+
+
+class TestRepeatingLines:
+    """Cross-page header/footer/watermark line stripping."""
+
+    PATTERNS = {"研究报告标题", "第# 页", "火星加速器X云启资本"}
+
+    def test_exact_line_removed(self):
+        inp = "正文\n研究报告标题\n第21 页\n下一段"
+        stats = PostProcessStats()
+        out = _strip_repeating_lines(inp, self.PATTERNS, stats)
+        assert "研究报告标题" not in out
+        assert "第21 页" not in out
+        assert "正文" in out and "下一段" in out
+        assert stats.pdf_header_footer_lines_removed == 2
+
+    def test_bold_wrapped_line_removed(self):
+        """Bold-wrapped header in markdown still matches plain-text pattern."""
+        inp = "**研究报告标题**  \n正文"
+        stats = PostProcessStats()
+        out = _strip_repeating_lines(inp, self.PATTERNS, stats)
+        assert "研究报告标题" not in out
+        assert stats.pdf_header_footer_lines_removed == 1
+
+    def test_merged_footer_and_pagenum_removed(self):
+        """Converter may merge footer + page number into one line."""
+        inp = "**火星加速器X云启资本** 第49 页\n正文段落"
+        stats = PostProcessStats()
+        out = _strip_repeating_lines(inp, self.PATTERNS, stats)
+        assert "火星加速器" not in out
+        assert "正文段落" in out
+        assert stats.pdf_header_footer_lines_removed == 1
+
+    def test_body_line_kept(self):
+        """Normal body lines are never touched."""
+        inp = "核心判断四：2026 年更适合被定义为规模化探索拐点年"
+        stats = PostProcessStats()
+        assert _strip_repeating_lines(inp, self.PATTERNS, stats) == inp
+        assert stats.pdf_header_footer_lines_removed == 0
+
+    def test_normalize_strips_bold_and_digits(self):
+        assert _normalize_repeat_line("**第21 页**") == "第# 页"
+        assert _normalize_repeat_line("## 第3 章 标题") == "第# 章 标题"
+
+
+class TestImagePathsRelative:
+    """Absolute asset paths in image refs become relative to output dir."""
+
+    def test_absolute_to_relative(self, tmp_path):
+        assets = tmp_path / "out" / "assets"
+        assets.mkdir(parents=True)
+        outdir = tmp_path / "out"
+        inp = f"![]({assets}/img1.png)"
+        stats = PostProcessStats()
+        out = _make_image_paths_relative(inp, assets, outdir, stats)
+        assert out == "![](assets/img1.png)"
+        assert stats.image_paths_fixed == 1
+
+    def test_other_paths_untouched(self, tmp_path):
+        assets = tmp_path / "assets"
+        assets.mkdir()
+        inp = "![](http://example.com/x.png) ![](local/y.png)"
+        stats = PostProcessStats()
+        out = _make_image_paths_relative(inp, assets, tmp_path, stats)
+        assert out == inp
+        assert stats.image_paths_fixed == 0

--- a/daymade-skill/skill-creator/SKILL.md
+++ b/daymade-skill/skill-creator/SKILL.md
@@ -1397,6 +1397,23 @@ When editing, remember that the skill is being created for another instance of C
    memory-paraphrased near-synonym characters (`也` vs `都`) — both escape
    self-review, and both get caught only by the tool rejecting your whole map (one
    map rejected twice in a row for exactly those two reasons).
+
+   **The needle proves a line survives, not that a concept survives.** A
+   `heading` candidate's needle can match any line in the new file while the
+   *section it titled* — the heading plus its body content — has been scattered
+   across other sections or compressed beyond recognition. Text-level survival
+   is not semantic survival. For every `heading` candidate, after the needle
+   passes, additionally verify: (a) the new file still has a section covering
+   the same topic (find the corresponding heading or content block by meaning,
+   not by string match), and (b) the new section's body is not trivially smaller
+   than the old one — count the old section's non-blank lines and compare with
+   the new section's. A section whose body shrank by more than half needs a
+   `semantic_review` explaining what was deliberately compressed and why the
+   compression is lossless. Skipping this check is how a restructure reports
+   "162/162 preserved" while a named principle the user later asks about has
+   silently lost its dedicated section (real case 2026-08-30: an "Outcome-first
+   gate" section was scattered into a summary table row; every needle passed;
+   the user had to ask "有没有丢失东西" to surface it).
 5. Verify the completed review. Hashes make the review stale after any further
    edit, so regenerate and reclassify when the candidate changes. A passing
    verification writes `.skill-regression-reviewed`, a content-bound local status


### PR DESCRIPTION
## 背景

62 页中文研报（带斜向水印/页眉页脚/OCR 图片区）实测暴露：doc-to-markdown 的 PDF 路径完全没有后处理（DOCX 路径有 8 项），四个可复现缺陷。

## 本 PR 含两个自洽 commit（共享 checkout 下另一 session 的工作搭车，均为用户本人提交、各自完整）

### 1. `01024dd` fix(doc-to-markdown): PDF 后处理三件套 + heavy 退化大声警告（v1.12.0）

| 缺陷 | 修复 | 验证 |
|---|---|---|
| Tesseract OCR 乱码块注入正文（`<!-- Start of picture text -->`） | 整块清除，图片保留 | 12 块清除 |
| 页眉/页脚/水印零过滤 | pymupdf 跨页扫描：同一归一化行 ≥60% 页出现即删；覆盖粗体壳与页脚+页码合并行变体 | 242 行删除、0 残留、正文零误删 |
| heavy 单引擎失败半静默退化 | stderr 打印 `⚠️ HEAVY MODE DEGRADED ... NOT multi-tool verified` | 重跑可见 |
| 图片引用绝对路径（`/tmp/...`） | 重写为相对输出目录路径 | 12 处转相对 |

测试：新增 `TestStripOcrPictureText` / `TestRepeatingLines` / `TestImagePathsRelative` 共 10 条，**41 全过**（31 旧测试无回归）。
边界：SKILL.md Known limits 如实标注（重复段落、TOC 误检、跨页表未合并、单元格内水印碎片——后者超出通用后处理边界，未内联）。

### 2. `f3fabc6` docs(skill-creator): needle proves line survival, not concept survival (v1.32.1)

skill-creator SKILL.md 方法论补充：heading candidate 的 needle 通过仅证明行存活，不证明其小节语义存活；补「按意义找回小节 + 正文行数缩水过半需 semantic_review」的验证步骤。marketplace.json 同时携带 daymade-audio 1.32.2→1.32.3（并行 session 版本递增，同文件）。

## Checks

f3fabc6（当前 head）上 4/4 全绿：Marketplace manifest / Secret scan / Touched skills still validate / Registered test suites (Linux)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)