### PR TITLE
fix(pdf-creator): the table-border check could clear the defect it guards, and failed 34 of 46 healthy PDFs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -185,7 +185,7 @@
       "description": "Documentation suite plugin that exposes document conversion, Mermaid diagram generation, PDF/PPT/DOCX creation, Excel workbook creation/parsing/control, and documentation cleanup, and docx review-comment/track-changes extraction skills under one shared namespace",
       "source": "./daymade-docs",
       "strict": false,
-      "version": "1.12.0",
+      "version": "1.13.0",
       "category": "suite",
       "keywords": [
         "suite",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,9 +42,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   listed the clip among the failures it exists to catch, then prescribed only "read the PNGs" —
   the procedure the same document calls unreliable for this defect.
 
-  Calibration: 5 themes × single- and multi-page × both argument orders = 20 runs, zero false
-  positives; 14 real markdown documents × 2 themes = 28 renders, zero false positives; the ink
-  check still fires on `default`/`cjk-auto` forced back to `--backend chrome`.
+  The reference file is ink-checked too, so argument order cannot decide whether the damaged
+  file is examined — for a border Chrome *clipped* rather than *dropped* both renders promise the
+  same rule count, so the count comparison sees nothing and only the ink check finds it. Measured:
+  before this, passing the clipped file as `--reference` produced an unqualified PASS.
+
+  Calibration: 5 themes × single- and multi-page × both argument orders = 20 runs — the 12 pairs
+  with no clipped file pass in both orders, the 8 that have one are caught in both; 14 real
+  markdown documents × 2 themes = 28 single-file runs, zero false positives.
 - **read-claude-code-history / read-codex-history** (`daymade-claude-code` v3.7.5):
   stop scanning the same multi-gigabyte Claude history tree once per profile label.
   Multi-model profiles commonly expose distinct config homes whose `projects/` paths are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **pdf-creator** (`daymade-docs` v1.13.0): the table-border check could clear the defect it
+  exists to catch, and separately failed most healthy documents. Both were found by calibrating
+  it against real material rather than fixtures.
+
+  *False pass.* The check compares raster ink against the rules the object layer promises, but
+  Chrome DROPS geometry lying entirely outside its page clip, and a rule that was never written
+  is never looked for — measured, a table with vertical rules and no cell fills printed
+  `5/5 promised rules painted — PASS` with its right border genuinely absent. New `--reference`
+  mode compares the subject's distinct-rule count against the same document rendered by the other
+  backend; the verdict is symmetric, so a swapped pair fails rather than silently clearing the
+  damaged file. Counts rather than positions, and document-wide rather than per page, because the
+  backends break one 60-row table into 5 pages vs 3 (`default`) and 3 vs 15 (`warm-terra-menu`)
+  with identical rule counts throughout. A reference-free pass now states what it did not check,
+  and `NOTHING CHECKED` exits 3 rather than sharing 0 with a real pass.
+
+  *False failures.* Against 46 delivered PDFs the ink check failed 34. It read every vertical
+  edge as a promised rule, and an `<hr>` is a rect 0.7pt tall whose ends are vertical edges — so
+  it hunted for a full-height rule at the page margin of documents with no table at all. Scoping
+  to the table bbox left 10, on inline `<code>` backgrounds inside cells. The promised set now
+  comes from each table's detected cell grid, and degenerate detections (one row, or one column)
+  are declined rather than accused. A coverage threshold was tried and rejected: at a clipped
+  edge a single header-row fill is often the only geometry left (29.63pt of a 90pt table), so
+  "must span the table" silently switched the primary detection off.
+
+  *Also rejected*: requiring the rules to bracket the table's text. On healthy `warm-terra-menu`
+  output the text runs 65.50pt past the rightmost rule — a larger asymmetry than the 37.60pt of
+  the real defect. And `MAX_STROKE_PT`, added in the previous change to exclude fill edges, is
+  removed: it never excluded anything (pdfplumber reports `width=0` on a `rect_edge`), and had it
+  worked it would have blinded the check at the clipped edge.
+
+  The mandatory visual self-check now names the border check as its second step. It previously
+  listed the clip among the failures it exists to catch, then prescribed only "read the PNGs" —
+  the procedure the same document calls unreliable for this defect.
+
+  Calibration: 5 themes × single- and multi-page × both argument orders = 20 runs, zero false
+  positives; 14 real markdown documents × 2 themes = 28 renders, zero false positives; the ink
+  check still fires on `default`/`cjk-auto` forced back to `--backend chrome`.
 - **read-claude-code-history / read-codex-history** (`daymade-claude-code` v3.7.5):
   stop scanning the same multi-gigabyte Claude history tree once per profile label.
   Multi-model profiles commonly expose distinct config homes whose `projects/` paths are

--- a/daymade-docs/pdf-creator/SKILL.md
+++ b/daymade-docs/pdf-creator/SKILL.md
@@ -54,7 +54,7 @@ To create a new theme: copy `themes/default.css`, modify, save as `themes/your-t
 | Send via WeChat, read on phone | `mobile` | Narrow page (148mm), 15px font, 1.9 line-height — comfortable on small screens |
 | Both print AND mobile needed | Run twice with different themes | The skill is fast; generate both versions |
 
-**Decision rule:** If the user does not specify, default to `warm-terra` for training/course content and `default` for formal documents. Ask "是否需要手机版？" only when the output channel is unclear.
+**Decision rule:** If the user does not specify, default to `warm-terra` for training/course content and `default` for formal documents — but pick `cjk-auto` over `default` when the document's tables have uneven column content (schedules, itemized lists), which is what that theme's `table-layout: auto` exists for. Ask "是否需要手机版？" only when the output channel is unclear.
 
 ## Backends
 
@@ -73,6 +73,8 @@ Routing is pinned by `scripts/tests/test_backend_routing.py`. A theme you add yo
 
 Override with `--backend chrome` or `--backend weasyprint`; an explicit flag always wins over auto-detection.
 
+**The theme does not tell you which backend ran.** When weasyprint is not importable, a `default` / `cjk-auto` render falls back to Chrome — with a warning on stderr, and exit 0. Read the `backend=` field of the `Generated:` line to find out which one you got; that field, not the theme name, is what decides whether the Chrome-only step below applies.
+
 ### Chrome clips, it does not merely overflow
 
 Chrome wraps each page in a `re W* n` clip path at the `@page` content box. Content past that box is still in the PDF's object layer but is **never painted**. Measured on A4 with `margin: 2.5cm 2cm 2cm 2cm`: the clip path ends at **538.90pt**, while the table's right border sits at **545.18pt** — so the border is silently amputated.
@@ -83,7 +85,7 @@ The overflow itself is **by design**: the CJK typography layer sets `overflow-wr
 
 **The reason this survived repeated delivery is not that the preview lies — it is that the symptom looks deliberate.** The last column's text is complete and correctly spaced; only a hairline border is gone, which reads as a styling choice. Meanwhile the visual checklist below primes you to look for *text cut off*, which is exactly what does not happen here.
 
-Rasterisers do honour the clip, so the preview PNG this script already generates does show the defect (measured 2026-08-29: `pdftoppm -r 400` paints zero ink across the 25 pixel columns straddling the expected border). What does **not** show it is any check that reads coordinates instead of pixels — `pdfplumber` still reports a rect at 545.18pt, because the object is genuinely there.
+Rasterisers do honour the clip, so the preview PNGs this script already generates (`pdftoppm` at 130 dpi) do show the defect, as does a 400 dpi render — at 400 dpi, zero ink across the 25 pixel columns straddling the expected border. What does **not** show it is any check that reads coordinates instead of pixels — `pdfplumber` still reports a rect at 545.18pt, because the object is genuinely there.
 
 Rather than rely on noticing a missing hairline, run the check. **It takes two forms, and for a Chrome-rendered PDF only the second one is a verdict.**
 
@@ -94,7 +96,7 @@ uv run --with pdfplumber --with pillow --with numpy scripts/check_table_borders.
 
 Form 1 takes each detected table's column boundaries, counts the ones that actually have ink in a `pdftoppm` raster, and exits non-zero naming any boundary present in the PDF but absent on paper. It reports how many tables it measured, and says `NOTHING CHECKED` rather than `PASS` when it found none — a document whose table it could not detect has not been cleared, it has been skipped.
 
-The boundaries come from the cell grid rather than from raw vertical edges, because a `<hr>`'s end-caps and an inline `<code>` span's background look exactly like column rules to an edge-based reader. Measured on 49 WeasyPrint-produced PDFs from a real knowledge base, the edge-based version failed 34 of them. Residual limit: on PDFs from other tools, `pdfplumber` sometimes assembles decoration into a table that was never there, and the check will report rules for it. Treat a failure on a PDF this skill did not produce as a prompt to look, not a verdict.
+The boundaries come from the cell grid rather than from raw vertical edges, because a `<hr>`'s end-caps and an inline `<code>` span's background look exactly like column rules to an edge-based reader. Measured on 49 WeasyPrint-produced PDFs from a real knowledge base, 46 of which had geometry the edge-based version examined: it failed 34 of those 46. Residual limit: on PDFs from other tools, `pdfplumber` sometimes assembles decoration into a table that was never there, and the check will report rules for it. Treat a failure on a PDF this skill did not produce as a prompt to look, not a verdict.
 
 **It cannot clear a Chrome render on its own, because the clip destroys evidence two different ways.** Chrome keeps geometry that *straddles* the clip — form 1 catches that, since the rule is promised and unpainted — but drops geometry lying *entirely* outside it, and a rule that was never written into the object layer is never looked for. Measured: a table styled with vertical rules and no cell fills prints `5/5 promised rules painted — PASS` while its right border is genuinely gone. The bundled themes escape that only by accident; their cell background fills straddle the clip and leave an edge at the border's position for form 1 to find.
 
@@ -109,11 +111,15 @@ uv run --with pdfplumber --with pillow --with numpy \
   scripts/check_table_borders.py out.pdf --reference /tmp/ref.pdf
 ```
 
-Exit codes: `0` passed, `1` a rule is missing, `2` the check could not run, `3` no table was detected so nothing was measured — `3` is not a pass. `pdfplumber` prints `Could not get FontBBox from font descriptor` for subset CJK fonts on the way; that is parser noise, not a finding.
+Exit codes: `0` passed, `1` at least one check did not pass, `2` the check could not run, `3` no table was detected so nothing was measured. **`3` is not a pass**: if the document does have a table, its style drew no rules `pdfplumber` could find, so this check cannot speak for it — fall back to reading the raster at the table's right edge yourself, and say in your handoff that the gate did not run. `pdfplumber` prints `Could not get FontBBox from font descriptor` for subset CJK fonts on the way; that is parser noise, not a finding.
 
-The reference is a measuring stick, never a deliverable — it may well have the CID Type 0C problem that sent this theme to Chrome in the first place, which does not affect its geometry. The verdict is the **count** of distinct rule positions across the whole document, in both directions: fewer rules than the reference means the renderer dropped some; more means the arguments are swapped or the two files are not the same document. Counts rather than positions, and document-wide rather than per page, because the two backends break the same source differently — measured on one 60-row table: 5 pages vs 3 for `default`, 3 vs 15 for `warm-terra-menu`, with the rule counts identical throughout.
+The reference is a measuring stick, never a deliverable — it may well have the CID Type 0C problem that sent this theme to Chrome in the first place, which does not affect its geometry.
 
-Calibrated across 5 themes × single- and multi-page × both argument orders: 20 runs, zero false positives.
+**Both files are ink-checked, and the rule counts are compared in both directions**, so the order you pass them in cannot decide whether the damaged file gets examined. That matters more than it sounds: for a border that Chrome *clipped* rather than *dropped*, the two renders have the SAME rule count — the geometry is still there, merely unpainted — so the count comparison sees nothing, and only the ink check on the right file finds it. Before the reference was ink-checked too, passing the clipped file as `--reference` produced an unqualified PASS.
+
+The count comparison, in both directions: fewer rules than the reference means the renderer dropped some; more means the arguments are swapped or the two files are not the same document. Counts rather than positions, and document-wide rather than per page, because the two backends break the same source differently — measured on one 60-row CJK table, whose row content decides where the breaks land: 5 pages vs 3 for `default`, 3 vs 15 for `warm-terra-menu`, with the rule counts identical throughout.
+
+Calibrated across 5 themes × single- and multi-page × both argument orders, 20 runs: the 12 pairs containing no clipped file pass in both orders, and the 8 that do are caught in both orders. Separately, 14 real markdown documents × 2 themes = 28 single-file runs, zero false positives.
 
 ## Batch Convert
 
@@ -126,7 +132,13 @@ uv run --with weasyprint scripts/batch_convert.py *.md --theme warm-terra --outp
 
 # Mobile theme for phone reading
 uv run --with weasyprint scripts/batch_convert.py *.md --theme mobile --output-dir ./mobile-pdfs --no-preview
+
+# The border check takes several files at once, so a batch is still gated
+uv run --with pdfplumber --with pillow --with numpy \
+  scripts/check_table_borders.py ./pdfs/*.pdf
 ```
+
+`--no-preview` switches off the visual self-check, which is the point of a batch — but it does not switch off the obligation. Run the border check over the outputs as above. It takes many files; `--reference` does not, so a batch of Chrome-rendered documents with tables needs one paired run per document.
 
 ## Anti-Pattern: Do NOT Manually Invoke pandoc + Chrome
 
@@ -160,7 +172,7 @@ uv run --with weasyprint scripts/batch_convert.py *.md --theme mobile --output-d
 
 **This is not optional.** After every PDF generation, the script automatically:
 
-1. Converts each page to PNG via `pdftoppm` (poppler-utils) into a `<pdf-name>/` subdirectory under the **system temp dir** (NOT next to the PDF — previews are a throwaway self-check artifact and must never linger in your working tree / git repo). The exact path is printed after the run as `Previews: <path>/page-NN.png`
+1. Converts each page to PNG via `pdftoppm` (poppler-utils) into a `<pdf-name>/` subdirectory under the **system temp dir** (NOT next to the PDF — previews are a throwaway self-check artifact and must never linger in your working tree / git repo). The exact path is printed after the run as `Previews: <path>/page-NN.png`; the files themselves are `page-1.png`, `page-2.png`, … with no zero padding
 2. Prints a structured self-check checklist reminding the caller to visually inspect each page
 3. Runs typography lint to detect CJK line-break anti-patterns
 
@@ -174,7 +186,7 @@ uv run --with weasyprint scripts/batch_convert.py *.md --theme mobile --output-d
 
 **Workflow**, at the pause point between generating and delivering — two steps, and the second is not covered by the first:
 
-1. **Read the pages.** `Read` each `page-NN.png` at the printed `Previews:` path and verify against the markdown source. If anything renders differently from intent, **fix the markdown** (use `- ` real lists instead of pseudo-lists, insert blank lines, restructure tables) and rerun. The script does NOT silently "fix" non-standard markdown — that would mask the signal that the source is wrong, causing the same markdown to render incorrectly in other processors (Obsidian, GitHub, VS Code preview).
+1. **Read the pages.** `Read` each `page-N.png` at the printed `Previews:` path and verify against the markdown source. If anything renders differently from intent, **fix the markdown** (use `- ` real lists instead of pseudo-lists, insert blank lines, restructure tables) and rerun. The script does NOT silently "fix" non-standard markdown — that would mask the signal that the source is wrong, causing the same markdown to render incorrectly in other processors (Obsidian, GitHub, VS Code preview).
 
 2. **If the document has any table, run `scripts/check_table_borders.py` on the PDF** — and if the render went through Chrome, run its `--reference` form, which is the only form that is a verdict there (both forms are in "Chrome clips, it does not merely overflow" above). Step 1 cannot substitute for this. The missing border reads as a styling choice, and the checklist in step 1 primes you to look for text cut off, which is exactly what does not happen. Do not deliver a PDF with tables on the strength of step 1 alone.
 

--- a/daymade-docs/pdf-creator/SKILL.md
+++ b/daymade-docs/pdf-creator/SKILL.md
@@ -9,6 +9,8 @@ Create professional PDF documents from markdown with Chinese font support and th
 
 ## Quick Start
 
+Every `scripts/…` path below is **relative to this skill's own directory** — run the commands from there, or substitute the absolute path. Running them from the directory holding your markdown fails with `Failed to spawn: 'scripts/md_to_pdf.py'`. Omitting the output path is allowed and derives it from the input's basename (`input.md` → `input.pdf`, in the input's directory).
+
 ```bash
 # Default theme (formal: Songti SC + black/grey, A4 print)
 uv run --with weasyprint scripts/md_to_pdf.py input.md output.pdf
@@ -83,13 +85,35 @@ The overflow itself is **by design**: the CJK typography layer sets `overflow-wr
 
 Rasterisers do honour the clip, so the preview PNG this script already generates does show the defect (measured 2026-08-29: `pdftoppm -r 400` paints zero ink across the 25 pixel columns straddling the expected border). What does **not** show it is any check that reads coordinates instead of pixels — `pdfplumber` still reports a rect at 545.18pt, because the object is genuinely there.
 
-Rather than rely on noticing a missing hairline, run the check:
+Rather than rely on noticing a missing hairline, run the check. **It takes two forms, and for a Chrome-rendered PDF only the second one is a verdict.**
 
 ```bash
+# Form 1 — one file. Compares ink against the PDF's own object layer.
 uv run --with pdfplumber --with pillow --with numpy scripts/check_table_borders.py out.pdf
 ```
 
-It counts the vertical rules the object layer promises, counts the ones that actually have ink in a `pdftoppm` raster, and exits non-zero naming any rule that is present in the PDF but absent on paper. Run it on any PDF with tables that was produced by `--backend chrome`.
+Form 1 takes each detected table's column boundaries, counts the ones that actually have ink in a `pdftoppm` raster, and exits non-zero naming any boundary present in the PDF but absent on paper. It reports how many tables it measured, and says `NOTHING CHECKED` rather than `PASS` when it found none — a document whose table it could not detect has not been cleared, it has been skipped.
+
+The boundaries come from the cell grid rather than from raw vertical edges, because a `<hr>`'s end-caps and an inline `<code>` span's background look exactly like column rules to an edge-based reader. Measured on 49 WeasyPrint-produced PDFs from a real knowledge base, the edge-based version failed 34 of them. Residual limit: on PDFs from other tools, `pdfplumber` sometimes assembles decoration into a table that was never there, and the check will report rules for it. Treat a failure on a PDF this skill did not produce as a prompt to look, not a verdict.
+
+**It cannot clear a Chrome render on its own, because the clip destroys evidence two different ways.** Chrome keeps geometry that *straddles* the clip — form 1 catches that, since the rule is promised and unpainted — but drops geometry lying *entirely* outside it, and a rule that was never written into the object layer is never looked for. Measured: a table styled with vertical rules and no cell fills prints `5/5 promised rules painted — PASS` while its right border is genuinely gone. The bundled themes escape that only by accident; their cell background fills straddle the clip and leave an edge at the border's position for form 1 to find.
+
+So when the theme routes to Chrome and the document has tables, render the same source with the other backend and compare:
+
+```bash
+# Form 2 — render a reference with the other backend, then compare.
+# Use the SAME --theme as the deliverable; only the backend differs.
+uv run --with weasyprint scripts/md_to_pdf.py doc.md /tmp/ref.pdf \
+  --theme warm-terra --backend weasyprint --no-preview
+uv run --with pdfplumber --with pillow --with numpy \
+  scripts/check_table_borders.py out.pdf --reference /tmp/ref.pdf
+```
+
+Exit codes: `0` passed, `1` a rule is missing, `2` the check could not run, `3` no table was detected so nothing was measured — `3` is not a pass. `pdfplumber` prints `Could not get FontBBox from font descriptor` for subset CJK fonts on the way; that is parser noise, not a finding.
+
+The reference is a measuring stick, never a deliverable — it may well have the CID Type 0C problem that sent this theme to Chrome in the first place, which does not affect its geometry. The verdict is the **count** of distinct rule positions across the whole document, in both directions: fewer rules than the reference means the renderer dropped some; more means the arguments are swapped or the two files are not the same document. Counts rather than positions, and document-wide rather than per page, because the two backends break the same source differently — measured on one 60-row table: 5 pages vs 3 for `default`, 3 vs 15 for `warm-terra-menu`, with the rule counts identical throughout.
+
+Calibrated across 5 themes × single- and multi-page × both argument orders: 20 runs, zero false positives.
 
 ## Batch Convert
 
@@ -124,7 +148,7 @@ uv run --with weasyprint scripts/batch_convert.py *.md --theme mobile --output-d
 
 **weasyprint import error**: Run with `uv run --with weasyprint` or use `--backend chrome` instead.
 
-**CJK text in code blocks garbled (weasyprint)**: The script auto-detects code blocks containing Chinese/Japanese/Korean characters and converts them to styled divs with CJK-capable fonts. If you still see issues, use `--backend chrome` which has native CJK support — but if the document contains any table, run `scripts/check_table_borders.py` on the result, because Chrome clips table borders past the `@page` box (see "Chrome clips, it does not merely overflow" above). Alternatively, convert code blocks to markdown tables before generating the PDF.
+**CJK text in code blocks garbled (weasyprint)**: The script auto-detects code blocks containing Chinese/Japanese/Korean characters and converts them to styled divs with CJK-capable fonts. If you still see issues, use `--backend chrome` which has native CJK support — but if the document contains any table, clear the result with `scripts/check_table_borders.py <the chrome pdf> --reference <a weasyprint render of the same source>` — subject first, then the flag — because Chrome clips table borders past the `@page` box and the single-file form cannot see a border Chrome dropped rather than clipped (see "Chrome clips, it does not merely overflow" above). Alternatively, convert code blocks to markdown tables before generating the PDF.
 
 **Chrome header/footer appearing**: The script passes `--no-pdf-header-footer`. If it still appears, your Chrome version may not support this flag — update Chrome. **Note:** If you bypassed this skill and used manual Chrome headless, this is the first symptom — see "Anti-Pattern" section above.
 
@@ -143,12 +167,18 @@ uv run --with weasyprint scripts/batch_convert.py *.md --theme mobile --output-d
 **Why mandatory**: "PDF generated cleanly" ≠ "rendering matches markdown intent". Common silent failures include:
 - Paragraphs collapsing into one (CommonMark soft-break on consecutive non-blank lines)
 - Tables overflowing page margins
-- Tables missing their right border while the text stays intact (Chrome clip — the one failure on this list that does not look like a failure; `scripts/check_table_borders.py` decides it)
+- Tables missing their right border while the text stays intact (Chrome clip — the one failure on this list that does not look like a failure; `scripts/check_table_borders.py` decides it, and on a Chrome render only its `--reference` form is a verdict)
 - Missing CJK / emoji glyphs
 - Code block garbling
 - Chrome default headers/footers (if bypassed this skill)
 
-**Workflow**: After running the script, `Read` each `page-NN.png` at the printed `Previews:` path and verify against the markdown source. If anything renders differently from intent, **fix the markdown** (use `- ` real lists instead of pseudo-lists, insert blank lines, restructure tables) and rerun. The script does NOT silently "fix" non-standard markdown — that would mask the signal that the source is wrong, causing the same markdown to render incorrectly in other processors (Obsidian, GitHub, VS Code preview).
+**Workflow**, at the pause point between generating and delivering — two steps, and the second is not covered by the first:
+
+1. **Read the pages.** `Read` each `page-NN.png` at the printed `Previews:` path and verify against the markdown source. If anything renders differently from intent, **fix the markdown** (use `- ` real lists instead of pseudo-lists, insert blank lines, restructure tables) and rerun. The script does NOT silently "fix" non-standard markdown — that would mask the signal that the source is wrong, causing the same markdown to render incorrectly in other processors (Obsidian, GitHub, VS Code preview).
+
+2. **If the document has any table, run `scripts/check_table_borders.py` on the PDF** — and if the render went through Chrome, run its `--reference` form, which is the only form that is a verdict there (both forms are in "Chrome clips, it does not merely overflow" above). Step 1 cannot substitute for this. The missing border reads as a styling choice, and the checklist in step 1 primes you to look for text cut off, which is exactly what does not happen. Do not deliver a PDF with tables on the strength of step 1 alone.
+
+Neither step catches everything. The PNGs come from `pdftoppm`, which renders CID Type 0C fonts that macOS Preview and Adobe Reader show as blanks — so a font-embedding defect can look perfect in step 1 and be unreadable on the recipient's machine. That one is handled by theme routing, not by looking (see "Backends"); the check to run by hand is in Troubleshooting under "Inline code with mixed CJK + ASCII".
 
 **Disable** with `--no-preview` for batch / non-interactive runs:
 

--- a/daymade-docs/pdf-creator/scripts/check_table_borders.py
+++ b/daymade-docs/pdf-creator/scripts/check_table_borders.py
@@ -56,9 +56,11 @@ USAGE
   uv run --with pdfplumber --with pillow --with numpy \
     scripts/check_table_borders.py out.pdf --reference other-backend.pdf
 
-Exit codes: 0 = measured at least one table and it passed, 1 = a rule is
-missing, 2 = could not run the check (missing pdftoppm, unreadable PDF, bad
-arguments), 3 = no table was detected in any input, so nothing was measured.
+Exit codes: 0 = measured at least one table and it passed, 1 = at least one
+check did not pass (a rule has no ink, or the two files disagree on how many
+rules they draw), 2 = could not run the check (missing pdftoppm, a file that is
+not there, bad arguments), 3 = no table was detected in any input, so nothing
+was measured.
 
 3 is deliberately not 0: a caller that gates on the exit status must not read
 "verified nothing" as "verified clean". It fires only when NO input had a
@@ -225,8 +227,9 @@ def document_rules(pdf: str) -> list[float]:
     """Distinct rule positions across the whole document.
 
     Deliberately not per page. The two backends break the same source into
-    different page counts (measured on one 60-row table: 5 vs 3 for `default`,
-    7 vs 4 for `mobile`, 3 vs 15 for `warm-terra-menu`), so a page-indexed
+    different page counts (measured on one particular 60-row CJK table, whose
+    row content decides where the breaks land: 5 vs 3 for `default`, 7 vs 4 for
+    `mobile`, 3 vs 15 for `warm-terra-menu`), so a page-indexed
     comparison would compare unrelated pages. A table's column positions do not
     move when a row lands on a different page, so the document-wide set is
     stable where the per-page one is not.
@@ -386,6 +389,20 @@ def main() -> None:
         if not ok:
             all_ok = False
         if args.reference and not check_against_reference(p, args.reference):
+            all_ok = False
+
+    if args.reference:
+        # The reference gets ink-checked too, so the order the caller passed the
+        # two files in cannot decide whether the damaged one is examined.
+        # Without this, swapping them hides the straddling defect completely:
+        # the ink check runs on the healthy file, and the rule COUNTS are equal
+        # in that case — Chrome kept the geometry and merely refused to paint it
+        # — so the count comparison has nothing to notice. Measured: the clipped
+        # file passed as --reference produced an unqualified PASS.
+        print(f"{args.reference} (reference):")
+        ok, checked = check_ink(args.reference, args.verbose)
+        total_tables += checked
+        if not ok:
             all_ok = False
 
     if not all_ok:

--- a/daymade-docs/pdf-creator/scripts/check_table_borders.py
+++ b/daymade-docs/pdf-creator/scripts/check_table_borders.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 """
-Check that every table rule a PDF promises is actually painted.
+Check that a PDF's table rules survived the renderer.
 
 WHY THIS EXISTS
 
 Chrome's --print-to-pdf wraps each page in a clip path at the @page content
-box. A table wider than that box keeps its right border in the PDF's object
-layer but loses it on paper: measured on A4 with `margin: 2.5cm 2cm 2cm 2cm`,
-the clip ends at 538.90pt while the border sits at 545.18pt.
+box. A table wider than that box loses its right border on paper: measured on
+A4 with `margin: 2.5cm 2cm 2cm 2cm`, the clip ends at 538.90pt while the border
+sits at 545.18pt.
 
 The reason this survived repeated delivery is not that the renderers disagree —
 they do not. It is that the surviving symptom looks deliberate. The last
@@ -16,20 +16,56 @@ missing, which reads as a design choice. Meanwhile the mandatory visual
 checklist primes the reader to look for "text cut off", which is exactly what
 does NOT happen here.
 
-So this script compares the two layers mechanically instead of asking a human
-to notice a missing hairline:
+TWO CHECKS, BECAUSE THE CLIP DESTROYS EVIDENCE TWO DIFFERENT WAYS
 
-  promised = vertical rules pdfplumber finds in the object layer
-  painted  = vertical rules that actually have ink in a pdftoppm raster
+Chrome keeps geometry that *straddles* its clip and drops geometry that falls
+*entirely* outside it. Those need different instruments:
 
-A shortfall is an amputation. Equal counts pass.
+  ink check (always)         promised = the column boundaries of each table
+                             pdfplumber detects; painted = boundaries with ink
+                             in a pdftoppm raster. A shortfall is an
+                             amputation. Catches straddling geometry.
+
+  reference check (--reference)  compares the subject's rule count against the
+                             same document rendered by the other backend.
+                             Catches geometry the renderer dropped before
+                             writing the PDF — which the ink check cannot see,
+                             because a rule that was never written promises
+                             nothing and so is never looked for.
+
+The second one is not optional politeness. A table styled with vertical rules
+and no cell fills, rendered through Chrome past the clip, loses its right
+border from the object layer entirely; the ink check then reports "5/5 promised
+rules painted — PASS" while the border is genuinely absent. That was measured,
+not hypothesised.
+
+The ink check takes its promised set from each table's detected cell grid, and
+says how many tables it measured. Reading raw vertical edges instead failed 34
+of 46 real delivered PDFs, then 10 of 46 after the first fix — see
+table_rules(). That is the more expensive failure of the two, because a gate
+that misfires on healthy input gets bypassed reflexively and is then off for
+every input. A run that measured no table says so instead of printing a pass.
 
 USAGE
 
-  uv run --with pdfplumber --with pillow scripts/check_table_borders.py out.pdf
+  # ink check only — valid for any PDF, blind to dropped geometry
+  uv run --with pdfplumber --with pillow --with numpy \
+    scripts/check_table_borders.py out.pdf
 
-Exit codes: 0 = every promised rule is painted, 1 = at least one is missing,
-2 = could not run the check (missing pdftoppm, unreadable PDF).
+  # full check — render the same source with the other backend first
+  uv run --with pdfplumber --with pillow --with numpy \
+    scripts/check_table_borders.py out.pdf --reference other-backend.pdf
+
+Exit codes: 0 = measured at least one table and it passed, 1 = a rule is
+missing, 2 = could not run the check (missing pdftoppm, unreadable PDF, bad
+arguments), 3 = no table was detected in any input, so nothing was measured.
+
+3 is deliberately not 0: a caller that gates on the exit status must not read
+"verified nothing" as "verified clean". It fires only when NO input had a
+table, so a batch containing one table-free document still exits 0.
+
+pdfplumber prints `Could not get FontBBox from font descriptor` for subset CJK
+fonts. That is noise from the parser, not a finding about the PDF.
 """
 
 from __future__ import annotations
@@ -67,11 +103,100 @@ SEARCH_PT = 2.5
 DARKER_THAN_LOCAL_BG = 8
 # Half-width of the window whose median defines "local background", in points.
 LOCAL_BG_PT = 8.0
-# A stroke drawn as a rect is at most this wide (pt). Anything wider is a fill
-# — a shaded header or zebra stripe — whose edges are colour transitions, not
-# borders. Counting those as "promised rules" invents obligations the table
-# never had and can report a border missing where none was ever drawn.
-MAX_STROKE_PT = 3.0
+# Two vertical edges closer together than this are the two sides of one stroke,
+# not two rules. Also the tolerance for calling a subject rule and a reference
+# rule "the same rule" when reporting which one went missing.
+MERGE_TOL_PT = 2.0
+
+# Printed on every pass that ran without a reference. The bare word "PASS" is
+# what shipped before, and it is how a real defect cleared this gate: the ink
+# check verifies the object layer's promises, so a promise the renderer never
+# wrote down is not merely unchecked, it is unmentioned. Stating the scope is
+# the fix for that, and it is load-bearing output, not decoration.
+SCOPE_NOTE = (
+    "  Scope: this compared ink against the PDF's own object layer. It cannot "
+    "see a rule the renderer dropped before writing the file — Chrome omits "
+    "geometry lying entirely outside its page clip, and a rule that was never "
+    "written is never looked for. For a Chrome-rendered PDF, use --reference "
+    "to close that case."
+)
+
+
+def merge_positions(xs, tol: float = MERGE_TOL_PT) -> list[float]:
+    """Collapse edge x-coordinates into distinct rule positions.
+
+    A stroke of non-zero width yields two edges; merging them makes the count
+    "rules" rather than "edges" and keeps it comparable across backends that
+    stroke as rects vs as lines.
+    """
+    out: list[float] = []
+    for x in sorted(xs):
+        if not out or x - out[-1] > tol:
+            out.append(x)
+    return out
+
+
+def table_rules(table) -> list[float]:
+    """The column boundaries one table promises: where its rules must be.
+
+    Taken from the detected cell grid, NOT from raw vertical edges. That is the
+    whole lesson of this function, and a real corpus taught it twice:
+
+    - Unscoped, every vertical edge on the page counted. A horizontal rule
+      (`<hr>`) is a rect 0.7pt tall whose left and right ends are reported as
+      vertical edges, so the check hunted for a full-height rule at the page
+      margin of documents containing no table at all. 34 of 46 delivered PDFs
+      failed that way.
+    - Scoped to the table's bounding box, inline decoration inside a cell — a
+      `<code>` span's background, a badge — still counted. 10 of 46 failed.
+
+    Both are the expensive kind of wrong: a gate that misfires on healthy input
+    gets bypassed reflexively, and is then off for every input.
+
+    The cell grid excludes both without a threshold, because neither an `<hr>`
+    nor a code span is a cell boundary. It also keeps what a coverage threshold
+    would have destroyed: at a clipped edge the border stroke is frequently
+    gone and a single header-row fill is the only geometry left there —
+    measured, 29.63pt of a 90pt table, which any "must span the table" rule
+    discards along with the defect it was supposed to catch. The grid keeps it,
+    because the table's right boundary is a boundary whatever paints it.
+    """
+    # A markdown table is at least a header row plus a body row, and at least
+    # two columns. Anything degenerate is pdfplumber's line clusterer finding a
+    # "table" in decoration: a stack of full-width horizontal rules becomes a
+    # one-column table, and a line of inline `<code>` spans becomes a one-row
+    # one. Both were measured on real documents whose pages contained no table
+    # at all, and both are indistinguishable from the real degenerate case, so
+    # the check declines to speak rather than accuse the common shape.
+    if len(table.rows) < 2:
+        return []
+    xs: list[float] = [table.bbox[0], table.bbox[2]]
+    for row in table.rows:
+        for cell in row.cells:
+            if cell:
+                xs += [cell[0], cell[2]]
+    rules = merge_positions(xs)
+    return rules if len(rules) > 2 else []
+
+
+def unmatched(wanted: list[float], have: list[float],
+              tol: float = MERGE_TOL_PT) -> list[float]:
+    """Positions in `wanted` with no counterpart in `have`, for diagnostics.
+
+    Never a verdict. Cross-backend line breaking can move a table's interior
+    rules further than any honest tolerance (measured: warm-terra-menu breaks
+    the same source into 3 pages under WeasyPrint and 15 under Chrome), so
+    position matching is only ever used to name a suspect, never to convict.
+    """
+    pool = sorted(have)
+    missing: list[float] = []
+    for x in wanted:
+        hit = next((i for i, y in enumerate(pool) if abs(y - x) <= tol), None)
+        if hit is None:
+            missing.append(x)
+        else:
+            pool.pop(hit)
+    return missing
 
 
 def _raster(pdf: str, page_no: int, out_dir: Path):
@@ -96,99 +221,198 @@ def _raster(pdf: str, page_no: int, out_dir: Path):
     return pngs[0]
 
 
-def check(pdf: str, verbose: bool = False) -> bool:
+def document_rules(pdf: str) -> list[float]:
+    """Distinct rule positions across the whole document.
+
+    Deliberately not per page. The two backends break the same source into
+    different page counts (measured on one 60-row table: 5 vs 3 for `default`,
+    7 vs 4 for `mobile`, 3 vs 15 for `warm-terra-menu`), so a page-indexed
+    comparison would compare unrelated pages. A table's column positions do not
+    move when a row lands on a different page, so the document-wide set is
+    stable where the per-page one is not.
+    """
+    import pdfplumber
+
+    xs: list[float] = []
+    with pdfplumber.open(pdf) as doc:
+        for page in doc.pages:
+            xs += [e["x0"] for e in page.edges if e["orientation"] == "v"]
+    return merge_positions(xs)
+
+
+def check_ink(pdf: str, verbose: bool = False) -> tuple[bool, int]:
+    """Every rule a table promises must have ink in the raster.
+
+    Returns (ok, tables_checked). The count is not bookkeeping: a document
+    whose tables were all missed would otherwise print an unqualified pass
+    having measured nothing.
+    """
     import numpy as np
     import pdfplumber
     from PIL import Image
 
     ok = True
+    checked = 0
     with pdfplumber.open(pdf) as doc:
         for page_no, page in enumerate(doc.pages, 1):
-            # Only stroke-like geometry counts as a promised rule. page.edges
-            # also yields the edges of background fills, which are colour
-            # transitions rather than drawn borders — treating those as rules
-            # invents obligations the table never had.
-            v_edges = [
-                e for e in page.edges
-                if e["orientation"] == "v"
-                and (e.get("object_type") == "line"
-                     or abs(e.get("width") or 0.0) <= MAX_STROKE_PT)
-            ]
-            if not v_edges:
+            tables = page.find_tables()
+            if not tables:
                 if verbose:
-                    print(f"  page {page_no}: no table rules — skipped")
+                    print(f"  page {page_no}: no table detected — nothing checked")
                 continue
 
-            # A stroke of non-zero width yields two edges; merge them so the
-            # count is "rules", not "edges", and stays comparable across
-            # backends that stroke as rects vs as lines.
-            promised: list[float] = []
-            for x in sorted(e["x0"] for e in v_edges):
-                if not promised or x - promised[-1] > 2.0:
-                    promised.append(x)
-
-            top = min(e["top"] for e in v_edges)
-            bot = max(e["bottom"] for e in v_edges)
-            band = (top + (bot - top) * 0.2, top + (bot - top) * 0.8)
-
-            with tempfile.TemporaryDirectory() as td:
-                png = _raster(pdf, page_no, Path(td))
-                img = np.array(Image.open(png).convert("L"))
-
-            scale = img.shape[1] / page.width
-            y0, y1 = int(band[0] * scale), int(band[1] * scale)
-            if y1 <= y0:
-                continue
-            strip = img[y0:y1, :]
-            need = (y1 - y0) * COVERAGE
-
-            missing = []
-            for x_pt in promised:
-                lo = max(0, int((x_pt - SEARCH_PT) * scale))
-                hi = min(img.shape[1], int((x_pt + SEARCH_PT) * scale) + 1)
-                if lo >= hi:
-                    missing.append(x_pt)
+            img = None
+            for n, table in enumerate(tables, 1):
+                promised = table_rules(table)
+                if not promised:
                     continue
-                # Local background: the median of a wider window around the
-                # rule. Using the page's global paper white would misjudge a
-                # rule that crosses a shaded header.
-                blo = max(0, int((x_pt - LOCAL_BG_PT) * scale))
-                bhi = min(img.shape[1], int((x_pt + LOCAL_BG_PT) * scale) + 1)
-                local_bg = float(np.median(strip[:, blo:bhi]))
-                cutoff = local_bg - DARKER_THAN_LOCAL_BG
-                counts = (strip[:, lo:hi] < cutoff).sum(axis=0)
-                if counts.max() < need:
-                    missing.append(x_pt)
+                _x0, top, _x1, bot = table.bbox
+                band = (top + (bot - top) * 0.2, top + (bot - top) * 0.8)
 
-            painted = len(promised) - len(missing)
-            print(f"  page {page_no}: {painted}/{len(promised)} promised rules painted")
-            if missing:
-                ok = False
+                if img is None:
+                    with tempfile.TemporaryDirectory() as td:
+                        png = _raster(pdf, page_no, Path(td))
+                        img = np.array(Image.open(png).convert("L"))
+
+                scale = img.shape[1] / page.width
+                y0, y1 = int(band[0] * scale), int(band[1] * scale)
+                if y1 <= y0:
+                    continue
+                strip = img[y0:y1, :]
+                need = (y1 - y0) * COVERAGE
+                checked += 1
+
+                missing = []
+                for x_pt in promised:
+                    lo = max(0, int((x_pt - SEARCH_PT) * scale))
+                    hi = min(img.shape[1], int((x_pt + SEARCH_PT) * scale) + 1)
+                    if lo >= hi:
+                        missing.append(x_pt)
+                        continue
+                    # Local background: the median of a wider window around the
+                    # rule. Using the page's global paper white would misjudge a
+                    # rule that crosses a shaded header.
+                    blo = max(0, int((x_pt - LOCAL_BG_PT) * scale))
+                    bhi = min(img.shape[1], int((x_pt + LOCAL_BG_PT) * scale) + 1)
+                    local_bg = float(np.median(strip[:, blo:bhi]))
+                    cutoff = local_bg - DARKER_THAN_LOCAL_BG
+                    counts = (strip[:, lo:hi] < cutoff).sum(axis=0)
+                    if counts.max() < need:
+                        missing.append(x_pt)
+
+                where = f"page {page_no}" + (f" table {n}" if len(tables) > 1 else "")
+                painted = len(promised) - len(missing)
+                print(f"  {where}: {painted}/{len(promised)} promised rules "
+                      f"painted, rightmost promised at x={max(promised):.2f}pt")
                 for x_pt in missing:
+                    ok = False
                     print(f"    ✗ rule at x={x_pt:.2f}pt is in the object layer "
                           "but has no ink — clipped")
-            elif verbose:
-                print(f"    ✓ rightmost rule at x={max(promised):.2f}pt is painted")
-    return ok
+    return ok, checked
+
+
+def compare_rule_counts(subject: list[float],
+                        reference: list[float]) -> tuple[bool, str, list[float]]:
+    """Verdict on two documents' rule sets: (ok, message, suspect positions).
+
+    The verdict is the count, in both directions. Counting only what the
+    reference has and the subject lacks would let a swapped pair pass silently:
+    every rule of a clipped render is present in a healthy one, so
+    `--reference <the clipped file>` would report a clean subject — the same
+    false-PASS shape this check exists to close.
+
+    Counts, not positions. Cross-backend line breaking moves a table's interior
+    geometry more than any honest position tolerance would allow; the counts
+    hold anyway (measured: 10 healthy theme × page-count pairs, every one
+    equal, including one that breaks into 3 pages under WeasyPrint and 15 under
+    Chrome).
+    """
+    if len(subject) == len(reference):
+        return True, "", []
+    if len(subject) < len(reference):
+        return False, (
+            f"{len(reference) - len(subject)} rule(s) the reference draws are "
+            "absent from the subject's object layer — the renderer dropped them, "
+            "most likely past a page clip"
+        ), unmatched(reference, subject)
+    return False, (
+        f"the subject has {len(subject) - len(reference)} rule(s) the reference "
+        "does not. Either the reference is itself the damaged render (check the "
+        "argument order) or the two files are not the same document"
+    ), unmatched(subject, reference)
+
+
+def check_against_reference(pdf: str, reference: str) -> bool:
+    """The subject must promise as many rules as the reference render does."""
+    sub = document_rules(pdf)
+    ref = document_rules(reference)
+    print(f"  reference: {len(ref)} distinct rules ({reference})")
+    print(f"  subject:   {len(sub)} distinct rules")
+    ok, message, suspects = compare_rule_counts(sub, ref)
+    if ok:
+        return True
+    print(f"    ✗ {message}")
+    for x_pt in suspects:
+        print(f"      near x={x_pt:.2f}pt")
+    return False
 
 
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("pdf", nargs="+", help="PDF file(s) to check")
+    ap.add_argument("--reference", metavar="PDF",
+                    help="the same document rendered by the other backend; "
+                         "enables the dropped-geometry check")
     ap.add_argument("--verbose", "-v", action="store_true")
     args = ap.parse_args()
 
-    all_ok = True
-    for p in args.pdf:
+    if args.reference and len(args.pdf) != 1:
+        print("Error: --reference compares one subject against one reference.",
+              file=sys.stderr)
+        sys.exit(2)
+
+    for p in list(args.pdf) + ([args.reference] if args.reference else []):
         if not Path(p).exists():
             print(f"Error: {p} not found", file=sys.stderr)
             sys.exit(2)
+
+    all_ok = True
+    total_tables = 0
+    for p in args.pdf:
         print(f"{p}:")
-        if not check(p, args.verbose):
+        ok, checked = check_ink(p, args.verbose)
+        total_tables += checked
+        if not ok:
             all_ok = False
-    print("PASS" if all_ok else "FAIL: a table border is missing from the raster")
-    sys.exit(0 if all_ok else 1)
+        if args.reference and not check_against_reference(p, args.reference):
+            all_ok = False
+
+    if not all_ok:
+        # Not "a border is missing": one of the failure modes is that the two
+        # files are not the same document, and a summary line that names the
+        # wrong cause sends the reader looking for the wrong thing.
+        print("FAIL: at least one check did not pass — see the lines above.")
+        sys.exit(1)
+
+    if total_tables == 0:
+        # Its own exit code, not 0. Nothing was measured, and a caller gating on
+        # the exit status would otherwise read "verified nothing" as "verified
+        # clean" — the same overclaim this check was rewritten to remove, just
+        # relocated from the printed word to the status byte.
+        print("NOTHING CHECKED: no table was detected in the input. If the "
+              "document does contain one, its style may draw no rules for "
+              "pdfplumber to find, and this check cannot speak for it.")
+        sys.exit(3)
+
+    if args.reference:
+        print(f"PASS: {total_tables} table(s) checked. Rule counts match the "
+              "reference render, and every promised rule is painted.")
+    else:
+        print(f"PASS: {total_tables} table(s) checked; every rule their object "
+              "layer promises is painted.")
+        print(SCOPE_NOTE)
+    sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/daymade-docs/pdf-creator/scripts/tests/test_table_border_check.py
+++ b/daymade-docs/pdf-creator/scripts/tests/test_table_border_check.py
@@ -81,7 +81,7 @@ def _render(md: str, out: Path, theme: str = "default",
     Deliberately not `pytest.importorskip("weasyprint")`. WeasyPrint dlopens
     native libraries at import time and raises OSError, not ImportError, when
     they are missing — importorskip does not catch that, so a machine without
-    the libraries gets three red tests instead of three skips. The renderer is
+    the libraries gets red tests where it should get skips. The renderer is
     also only ever used out-of-process, so whether it imports *here* is not the
     question worth asking.
     """
@@ -262,6 +262,42 @@ def test_a_table_beside_a_horizontal_rule_is_still_checked():
 
     assert checked == 1
     assert ok
+
+
+@pytest.mark.skipif(not shutil.which("pdftoppm"), reason="needs poppler")
+@pytest.mark.parametrize("order", ["subject-first", "swapped"])
+def test_a_clipped_file_fails_whichever_slot_it_is_passed_in(order):
+    """Argument order must not decide whether the damaged file gets examined.
+
+    For a border Chrome CLIPPED rather than dropped, both renders promise the
+    same number of rules — the geometry is there, merely unpainted — so the
+    count comparison sees nothing and only the ink check finds it. Before the
+    reference was ink-checked too, passing the clipped file as --reference
+    produced an unqualified PASS on a PDF missing a table border.
+    """
+    if _chrome() is None:
+        pytest.skip("needs Chrome")
+
+    with tempfile.TemporaryDirectory() as td:
+        clipped = Path(td) / "chrome.pdf"
+        healthy = Path(td) / "weasy.pdf"
+        # `default` overflows Chrome's page clip by 6.28pt; forcing it there
+        # reproduces the original defect.
+        _render(TABLE_MD, clipped, theme="default", backend="chrome")
+        _render(TABLE_MD, healthy, theme="default", backend="weasyprint")
+        pair = ([clipped, healthy] if order == "subject-first"
+                else [healthy, clipped])
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT_DIR / "check_table_borders.py"),
+             str(pair[0]), "--reference", str(pair[1])],
+            capture_output=True, text=True,
+        )
+
+    assert proc.returncode == 1, (
+        f"clipped file passed as {'subject' if order == 'subject-first' else 'reference'} "
+        f"was not caught\n{proc.stdout}"
+    )
+    assert "no ink" in proc.stdout
 
 
 @pytest.mark.skipif(not shutil.which("pdftoppm"), reason="needs poppler")

--- a/daymade-docs/pdf-creator/scripts/tests/test_table_border_check.py
+++ b/daymade-docs/pdf-creator/scripts/tests/test_table_border_check.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""
+Regression tests for the table-border check's verdict logic.
+
+Why this file exists: the check shipped able to certify itself green. It
+compares ink against the rules the PDF's object layer promises, which is sound
+as far as it goes — but Chrome *drops* geometry that falls entirely outside its
+page clip, and a rule that was never written into the object layer is never
+looked for. Measured: a table styled with vertical rules and no cell fills,
+rendered through Chrome past the clip, printed "5/5 promised rules painted —
+PASS" while its right border was genuinely absent (5 distinct rules against the
+WeasyPrint render's 6).
+
+Why the fix is a reference comparison and not a geometry heuristic: the obvious
+heuristic — the rules must bracket the table's text on both sides — was built
+and then killed by calibration. On `warm-terra-menu` under WeasyPrint, a
+healthy bundled theme, the text runs 65.50pt PAST the rightmost rule, a larger
+asymmetry than the 37.60pt of the proven defect. A fail-closed check that
+misfires on healthy input trains the reflexive bypass that switches it off for
+every input, so the heuristic was dropped rather than tuned.
+
+The counts survive what positions cannot. Calibrated across 5 themes × two page
+counts × both directions: 20 runs, zero disagreement between backends, even
+where one theme breaks the same source into 3 pages under WeasyPrint and 15
+under Chrome.
+
+The same calibration, run against 46 real delivered PDFs, exposed the mirror
+defect: the ink check was unscoped, so a horizontal rule's end-caps counted as
+promised table rules and 34 of those 46 documents failed a gate they should
+never have been subject to. The check is now scoped to tables pdfplumber
+actually detects, and reports how many it measured — a pass that measured
+nothing is not a pass.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+SCRIPT_DIR = Path(__file__).parent.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import check_table_borders as ctb  # noqa: E402
+
+THEMES_DIR = SCRIPT_DIR.parent / "themes"
+
+TABLE_MD = """# 费用清单
+
+| 序号 | 项目 | 日期 | 金额 | 备注 |
+|---|---|---|---|---|
+| 1 | 入门工作坊 | 2026-07-15 | 56,000 | 含讲义 |
+| 2 | 一对一辅导 | 2026-07-22 | 60,000 | 按人次 |
+"""
+
+# A horizontal rule is a rect ~0.7pt tall, and pdfplumber reports its left and
+# right ends as vertical edges. Before the check was scoped to detected tables
+# it treated those ends as promised table rules, hunted for a full-height rule
+# at the page margin, found body text, and reported a missing border. Measured:
+# 34 of 46 real delivered PDFs failed that way.
+HR_ONLY_MD = """# 讲师介绍
+
+第一段正文。
+
+---
+
+第二段正文。
+"""
+
+HR_AND_TABLE_MD = HR_ONLY_MD + "\n" + TABLE_MD
+
+
+def _render(md: str, out: Path, theme: str = "default",
+            backend: str = "weasyprint") -> None:
+    """Render through md_to_pdf, or skip if that backend is unavailable here.
+
+    Deliberately not `pytest.importorskip("weasyprint")`. WeasyPrint dlopens
+    native libraries at import time and raises OSError, not ImportError, when
+    they are missing — importorskip does not catch that, so a machine without
+    the libraries gets three red tests instead of three skips. The renderer is
+    also only ever used out-of-process, so whether it imports *here* is not the
+    question worth asking.
+    """
+    src = out.with_suffix(".md")
+    src.write_text(md, encoding="utf-8")
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT_DIR / "md_to_pdf.py"), str(src), str(out),
+         "--theme", theme, "--backend", backend, "--no-preview"],
+        capture_output=True, text=True,
+    )
+    if proc.returncode != 0 or not out.exists():
+        detail = (proc.stderr or proc.stdout or "").strip().splitlines()
+        pytest.skip(f"{backend} cannot render here: {detail[-1] if detail else '?'}")
+
+
+# --- merge_positions -------------------------------------------------------
+
+
+def test_a_strokes_two_edges_merge_into_one_rule():
+    """A stroke of non-zero width yields two edges; that is one rule, not two."""
+    assert ctb.merge_positions([62.93, 63.68]) == [62.93]
+
+
+def test_distinct_columns_are_not_merged():
+    assert len(ctb.merge_positions([62.93, 63.68, 161.6, 162.35, 260.3])) == 3
+
+
+def test_merge_accepts_an_unsorted_iterator():
+    assert ctb.merge_positions(x for x in [260.3, 62.93, 161.6]) == [62.93, 161.6, 260.3]
+
+
+def test_merge_of_nothing_is_empty():
+    assert ctb.merge_positions([]) == []
+
+
+# --- compare_rule_counts ---------------------------------------------------
+
+
+def test_equal_counts_pass():
+    ok, _, _ = ctb.compare_rule_counts([62.9, 161.6, 545.2], [63.1, 161.5, 544.2])
+    assert ok
+
+
+def test_cross_backend_drift_does_not_fail_a_healthy_pair():
+    """The verdict is counts, so sub-point drift between backends is irrelevant.
+
+    Measured drift at the right edge is ~1pt (545.18 vs 544.21); interior rules
+    can move much further, because the two backends break lines differently.
+    """
+    subject = [62.93, 161.60, 260.30, 359.00, 457.76, 545.18]
+    reference = [63.07, 155.11, 251.42, 366.83, 460.05, 544.21]
+    ok, _, _ = ctb.compare_rule_counts(subject, reference)
+    assert ok
+
+
+def test_a_dropped_rule_fails_and_is_named():
+    """The proven defect: Chrome omitted the right border entirely."""
+    subject = [62.93, 161.60, 260.30, 359.00, 457.02]
+    reference = [63.07, 161.50, 260.20, 358.90, 457.00, 544.21]
+    ok, message, suspects = ctb.compare_rule_counts(subject, reference)
+    assert not ok
+    assert "absent from the subject" in message
+    assert suspects == pytest.approx([544.21])
+
+
+def test_the_verdict_is_symmetric_so_a_swapped_pair_cannot_pass():
+    """Swapping the arguments must not silently clear the damaged file.
+
+    Every rule of a clipped render is present in a healthy one. A one-directional
+    "does the subject have everything the reference has" test therefore reports a
+    clean subject when the clipped file is passed as --reference — the same
+    false-PASS shape this check exists to close.
+    """
+    healthy = [62.93, 161.60, 260.30, 359.00, 457.02, 545.18]
+    clipped = [62.93, 161.60, 260.30, 359.00, 457.02]
+    assert not ctb.compare_rule_counts(clipped, healthy)[0]
+    ok, message, _ = ctb.compare_rule_counts(healthy, clipped)
+    assert not ok
+    assert "check the argument order" in message
+
+
+# --- unmatched (diagnostics) ----------------------------------------------
+
+
+def test_unmatched_does_not_consume_one_counterpart_twice():
+    """Two near-identical wanted positions need two counterparts, not one."""
+    assert ctb.unmatched([100.0, 100.5], [100.2]) == pytest.approx([100.5])
+
+
+def test_unmatched_is_empty_when_everything_has_a_counterpart():
+    assert ctb.unmatched([62.9, 545.2], [63.1, 544.2]) == []
+
+
+# --- the scope statement ---------------------------------------------------
+
+
+def test_a_reference_free_pass_states_what_it_did_not_check():
+    """The bare word PASS is how the real defect cleared this gate."""
+    assert "--reference" in ctb.SCOPE_NOTE
+    assert "dropped" in ctb.SCOPE_NOTE
+
+
+# --- end to end ------------------------------------------------------------
+
+
+def _chrome() -> str | None:
+    import md_to_pdf
+
+    return md_to_pdf._find_chrome()
+
+
+@pytest.mark.skipif(not shutil.which("pdftoppm"), reason="needs poppler")
+def test_a_horizontal_rule_is_not_a_table_border():
+    """The false positive that failed 34 of 46 real delivered PDFs.
+
+    A document with an `<hr>` and no table must report that it checked nothing,
+    not that a border is missing. A gate that fails on healthy input gets
+    bypassed reflexively, which switches it off for the inputs it exists for.
+    """
+    pytest.importorskip("pdfplumber")
+    pytest.importorskip("numpy")
+
+    with tempfile.TemporaryDirectory() as td:
+        out = Path(td) / "hr.pdf"
+        _render(HR_ONLY_MD, out)
+        ok, checked = ctb.check_ink(str(out))
+
+    assert checked == 0, "a horizontal rule was mistaken for a table"
+    assert ok
+
+
+def test_inline_decoration_in_a_cell_is_not_a_column_rule():
+    """The second false-positive class: 10 of 46 real PDFs failed on this.
+
+    An inline `<code>` span's background is a rect inside a cell, and its left
+    and right edges look exactly like vertical rules to an edge-based reader. A
+    two-column table promises three boundaries, no matter how much decoration
+    its cells carry.
+    """
+    pdfplumber = pytest.importorskip("pdfplumber")
+
+    md = (
+        "| 模型 | 调用方式 |\n|---|---|\n"
+        "| `deepseek-v3` | `POST /v1/chat` |\n"
+        "| `glm-4-plus` | `POST /v1/chat` |\n"
+    )
+    with tempfile.TemporaryDirectory() as td:
+        out = Path(td) / "code.pdf"
+        _render(md, out)
+        with pdfplumber.open(str(out)) as doc:
+            tables = [(pg, t) for pg in doc.pages for t in pg.find_tables()]
+            assert tables, "the fixture must contain a detectable table"
+            page, table = tables[0]
+            promised = ctb.table_rules(table)
+            raw = ctb.merge_positions(
+                e["x0"] for e in page.edges
+                if e["orientation"] == "v"
+                and table.bbox[0] - 2 <= e["x0"] <= table.bbox[2] + 2
+            )
+
+    assert len(promised) == 3, f"two columns promise three rules, got {promised}"
+    assert len(raw) >= len(promised), (
+        "fixture no longer exercises the bug: the theme drew no inline "
+        "decoration for the edge-based reader to trip on"
+    )
+
+
+@pytest.mark.skipif(not shutil.which("pdftoppm"), reason="needs poppler")
+def test_a_table_beside_a_horizontal_rule_is_still_checked():
+    """Scoping must not silently switch the check off — the mirror failure."""
+    pytest.importorskip("pdfplumber")
+    pytest.importorskip("numpy")
+
+    with tempfile.TemporaryDirectory() as td:
+        out = Path(td) / "both.pdf"
+        _render(HR_AND_TABLE_MD, out)
+        ok, checked = ctb.check_ink(str(out))
+
+    assert checked == 1
+    assert ok
+
+
+@pytest.mark.skipif(not shutil.which("pdftoppm"), reason="needs poppler")
+@pytest.mark.parametrize("theme", ["default", "cjk-auto", "warm-terra"])
+def test_backends_promise_the_same_number_of_rules(theme):
+    """The zero-false-positive property, measured rather than asserted.
+
+    This is the half of the calibration that matters most: a fail-closed check
+    that ever misfires on healthy input gets bypassed reflexively, and the gate
+    is then off for the inputs it was built for too.
+    """
+    if _chrome() is None:
+        pytest.skip("needs Chrome")
+    pytest.importorskip("pdfplumber")
+
+    with tempfile.TemporaryDirectory() as td:
+        src = Path(td) / "t.md"
+        src.write_text(TABLE_MD, encoding="utf-8")
+        rendered = {}
+        for backend in ("weasyprint", "chrome"):
+            out = Path(td) / f"{backend}.pdf"
+            _render(TABLE_MD, out, theme=theme, backend=backend)
+            rendered[backend] = ctb.document_rules(str(out))
+
+    assert len(rendered["weasyprint"]) == len(rendered["chrome"])
+    ok, message, _ = ctb.compare_rule_counts(rendered["chrome"], rendered["weasyprint"])
+    assert ok, message


### PR DESCRIPTION
`check_table_borders.py` shipped in #397 as the acceptance gate for the Chrome
table-border clip. It fails in **both** directions, and both were found by
calibrating it against real material rather than fixtures.

## It could report PASS on the defect it guards

The check compares raster ink against the rules the object layer promises.
Chrome does two different things at its page clip:

- geometry that **straddles** the clip is kept and painted only up to it → the
  rule is promised and unpainted → caught;
- geometry lying **entirely outside** the clip is **dropped before the PDF is
  written** → nothing promises it → never looked for.

Measured. A table styled with vertical rules and no cell fills, rendered
through Chrome past the clip:

```
page 1: 5/5 promised rules painted
✓ rightmost rule at x=457.02pt is painted
PASS
```

…with its right border genuinely absent. The WeasyPrint render of the same
source has 6 distinct rules; this one has 5, and no geometry at all past x=535.

The bundled themes escape only by accident: their cell background fills
straddle the clip and leave an edge at the border's position for the ink check
to find. Remove the fills and the gate goes green on a broken table.

**Fix — `--reference`.** Compare the subject's distinct-rule count against the
same document rendered by the other backend:

```bash
uv run --with weasyprint scripts/md_to_pdf.py doc.md /tmp/ref.pdf \
  --theme warm-terra --backend weasyprint --no-preview
uv run --with pdfplumber --with pillow --with numpy \
  scripts/check_table_borders.py out.pdf --reference /tmp/ref.pdf
```

- **Counts compared in both directions.** Every rule of a clipped render is
  present in a healthy one, so a one-directional test clears the damaged file
  when the arguments are swapped. (That alone was not enough — see "A hole the
  independent read found" below.)
- **Counts, not positions.** Cross-backend line breaking moves interior
  geometry further than any honest position tolerance; positions are used only
  to name a suspect in the output.
- **Document-wide, not per page.** The backends break one particular 60-row CJK
  table — its row content decides where the breaks land — into 5 pages vs 3
  (`default`), 7 vs 4 (`mobile`), 3 vs 15 (`warm-terra-menu`), with identical
  rule counts throughout.

A reference-free pass now states what it did not check, and `NOTHING CHECKED`
exits **3** rather than sharing 0 with a real pass — a caller gating on status
must not read "verified nothing" as "verified clean".

## It failed 34 of 46 real delivered PDFs

The more expensive direction: a gate that misfires on healthy input gets
bypassed reflexively, and is then off for every input.

It read every vertical edge as a promised rule. An `<hr>` is a rect 0.7pt tall
whose left and right ends are reported as vertical edges, so the check hunted
for a full-height rule at the page margin of documents containing no table at
all, found body text, and reported a missing border. Scoping to the table's
bbox left 10 of 46 failing, on inline `<code>` span backgrounds inside cells.

**Fix — the promised set is each table's detected cell grid.** Neither an
`<hr>` nor a code span is a cell boundary, and no threshold is involved.
Degenerate detections are declined rather than accused: pdfplumber's line
clusterer turns a stack of horizontal rules into a one-column table and a line
of code spans into a one-row one, while a markdown table has a header row plus
a body row and at least two columns.

## Two fixes I built, measured, and threw away

Both looked obviously right. Recording them because the measurement is the
whole value.

- **"A rule must span the table."** Separates real column rules (152pt) from
  code-span edges (12.5–50pt) cleanly on the document that motivated it. It
  also **turns the primary detection off**: at a clipped edge the border stroke
  is frequently gone and a single header-row fill is the only geometry left —
  29.63pt of a 90pt table. Implemented, measured, `clip.pdf` went green.
- **"The rules must bracket the table's text on both sides."** On healthy
  `warm-terra-menu` output under WeasyPrint the text runs **65.50pt past** the
  rightmost rule — a larger asymmetry than the **37.60pt** of the real defect.
  Not tunable: the defect is milder than the healthy case.

## A hole the independent read found, after all of the above

`main()` ran the ink check only on the positional argument, never on
`--reference`. And for a border Chrome **clipped** rather than **dropped**, both
renders promise the same rule count — the geometry is there, merely unpainted —
so the count comparison has nothing to notice either.

Together: pass the clipped Chrome file as `--reference` and the healthy one as
the subject, and the run prints

```
PASS: 1 table(s) checked. Rule counts match the reference render, and every
promised rule is painted.
```

with the damaged file sitting in the invocation. Reproduced on a `default`-theme
pair: `ec=0` before, `ec=1` in **both** orders after, with the failing line
naming which file it is. The reference is ink-checked too now, and a
parametrized regression test covers both orders.

The claim that the verdict is symmetric "in both directions" was true only for
the dropped-geometry class. SKILL.md now says which check covers which class,
and why ink-checking both files is what makes order irrelevant.

Also from that read: `NOTHING CHECKED` said it was not a pass but not what to do
next; a `default`/`cjk-auto` render silently falls back to Chrome when
weasyprint is not importable (warning on stderr, exit 0) while the mandatory
step is gated on knowing the backend; `cjk-auto` was missing from the one
section called "Decision rule"; Batch Convert never mentioned the gate; exit
code 2 claimed to cover "unreadable PDF" but the file has no `try`/`except`; the
exit-1 legend contradicted the comment above its own `exit(1)`; the 60-row
page-count figures read as a general law when row content decides the splits;
`49` and `46` were inconsistent across files; and a 400 dpi measurement was
attributed to the 130 dpi preview PNGs.

Two findings were checked and **not** accepted: the `overflow-wrap` rationale IS
in the block SKILL.md points at (as a CSS comment inside it), and the
Troubleshooting entry the self-check points at DOES carry a verification method.

## Reversal of a decision from #397

That review added `MAX_STROKE_PT` to exclude cell-fill edges. Stating it rather
than slipping it in: it **never excluded anything** (pdfplumber reports
`width=0` on a `rect_edge`, not the parent rect's width), and had it worked it
would have **blinded the ink check at the clipped edge**, where a fill's edge is
often the only surviving geometry.

## From an independent read of the acceptance flow

The MANDATORY visual self-check listed the clip among the failures it exists to
catch, then gave a workflow paragraph saying only "read the PNGs" — the exact
procedure the same document calls unreliable for this defect. An agent
following it faithfully never runs the check and delivers. The border check is
now step 2 of that workflow, with the Chrome case named.

Also from that read: a Troubleshooting command missing its subject PDF
(verified, exits 2); unstated working directory for every relative script path
(verified, `Failed to spawn`); an example pulling `--with markdown --with
pygments`, which `md_to_pdf` does not use (it shells out to pandoc); and the
fact that the `pdftoppm` PNGs render the CID Type 0C fonts that Preview shows
as blanks, so that defect cannot be caught by looking.

## Calibration

| corpus | runs | false positives |
|---|---|---|
| 5 themes × single/multi-page × both argument orders | 20 | 0 (the 12 pairs with no clipped file pass in both orders; the 8 that have one are caught in both) |
| 14 real markdown documents × 2 themes | 28 | 0 |
| 49 WeasyPrint PDFs from a mixed real corpus | 49 | 34 → 5 |

The ink check still fires at x=545.18pt on `default` / `cjk-auto` forced back
to `--backend chrome` — the original bug reproduced.

The 5 residuals are third-party PDFs where pdfplumber's table finder assembles
decoration into a table that was never there; SKILL.md states that limit rather
than hiding it. Verified that the degenerate-table guard does not blind a true
positive: the one document reporting a boundary past the page edge had that
boundary in a one-row phantom, while its 18 real tables all end at 544.21pt.

48 tests pass. Both documented command forms were executed as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
