### PR TITLE
fix(asr): unify speaker bundle time and receipt contracts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -283,7 +283,7 @@
       "description": "Audio processing suite covering the full speech pipeline: ASR transcription (Qwen3, StepFun) with batch-mode guards against music-only repetition-loop hallucinations, speaker diarization and CAM++ voiceprint identification for multi-speaker recordings, transcript error correction, structured meeting minutes generation, and TTS voice synthesis (StepFun). Install once for the complete audio workflow.",
       "source": "./daymade-audio",
       "strict": false,
-      "version": "1.32.3",
+      "version": "1.32.4",
       "category": "suite",
       "keywords": [
         "suite",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **daymade-audio / asr-transcribe-to-text** (`daymade-audio` v1.32.4): prevent single-character or degenerate aligned turns from emitting `start == end` and `duration == 0`. The Qwen aligner and Whisper.cpp late-fusion producer now share one half-up integer-millisecond contract for direct and interpolated lattice points, turn fields, TXT, CSV, and alignment JSON; degenerate turns receive only the smallest 1 ms interval and never borrow a later timestamp across a speaker change or long silence. Both speaker-bundle producers record their reviewed edge-inheritance tolerance in the final receipt (Qwen 1 s; overlap-only fusion 0 s), and the shared time-contract module is covered by each pipeline hash. This keeps identically named artifacts semantically consistent without weakening downstream positive-duration or diarization-support checks; the receipt-less legacy cascade remains outside the strict bundle contract.
 - **pdf-creator** (`daymade-docs` v1.13.0): the table-border check could clear the defect it
   exists to catch, and separately failed most healthy documents. Both were found by calibrating
   it against real material rather than fixtures.

--- a/daymade-audio/asr-transcribe-to-text/scripts/align_speakers.py
+++ b/daymade-audio/asr-transcribe-to-text/scripts/align_speakers.py
@@ -38,6 +38,16 @@ import json
 import sys
 from pathlib import Path
 
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+from speaker_time_contract import (
+    MILLISECOND_S,
+    format_timestamp,
+    positive_turn_bounds,
+    to_seconds,
+)
+
 # Chars dropped when normalizing for alignment (CJK + ASCII punctuation, spaces).
 _DROP = set(" \t\n\r，。！？；：、（）【】《》〈〉“”‘’\"'—…·~～.,!?;:'\"()[]{}<>-—_+*=/\\|@#$%^&`…‥•·、　")
 
@@ -54,6 +64,11 @@ MIN_ANCHOR_RATIO = 0.5
 # is adversarial inputs, not real double-transcribed audio), but warn at scale
 # rather than hang silently. For multi-hour recordings, split the audio.
 ALIGN_LEN_WARN = 25000
+# Output timestamps have millisecond precision, so one millisecond is the
+# smallest representable positive turn. Single-character interjections can
+# otherwise inherit one timing-lattice midpoint for both boundaries and emit a
+# zero-duration CSV row that downstream evidence players cannot consume.
+MIN_TURN_DURATION_S = MILLISECOND_S
 
 
 def log(msg):
@@ -89,7 +104,7 @@ def whisper_char_lattice(words):
             # Linear interpolation across the word span, midpoint of each slot.
             t = start + (end - start) * (j + 0.5) / n
             chars.append(c.lower() if "A" <= c <= "Z" else c)
-            times.append(round(t, 3))
+            times.append(to_seconds(t))
     return chars, times
 
 
@@ -127,7 +142,7 @@ def assign_times(qwen_chars, whisper_times, anchors):
         span = hi - lo
         for i in range(lo + 1, hi):
             frac = (i - lo) / span
-            times[i] = round(t_lo + (t_hi - t_lo) * frac, 3)
+            times[i] = to_seconds(t_lo + (t_hi - t_lo) * frac)
     anchored_ratio = len(anchor_by_q) / n if n else 0.0
     return times, round(anchored_ratio, 4)
 
@@ -193,12 +208,16 @@ def build_turns(qwen_raw, raw_idx, times, speakers, max_gap):
         text = qwen_raw[raw_lo:raw_hi].strip()
         if not text:
             continue
+        # Do not borrow the next char's midpoint: the turn may have been split
+        # precisely because that next point is another speaker or a long
+        # silence beyond max_gap. The shared contract adds only one millisecond.
+        start, end, duration = positive_turn_bounds(
+            times[lo], times[hi - 1]
+        )
         out.append({
-            "start": times[lo],
-            "end": times[hi - 1],
-            # Clamp >=0: overlapping whisper word spans can make end<start locally;
-            # a negative duration would confuse downstream consumers.
-            "duration": round(max(0.0, (times[hi - 1] or 0) - (times[lo] or 0)), 3),
+            "start": start,
+            "end": end,
+            "duration": duration,
             "speaker": sp,
             "text": text,
         })
@@ -233,9 +252,7 @@ def align(qwen_text, whisper_words, diar_segments, max_gap=MAX_GAP_DEFAULT):
 
 
 def fmt(sec):
-    sec = sec or 0
-    m, s = int(sec // 60), int(sec % 60)
-    return f"{m:02d}:{s:02d}.{int((sec % 1) * 1000):03d}"
+    return format_timestamp(sec)
 
 
 def write_outputs(turns, report, wav_name, out_dir, stem):

--- a/daymade-audio/asr-transcribe-to-text/scripts/fuse_whispercpp_diarization.py
+++ b/daymade-audio/asr-transcribe-to-text/scripts/fuse_whispercpp_diarization.py
@@ -24,9 +24,17 @@ import unicodedata
 import wave
 from pathlib import Path
 
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+from speaker_time_contract import (
+    format_timestamp,
+    positive_turn_bounds,
+)
 
 PIPELINE_ID = "whispercpp-pyannote-late-fusion-v1"
 FINAL_RECEIPT_SCHEMA = "speaker-bundle-receipt-v1"
+SPEAKER_VALIDATION_CONTRACT = {"speaker_edge_tolerance_s": 0.0}
 CSV_FIELDS = ("file", "start", "end", "duration", "speaker", "text")
 
 
@@ -350,11 +358,19 @@ def merge_turns(segments, max_gap):
     return turns
 
 
-def format_timestamp(seconds):
-    milliseconds = round(seconds * 1000)
-    minutes, remainder = divmod(milliseconds, 60_000)
-    secs, millis = divmod(remainder, 1000)
-    return f"{minutes:02d}:{secs:02d}.{millis:03d}"
+def canonicalize_turns(turns):
+    canonical = []
+    for turn in turns:
+        start, end, duration = positive_turn_bounds(
+            turn["start"], turn["end"]
+        )
+        canonical.append({
+            **turn,
+            "start": start,
+            "end": end,
+            "duration": duration,
+        })
+    return canonical
 
 
 def render_txt(source_name, turns):
@@ -382,9 +398,9 @@ def render_csv(source_name, turns):
         writer.writerow(
             {
                 "file": source_name,
-                "start": round(turn["start"], 3),
-                "end": round(turn["end"], 3),
-                "duration": round(turn["end"] - turn["start"], 3),
+                "start": turn["start"],
+                "end": turn["end"],
+                "duration": turn["duration"],
                 "speaker": turn["speaker"],
                 "text": turn["text"],
             }
@@ -396,9 +412,9 @@ def csv_turn_contract_sha256(turns, source_name):
     rows = [
         {
             "file": source_name,
-            "start": str(round(turn["start"], 3)),
-            "end": str(round(turn["end"], 3)),
-            "duration": str(round(turn["end"] - turn["start"], 3)),
+            "start": str(turn["start"]),
+            "end": str(turn["end"]),
+            "duration": str(turn["duration"]),
             "speaker": turn["speaker"],
             "text": turn["text"],
         }
@@ -467,10 +483,16 @@ def main():
     script_path = Path(__file__).resolve()
     runner_path = script_path.with_name("transcribe_long_whispercpp.py")
     diarizer_path = script_path.with_name("diarize_speakers.py")
+    time_contract_path = script_path.with_name("speaker_time_contract.py")
     diarizer_lock_path = diarizer_path.with_suffix(
         f"{diarizer_path.suffix}.lock"
     )
-    for producer_path in (runner_path, diarizer_path, diarizer_lock_path):
+    for producer_path in (
+        runner_path,
+        diarizer_path,
+        diarizer_lock_path,
+        time_contract_path,
+    ):
         if not producer_path.is_file():
             raise ValueError(f"pipeline producer is missing: {producer_path}")
     frozen_producers = {
@@ -478,6 +500,7 @@ def main():
         "fuse_whispercpp_diarization.py": source_identity(script_path),
         "diarize_speakers.py": source_identity(diarizer_path),
         "diarize_speakers.py.lock": source_identity(diarizer_lock_path),
+        "speaker_time_contract.py": source_identity(time_contract_path),
     }
     whisper_segments = timed_segments(whisper_payload)
     diar_segments = diarization_segments(diarization_payload)
@@ -568,7 +591,7 @@ def main():
         whisper_segments, diar_segments, args.min_speech_overlap
     )
     deduplicated, discarded_repeats = collapse_repeat_runs(grounded)
-    turns = merge_turns(deduplicated, args.max_gap)
+    turns = canonicalize_turns(merge_turns(deduplicated, args.max_gap))
     if not turns:
         raise RuntimeError("fusion produced no speech-grounded turns")
     require_owner_alive(args.owner_pid)
@@ -699,6 +722,7 @@ def main():
         "pipeline": pipeline_contract,
         "parameters": parameters_contract,
         "model_contract": model_contract,
+        "validation": dict(SPEAKER_VALIDATION_CONTRACT),
     }
     atomic_write_json(receipt_path, receipt)
     print(

--- a/daymade-audio/asr-transcribe-to-text/scripts/speaker_time_contract.py
+++ b/daymade-audio/asr-transcribe-to-text/scripts/speaker_time_contract.py
@@ -1,0 +1,41 @@
+"""Canonical millisecond contract shared by speaker-bundle producers."""
+
+from decimal import Decimal, ROUND_HALF_UP
+
+
+TIME_CONTRACT_ID = "speaker-time-ms-half-up-v1"
+MILLISECOND_S = 0.001
+_MS_PER_SECOND = Decimal("1000")
+_ONE_MS = Decimal("1")
+
+
+def to_milliseconds(seconds):
+    """Convert seconds to integer milliseconds with explicit half-up rounding."""
+    return int(
+        (Decimal(str(seconds or 0.0)) * _MS_PER_SECOND).quantize(
+            _ONE_MS,
+            rounding=ROUND_HALF_UP,
+        )
+    )
+
+
+def to_seconds(seconds):
+    """Return the canonical millisecond-aligned seconds value."""
+    return to_milliseconds(seconds) / 1000
+
+
+def positive_turn_bounds(start, end):
+    """Return canonical start/end/duration, enforcing one positive millisecond."""
+    start_ms = to_milliseconds(start)
+    end_ms = to_milliseconds(end)
+    if end_ms <= start_ms:
+        end_ms = start_ms + 1
+    return start_ms / 1000, end_ms / 1000, (end_ms - start_ms) / 1000
+
+
+def format_timestamp(seconds):
+    """Format canonical milliseconds as total minutes plus seconds."""
+    total_ms = to_milliseconds(seconds)
+    minutes, remainder_ms = divmod(total_ms, 60_000)
+    secs, milliseconds = divmod(remainder_ms, 1_000)
+    return f"{minutes:02d}:{secs:02d}.{milliseconds:03d}"

--- a/daymade-audio/asr-transcribe-to-text/scripts/speaker_transcribe.py
+++ b/daymade-audio/asr-transcribe-to-text/scripts/speaker_transcribe.py
@@ -47,6 +47,7 @@ import argparse
 import csv
 import io
 import json
+import math
 import os
 import re
 import signal
@@ -273,11 +274,22 @@ def _pipeline_contract():
         "word_timestamps_whisper.py",
         "diarize_speakers.py",
         "align_speakers.py",
+        "speaker_time_contract.py",
     )
     return {
         name: _sha256_file(HERE / name)
         for name in scripts
     }
+
+
+def _validation_contract():
+    """Freeze producer-owned bounds that downstream artifact checks consume."""
+    from align_speakers import SEG_EDGE_TOLERANCE
+
+    tolerance = float(SEG_EDGE_TOLERANCE)
+    if not math.isfinite(tolerance) or tolerance < 0:
+        raise RuntimeError("aligner speaker-edge tolerance is invalid")
+    return {"speaker_edge_tolerance_s": tolerance}
 
 
 def _external_text_identity(text_file):
@@ -293,7 +305,12 @@ def _external_text_identity(text_file):
 
 
 def _write_final_receipt(
-    wav, out_dir, stem, parameters, pipeline_contract=None
+    wav,
+    out_dir,
+    stem,
+    parameters,
+    pipeline_contract=None,
+    validation_contract=None,
 ):
     """Atomically commit the complete bundle after every final artifact exists."""
     artifacts = {}
@@ -312,6 +329,7 @@ def _write_final_receipt(
         "artifacts": artifacts,
         "pipeline": pipeline_contract or _pipeline_contract(),
         "parameters": parameters,
+        "validation": validation_contract or _validation_contract(),
         "model_contract": {
             "id": DEFAULT_MODEL_ID,
             "revision": DEFAULT_MODEL_REVISION,
@@ -867,6 +885,7 @@ def leg_align(
     text_file=None,
     receipt_parameters=None,
     receipt_pipeline=None,
+    receipt_validation=None,
 ):
     """Leg 4: attach speakers to full text, write the output contract.
     Per-file resilient — one bad file is recorded as failed, not a batch crash;
@@ -951,6 +970,7 @@ def leg_align(
             stem,
             receipt_parameters or {},
             receipt_pipeline,
+            receipt_validation,
         )
     if failed:
         log(f"FAILED/skipped files: {failed}")
@@ -1023,6 +1043,7 @@ def main():
     # this process runs, downstream current-contract validation rejects the old
     # process instead of attributing its outputs to the new on-disk code.
     receipt_pipeline = _pipeline_contract()
+    receipt_validation = _validation_contract()
 
     decoder = diarize_all(
         args.inputs,
@@ -1052,6 +1073,7 @@ def main():
         args.text_file,
         receipt_parameters,
         receipt_pipeline,
+        receipt_validation,
     )
     log("Done.")
 

--- a/daymade-audio/asr-transcribe-to-text/tests/test_alignment_turns.py
+++ b/daymade-audio/asr-transcribe-to-text/tests/test_alignment_turns.py
@@ -1,0 +1,163 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "align_speakers.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("align_speakers_test", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class PositiveTurnDurationTests(unittest.TestCase):
+    def setUp(self):
+        self.align = load_module()
+
+    def test_single_character_turns_use_only_the_minimum_tick(self):
+        raw = "甲乙"
+        _chars, raw_idx = self.align.normalize_stream(raw)
+
+        turns = self.align.build_turns(
+            raw,
+            raw_idx,
+            [14.6, 14.8],
+            ["SPEAKER_00", "SPEAKER_01"],
+            max_gap=2.0,
+        )
+
+        self.assertEqual(len(turns), 2)
+        self.assertEqual(turns[0]["start"], 14.6)
+        self.assertEqual(turns[0]["end"], 14.601)
+        self.assertEqual(turns[0]["duration"], 0.001)
+        self.assertEqual(turns[1]["start"], 14.8)
+        self.assertEqual(turns[1]["end"], 14.801)
+        self.assertEqual(turns[1]["duration"], 0.001)
+        for turn in turns:
+            self.assertGreater(turn["end"], turn["start"])
+            self.assertEqual(
+                turn["duration"], round(turn["end"] - turn["start"], 3)
+            )
+
+    def test_long_gap_does_not_expand_previous_turn_across_silence(self):
+        raw = "甲乙"
+        _chars, raw_idx = self.align.normalize_stream(raw)
+
+        turns = self.align.build_turns(
+            raw,
+            raw_idx,
+            [10.0, 30.0],
+            ["SPEAKER_00", "SPEAKER_00"],
+            max_gap=2.0,
+        )
+
+        self.assertEqual(turns[0]["start"], 10.0)
+        self.assertEqual(turns[0]["end"], 10.001)
+        self.assertEqual(turns[0]["duration"], 0.001)
+
+    def test_long_gap_and_speaker_change_preserve_both_turns(self):
+        raw = "甲乙"
+        _chars, raw_idx = self.align.normalize_stream(raw)
+
+        turns = self.align.build_turns(
+            raw,
+            raw_idx,
+            [10.0, 30.0],
+            ["SPEAKER_00", "SPEAKER_01"],
+            max_gap=2.0,
+        )
+
+        self.assertEqual(
+            [(turn["speaker"], turn["text"]) for turn in turns],
+            [("SPEAKER_00", "甲"), ("SPEAKER_01", "乙")],
+        )
+        self.assertEqual(turns[0]["end"], 10.001)
+        self.assertEqual(turns[1]["start"], 30.0)
+        self.assertLess(
+            self.align.fmt(turns[0]["end"]),
+            self.align.fmt(turns[1]["start"]),
+        )
+
+    def test_repeated_lattice_times_still_produce_positive_turns(self):
+        raw = "甲乙"
+        _chars, raw_idx = self.align.normalize_stream(raw)
+        turns = self.align.build_turns(
+            raw,
+            raw_idx,
+            [14.8, 14.8],
+            ["SPEAKER_00", "SPEAKER_01"],
+            max_gap=2.0,
+        )
+        self.assertTrue(all(turn["duration"] == 0.001 for turn in turns))
+
+    def test_turn_fields_and_formatter_share_half_up_millisecond_rounding(self):
+        raw = "甲乙"
+        _chars, raw_idx = self.align.normalize_stream(raw)
+        turns = self.align.build_turns(
+            raw,
+            raw_idx,
+            [59.9985, 60.0005],
+            ["SPEAKER_00", "SPEAKER_01"],
+            max_gap=2.0,
+        )
+
+        self.assertEqual(turns[0]["start"], 59.999)
+        self.assertEqual(turns[0]["end"], 60.0)
+        self.assertEqual(turns[1]["start"], 60.001)
+        self.assertEqual(turns[1]["end"], 60.002)
+        self.assertEqual(self.align.fmt(turns[0]["start"]), "00:59.999")
+        self.assertEqual(self.align.fmt(turns[1]["start"]), "01:00.001")
+
+    def test_word_lattice_uses_half_up_before_building_turns(self):
+        chars, times = self.align.whisper_char_lattice([
+            {"word": "甲", "start": 59.997, "end": 60.0},
+        ])
+        turns = self.align.build_turns(
+            "甲",
+            [0],
+            times,
+            ["SPEAKER_00"],
+            max_gap=2.0,
+        )
+
+        self.assertEqual(chars, ["甲"])
+        self.assertEqual(times, [59.999])
+        self.assertEqual(turns[0]["start"], 59.999)
+        self.assertEqual(turns[0]["end"], 60.0)
+        self.assertEqual(self.align.fmt(turns[0]["start"]), "00:59.999")
+
+    def test_interpolated_anchor_uses_half_up_before_turn_building(self):
+        times, ratio = self.align.assign_times(
+            ["甲", "乙", "丙"],
+            [59.997, 60.0],
+            [(0, 0), (2, 1)],
+        )
+        turns = self.align.build_turns(
+            "甲乙丙",
+            [0, 1, 2],
+            times,
+            ["SPEAKER_00", "SPEAKER_01", "SPEAKER_02"],
+            max_gap=2.0,
+        )
+
+        self.assertEqual(ratio, 0.6667)
+        self.assertEqual(times, [59.997, 59.999, 60.0])
+        self.assertEqual(turns[1]["start"], 59.999)
+        self.assertEqual(turns[1]["end"], 60.0)
+        self.assertEqual(turns[1]["text"], "乙")
+        self.assertEqual(turns[1]["speaker"], "SPEAKER_01")
+
+    def test_formatter_preserves_the_minimum_millisecond_tick(self):
+        self.assertEqual(self.align.fmt(14.8), "00:14.800")
+        self.assertEqual(self.align.fmt(14.801), "00:14.801")
+        self.assertEqual(self.align.fmt(59.9985), "00:59.999")
+        self.assertEqual(self.align.fmt(59.9995), "01:00.000")
+        self.assertEqual(self.align.fmt(60.0005), "01:00.001")
+        self.assertEqual(self.align.fmt(125.6786), "02:05.679")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/daymade-audio/asr-transcribe-to-text/tests/test_long_audio_safety.py
+++ b/daymade-audio/asr-transcribe-to-text/tests/test_long_audio_safety.py
@@ -873,6 +873,10 @@ class LongAudioSafetyTests(unittest.TestCase):
             self.assertEqual(receipt["schema"], speaker.FINAL_RECEIPT_SCHEMA)
             self.assertEqual(receipt["parameters"], parameters)
             self.assertEqual(
+                receipt["validation"],
+                {"speaker_edge_tolerance_s": 1.0},
+            )
+            self.assertEqual(
                 receipt["model_contract"]["revision"],
                 local_mlx.DEFAULT_MODEL_REVISION,
             )

--- a/daymade-audio/asr-transcribe-to-text/tests/test_speaker_bundle_time_contract.py
+++ b/daymade-audio/asr-transcribe-to-text/tests/test_speaker_bundle_time_contract.py
@@ -1,0 +1,149 @@
+import csv
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = SKILL_ROOT / "scripts"
+
+
+def load_module(name):
+    path = SCRIPTS / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(f"{name}_contract_test", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+align = load_module("align_speakers")
+fusion = load_module("fuse_whispercpp_diarization")
+speaker = load_module("speaker_transcribe")
+
+
+def csv_contract(path):
+    with Path(path).open(encoding="utf-8", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+    contract = [
+        {field: row.get(field) for field in fusion.CSV_FIELDS}
+        for row in rows
+    ]
+    digest = hashlib.sha256(
+        json.dumps(
+            contract,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    return rows, digest
+
+
+class SpeakerBundleTimeContractTests(unittest.TestCase):
+    def test_qwen_and_fusion_emit_the_same_half_millisecond_bundle(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "fixture.wav"
+            source.write_bytes(b"synthetic wav bytes")
+            qwen_dir = root / "qwen"
+            fusion_dir = root / "fusion"
+            qwen_dir.mkdir()
+            fusion_dir.mkdir()
+
+            _chars, lattice = align.whisper_char_lattice([
+                {"word": "甲", "start": 59.997, "end": 60.0},
+            ])
+            qwen_turns = align.build_turns(
+                "甲", [0], lattice, ["SPEAKER_00"], max_gap=2.0
+            )
+            report = {
+                "trustworthy": True,
+                "anchored_ratio": 1.0,
+                "num_turns": 1,
+                "speakers": ["SPEAKER_00"],
+            }
+            align.write_outputs(
+                qwen_turns,
+                report,
+                source.name,
+                qwen_dir,
+                "fixture",
+            )
+            (qwen_dir / "fixture.diarization.json").write_text(
+                json.dumps({
+                    "segments": [
+                        {
+                            "start": 59.9,
+                            "end": 60.1,
+                            "speaker": "SPEAKER_00",
+                        }
+                    ]
+                }),
+                encoding="utf-8",
+            )
+            speaker._stamp_alignment_source(
+                source,
+                qwen_dir,
+                "fixture",
+                speaker._source_audio_identity(source),
+            )
+
+            fusion_turns = fusion.canonicalize_turns([
+                {
+                    "start": 59.9985,
+                    "end": 59.9995,
+                    "speaker": "SPEAKER_00",
+                    "text": "甲",
+                }
+            ])
+            (fusion_dir / "fixture.txt").write_text(
+                fusion.render_txt(source.name, fusion_turns),
+                encoding="utf-8",
+            )
+            (fusion_dir / "fixture.csv").write_text(
+                fusion.render_csv(source.name, fusion_turns),
+                encoding="utf-8",
+            )
+
+            qwen_rows, qwen_hash = csv_contract(qwen_dir / "fixture.csv")
+            fusion_rows, fusion_hash = csv_contract(fusion_dir / "fixture.csv")
+            qwen_alignment = json.loads(
+                (qwen_dir / "fixture.alignment.json").read_text(encoding="utf-8")
+            )
+
+            self.assertEqual(qwen_rows, fusion_rows)
+            self.assertEqual(
+                (qwen_rows[0]["start"], qwen_rows[0]["end"], qwen_rows[0]["duration"]),
+                ("59.999", "60.0", "0.001"),
+            )
+            self.assertIn(
+                "[00:59.999 - 01:00.000] SPEAKER_00",
+                (qwen_dir / "fixture.txt").read_text(encoding="utf-8"),
+            )
+            self.assertIn(
+                "[00:59.999 - 01:00.000] SPEAKER_00",
+                (fusion_dir / "fixture.txt").read_text(encoding="utf-8"),
+            )
+            self.assertEqual(
+                qwen_alignment["turn_contract"]["sha256"],
+                qwen_hash,
+            )
+            self.assertEqual(
+                fusion.csv_turn_contract_sha256(fusion_turns, source.name),
+                fusion_hash,
+            )
+            self.assertEqual(
+                speaker._validation_contract(),
+                {"speaker_edge_tolerance_s": 1.0},
+            )
+            self.assertEqual(
+                fusion.SPEAKER_VALIDATION_CONTRACT,
+                {"speaker_edge_tolerance_s": 0.0},
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/daymade-audio/asr-transcribe-to-text/tests/test_whispercpp_fusion.py
+++ b/daymade-audio/asr-transcribe-to-text/tests/test_whispercpp_fusion.py
@@ -168,6 +168,24 @@ class WhisperCppFusionTests(unittest.TestCase):
     def test_long_timestamp_uses_total_minutes_for_existing_bundle_parser(self):
         self.assertEqual(fusion.format_timestamp(3 * 3600 + 22 * 60 + 4.55), "202:04.550")
 
+    def test_fusion_artifacts_share_half_up_millisecond_turns(self):
+        turns = fusion.canonicalize_turns([
+            {
+                "start": 59.9985,
+                "end": 60.0005,
+                "speaker": "SPEAKER_00",
+                "text": "half millisecond",
+            }
+        ])
+        txt = fusion.render_txt("fixture.wav", turns)
+        csv_text = fusion.render_csv("fixture.wav", turns)
+
+        self.assertEqual(turns[0]["start"], 59.999)
+        self.assertEqual(turns[0]["end"], 60.001)
+        self.assertEqual(turns[0]["duration"], 0.002)
+        self.assertIn("[00:59.999 - 01:00.001]", txt)
+        self.assertIn("fixture.wav,59.999,60.001,0.002", csv_text)
+
     def test_main_emits_the_existing_speaker_bundle_contract(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -199,6 +217,11 @@ class WhisperCppFusionTests(unittest.TestCase):
         self.assertEqual(alignment["parameters"]["processing_end_s"], 1.0)
         self.assertEqual(alignment["report"]["num_turns"], 1)
         self.assertIn("diarize_speakers.py.lock", receipt["pipeline"])
+        self.assertIn("speaker_time_contract.py", receipt["pipeline"])
+        self.assertEqual(
+            receipt["validation"],
+            {"speaker_edge_tolerance_s": 0.0},
+        )
         self.assertEqual(
             receipt["model_contract"]["diarization"]["id"],
             "pyannote/speaker-diarization-3.1",


### PR DESCRIPTION
## What changed

- add one shared HALF_UP integer-millisecond contract for Qwen alignment and Whisper.cpp late fusion
- guarantee positive 1 ms degenerate turns without borrowing a later speaker/silence boundary
- keep TXT, CSV, alignment JSON, and parsed turn hashes on the same serialized values
- bind the shared time module and producer-owned diarization edge tolerance into final receipts
- add direct-lattice, interpolated-anchor, long-gap, half-millisecond, receipt, and dual-producer bundle regressions

## Verification

- 55 registered ASR tests pass on macOS
- skill validation, existing-capability migration audit, security scan, and packaging pass against current main
- multiple fresh immutable-snapshot reviews converged to 0 blocker / 0 major / 0 minor
- a cached real canary produced the new receipt and remained correctly rejected by the strict consumer for an ungrounded turn outside all allowed diarization support

## Boundary

This does not claim that long-file local ASR is production-ready and does not weaken any downstream quality gate. The receipt-less legacy cascade remains outside the strict bundle contract.
