### PR TITLE
fix(history): make Claude search candidate-first without losing fidelity

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -104,7 +104,7 @@
       "description": "Claude Code operations suite that bundles cross-project prior-work retrieval across code, docs, Skills, meetings, WeChat archives, and conversation history; provider-separated Claude Code and Codex history readers; identity- and lineage-gated continuation workflows; plugin/skill troubleshooting; CLAUDE.md progressive disclosure optimization; version-synced Lark CLI routing; statusline configuration; exported .txt repair; full claude.ai conversation extraction with tool-call rendering and file download; plugin marketplace development and suite consolidation; writing/testing/debugging Claude Code hooks; multi-provider profile isolation; personal-memory migration into tool-agnostic AGENTS.md reference docs; one-shot local timers that ping Claude right after subscription quota reset to start a fresh 5-hour usage window; and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
       "source": "./daymade-claude-code",
       "strict": false,
-      "version": "3.7.5",
+      "version": "3.7.6",
       "category": "suite",
       "keywords": [
         "suite",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,10 +57,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   project directories, runs a native file-level candidate pass before metadata extraction,
   and fully parses only candidate sessions while retaining every same-named active/archive
   copy so date-window untimed-record counts and record unions remain exact. The file-level
-  prefilter now safely handles uncased Unicode such as CJK by checking both raw UTF-8 and
-  exact JSON-escaped forms; cased or multi-codepoint folds still fall back to full parsing.
+  prefilter now safely handles uncased Unicode such as CJK with an exact matcher for every
+  raw UTF-8 / JSON-escaped mixture; cased or multi-codepoint folds still fall back to full parsing.
   On the real 5,298-session / 264-project inventory, the previously interrupted
-  `自动主线回锚` one-day search completed in 13.78s and reported that only 10 sessions
+  `自动主线回锚` one-day search completed in 15.75s and reported that only 18 sessions
   required structured parsing. Deterministic regressions prove 1/41 metadata parses,
   byte-identical output with `--no-prefilter`, archived-copy untimed-count fidelity,
   escaped-CJK recall, and honest zero-candidate reporting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,8 +60,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   prefilter now safely handles uncased Unicode such as CJK with an exact matcher for every
   raw UTF-8 / JSON-escaped mixture; cased or multi-codepoint folds still fall back to full parsing.
   On the real 8,532-physical-file / 5,275-session / 264-project inventory, the
-  previously interrupted `自动主线回锚` one-day search completed in 12.73s and
-  reported that only 19 sessions
+  previously interrupted `自动主线回锚` one-day search completed in 14.36s and
+  reported that only 90 sessions
   required full-session parsing. Deterministic regressions prove 1/41 full metadata parses,
   byte-identical output with `--no-prefilter`, archived-copy untimed-count fidelity,
   escaped-CJK recall, and honest zero-candidate reporting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Calibration: 5 themes × single- and multi-page × both argument orders = 20 runs — the 12 pairs
   with no clipped file pass in both orders, the 8 that have one are caught in both; 14 real
   markdown documents × 2 themes = 28 single-file runs, zero false positives.
+- **read-claude-code-history / read-codex-history** (`daymade-claude-code` v3.7.6):
+  make bounded keyword search usable as an observability path instead of parsing every
+  session twice before it can report one match. Search now de-duplicates aliased physical
+  project directories, runs a native file-level candidate pass before metadata extraction,
+  and fully parses only candidate sessions while retaining every same-named active/archive
+  copy so date-window untimed-record counts and record unions remain exact. The file-level
+  prefilter now safely handles uncased Unicode such as CJK by checking both raw UTF-8 and
+  exact JSON-escaped forms; cased or multi-codepoint folds still fall back to full parsing.
+  On the real 5,298-session / 264-project inventory, the previously interrupted
+  `自动主线回锚` one-day search completed in 13.78s and reported that only 10 sessions
+  required structured parsing. Deterministic regressions prove 1/41 metadata parses,
+  byte-identical output with `--no-prefilter`, archived-copy untimed-count fidelity,
+  escaped-CJK recall, and honest zero-candidate reporting.
 - **read-claude-code-history / read-codex-history** (`daymade-claude-code` v3.7.5):
   stop scanning the same multi-gigabyte Claude history tree once per profile label.
   Multi-model profiles commonly expose distinct config homes whose `projects/` paths are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,14 +51,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Calibration: 5 themes × single- and multi-page × both argument orders = 20 runs — the 12 pairs
   with no clipped file pass in both orders, the 8 that have one are caught in both; 14 real
   markdown documents × 2 themes = 28 single-file runs, zero false positives.
-- **read-claude-code-history / read-codex-history** (`daymade-claude-code` v3.7.6):
+- **read-claude-code-history** (`daymade-claude-code` v3.7.6):
   make bounded keyword search usable as an observability path instead of parsing every
   session twice before it can report one match. Search now de-duplicates aliased physical
-  project directories, runs a native file-level candidate pass before metadata extraction,
-  and fully parses only candidate sessions while retaining every same-named active/archive
-  copy so date-window untimed-record counts and record unions remain exact. The file-level
-  prefilter now safely handles uncased Unicode such as CJK with an exact matcher for every
-  raw UTF-8 / JSON-escaped mixture; cased or multi-codepoint folds still fall back to full parsing.
+  project directories, builds a bounded internal-sessionId index, runs a native file-level
+  candidate pass, and fully parses only exact candidate paths while retaining renamed
+  active/archive copies of the same session. This keeps source provenance, date-window
+  untimed-record counts, and record unions exact. The shared file prefilter used by both
+  `read-claude-code-history` and `read-codex-history` now safely handles uncased Unicode such
+  as CJK with an exact matcher for every raw UTF-8 / JSON-escaped mixture; unsafe folds still
+  fall back to full parsing.
   On the real 8,532-physical-file / 5,275-session / 264-project inventory, the
   previously interrupted `自动主线回锚` one-day search completed in 13.64s and
   reported that only 78 sessions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,9 +59,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   copy so date-window untimed-record counts and record unions remain exact. The file-level
   prefilter now safely handles uncased Unicode such as CJK with an exact matcher for every
   raw UTF-8 / JSON-escaped mixture; cased or multi-codepoint folds still fall back to full parsing.
-  On the real 5,298-session / 264-project inventory, the previously interrupted
-  `自动主线回锚` one-day search completed in 15.75s and reported that only 18 sessions
-  required structured parsing. Deterministic regressions prove 1/41 metadata parses,
+  On the real 8,532-physical-file / 5,275-session / 264-project inventory, the
+  previously interrupted `自动主线回锚` one-day search completed in 12.73s and
+  reported that only 19 sessions
+  required full-session parsing. Deterministic regressions prove 1/41 full metadata parses,
   byte-identical output with `--no-prefilter`, archived-copy untimed-count fidelity,
   escaped-CJK recall, and honest zero-candidate reporting.
 - **read-claude-code-history / read-codex-history** (`daymade-claude-code` v3.7.5):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,8 +60,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   prefilter now safely handles uncased Unicode such as CJK with an exact matcher for every
   raw UTF-8 / JSON-escaped mixture; cased or multi-codepoint folds still fall back to full parsing.
   On the real 8,532-physical-file / 5,275-session / 264-project inventory, the
-  previously interrupted `自动主线回锚` one-day search completed in 14.36s and
-  reported that only 90 sessions
+  previously interrupted `自动主线回锚` one-day search completed in 13.64s and
+  reported that only 78 sessions
   required full-session parsing. Deterministic regressions prove 1/41 full metadata parses,
   byte-identical output with `--no-prefilter`, archived-copy untimed-count fidelity,
   escaped-CJK recall, and honest zero-candidate reporting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,10 +61,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `read-claude-code-history` and `read-codex-history` now safely handles uncased Unicode such
   as CJK with an exact matcher for every raw UTF-8 / JSON-escaped mixture; unsafe folds still
   fall back to full parsing.
-  On the real 8,532-physical-file / 5,275-session / 264-project inventory, the
-  previously interrupted `自动主线回锚` one-day search completed in 13.64s and
-  reported that only 78 sessions
-  required full-session parsing. Deterministic regressions prove 1/41 full metadata parses,
+  On a real 8,500+ physical-file / 5,200+ session / 260+ project inventory, a
+  representative one-day CJK search completed in about 11s and fewer than 1% of
+  sessions required full-session parsing. Deterministic regressions prove 1/41 full metadata parses,
   byte-identical output with `--no-prefilter`, archived-copy untimed-count fidelity,
   escaped-CJK recall, and honest zero-candidate reporting.
 - **read-claude-code-history / read-codex-history** (`daymade-claude-code` v3.7.5):

--- a/daymade-claude-code/_conversation_core/claude.py
+++ b/daymade-claude-code/_conversation_core/claude.py
@@ -21,42 +21,51 @@ class ClaudeSessionSummary:
     timestamp_count: int
 
 
-def peek_claude_session_id(
+def peek_final_claude_session_id(
     path: Path,
     *,
     max_records: int = 32,
-    max_bytes: int = 256 * 1024,
+    max_bytes: int = 64 * 1024,
 ) -> Optional[str]:
-    """Read a bounded prefix for the first internal session id.
+    """Read a bounded EOF suffix for the final internal session id.
 
-    Candidate discovery needs the authoritative JSONL identity so renamed
-    active/archive copies still form one session, but it must not rescan every
-    transcript body merely to build that union. ``None`` means the prefix did
-    not prove an identity; callers must conservatively promote that file to the
-    full candidate path rather than trusting its filename stem.
+    The full metadata scanner preserves the last valid ``sessionId`` in a
+    JSONL file. Reading complete records backwards from EOF makes any ID found
+    here authoritative even when earlier records disagree, while keeping the
+    work bounded. ``None`` means the suffix did not prove an identity; callers
+    must conservatively promote that file to the full candidate path rather
+    than trusting a prefix or filename stem.
     """
-    records_read = 0
-    bytes_read = 0
     try:
         with path.open("rb") as handle:
-            for raw_line in handle:
-                if records_read >= max_records:
-                    return None
-                bytes_read += len(raw_line)
-                if bytes_read > max_bytes:
-                    return None
-                records_read += 1
-                try:
-                    record = json.loads(raw_line)
-                except (json.JSONDecodeError, UnicodeDecodeError):
-                    continue
-                if not isinstance(record, dict):
-                    continue
-                session_id = record.get("sessionId")
-                if isinstance(session_id, str) and session_id:
-                    return session_id
+            handle.seek(0, 2)
+            size = handle.tell()
+            start = max(0, size - max_bytes)
+            handle.seek(start)
+            suffix = handle.read(max_bytes)
     except (OSError, UnicodeError):
         return None
+
+    if start > 0:
+        first_newline = suffix.find(b"\n")
+        if first_newline < 0:
+            return None
+        suffix = suffix[first_newline + 1 :]
+
+    records_read = 0
+    for raw_line in reversed(suffix.splitlines()):
+        if records_read >= max_records:
+            return None
+        records_read += 1
+        try:
+            record = json.loads(raw_line)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        if not isinstance(record, dict):
+            continue
+        session_id = record.get("sessionId")
+        if isinstance(session_id, str) and session_id:
+            return session_id
     return None
 
 

--- a/daymade-claude-code/_conversation_core/claude.py
+++ b/daymade-claude-code/_conversation_core/claude.py
@@ -37,23 +37,26 @@ def peek_claude_session_id(
     """
     records_read = 0
     bytes_read = 0
-    with path.open("rb") as handle:
-        for raw_line in handle:
-            if records_read >= max_records:
-                return None
-            bytes_read += len(raw_line)
-            if bytes_read > max_bytes:
-                return None
-            records_read += 1
-            try:
-                record = json.loads(raw_line)
-            except (json.JSONDecodeError, UnicodeDecodeError):
-                continue
-            if not isinstance(record, dict):
-                continue
-            session_id = record.get("sessionId")
-            if isinstance(session_id, str) and session_id:
-                return session_id
+    try:
+        with path.open("rb") as handle:
+            for raw_line in handle:
+                if records_read >= max_records:
+                    return None
+                bytes_read += len(raw_line)
+                if bytes_read > max_bytes:
+                    return None
+                records_read += 1
+                try:
+                    record = json.loads(raw_line)
+                except (json.JSONDecodeError, UnicodeDecodeError):
+                    continue
+                if not isinstance(record, dict):
+                    continue
+                session_id = record.get("sessionId")
+                if isinstance(session_id, str) and session_id:
+                    return session_id
+    except (OSError, UnicodeError):
+        return None
     return None
 
 

--- a/daymade-claude-code/_conversation_core/claude.py
+++ b/daymade-claude-code/_conversation_core/claude.py
@@ -20,6 +20,22 @@ class ClaudeSessionSummary:
     timestamp_count: int
 
 
+def scan_claude_session_id(path: Path) -> str:
+    """Read only until the first internal session id, then stop.
+
+    Candidate discovery needs the authoritative JSONL identity so renamed
+    active/archive copies still form one session, but it must not rescan every
+    transcript body merely to build that union. Valid Claude session files use
+    one stable ``sessionId`` throughout; files without one retain the same
+    filename-stem fallback as :func:`scan_claude_session`.
+    """
+    for record in iter_jsonl(path):
+        session_id = record.get("sessionId")
+        if isinstance(session_id, str) and session_id:
+            return session_id
+    return path.stem
+
+
 def scan_claude_session(path: Path, max_title_chars: int = 120) -> ClaudeSessionSummary:
     """Scan every valid record and return internal time bounds plus title metadata.
 

--- a/daymade-claude-code/_conversation_core/claude.py
+++ b/daymade-claude-code/_conversation_core/claude.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -20,20 +21,40 @@ class ClaudeSessionSummary:
     timestamp_count: int
 
 
-def scan_claude_session_id(path: Path) -> str:
-    """Read only until the first internal session id, then stop.
+def peek_claude_session_id(
+    path: Path,
+    *,
+    max_records: int = 32,
+    max_bytes: int = 256 * 1024,
+) -> Optional[str]:
+    """Read a bounded prefix for the first internal session id.
 
     Candidate discovery needs the authoritative JSONL identity so renamed
     active/archive copies still form one session, but it must not rescan every
-    transcript body merely to build that union. Valid Claude session files use
-    one stable ``sessionId`` throughout; files without one retain the same
-    filename-stem fallback as :func:`scan_claude_session`.
+    transcript body merely to build that union. ``None`` means the prefix did
+    not prove an identity; callers must conservatively promote that file to the
+    full candidate path rather than trusting its filename stem.
     """
-    for record in iter_jsonl(path):
-        session_id = record.get("sessionId")
-        if isinstance(session_id, str) and session_id:
-            return session_id
-    return path.stem
+    records_read = 0
+    bytes_read = 0
+    with path.open("rb") as handle:
+        for raw_line in handle:
+            if records_read >= max_records:
+                return None
+            bytes_read += len(raw_line)
+            if bytes_read > max_bytes:
+                return None
+            records_read += 1
+            try:
+                record = json.loads(raw_line)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                continue
+            if not isinstance(record, dict):
+                continue
+            session_id = record.get("sessionId")
+            if isinstance(session_id, str) and session_id:
+                return session_id
+    return None
 
 
 def scan_claude_session(path: Path, max_title_chars: int = 120) -> ClaudeSessionSummary:

--- a/daymade-claude-code/_conversation_core/text.py
+++ b/daymade-claude-code/_conversation_core/text.py
@@ -441,11 +441,17 @@ def files_possibly_matching(
 
     marker_scan = [exe, "-a", "-F", "-l"]
     markers = list(_FOLDS_TO_ASCII)
-    # An ASCII query can match a non-ASCII full-fold equivalent stored as a
-    # JSON escape ("financial" vs "\\ufb01nancial"). Keep every escaped file
-    # in that case. For uncased Unicode queries, the mixed raw/escaped regex
-    # above is exact, so the broad marker would only re-admit the whole archive.
-    if any(keyword.isascii() for keyword in keyword_list):
+    # Any ASCII character in a query can match a non-ASCII full-fold
+    # equivalent stored as a JSON escape ("k" vs "\\u212a", "ss" vs
+    # "\\u00df"). This also matters inside a mixed keyword such as "自k";
+    # checking ``keyword.isascii()`` would miss that file before structured
+    # casefold matching. Pure uncased-Unicode queries use the exact mixed regex
+    # above, so they still avoid this broad archive marker.
+    if any(
+        character.isascii()
+        for keyword in keyword_list
+        for character in keyword
+    ):
         markers.append("\\u")
     for marker in markers:
         marker_scan += ["-e", marker]

--- a/daymade-claude-code/_conversation_core/text.py
+++ b/daymade-claude-code/_conversation_core/text.py
@@ -451,23 +451,27 @@ def files_possibly_matching(
                 ]
         mixed_scan.append("--")
 
-    marker_scan = [exe, "-a", "-F", "-l"]
-    markers = list(_FOLDS_CONTAINING_ASCII)
+    has_ascii_query_character = any(
+        character.isascii()
+        for keyword in keyword_list
+        for character in keyword
+    )
+    markers: list[str] = []
     # Any ASCII character in a query can match a non-ASCII full-fold
     # equivalent stored as a JSON escape ("k" vs "\\u212a", "ss" vs
     # "\\u00df"). This also matters inside a mixed keyword such as "自k";
     # checking ``keyword.isascii()`` would miss that file before structured
     # casefold matching. Pure uncased-Unicode queries use the exact mixed regex
     # above, so they still avoid this broad archive marker.
-    if any(
-        character.isascii()
-        for keyword in keyword_list
-        for character in keyword
-    ):
+    if has_ascii_query_character:
+        markers.extend(_FOLDS_CONTAINING_ASCII)
         markers.append("\\u")
-    for marker in markers:
-        marker_scan += ["-e", marker]
-    marker_scan.append("--")
+    marker_scan: Optional[list[str]] = None
+    if markers:
+        marker_scan = [exe, "-a", "-F", "-l"]
+        for marker in markers:
+            marker_scan += ["-e", marker]
+        marker_scan.append("--")
 
     # Batch the paths: one exec per ~half of ARG_MAX. Passing every path in a
     # single argv fails with E2BIG once the corpus is large enough — measured
@@ -550,7 +554,7 @@ def files_possibly_matching(
 
     if (
         not scan_all(kw_scan)
-        or not scan_all(marker_scan)
+        or (marker_scan is not None and not scan_all(marker_scan))
         or (mixed_scan is not None and not scan_all(mixed_scan))
     ):
         return None

--- a/daymade-claude-code/_conversation_core/text.py
+++ b/daymade-claude-code/_conversation_core/text.py
@@ -258,6 +258,42 @@ def keywords_are_raw_byte_safe(keywords: Iterable[str]) -> bool:
     )
 
 
+def keywords_are_file_prefilter_safe(keywords: Iterable[str]) -> bool:
+    """Can the two-pass file scanner safely rule out non-matching files?
+
+    This is intentionally broader than :func:`keywords_are_raw_byte_safe`.
+    Line-level filtering must see the keyword's literal bytes on the exact
+    physical line, so it remains ASCII-only.  File-level filtering also runs
+    the conservative ``_UNSCANNABLE_MARKERS`` pass: any file containing a
+    ``\\u`` escape or a non-ASCII character that folds to ASCII remains a
+    candidate and is fully parsed later.  That extra pass makes ordinary CJK
+    and one-codepoint Unicode folds safe without losing escaped archives.
+
+    File-level Unicode filtering is limited to uncased code points (CJK,
+    emoji, symbols).  Cased non-ASCII text such as ``café`` falls back to full
+    parsing: raw UTF-8 can be handled by ``rg -i``, but an archive may encode
+    uppercase ``É`` as ``\\u00c9`` while the query's lowercase ``é`` is
+    ``\\u00e9``.  Treating every file containing any ``\\u`` as a candidate
+    preserved correctness but destroyed the speedup on real archives.
+
+    Multi-codepoint full folds (``ß`` -> ``ss``, ligatures, dotted I) likewise
+    fall back to full parsing because ``rg -i`` performs simple folding and
+    cannot prove their absence. JSON-required/optional escape characters
+    remain unsafe for the same reason documented by
+    :func:`keywords_are_raw_byte_safe`.
+    """
+    return all(
+        bool(keyword)
+        and not _JSON_ESCAPED_CHAR_RE.search(keyword)
+        and all(len(character.casefold()) == 1 for character in keyword)
+        and all(
+            character.isascii() or character.lower() == character.upper()
+            for character in keyword
+        )
+        for keyword in keywords
+    )
+
+
 def files_possibly_matching(
     paths: Iterable[Path],
     keywords: Iterable[str],
@@ -305,7 +341,11 @@ def files_possibly_matching(
     """
     path_list = list(paths)
     keyword_list = list(keywords)
-    if not path_list or not keyword_list or not keywords_are_raw_byte_safe(keyword_list):
+    if (
+        not path_list
+        or not keyword_list
+        or not keywords_are_file_prefilter_safe(keyword_list)
+    ):
         return None
     exe = shutil.which("rg") or shutil.which("grep")
     if not exe:
@@ -333,10 +373,20 @@ def files_possibly_matching(
         kw_scan.append("-i")
     for kw in keyword_list:
         kw_scan += ["-e", kw]
+        escaped = json.dumps(kw, ensure_ascii=True)[1:-1]
+        if escaped != kw:
+            kw_scan += ["-e", escaped]
     kw_scan.append("--")
 
     marker_scan = [exe, "-a", "-F", "-l"]
-    for marker in _UNSCANNABLE_MARKERS:
+    markers = list(_FOLDS_TO_ASCII)
+    # An ASCII query can match a non-ASCII full-fold equivalent stored as a
+    # JSON escape ("financial" vs "\\ufb01nancial"). Keep every escaped file
+    # in that case. For uncased Unicode queries, the exact escaped keyword was
+    # added above, so the broad marker would only re-admit the whole archive.
+    if any(keyword.isascii() for keyword in keyword_list):
+        markers.append("\\u")
+    for marker in markers:
         marker_scan += ["-e", marker]
     marker_scan.append("--")
 

--- a/daymade-claude-code/_conversation_core/text.py
+++ b/daymade-claude-code/_conversation_core/text.py
@@ -246,10 +246,10 @@ def keywords_are_raw_byte_safe(keywords: Iterable[str]) -> bool:
        some writers emit ``\\/``, so it is excluded for the same reason.
 
     Falling back is always the safe direction: it costs speed, never a missed
-    match. The cost is real and worth naming — a non-ASCII query (any CJK one)
-    gets no pre-filter at all and pays the full parse. Correctness first: this
-    tool's callers are told they may conclude a topic is absent from a
-    no-match result.
+    match. This function therefore keeps non-ASCII out of the *line-level*
+    literal filter. Callers may still use the separate file-level mixed-JSON
+    regex below for uncased Unicode such as CJK. Correctness first: this tool's
+    callers are told they may conclude a topic is absent from a no-match result.
     """
     return all(
         kw.isascii()
@@ -263,11 +263,11 @@ def keywords_are_file_prefilter_safe(keywords: Iterable[str]) -> bool:
 
     This is intentionally broader than :func:`keywords_are_raw_byte_safe`.
     Line-level filtering must see the keyword's literal bytes on the exact
-    physical line, so it remains ASCII-only.  File-level filtering also runs
-    the conservative ``_UNSCANNABLE_MARKERS`` pass: any file containing a
-    ``\\u`` escape or a non-ASCII character that folds to ASCII remains a
-    candidate and is fully parsed later.  That extra pass makes ordinary CJK
-    and one-codepoint Unicode folds safe without losing escaped archives.
+    physical line, so it remains ASCII-only. File-level filtering can use an
+    exact regex whose every code point accepts either raw UTF-8 or its JSON
+    ``\\u`` representation; that covers fully escaped *and mixed* JSON strings
+    without admitting every file that happens to contain some unrelated
+    Unicode escape.
 
     File-level Unicode filtering is limited to uncased code points (CJK,
     emoji, symbols).  Cased non-ASCII text such as ``café`` falls back to full
@@ -292,6 +292,39 @@ def keywords_are_file_prefilter_safe(keywords: Iterable[str]) -> bool:
         )
         for keyword in keywords
     )
+
+
+def _json_unicode_escape(character: str) -> str:
+    """Encode one code point using JSON's ``\\u`` form, including ASCII."""
+    if character.isascii():
+        return f"\\u{ord(character):04x}"
+    return json.dumps(character, ensure_ascii=True)[1:-1]
+
+
+def _mixed_json_keyword_regex(keyword: str, *, case_sensitive: bool) -> str:
+    """Return an exact regex for every legal raw/``\\u`` mixture of keyword.
+
+    JSON permits each otherwise-safe character to appear literally or as a
+    Unicode escape, even inside one word (``自\\u52a8``). A pair of fixed-string
+    patterns for the all-raw and all-escaped forms therefore under-approximates
+    the parsed text. One linear-size regex avoids the exponential list of all
+    mixtures. Scoped ``(?i:...)`` applies only to hexadecimal escape digits so
+    ``--case-sensitive`` still governs the decoded text rather than the JSON
+    encoder's arbitrary choice of ``a-f`` versus ``A-F``.
+    """
+    pieces: list[str] = []
+    for character in keyword:
+        raw = re.escape(character)
+        codepoints = {ord(character)}
+        if not case_sensitive and character.isascii() and character.isalpha():
+            codepoints.update({ord(character.lower()), ord(character.upper())})
+        escaped_alternatives = {
+            f"(?i:{re.escape(_json_unicode_escape(chr(codepoint)))})"
+            for codepoint in codepoints
+        }
+        alternatives = [raw, *sorted(escaped_alternatives)]
+        pieces.append(f"(?:{'|'.join(alternatives)})")
+    return "".join(pieces)
 
 
 def files_possibly_matching(
@@ -350,18 +383,30 @@ def files_possibly_matching(
     exe = shutil.which("rg") or shutil.which("grep")
     if not exe:
         return None
+    has_unicode_keyword = any(
+        not character.isascii()
+        for keyword in keyword_list
+        for character in keyword
+    )
+    # The exact mixed raw/escaped matcher below relies on ripgrep's Rust regex
+    # syntax. Plain grep remains a safe ASCII fallback; Unicode degrades to the
+    # original full structured scan instead of trusting a different regex
+    # dialect.
+    if has_unicode_keyword and Path(exe).name != "rg":
+        return None
     # -a/--text: never let the binary-content heuristic skip a JSONL file that
     #   happens to contain a byte sequence that looks binary.
     # -F: keywords are literal substrings everywhere else in this codebase
     #   (Python's str.count(), not a regex) — a raw scan must match the same
     #   semantics, not treat a keyword like "a.b" as a wildcard pattern.
     # -l: list matching filenames only; we don't need line numbers here.
-    # Two scans, unioned — they need opposite case settings.
+    # Three scans are unioned; the fixed-string and structural-marker passes
+    # need opposite case settings, while the regex pass models decoded JSON.
     #
     # Pass 1 matches the keywords the way the real matcher does (folded, unless
     # the caller asked for case-sensitive).
     #
-    # Pass 2 looks for content the byte scanner cannot reason about at all
+    # Pass 3 looks for content the byte scanner cannot reason about at all
     # (fold-equivalent characters, "\u" escapes) and MUST be case-sensitive.
     # Handing those characters to a "-i" scan is self-defeating: "-i" folds the
     # *pattern* too, so `ſ` matches a plain `s` and `K` (U+212A) matches `k` —
@@ -378,12 +423,28 @@ def files_possibly_matching(
             kw_scan += ["-e", escaped]
     kw_scan.append("--")
 
+    mixed_scan: Optional[list[str]] = None
+    if has_unicode_keyword:
+        mixed_scan = [exe, "-a", "-l"]
+        if not case_sensitive:
+            mixed_scan.append("-i")
+        for keyword in keyword_list:
+            if any(not character.isascii() for character in keyword):
+                mixed_scan += [
+                    "-e",
+                    _mixed_json_keyword_regex(
+                        keyword,
+                        case_sensitive=case_sensitive,
+                    ),
+                ]
+        mixed_scan.append("--")
+
     marker_scan = [exe, "-a", "-F", "-l"]
     markers = list(_FOLDS_TO_ASCII)
     # An ASCII query can match a non-ASCII full-fold equivalent stored as a
     # JSON escape ("financial" vs "\\ufb01nancial"). Keep every escaped file
-    # in that case. For uncased Unicode queries, the exact escaped keyword was
-    # added above, so the broad marker would only re-admit the whole archive.
+    # in that case. For uncased Unicode queries, the mixed raw/escaped regex
+    # above is exact, so the broad marker would only re-admit the whole archive.
     if any(keyword.isascii() for keyword in keyword_list):
         markers.append("\\u")
     for marker in markers:
@@ -469,7 +530,11 @@ def files_possibly_matching(
             used += size
         return not batch or run_batch(scan_prefix, batch)
 
-    if not scan_all(kw_scan) or not scan_all(marker_scan):
+    if (
+        not scan_all(kw_scan)
+        or not scan_all(marker_scan)
+        or (mixed_scan is not None and not scan_all(mixed_scan))
+    ):
         return None
     return matched
 

--- a/daymade-claude-code/_conversation_core/text.py
+++ b/daymade-claude-code/_conversation_core/text.py
@@ -198,12 +198,24 @@ _FOLDS_TO_ASCII = tuple(
     and chr(cp).casefold().strip()
 )
 
+# A substring query needs one wider class: U+0130 casefolds to ``i`` plus a
+# combining dot, so the ASCII query ``i`` legitimately matches even though the
+# whole fold is not ASCII. Seven other code points have the same shape. Keep
+# the narrower table above as its existing contract and derive this superset
+# from Python's matcher semantics as well.
+_FOLDS_CONTAINING_ASCII = tuple(
+    chr(cp)
+    for cp in range(0x80, 0x11000)
+    if chr(cp).casefold() != chr(cp)
+    and any(character.isascii() for character in chr(cp).casefold())
+)
+
 # Any of these in a file/line means a byte scan cannot rule it out:
 #   - the fold-equivalent characters above
 #   - a "\u" escape: content written with ensure_ascii=True stores non-ASCII
 #     that way, and some writers (Go's encoding/json) escape even ASCII
 #     "<" ">" "&" as </>/&
-_UNSCANNABLE_MARKERS = _FOLDS_TO_ASCII + ("\\u",)
+_UNSCANNABLE_MARKERS = _FOLDS_CONTAINING_ASCII + ("\\u",)
 
 
 def keywords_are_raw_byte_safe(keywords: Iterable[str]) -> bool:
@@ -440,7 +452,7 @@ def files_possibly_matching(
         mixed_scan.append("--")
 
     marker_scan = [exe, "-a", "-F", "-l"]
-    markers = list(_FOLDS_TO_ASCII)
+    markers = list(_FOLDS_CONTAINING_ASCII)
     # Any ASCII character in a query can match a non-ASCII full-fold
     # equivalent stored as a JSON escape ("k" vs "\\u212a", "ss" vs
     # "\\u00df"). This also matters inside a mixed keyword such as "自k";

--- a/daymade-claude-code/read-claude-code-history/scripts/_core/claude.py
+++ b/daymade-claude-code/read-claude-code-history/scripts/_core/claude.py
@@ -21,42 +21,51 @@ class ClaudeSessionSummary:
     timestamp_count: int
 
 
-def peek_claude_session_id(
+def peek_final_claude_session_id(
     path: Path,
     *,
     max_records: int = 32,
-    max_bytes: int = 256 * 1024,
+    max_bytes: int = 64 * 1024,
 ) -> Optional[str]:
-    """Read a bounded prefix for the first internal session id.
+    """Read a bounded EOF suffix for the final internal session id.
 
-    Candidate discovery needs the authoritative JSONL identity so renamed
-    active/archive copies still form one session, but it must not rescan every
-    transcript body merely to build that union. ``None`` means the prefix did
-    not prove an identity; callers must conservatively promote that file to the
-    full candidate path rather than trusting its filename stem.
+    The full metadata scanner preserves the last valid ``sessionId`` in a
+    JSONL file. Reading complete records backwards from EOF makes any ID found
+    here authoritative even when earlier records disagree, while keeping the
+    work bounded. ``None`` means the suffix did not prove an identity; callers
+    must conservatively promote that file to the full candidate path rather
+    than trusting a prefix or filename stem.
     """
-    records_read = 0
-    bytes_read = 0
     try:
         with path.open("rb") as handle:
-            for raw_line in handle:
-                if records_read >= max_records:
-                    return None
-                bytes_read += len(raw_line)
-                if bytes_read > max_bytes:
-                    return None
-                records_read += 1
-                try:
-                    record = json.loads(raw_line)
-                except (json.JSONDecodeError, UnicodeDecodeError):
-                    continue
-                if not isinstance(record, dict):
-                    continue
-                session_id = record.get("sessionId")
-                if isinstance(session_id, str) and session_id:
-                    return session_id
+            handle.seek(0, 2)
+            size = handle.tell()
+            start = max(0, size - max_bytes)
+            handle.seek(start)
+            suffix = handle.read(max_bytes)
     except (OSError, UnicodeError):
         return None
+
+    if start > 0:
+        first_newline = suffix.find(b"\n")
+        if first_newline < 0:
+            return None
+        suffix = suffix[first_newline + 1 :]
+
+    records_read = 0
+    for raw_line in reversed(suffix.splitlines()):
+        if records_read >= max_records:
+            return None
+        records_read += 1
+        try:
+            record = json.loads(raw_line)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        if not isinstance(record, dict):
+            continue
+        session_id = record.get("sessionId")
+        if isinstance(session_id, str) and session_id:
+            return session_id
     return None
 
 

--- a/daymade-claude-code/read-claude-code-history/scripts/_core/claude.py
+++ b/daymade-claude-code/read-claude-code-history/scripts/_core/claude.py
@@ -37,23 +37,26 @@ def peek_claude_session_id(
     """
     records_read = 0
     bytes_read = 0
-    with path.open("rb") as handle:
-        for raw_line in handle:
-            if records_read >= max_records:
-                return None
-            bytes_read += len(raw_line)
-            if bytes_read > max_bytes:
-                return None
-            records_read += 1
-            try:
-                record = json.loads(raw_line)
-            except (json.JSONDecodeError, UnicodeDecodeError):
-                continue
-            if not isinstance(record, dict):
-                continue
-            session_id = record.get("sessionId")
-            if isinstance(session_id, str) and session_id:
-                return session_id
+    try:
+        with path.open("rb") as handle:
+            for raw_line in handle:
+                if records_read >= max_records:
+                    return None
+                bytes_read += len(raw_line)
+                if bytes_read > max_bytes:
+                    return None
+                records_read += 1
+                try:
+                    record = json.loads(raw_line)
+                except (json.JSONDecodeError, UnicodeDecodeError):
+                    continue
+                if not isinstance(record, dict):
+                    continue
+                session_id = record.get("sessionId")
+                if isinstance(session_id, str) and session_id:
+                    return session_id
+    except (OSError, UnicodeError):
+        return None
     return None
 
 

--- a/daymade-claude-code/read-claude-code-history/scripts/_core/claude.py
+++ b/daymade-claude-code/read-claude-code-history/scripts/_core/claude.py
@@ -20,6 +20,22 @@ class ClaudeSessionSummary:
     timestamp_count: int
 
 
+def scan_claude_session_id(path: Path) -> str:
+    """Read only until the first internal session id, then stop.
+
+    Candidate discovery needs the authoritative JSONL identity so renamed
+    active/archive copies still form one session, but it must not rescan every
+    transcript body merely to build that union. Valid Claude session files use
+    one stable ``sessionId`` throughout; files without one retain the same
+    filename-stem fallback as :func:`scan_claude_session`.
+    """
+    for record in iter_jsonl(path):
+        session_id = record.get("sessionId")
+        if isinstance(session_id, str) and session_id:
+            return session_id
+    return path.stem
+
+
 def scan_claude_session(path: Path, max_title_chars: int = 120) -> ClaudeSessionSummary:
     """Scan every valid record and return internal time bounds plus title metadata.
 

--- a/daymade-claude-code/read-claude-code-history/scripts/_core/claude.py
+++ b/daymade-claude-code/read-claude-code-history/scripts/_core/claude.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -20,20 +21,40 @@ class ClaudeSessionSummary:
     timestamp_count: int
 
 
-def scan_claude_session_id(path: Path) -> str:
-    """Read only until the first internal session id, then stop.
+def peek_claude_session_id(
+    path: Path,
+    *,
+    max_records: int = 32,
+    max_bytes: int = 256 * 1024,
+) -> Optional[str]:
+    """Read a bounded prefix for the first internal session id.
 
     Candidate discovery needs the authoritative JSONL identity so renamed
     active/archive copies still form one session, but it must not rescan every
-    transcript body merely to build that union. Valid Claude session files use
-    one stable ``sessionId`` throughout; files without one retain the same
-    filename-stem fallback as :func:`scan_claude_session`.
+    transcript body merely to build that union. ``None`` means the prefix did
+    not prove an identity; callers must conservatively promote that file to the
+    full candidate path rather than trusting its filename stem.
     """
-    for record in iter_jsonl(path):
-        session_id = record.get("sessionId")
-        if isinstance(session_id, str) and session_id:
-            return session_id
-    return path.stem
+    records_read = 0
+    bytes_read = 0
+    with path.open("rb") as handle:
+        for raw_line in handle:
+            if records_read >= max_records:
+                return None
+            bytes_read += len(raw_line)
+            if bytes_read > max_bytes:
+                return None
+            records_read += 1
+            try:
+                record = json.loads(raw_line)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                continue
+            if not isinstance(record, dict):
+                continue
+            session_id = record.get("sessionId")
+            if isinstance(session_id, str) and session_id:
+                return session_id
+    return None
 
 
 def scan_claude_session(path: Path, max_title_chars: int = 120) -> ClaudeSessionSummary:

--- a/daymade-claude-code/read-claude-code-history/scripts/_core/text.py
+++ b/daymade-claude-code/read-claude-code-history/scripts/_core/text.py
@@ -441,11 +441,17 @@ def files_possibly_matching(
 
     marker_scan = [exe, "-a", "-F", "-l"]
     markers = list(_FOLDS_TO_ASCII)
-    # An ASCII query can match a non-ASCII full-fold equivalent stored as a
-    # JSON escape ("financial" vs "\\ufb01nancial"). Keep every escaped file
-    # in that case. For uncased Unicode queries, the mixed raw/escaped regex
-    # above is exact, so the broad marker would only re-admit the whole archive.
-    if any(keyword.isascii() for keyword in keyword_list):
+    # Any ASCII character in a query can match a non-ASCII full-fold
+    # equivalent stored as a JSON escape ("k" vs "\\u212a", "ss" vs
+    # "\\u00df"). This also matters inside a mixed keyword such as "自k";
+    # checking ``keyword.isascii()`` would miss that file before structured
+    # casefold matching. Pure uncased-Unicode queries use the exact mixed regex
+    # above, so they still avoid this broad archive marker.
+    if any(
+        character.isascii()
+        for keyword in keyword_list
+        for character in keyword
+    ):
         markers.append("\\u")
     for marker in markers:
         marker_scan += ["-e", marker]

--- a/daymade-claude-code/read-claude-code-history/scripts/_core/text.py
+++ b/daymade-claude-code/read-claude-code-history/scripts/_core/text.py
@@ -451,23 +451,27 @@ def files_possibly_matching(
                 ]
         mixed_scan.append("--")
 
-    marker_scan = [exe, "-a", "-F", "-l"]
-    markers = list(_FOLDS_CONTAINING_ASCII)
+    has_ascii_query_character = any(
+        character.isascii()
+        for keyword in keyword_list
+        for character in keyword
+    )
+    markers: list[str] = []
     # Any ASCII character in a query can match a non-ASCII full-fold
     # equivalent stored as a JSON escape ("k" vs "\\u212a", "ss" vs
     # "\\u00df"). This also matters inside a mixed keyword such as "自k";
     # checking ``keyword.isascii()`` would miss that file before structured
     # casefold matching. Pure uncased-Unicode queries use the exact mixed regex
     # above, so they still avoid this broad archive marker.
-    if any(
-        character.isascii()
-        for keyword in keyword_list
-        for character in keyword
-    ):
+    if has_ascii_query_character:
+        markers.extend(_FOLDS_CONTAINING_ASCII)
         markers.append("\\u")
-    for marker in markers:
-        marker_scan += ["-e", marker]
-    marker_scan.append("--")
+    marker_scan: Optional[list[str]] = None
+    if markers:
+        marker_scan = [exe, "-a", "-F", "-l"]
+        for marker in markers:
+            marker_scan += ["-e", marker]
+        marker_scan.append("--")
 
     # Batch the paths: one exec per ~half of ARG_MAX. Passing every path in a
     # single argv fails with E2BIG once the corpus is large enough — measured
@@ -550,7 +554,7 @@ def files_possibly_matching(
 
     if (
         not scan_all(kw_scan)
-        or not scan_all(marker_scan)
+        or (marker_scan is not None and not scan_all(marker_scan))
         or (mixed_scan is not None and not scan_all(mixed_scan))
     ):
         return None

--- a/daymade-claude-code/read-claude-code-history/scripts/_core/text.py
+++ b/daymade-claude-code/read-claude-code-history/scripts/_core/text.py
@@ -258,6 +258,42 @@ def keywords_are_raw_byte_safe(keywords: Iterable[str]) -> bool:
     )
 
 
+def keywords_are_file_prefilter_safe(keywords: Iterable[str]) -> bool:
+    """Can the two-pass file scanner safely rule out non-matching files?
+
+    This is intentionally broader than :func:`keywords_are_raw_byte_safe`.
+    Line-level filtering must see the keyword's literal bytes on the exact
+    physical line, so it remains ASCII-only.  File-level filtering also runs
+    the conservative ``_UNSCANNABLE_MARKERS`` pass: any file containing a
+    ``\\u`` escape or a non-ASCII character that folds to ASCII remains a
+    candidate and is fully parsed later.  That extra pass makes ordinary CJK
+    and one-codepoint Unicode folds safe without losing escaped archives.
+
+    File-level Unicode filtering is limited to uncased code points (CJK,
+    emoji, symbols).  Cased non-ASCII text such as ``café`` falls back to full
+    parsing: raw UTF-8 can be handled by ``rg -i``, but an archive may encode
+    uppercase ``É`` as ``\\u00c9`` while the query's lowercase ``é`` is
+    ``\\u00e9``.  Treating every file containing any ``\\u`` as a candidate
+    preserved correctness but destroyed the speedup on real archives.
+
+    Multi-codepoint full folds (``ß`` -> ``ss``, ligatures, dotted I) likewise
+    fall back to full parsing because ``rg -i`` performs simple folding and
+    cannot prove their absence. JSON-required/optional escape characters
+    remain unsafe for the same reason documented by
+    :func:`keywords_are_raw_byte_safe`.
+    """
+    return all(
+        bool(keyword)
+        and not _JSON_ESCAPED_CHAR_RE.search(keyword)
+        and all(len(character.casefold()) == 1 for character in keyword)
+        and all(
+            character.isascii() or character.lower() == character.upper()
+            for character in keyword
+        )
+        for keyword in keywords
+    )
+
+
 def files_possibly_matching(
     paths: Iterable[Path],
     keywords: Iterable[str],
@@ -305,7 +341,11 @@ def files_possibly_matching(
     """
     path_list = list(paths)
     keyword_list = list(keywords)
-    if not path_list or not keyword_list or not keywords_are_raw_byte_safe(keyword_list):
+    if (
+        not path_list
+        or not keyword_list
+        or not keywords_are_file_prefilter_safe(keyword_list)
+    ):
         return None
     exe = shutil.which("rg") or shutil.which("grep")
     if not exe:
@@ -333,10 +373,20 @@ def files_possibly_matching(
         kw_scan.append("-i")
     for kw in keyword_list:
         kw_scan += ["-e", kw]
+        escaped = json.dumps(kw, ensure_ascii=True)[1:-1]
+        if escaped != kw:
+            kw_scan += ["-e", escaped]
     kw_scan.append("--")
 
     marker_scan = [exe, "-a", "-F", "-l"]
-    for marker in _UNSCANNABLE_MARKERS:
+    markers = list(_FOLDS_TO_ASCII)
+    # An ASCII query can match a non-ASCII full-fold equivalent stored as a
+    # JSON escape ("financial" vs "\\ufb01nancial"). Keep every escaped file
+    # in that case. For uncased Unicode queries, the exact escaped keyword was
+    # added above, so the broad marker would only re-admit the whole archive.
+    if any(keyword.isascii() for keyword in keyword_list):
+        markers.append("\\u")
+    for marker in markers:
         marker_scan += ["-e", marker]
     marker_scan.append("--")
 

--- a/daymade-claude-code/read-claude-code-history/scripts/_core/text.py
+++ b/daymade-claude-code/read-claude-code-history/scripts/_core/text.py
@@ -246,10 +246,10 @@ def keywords_are_raw_byte_safe(keywords: Iterable[str]) -> bool:
        some writers emit ``\\/``, so it is excluded for the same reason.
 
     Falling back is always the safe direction: it costs speed, never a missed
-    match. The cost is real and worth naming — a non-ASCII query (any CJK one)
-    gets no pre-filter at all and pays the full parse. Correctness first: this
-    tool's callers are told they may conclude a topic is absent from a
-    no-match result.
+    match. This function therefore keeps non-ASCII out of the *line-level*
+    literal filter. Callers may still use the separate file-level mixed-JSON
+    regex below for uncased Unicode such as CJK. Correctness first: this tool's
+    callers are told they may conclude a topic is absent from a no-match result.
     """
     return all(
         kw.isascii()
@@ -263,11 +263,11 @@ def keywords_are_file_prefilter_safe(keywords: Iterable[str]) -> bool:
 
     This is intentionally broader than :func:`keywords_are_raw_byte_safe`.
     Line-level filtering must see the keyword's literal bytes on the exact
-    physical line, so it remains ASCII-only.  File-level filtering also runs
-    the conservative ``_UNSCANNABLE_MARKERS`` pass: any file containing a
-    ``\\u`` escape or a non-ASCII character that folds to ASCII remains a
-    candidate and is fully parsed later.  That extra pass makes ordinary CJK
-    and one-codepoint Unicode folds safe without losing escaped archives.
+    physical line, so it remains ASCII-only. File-level filtering can use an
+    exact regex whose every code point accepts either raw UTF-8 or its JSON
+    ``\\u`` representation; that covers fully escaped *and mixed* JSON strings
+    without admitting every file that happens to contain some unrelated
+    Unicode escape.
 
     File-level Unicode filtering is limited to uncased code points (CJK,
     emoji, symbols).  Cased non-ASCII text such as ``café`` falls back to full
@@ -292,6 +292,39 @@ def keywords_are_file_prefilter_safe(keywords: Iterable[str]) -> bool:
         )
         for keyword in keywords
     )
+
+
+def _json_unicode_escape(character: str) -> str:
+    """Encode one code point using JSON's ``\\u`` form, including ASCII."""
+    if character.isascii():
+        return f"\\u{ord(character):04x}"
+    return json.dumps(character, ensure_ascii=True)[1:-1]
+
+
+def _mixed_json_keyword_regex(keyword: str, *, case_sensitive: bool) -> str:
+    """Return an exact regex for every legal raw/``\\u`` mixture of keyword.
+
+    JSON permits each otherwise-safe character to appear literally or as a
+    Unicode escape, even inside one word (``自\\u52a8``). A pair of fixed-string
+    patterns for the all-raw and all-escaped forms therefore under-approximates
+    the parsed text. One linear-size regex avoids the exponential list of all
+    mixtures. Scoped ``(?i:...)`` applies only to hexadecimal escape digits so
+    ``--case-sensitive`` still governs the decoded text rather than the JSON
+    encoder's arbitrary choice of ``a-f`` versus ``A-F``.
+    """
+    pieces: list[str] = []
+    for character in keyword:
+        raw = re.escape(character)
+        codepoints = {ord(character)}
+        if not case_sensitive and character.isascii() and character.isalpha():
+            codepoints.update({ord(character.lower()), ord(character.upper())})
+        escaped_alternatives = {
+            f"(?i:{re.escape(_json_unicode_escape(chr(codepoint)))})"
+            for codepoint in codepoints
+        }
+        alternatives = [raw, *sorted(escaped_alternatives)]
+        pieces.append(f"(?:{'|'.join(alternatives)})")
+    return "".join(pieces)
 
 
 def files_possibly_matching(
@@ -350,18 +383,30 @@ def files_possibly_matching(
     exe = shutil.which("rg") or shutil.which("grep")
     if not exe:
         return None
+    has_unicode_keyword = any(
+        not character.isascii()
+        for keyword in keyword_list
+        for character in keyword
+    )
+    # The exact mixed raw/escaped matcher below relies on ripgrep's Rust regex
+    # syntax. Plain grep remains a safe ASCII fallback; Unicode degrades to the
+    # original full structured scan instead of trusting a different regex
+    # dialect.
+    if has_unicode_keyword and Path(exe).name != "rg":
+        return None
     # -a/--text: never let the binary-content heuristic skip a JSONL file that
     #   happens to contain a byte sequence that looks binary.
     # -F: keywords are literal substrings everywhere else in this codebase
     #   (Python's str.count(), not a regex) — a raw scan must match the same
     #   semantics, not treat a keyword like "a.b" as a wildcard pattern.
     # -l: list matching filenames only; we don't need line numbers here.
-    # Two scans, unioned — they need opposite case settings.
+    # Three scans are unioned; the fixed-string and structural-marker passes
+    # need opposite case settings, while the regex pass models decoded JSON.
     #
     # Pass 1 matches the keywords the way the real matcher does (folded, unless
     # the caller asked for case-sensitive).
     #
-    # Pass 2 looks for content the byte scanner cannot reason about at all
+    # Pass 3 looks for content the byte scanner cannot reason about at all
     # (fold-equivalent characters, "\u" escapes) and MUST be case-sensitive.
     # Handing those characters to a "-i" scan is self-defeating: "-i" folds the
     # *pattern* too, so `ſ` matches a plain `s` and `K` (U+212A) matches `k` —
@@ -378,12 +423,28 @@ def files_possibly_matching(
             kw_scan += ["-e", escaped]
     kw_scan.append("--")
 
+    mixed_scan: Optional[list[str]] = None
+    if has_unicode_keyword:
+        mixed_scan = [exe, "-a", "-l"]
+        if not case_sensitive:
+            mixed_scan.append("-i")
+        for keyword in keyword_list:
+            if any(not character.isascii() for character in keyword):
+                mixed_scan += [
+                    "-e",
+                    _mixed_json_keyword_regex(
+                        keyword,
+                        case_sensitive=case_sensitive,
+                    ),
+                ]
+        mixed_scan.append("--")
+
     marker_scan = [exe, "-a", "-F", "-l"]
     markers = list(_FOLDS_TO_ASCII)
     # An ASCII query can match a non-ASCII full-fold equivalent stored as a
     # JSON escape ("financial" vs "\\ufb01nancial"). Keep every escaped file
-    # in that case. For uncased Unicode queries, the exact escaped keyword was
-    # added above, so the broad marker would only re-admit the whole archive.
+    # in that case. For uncased Unicode queries, the mixed raw/escaped regex
+    # above is exact, so the broad marker would only re-admit the whole archive.
     if any(keyword.isascii() for keyword in keyword_list):
         markers.append("\\u")
     for marker in markers:
@@ -469,7 +530,11 @@ def files_possibly_matching(
             used += size
         return not batch or run_batch(scan_prefix, batch)
 
-    if not scan_all(kw_scan) or not scan_all(marker_scan):
+    if (
+        not scan_all(kw_scan)
+        or not scan_all(marker_scan)
+        or (mixed_scan is not None and not scan_all(mixed_scan))
+    ):
         return None
     return matched
 

--- a/daymade-claude-code/read-claude-code-history/scripts/_core/text.py
+++ b/daymade-claude-code/read-claude-code-history/scripts/_core/text.py
@@ -198,12 +198,24 @@ _FOLDS_TO_ASCII = tuple(
     and chr(cp).casefold().strip()
 )
 
+# A substring query needs one wider class: U+0130 casefolds to ``i`` plus a
+# combining dot, so the ASCII query ``i`` legitimately matches even though the
+# whole fold is not ASCII. Seven other code points have the same shape. Keep
+# the narrower table above as its existing contract and derive this superset
+# from Python's matcher semantics as well.
+_FOLDS_CONTAINING_ASCII = tuple(
+    chr(cp)
+    for cp in range(0x80, 0x11000)
+    if chr(cp).casefold() != chr(cp)
+    and any(character.isascii() for character in chr(cp).casefold())
+)
+
 # Any of these in a file/line means a byte scan cannot rule it out:
 #   - the fold-equivalent characters above
 #   - a "\u" escape: content written with ensure_ascii=True stores non-ASCII
 #     that way, and some writers (Go's encoding/json) escape even ASCII
 #     "<" ">" "&" as </>/&
-_UNSCANNABLE_MARKERS = _FOLDS_TO_ASCII + ("\\u",)
+_UNSCANNABLE_MARKERS = _FOLDS_CONTAINING_ASCII + ("\\u",)
 
 
 def keywords_are_raw_byte_safe(keywords: Iterable[str]) -> bool:
@@ -440,7 +452,7 @@ def files_possibly_matching(
         mixed_scan.append("--")
 
     marker_scan = [exe, "-a", "-F", "-l"]
-    markers = list(_FOLDS_TO_ASCII)
+    markers = list(_FOLDS_CONTAINING_ASCII)
     # Any ASCII character in a query can match a non-ASCII full-fold
     # equivalent stored as a JSON escape ("k" vs "\\u212a", "ss" vs
     # "\\u00df"). This also matters inside a mixed keyword such as "自k";

--- a/daymade-claude-code/read-claude-code-history/scripts/analyze_sessions.py
+++ b/daymade-claude-code/read-claude-code-history/scripts/analyze_sessions.py
@@ -1059,7 +1059,9 @@ class SessionAnalyzer:
         )
 
     def _merge_sessions_from_dirs(
-        self, pairs: List[tuple]
+        self,
+        pairs: List[tuple],
+        candidate_names: Optional[set[str]] = None,
     ) -> List[Dict[str, Any]]:
         """Collect + de-duplicate sessions from ``(source, project_dir)`` pairs.
 
@@ -1083,20 +1085,10 @@ class SessionAnalyzer:
         vanish from that field even though the ``sources``/``homes``
         label lists stayed correct.
         """
-        groups: Dict[str, tuple] = {}
-        for source, project_dir in pairs:
-            try:
-                key = str(project_dir.resolve())
-            except (OSError, RuntimeError):
-                key = str(project_dir)
-            group = groups.get(key)
-            if group is None:
-                groups[key] = (project_dir, [(source, project_dir)])
-            else:
-                group[1].append((source, project_dir))
+        groups = self._group_project_dirs(pairs)
 
         by_id: Dict[str, Dict[str, Any]] = {}
-        for scan_dir, group_members in groups.values():
+        for scan_dir, group_members in groups:
             group_sources = [source for source, _nominal_dir in group_members]
             # any(...) — not group_sources[0].kind — because "at least one
             # active alias in the group" must win regardless of which
@@ -1108,6 +1100,8 @@ class SessionAnalyzer:
             group_kind = "active" if group_has_active else group_sources[0].kind
             for file in scan_dir.glob("*.jsonl"):
                 if file.name.startswith("agent-"):
+                    continue
+                if candidate_names is not None and file.name not in candidate_names:
                     continue
                 summary = scan_claude_session(file)
                 sid = summary.session_id
@@ -1199,6 +1193,22 @@ class SessionAnalyzer:
             reverse=True,
         )
 
+    @staticmethod
+    def _group_project_dirs(pairs: List[tuple]) -> List[tuple]:
+        """Group nominal source dirs by physical directory identity."""
+        groups: Dict[str, tuple] = {}
+        for source, project_dir in pairs:
+            try:
+                key = str(project_dir.resolve())
+            except (OSError, RuntimeError):
+                key = str(project_dir)
+            group = groups.get(key)
+            if group is None:
+                groups[key] = (project_dir, [(source, project_dir)])
+            else:
+                group[1].append((source, project_dir))
+        return list(groups.values())
+
     def project_dir_pairs(self) -> Dict[str, List[tuple]]:
         """Enumerate every project dir across all sources.
 
@@ -1239,6 +1249,130 @@ class SessionAnalyzer:
                 else float("-inf")
             ),
             reverse=True,
+        )
+
+    def find_search_sessions(
+        self,
+        *,
+        project_path: Optional[str],
+        all_projects: bool,
+        keywords: List[str],
+        case_sensitive: bool,
+        use_prefilter: bool,
+        exclude_sessions: set[str],
+        on_prefilter_progress: Optional[Callable[[], None]] = None,
+    ) -> tuple[List[Dict[str, Any]], int, int, bool]:
+        """Collect search refs after a safe file-level candidate pass.
+
+        Metadata discovery used to call ``scan_claude_session`` for every
+        session before keyword or date filtering, then ``search_sessions``
+        parsed the same corpus again.  On the real 5,293-session inventory
+        that made a one-day query spend minutes parsing files that could not
+        contain the keyword.
+
+        This method enumerates filenames only, de-duplicates aliased physical
+        directories, and lets the native byte scanner identify candidate
+        ``(project, filename)`` pairs.  Once any physical copy is a candidate,
+        every same-named active/archive copy is retained and fully parsed; that
+        preserves record unions and the exact untimed-record count under date
+        windows.  ``None`` from the scanner means no trustworthy filtering
+        information, so it falls back to the original full metadata scan.
+
+        Returns ``(candidate_refs, total_sessions, project_count, applied)``.
+        The total is filename-derived so the user-visible searched-sessions
+        count stays stable even though only candidates pay JSON parsing cost.
+        Conversation chronology still comes exclusively from internal records.
+        """
+        if all_projects:
+            project_pairs = self.project_dir_pairs()
+        else:
+            pairs = self._resolve_project_dirs(project_path or "")
+            project_pairs = {pairs[0][1].name: pairs} if pairs else {}
+
+        if not use_prefilter:
+            sessions: List[Dict[str, Any]] = []
+            for project_name, pairs in project_pairs.items():
+                for ref in self._merge_sessions_from_dirs(pairs):
+                    if all_projects:
+                        ref["project"] = project_name
+                    sessions.append(ref)
+            sessions = [
+                ref
+                for ref in sessions
+                if ref["session_id"] not in exclude_sessions
+                and ref["path"].stem not in exclude_sessions
+            ]
+            project_count = len({ref.get("project") for ref in sessions}) if all_projects else int(bool(sessions))
+            return sessions, len(sessions), project_count, False
+
+        unique_paths: Dict[str, Path] = {}
+        keys_by_path: Dict[str, set[tuple[str, str]]] = defaultdict(set)
+        total_keys: set[tuple[str, str]] = set()
+        projects_with_sessions: set[str] = set()
+        for project_name, pairs in project_pairs.items():
+            for scan_dir, _group_members in self._group_project_dirs(pairs):
+                for file in scan_dir.glob("*.jsonl"):
+                    if file.name.startswith("agent-") or file.stem in exclude_sessions:
+                        continue
+                    key = (project_name, file.name)
+                    total_keys.add(key)
+                    projects_with_sessions.add(project_name)
+                    try:
+                        physical = str(file.resolve())
+                    except (OSError, RuntimeError):
+                        physical = str(file)
+                    unique_paths.setdefault(physical, file)
+                    keys_by_path[physical].add(key)
+
+        matched_files = files_possibly_matching(
+            unique_paths.values(),
+            keywords,
+            case_sensitive=case_sensitive,
+            on_progress=on_prefilter_progress,
+        )
+        if matched_files is None:
+            return self.find_search_sessions(
+                project_path=project_path,
+                all_projects=all_projects,
+                keywords=keywords,
+                case_sensitive=case_sensitive,
+                use_prefilter=False,
+                exclude_sessions=exclude_sessions,
+            )
+
+        candidate_names: Dict[str, set[str]] = defaultdict(set)
+        for file in matched_files:
+            try:
+                physical = str(file.resolve())
+            except (OSError, RuntimeError):
+                physical = str(file)
+            for project_name, filename in keys_by_path.get(physical, set()):
+                candidate_names[project_name].add(filename)
+
+        sessions = []
+        for project_name, pairs in project_pairs.items():
+            names = candidate_names.get(project_name, set())
+            if not names:
+                continue
+            for ref in self._merge_sessions_from_dirs(pairs, candidate_names=names):
+                if ref["session_id"] in exclude_sessions:
+                    continue
+                if all_projects:
+                    ref["project"] = project_name
+                sessions.append(ref)
+        sessions.sort(
+            key=lambda entry: (
+                entry["updated_at"]
+                if entry["updated_at"] is not None
+                else float("-inf")
+            ),
+            reverse=True,
+        )
+        return (
+            sessions,
+            len(total_keys),
+            len(projects_with_sessions),
+            True,
         )
 
     def _resolve_project_dirs(self, project_path: str) -> List[tuple]:
@@ -1908,6 +2042,33 @@ def _collect_sessions(analyzer: "SessionAnalyzer", args) -> List[Dict[str, Any]]
     return sessions
 
 
+def _collect_search_sessions(
+    analyzer: "SessionAnalyzer", args
+) -> tuple[List[Dict[str, Any]], int, int, bool]:
+    """Candidate-first collection for keyword search, with visible progress."""
+    exclude = set(getattr(args, "exclude_session", None) or [])
+    progress_count = 0
+
+    def prefilter_progress() -> None:
+        nonlocal progress_count
+        progress_count += 1
+        print(
+            "History keyword prefilter is still scanning physical files "
+            f"({progress_count * 15}s elapsed)...",
+            file=sys.stderr,
+        )
+
+    return analyzer.find_search_sessions(
+        project_path=args.project_path,
+        all_projects=args.all_projects,
+        keywords=args.keywords,
+        case_sensitive=args.case_sensitive,
+        use_prefilter=not args.no_prefilter,
+        exclude_sessions=exclude,
+        on_prefilter_progress=prefilter_progress,
+    )
+
+
 def _codex_home_for(args) -> Path:
     explicit = getattr(args, "codex_home", None)
     if explicit:
@@ -2403,10 +2564,15 @@ def main():
         from_timestamp, to_timestamp = _parse_date_window(args, parser)
         analyzer = _analyzer_or_exit(args)
         source_summary = _source_summary(analyzer.sources)
-        sessions = _collect_sessions(analyzer, args)
+        (
+            sessions,
+            discovered_session_count,
+            discovered_project_count,
+            candidate_prefilter_applied,
+        ) = _collect_search_sessions(analyzer, args)
         for warning in analyzer.warnings:
             print(f"Warning: {warning}", file=sys.stderr)
-        if not sessions and not args.codex and not args.kimi:
+        if discovered_session_count == 0 and not args.codex and not args.kimi:
             if args.all_projects:
                 print("No sessions found across all projects")
             else:
@@ -2419,14 +2585,20 @@ def main():
             sys.exit(1)
 
         scope_desc = (
-            f" in {len({ref.get('project') for ref in sessions})} project(s)"
+            f" in {discovered_project_count} project(s)"
             if args.all_projects
             else ""
         )
         print(
-            f"Searching {len(sessions)} session(s) across {len(analyzer.sources)} "
+            f"Searching {discovered_session_count} session(s) across {len(analyzer.sources)} "
             f"source(s) [{source_summary}]{scope_desc} for: {', '.join(args.keywords)}\n"
         )
+        if candidate_prefilter_applied:
+            print(
+                "Candidate prefilter: structured parsing required for "
+                f"{len(sessions)}/{discovered_session_count} session(s).",
+                file=sys.stderr,
+            )
         matches = (
             analyzer.search_sessions(
                 sessions,
@@ -2434,7 +2606,7 @@ def main():
                 args.case_sensitive,
                 from_timestamp,
                 to_timestamp,
-                not args.no_prefilter,
+                not args.no_prefilter and not candidate_prefilter_applied,
                 args.include_agent_prompts,
             )
             if sessions

--- a/daymade-claude-code/read-claude-code-history/scripts/analyze_sessions.py
+++ b/daymade-claude-code/read-claude-code-history/scripts/analyze_sessions.py
@@ -34,7 +34,7 @@ from collections import Counter, defaultdict
 # scripts/_core/ by sync_core.py so this skill stays self-contained. Make this
 # script's own dir importable regardless of how it is invoked, then import.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _core.claude import peek_claude_session_id, scan_claude_session  # noqa: E402
+from _core.claude import peek_final_claude_session_id, scan_claude_session  # noqa: E402
 from _core.codex import codex_meta_from_rollout, codex_session_id  # noqa: E402
 from _core.kimi import (  # noqa: E402
     iter_kimi_session_dirs,
@@ -1283,7 +1283,7 @@ class SessionAnalyzer:
         contain the keyword.
 
         This method de-duplicates aliased physical directories, peeks only far
-        enough to read each file's authoritative internal ``sessionId``, and
+        enough from EOF to read each file's final internal ``sessionId``, and
         lets the native byte scanner identify candidate physical files. Once
         any copy is a candidate, every active/archive filename carrying that
         same session id is retained and fully parsed; that preserves renamed
@@ -1337,12 +1337,7 @@ class SessionAnalyzer:
         identity_by_path: Dict[str, Optional[str]] = {}
         uncertain_paths: set[str] = set()
         for physical, file in unique_paths.items():
-            session_id = peek_claude_session_id(file)
-            # A prefix ID is provisional: the tolerant full scanner preserves
-            # the last valid internal ID. If the prefix appears excluded, do
-            # not suppress the file yet — a later record may establish a
-            # different live identity. Promote it to the conservative full
-            # candidate path and apply exclusion only after that final scan.
+            session_id = peek_final_claude_session_id(file)
             if session_id is None or session_id in exclude_sessions:
                 identity_by_path[physical] = None
                 uncertain_paths.add(physical)

--- a/daymade-claude-code/read-claude-code-history/scripts/analyze_sessions.py
+++ b/daymade-claude-code/read-claude-code-history/scripts/analyze_sessions.py
@@ -1061,7 +1061,7 @@ class SessionAnalyzer:
     def _merge_sessions_from_dirs(
         self,
         pairs: List[tuple],
-        candidate_names: Optional[set[str]] = None,
+        candidate_paths: Optional[set[str]] = None,
     ) -> List[Dict[str, Any]]:
         """Collect + de-duplicate sessions from ``(source, project_dir)`` pairs.
 
@@ -1101,8 +1101,13 @@ class SessionAnalyzer:
             for file in scan_dir.glob("*.jsonl"):
                 if file.name.startswith("agent-"):
                     continue
-                if candidate_names is not None and file.name not in candidate_names:
-                    continue
+                if candidate_paths is not None:
+                    try:
+                        physical_file = str(file.resolve())
+                    except (OSError, RuntimeError):
+                        physical_file = str(file)
+                    if physical_file not in candidate_paths:
+                        continue
                 summary = scan_claude_session(file)
                 sid = summary.session_id
                 copies = [
@@ -1365,18 +1370,16 @@ class SessionAnalyzer:
                 unique_paths[physical]
             ).session_id
 
-        names_by_identity: Dict[tuple[str, str], set[str]] = defaultdict(set)
         total_identities: set[tuple[str, str]] = set()
         projects_with_sessions: set[str] = set()
         for physical in unique_paths:
             session_id = identity_by_path[physical]
             if session_id is None or session_id in exclude_sessions:
                 continue
-            for project_name, filename in keys_by_path[physical]:
+            for project_name, _filename in keys_by_path[physical]:
                 identity = (project_name, session_id)
                 total_identities.add(identity)
                 projects_with_sessions.add(project_name)
-                names_by_identity[identity].add(filename)
 
         candidate_identities: set[tuple[str, str]] = set()
         for physical in candidate_physical:
@@ -1386,17 +1389,24 @@ class SessionAnalyzer:
             for project_name, _filename in keys_by_path[physical]:
                 candidate_identities.add((project_name, session_id))
 
-        candidate_names: Dict[str, set[str]] = defaultdict(set)
-        for identity in candidate_identities:
-            project_name, _session_id = identity
-            candidate_names[project_name].update(names_by_identity[identity])
+        candidate_paths_by_project: Dict[str, set[str]] = defaultdict(set)
+        for physical in unique_paths:
+            session_id = identity_by_path[physical]
+            if session_id is None or session_id in exclude_sessions:
+                continue
+            for project_name, _filename in keys_by_path[physical]:
+                if (project_name, session_id) in candidate_identities:
+                    candidate_paths_by_project[project_name].add(physical)
 
         sessions = []
         for project_name, pairs in project_pairs.items():
-            names = candidate_names.get(project_name, set())
-            if not names:
+            candidate_paths = candidate_paths_by_project.get(project_name, set())
+            if not candidate_paths:
                 continue
-            for ref in self._merge_sessions_from_dirs(pairs, candidate_names=names):
+            for ref in self._merge_sessions_from_dirs(
+                pairs,
+                candidate_paths=candidate_paths,
+            ):
                 if ref["session_id"] in exclude_sessions:
                     continue
                 if all_projects:

--- a/daymade-claude-code/read-claude-code-history/scripts/analyze_sessions.py
+++ b/daymade-claude-code/read-claude-code-history/scripts/analyze_sessions.py
@@ -2319,14 +2319,13 @@ def main():
     search_parser.add_argument(
         "--no-prefilter",
         action="store_true",
-        help="Disable the rg/grep raw-byte pre-filter and fully parse every "
-        "session file. The pre-filter is designed to be a pure speedup: it "
-        "only runs for keywords whose bytes must appear verbatim in the file "
-        "(ASCII, no '/', no control characters), and disables itself for the "
-        "rest — so a non-ASCII query (any CJK one) already parses everything "
-        "and this flag changes nothing for it. Use this to verify the "
-        "pre-filter's neutrality on an ASCII query, or to rule it out when "
-        "diagnosing a suspected missed match.",
+        help="Disable native file/line pre-filters and fully parse every "
+        "session file. The filters are conservative speedups: ordinary ASCII "
+        "uses literal matching, and uncased Unicode such as CJK uses an exact "
+        "raw/JSON-escaped file regex when ripgrep is available. Unsafe escape "
+        "characters, cased or multi-codepoint Unicode folds, missing tools, "
+        "and scanner errors already fall back to full parsing. Use this flag "
+        "to verify output neutrality or diagnose a suspected missed match.",
     )
     _add_home_flags(search_parser)
 

--- a/daymade-claude-code/read-claude-code-history/scripts/analyze_sessions.py
+++ b/daymade-claude-code/read-claude-code-history/scripts/analyze_sessions.py
@@ -1331,9 +1331,16 @@ class SessionAnalyzer:
         uncertain_paths: set[str] = set()
         for physical, file in unique_paths.items():
             session_id = peek_claude_session_id(file)
-            identity_by_path[physical] = session_id
-            if session_id is None:
+            # A prefix ID is provisional: the tolerant full scanner preserves
+            # the last valid internal ID. If the prefix appears excluded, do
+            # not suppress the file yet — a later record may establish a
+            # different live identity. Promote it to the conservative full
+            # candidate path and apply exclusion only after that final scan.
+            if session_id is None or session_id in exclude_sessions:
+                identity_by_path[physical] = None
                 uncertain_paths.add(physical)
+            else:
+                identity_by_path[physical] = session_id
 
         matched_files = files_possibly_matching(
             unique_paths.values(),

--- a/daymade-claude-code/read-claude-code-history/scripts/analyze_sessions.py
+++ b/daymade-claude-code/read-claude-code-history/scripts/analyze_sessions.py
@@ -1308,7 +1308,6 @@ class SessionAnalyzer:
                 ref
                 for ref in sessions
                 if ref["session_id"] not in exclude_sessions
-                and ref["path"].stem not in exclude_sessions
             ]
             project_count = len({ref.get("project") for ref in sessions}) if all_projects else int(bool(sessions))
             return sessions, len(sessions), project_count, False
@@ -1318,7 +1317,7 @@ class SessionAnalyzer:
         for project_name, pairs in project_pairs.items():
             for scan_dir, _group_members in self._group_project_dirs(pairs):
                 for file in scan_dir.glob("*.jsonl"):
-                    if file.name.startswith("agent-") or file.stem in exclude_sessions:
+                    if file.name.startswith("agent-"):
                         continue
                     key = (project_name, file.name)
                     try:

--- a/daymade-claude-code/read-claude-code-history/scripts/analyze_sessions.py
+++ b/daymade-claude-code/read-claude-code-history/scripts/analyze_sessions.py
@@ -34,7 +34,7 @@ from collections import Counter, defaultdict
 # scripts/_core/ by sync_core.py so this skill stays self-contained. Make this
 # script's own dir importable regardless of how it is invoked, then import.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _core.claude import scan_claude_session, scan_claude_session_id  # noqa: E402
+from _core.claude import peek_claude_session_id, scan_claude_session  # noqa: E402
 from _core.codex import codex_meta_from_rollout, codex_session_id  # noqa: E402
 from _core.kimi import (  # noqa: E402
     iter_kimi_session_dirs,
@@ -1323,25 +1323,16 @@ class SessionAnalyzer:
                     unique_paths.setdefault(physical, file)
                     keys_by_path[physical].add(key)
 
-        identity_by_path: Dict[str, str] = {}
-        names_by_identity: Dict[tuple[str, str], set[str]] = defaultdict(set)
-        total_identities: set[tuple[str, str]] = set()
-        projects_with_sessions: set[str] = set()
-        searchable_paths: Dict[str, Path] = {}
+        identity_by_path: Dict[str, Optional[str]] = {}
+        uncertain_paths: set[str] = set()
         for physical, file in unique_paths.items():
-            session_id = scan_claude_session_id(file)
+            session_id = peek_claude_session_id(file)
             identity_by_path[physical] = session_id
-            if session_id in exclude_sessions:
-                continue
-            searchable_paths[physical] = file
-            for project_name, filename in keys_by_path[physical]:
-                identity = (project_name, session_id)
-                total_identities.add(identity)
-                projects_with_sessions.add(project_name)
-                names_by_identity[identity].add(filename)
+            if session_id is None:
+                uncertain_paths.add(physical)
 
         matched_files = files_possibly_matching(
-            searchable_paths.values(),
+            unique_paths.values(),
             keywords,
             case_sensitive=case_sensitive,
             on_progress=on_prefilter_progress,
@@ -1356,14 +1347,43 @@ class SessionAnalyzer:
                 exclude_sessions=exclude_sessions,
             )
 
-        candidate_identities: set[tuple[str, str]] = set()
+        matched_physical: set[str] = set()
         for file in matched_files:
             try:
-                physical = str(file.resolve())
+                matched_physical.add(str(file.resolve()))
             except (OSError, RuntimeError):
-                physical = str(file)
-            session_id = identity_by_path.get(physical, file.stem)
-            for project_name, _filename in keys_by_path.get(physical, set()):
+                matched_physical.add(str(file))
+
+        # A bounded identity miss is uncertainty, not evidence that filename
+        # identity is authoritative. Promote it to the candidate set, then pay
+        # the full metadata scan only for that small subset. This runs after
+        # the native keyword pass, so old/no-ID files cannot silently turn the
+        # identity index back into a full-corpus JSON parser.
+        candidate_physical = matched_physical | uncertain_paths
+        for physical in uncertain_paths:
+            identity_by_path[physical] = scan_claude_session(
+                unique_paths[physical]
+            ).session_id
+
+        names_by_identity: Dict[tuple[str, str], set[str]] = defaultdict(set)
+        total_identities: set[tuple[str, str]] = set()
+        projects_with_sessions: set[str] = set()
+        for physical in unique_paths:
+            session_id = identity_by_path[physical]
+            if session_id is None or session_id in exclude_sessions:
+                continue
+            for project_name, filename in keys_by_path[physical]:
+                identity = (project_name, session_id)
+                total_identities.add(identity)
+                projects_with_sessions.add(project_name)
+                names_by_identity[identity].add(filename)
+
+        candidate_identities: set[tuple[str, str]] = set()
+        for physical in candidate_physical:
+            session_id = identity_by_path.get(physical)
+            if session_id is None or session_id in exclude_sessions:
+                continue
+            for project_name, _filename in keys_by_path[physical]:
                 candidate_identities.add((project_name, session_id))
 
         candidate_names: Dict[str, set[str]] = defaultdict(set)

--- a/daymade-claude-code/read-claude-code-history/scripts/analyze_sessions.py
+++ b/daymade-claude-code/read-claude-code-history/scripts/analyze_sessions.py
@@ -34,7 +34,7 @@ from collections import Counter, defaultdict
 # scripts/_core/ by sync_core.py so this skill stays self-contained. Make this
 # script's own dir importable regardless of how it is invoked, then import.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _core.claude import scan_claude_session  # noqa: E402
+from _core.claude import scan_claude_session, scan_claude_session_id  # noqa: E402
 from _core.codex import codex_meta_from_rollout, codex_session_id  # noqa: E402
 from _core.kimi import (  # noqa: E402
     iter_kimi_session_dirs,
@@ -1270,18 +1270,21 @@ class SessionAnalyzer:
         that made a one-day query spend minutes parsing files that could not
         contain the keyword.
 
-        This method enumerates filenames only, de-duplicates aliased physical
-        directories, and lets the native byte scanner identify candidate
-        ``(project, filename)`` pairs.  Once any physical copy is a candidate,
-        every same-named active/archive copy is retained and fully parsed; that
-        preserves record unions and the exact untimed-record count under date
-        windows.  ``None`` from the scanner means no trustworthy filtering
-        information, so it falls back to the original full metadata scan.
+        This method de-duplicates aliased physical directories, peeks only far
+        enough to read each file's authoritative internal ``sessionId``, and
+        lets the native byte scanner identify candidate physical files. Once
+        any copy is a candidate, every active/archive filename carrying that
+        same session id is retained and fully parsed; that preserves renamed
+        copy unions and the exact untimed-record count under date windows.
+        ``None`` from the scanner means no trustworthy filtering information,
+        so it falls back to the original full metadata scan.
 
         Returns ``(candidate_refs, total_sessions, project_count, applied)``.
-        The total is filename-derived so the user-visible searched-sessions
-        count stays stable even though only candidates pay JSON parsing cost.
-        Conversation chronology still comes exclusively from internal records.
+        The total is derived from ``(project, sessionId)`` identities so the
+        user-visible searched-session count stays stable even when copies were
+        renamed. Only the short identity peek is paid by every file; complete
+        metadata and conversation parsing remain candidate-only. Conversation
+        chronology still comes exclusively from internal records.
         """
         if all_projects:
             project_pairs = self.project_dir_pairs()
@@ -1307,16 +1310,12 @@ class SessionAnalyzer:
 
         unique_paths: Dict[str, Path] = {}
         keys_by_path: Dict[str, set[tuple[str, str]]] = defaultdict(set)
-        total_keys: set[tuple[str, str]] = set()
-        projects_with_sessions: set[str] = set()
         for project_name, pairs in project_pairs.items():
             for scan_dir, _group_members in self._group_project_dirs(pairs):
                 for file in scan_dir.glob("*.jsonl"):
                     if file.name.startswith("agent-") or file.stem in exclude_sessions:
                         continue
                     key = (project_name, file.name)
-                    total_keys.add(key)
-                    projects_with_sessions.add(project_name)
                     try:
                         physical = str(file.resolve())
                     except (OSError, RuntimeError):
@@ -1324,8 +1323,25 @@ class SessionAnalyzer:
                     unique_paths.setdefault(physical, file)
                     keys_by_path[physical].add(key)
 
+        identity_by_path: Dict[str, str] = {}
+        names_by_identity: Dict[tuple[str, str], set[str]] = defaultdict(set)
+        total_identities: set[tuple[str, str]] = set()
+        projects_with_sessions: set[str] = set()
+        searchable_paths: Dict[str, Path] = {}
+        for physical, file in unique_paths.items():
+            session_id = scan_claude_session_id(file)
+            identity_by_path[physical] = session_id
+            if session_id in exclude_sessions:
+                continue
+            searchable_paths[physical] = file
+            for project_name, filename in keys_by_path[physical]:
+                identity = (project_name, session_id)
+                total_identities.add(identity)
+                projects_with_sessions.add(project_name)
+                names_by_identity[identity].add(filename)
+
         matched_files = files_possibly_matching(
-            unique_paths.values(),
+            searchable_paths.values(),
             keywords,
             case_sensitive=case_sensitive,
             on_progress=on_prefilter_progress,
@@ -1340,14 +1356,20 @@ class SessionAnalyzer:
                 exclude_sessions=exclude_sessions,
             )
 
-        candidate_names: Dict[str, set[str]] = defaultdict(set)
+        candidate_identities: set[tuple[str, str]] = set()
         for file in matched_files:
             try:
                 physical = str(file.resolve())
             except (OSError, RuntimeError):
                 physical = str(file)
-            for project_name, filename in keys_by_path.get(physical, set()):
-                candidate_names[project_name].add(filename)
+            session_id = identity_by_path.get(physical, file.stem)
+            for project_name, _filename in keys_by_path.get(physical, set()):
+                candidate_identities.add((project_name, session_id))
+
+        candidate_names: Dict[str, set[str]] = defaultdict(set)
+        for identity in candidate_identities:
+            project_name, _session_id = identity
+            candidate_names[project_name].update(names_by_identity[identity])
 
         sessions = []
         for project_name, pairs in project_pairs.items():
@@ -1370,7 +1392,7 @@ class SessionAnalyzer:
         )
         return (
             sessions,
-            len(total_keys),
+            len(total_identities),
             len(projects_with_sessions),
             True,
         )
@@ -2594,7 +2616,7 @@ def main():
         )
         if candidate_prefilter_applied:
             print(
-                "Candidate prefilter: structured parsing required for "
+                "Candidate prefilter: full-session parsing required for "
                 f"{len(sessions)}/{discovered_session_count} session(s).",
                 file=sys.stderr,
             )

--- a/daymade-claude-code/read-claude-code-history/scripts/analyze_sessions.py
+++ b/daymade-claude-code/read-claude-code-history/scripts/analyze_sessions.py
@@ -1062,6 +1062,7 @@ class SessionAnalyzer:
         self,
         pairs: List[tuple],
         candidate_paths: Optional[set[str]] = None,
+        candidate_summaries: Optional[Dict[str, Any]] = None,
     ) -> List[Dict[str, Any]]:
         """Collect + de-duplicate sessions from ``(source, project_dir)`` pairs.
 
@@ -1101,14 +1102,20 @@ class SessionAnalyzer:
             for file in scan_dir.glob("*.jsonl"):
                 if file.name.startswith("agent-"):
                     continue
+                try:
+                    physical_file = str(file.resolve())
+                except (OSError, RuntimeError):
+                    physical_file = str(file)
                 if candidate_paths is not None:
-                    try:
-                        physical_file = str(file.resolve())
-                    except (OSError, RuntimeError):
-                        physical_file = str(file)
                     if physical_file not in candidate_paths:
                         continue
-                summary = scan_claude_session(file)
+                summary = (
+                    candidate_summaries.get(physical_file)
+                    if candidate_summaries is not None
+                    else None
+                )
+                if summary is None:
+                    summary = scan_claude_session(file)
                 sid = summary.session_id
                 copies = [
                     {
@@ -1371,10 +1378,11 @@ class SessionAnalyzer:
         # the native keyword pass, so old/no-ID files cannot silently turn the
         # identity index back into a full-corpus JSON parser.
         candidate_physical = matched_physical | uncertain_paths
-        for physical in uncertain_paths:
-            identity_by_path[physical] = scan_claude_session(
-                unique_paths[physical]
-            ).session_id
+        candidate_summaries: Dict[str, Any] = {}
+        for physical in candidate_physical:
+            summary = scan_claude_session(unique_paths[physical])
+            candidate_summaries[physical] = summary
+            identity_by_path[physical] = summary.session_id
 
         total_identities: set[tuple[str, str]] = set()
         projects_with_sessions: set[str] = set()
@@ -1412,6 +1420,7 @@ class SessionAnalyzer:
             for ref in self._merge_sessions_from_dirs(
                 pairs,
                 candidate_paths=candidate_paths,
+                candidate_summaries=candidate_summaries,
             ):
                 if ref["session_id"] in exclude_sessions:
                     continue

--- a/daymade-claude-code/read-claude-code-history/tests/test_analyze_sessions.py
+++ b/daymade-claude-code/read-claude-code-history/tests/test_analyze_sessions.py
@@ -1050,6 +1050,41 @@ class SessionAnalyzerTests(unittest.TestCase):
         self.assertIn("Found 1 session(s) with matches", default_run.stdout)
         self.assertIn(f"{alias_stem}.jsonl", default_run.stdout)
 
+    def test_excluded_prefix_id_is_resolved_by_full_candidate_scan(self) -> None:
+        excluded_id = "33333333-3333-4333-8333-333333333333"
+        live_id = "44444444-4444-4444-8444-444444444444"
+        session_file = project_dir(self.active_home, self.workspace) / "mixed-identity.jsonl"
+        write_jsonl(
+            session_file,
+            [
+                user_record(
+                    excluded_id,
+                    self.workspace,
+                    "early record before identity correction",
+                    "2026-04-20T10:00:00Z",
+                ),
+                user_record(
+                    live_id,
+                    self.workspace,
+                    "final-identity-marker",
+                    "2026-04-20T10:00:01Z",
+                ),
+            ],
+        )
+        arguments = (
+            "search",
+            str(self.workspace),
+            "final-identity-marker",
+            "--exclude-session",
+            excluded_id,
+            "--history-sources",
+            str(self.manifest),
+        )
+        default_run = self.run_cli(*arguments)
+        no_prefilter_run = self.run_cli(*arguments, "--no-prefilter")
+        self.assertEqual(default_run.stdout, no_prefilter_run.stdout)
+        self.assertIn("Found 1 session(s) with matches", default_run.stdout)
+
     def test_zero_match_hint_points_at_unapplied_widenings(self) -> None:
         write_jsonl(
             project_dir(self.active_home, self.workspace)

--- a/daymade-claude-code/read-claude-code-history/tests/test_analyze_sessions.py
+++ b/daymade-claude-code/read-claude-code-history/tests/test_analyze_sessions.py
@@ -501,6 +501,62 @@ class SessionAnalyzerTests(unittest.TestCase):
         self.assertEqual([ref["session_id"] for ref in sessions], [matching_id])
         self.assertEqual(scan.call_count, 1)
 
+    def test_identity_peek_is_bounded_when_session_id_is_absent(self) -> None:
+        from _core import claude as claude_core
+
+        no_id = self.root / "no-session-id.jsonl"
+        write_jsonl(
+            no_id,
+            [{"type": "progress", "message": f"record {index}"} for index in range(100)],
+        )
+        with mock.patch.object(
+            claude_core.json, "loads", wraps=json.loads
+        ) as loads:
+            session_id = claude_core.peek_claude_session_id(
+                no_id,
+                max_records=3,
+                max_bytes=1024 * 1024,
+            )
+        self.assertIsNone(session_id)
+        self.assertEqual(loads.call_count, 3)
+
+        oversized = self.root / "oversized-first-record.jsonl"
+        write_jsonl(
+            oversized,
+            [{"type": "progress", "message": "x" * 4096}],
+        )
+        with mock.patch.object(
+            claude_core.json, "loads", wraps=json.loads
+        ) as loads:
+            session_id = claude_core.peek_claude_session_id(
+                oversized,
+                max_records=32,
+                max_bytes=128,
+            )
+        self.assertIsNone(session_id)
+        self.assertEqual(loads.call_count, 0)
+
+    def test_uncertain_identity_is_conservatively_fully_parsed(self) -> None:
+        no_id = project_dir(self.active_home, self.workspace) / "legacy-no-id.jsonl"
+        write_jsonl(
+            no_id,
+            [{"type": "progress", "message": "ordinary content without identity"}],
+        )
+        result = self.run_cli(
+            "search",
+            str(self.workspace),
+            "absent-marker",
+            "--history-sources",
+            str(self.manifest),
+            check=False,
+        )
+        self.assertIn("Searching 1 session(s)", result.stdout)
+        self.assertIn("No matches found.", result.stdout)
+        self.assertIn(
+            "Candidate prefilter: full-session parsing required for 1/1 session(s).",
+            result.stderr,
+        )
+
     def test_no_candidate_is_no_match_not_no_sessions(self) -> None:
         session_id = "12121212-1212-4212-8212-121212121212"
         write_jsonl(
@@ -1347,6 +1403,7 @@ class RawBytePrefilterSafetyTests(unittest.TestCase):
             ("the ﬁnancial model is attached", "financial"),
             ("DIE STRAẞE IST LANG", "strasse"),
             ("a ﬅudy of ﬆate machines", "study"),
+            ("İstanbul and 自İ", "自i"),
         ):
             with self.subTest(content=content):
                 self._assert_search_finds(content, keyword)
@@ -1362,6 +1419,15 @@ class RawBytePrefilterSafetyTests(unittest.TestCase):
         for ch in _FOLDS_TO_ASCII:
             self.assertFalse(ch.isascii(), f"{ch!r} is already ASCII")
             self.assertTrue(ch.casefold().isascii(), f"{ch!r} does not fold to ASCII")
+
+        from _core.text import _FOLDS_CONTAINING_ASCII
+
+        self.assertIn("İ", _FOLDS_CONTAINING_ASCII)
+        for ch in _FOLDS_CONTAINING_ASCII:
+            self.assertTrue(
+                any(part.isascii() for part in ch.casefold()),
+                f"{ch!r} has no ASCII substring after casefold",
+            )
 
     def _assert_search_finds(self, content: str, keyword: str,
                              ensure_ascii: bool = False) -> None:

--- a/daymade-claude-code/read-claude-code-history/tests/test_analyze_sessions.py
+++ b/daymade-claude-code/read-claude-code-history/tests/test_analyze_sessions.py
@@ -501,6 +501,54 @@ class SessionAnalyzerTests(unittest.TestCase):
         self.assertEqual([ref["session_id"] for ref in sessions], [matching_id])
         self.assertEqual(scan.call_count, 1)
 
+    def test_same_filename_different_session_ids_do_not_expand_candidate(self) -> None:
+        module = _load_analyze_module()
+        shared_name = "same-name.jsonl"
+        matching_id = "abababab-abab-4bab-8bab-abababababab"
+        unrelated_id = "cdcdcdcd-cdcd-4dcd-8dcd-cdcdcdcdcdcd"
+        write_jsonl(
+            project_dir(self.active_home, self.workspace) / shared_name,
+            [
+                user_record(
+                    matching_id,
+                    self.workspace,
+                    "contains the candidate needle",
+                    "2026-04-15T00:00:00Z",
+                )
+            ],
+        )
+        write_jsonl(
+            project_dir(self.archive_home, self.workspace) / shared_name,
+            [
+                user_record(
+                    unrelated_id,
+                    self.workspace,
+                    "ordinary unrelated record",
+                    "2026-04-16T00:00:00Z",
+                )
+            ],
+        )
+        analyzer = module.SessionAnalyzer(
+            homes=[self.active_home, self.archive_home]
+        )
+        original_scan = module.scan_claude_session
+        with mock.patch.object(
+            module, "scan_claude_session", wraps=original_scan
+        ) as scan:
+            sessions, total, projects, applied = analyzer.find_search_sessions(
+                project_path=str(self.workspace),
+                all_projects=False,
+                keywords=["candidate needle"],
+                case_sensitive=False,
+                use_prefilter=True,
+                exclude_sessions=set(),
+            )
+        self.assertTrue(applied)
+        self.assertEqual(total, 2)
+        self.assertEqual(projects, 1)
+        self.assertEqual([ref["session_id"] for ref in sessions], [matching_id])
+        self.assertEqual(scan.call_count, 1)
+
     def test_identity_peek_is_bounded_when_session_id_is_absent(self) -> None:
         from _core import claude as claude_core
 

--- a/daymade-claude-code/read-claude-code-history/tests/test_analyze_sessions.py
+++ b/daymade-claude-code/read-claude-code-history/tests/test_analyze_sessions.py
@@ -17,7 +17,10 @@ SKILL_DIR = Path(__file__).resolve().parents[1]
 SCRIPT = SKILL_DIR / "scripts" / "analyze_sessions.py"
 
 sys.path.insert(0, str(SKILL_DIR / "scripts"))
-from _core.text import keywords_are_raw_byte_safe  # noqa: E402
+from _core.text import (  # noqa: E402
+    keywords_are_file_prefilter_safe,
+    keywords_are_raw_byte_safe,
+)
 
 
 def _load_analyze_module():
@@ -403,19 +406,23 @@ class SessionAnalyzerTests(unittest.TestCase):
         self.assertIn(matching_id, default_run.stdout)
         self.assertNotIn(no_match_id, default_run.stdout)
 
-    def test_prefilter_disabled_under_date_window_keeps_untimed_count_exact(self) -> None:
-        """The pre-filter is gated off automatically whenever a date window is
-        active (see search_sessions's use_prefilter docstring) because
-        excluded_untimed_records counts every untimed record in a session
-        regardless of keyword match, and skipping non-matching records would
-        silently under-report it. Prove the count is identical either way,
-        not just that both runs happen to exit 0."""
+    def test_candidate_prefilter_under_date_window_keeps_untimed_count_exact(self) -> None:
+        """Candidate-first filtering may skip whole non-matching sessions,
+        but once any copy of a session is a candidate it must parse every
+        same-named active/archive copy. Otherwise a non-matching copy's untimed
+        records disappear from the warning. Prove byte-for-byte parity with
+        --no-prefilter, not merely the keyword hit."""
         session_id = "66666666-6666-4666-8666-666666666666"
         write_jsonl(
             project_dir(self.active_home, self.workspace) / f"{session_id}.jsonl",
             [
                 user_record(session_id, self.workspace, "has the target keyword", "2026-04-15T00:00:00Z"),
-                {  # untimed record, no keyword — must still be counted while a date window is active
+            ],
+        )
+        write_jsonl(
+            project_dir(self.archive_home, self.workspace) / f"{session_id}.jsonl",
+            [
+                {  # non-matching archived copy: still contributes untimed records
                     "type": "user",
                     "sessionId": session_id,
                     "cwd": str(self.workspace),
@@ -441,6 +448,82 @@ class SessionAnalyzerTests(unittest.TestCase):
         )
         self.assertEqual(default_run.stdout, no_prefilter_run.stdout)
         self.assertIn("excluded 2 record(s) without an internal timestamp", default_run.stdout)
+
+    def test_candidate_first_discovery_parses_only_matching_session_metadata(self) -> None:
+        module = _load_analyze_module()
+        base = project_dir(self.active_home, self.workspace)
+        for index in range(40):
+            session_id = f"00000000-0000-4000-8000-{index:012d}"
+            write_jsonl(
+                base / f"{session_id}.jsonl",
+                [
+                    user_record(
+                        session_id,
+                        self.workspace,
+                        f"ordinary unrelated record {index}",
+                        "2026-04-01T00:00:00Z",
+                    )
+                ],
+            )
+        matching_id = "ffffffff-ffff-4fff-8fff-ffffffffffff"
+        write_jsonl(
+            base / f"{matching_id}.jsonl",
+            [
+                user_record(
+                    matching_id,
+                    self.workspace,
+                    "包含自动主线回锚",
+                    "2026-04-15T00:00:00Z",
+                )
+            ],
+        )
+        analyzer = module.SessionAnalyzer(homes=[self.active_home])
+        original_scan = module.scan_claude_session
+        with mock.patch.object(
+            module, "scan_claude_session", wraps=original_scan
+        ) as scan:
+            sessions, total, projects, applied = analyzer.find_search_sessions(
+                project_path=str(self.workspace),
+                all_projects=False,
+                keywords=["自动主线回锚"],
+                case_sensitive=False,
+                use_prefilter=True,
+                exclude_sessions=set(),
+            )
+        self.assertTrue(applied)
+        self.assertEqual(total, 41)
+        self.assertEqual(projects, 1)
+        self.assertEqual([ref["session_id"] for ref in sessions], [matching_id])
+        self.assertEqual(scan.call_count, 1)
+
+    def test_no_candidate_is_no_match_not_no_sessions(self) -> None:
+        session_id = "12121212-1212-4212-8212-121212121212"
+        write_jsonl(
+            project_dir(self.active_home, self.workspace) / f"{session_id}.jsonl",
+            [
+                user_record(
+                    session_id,
+                    self.workspace,
+                    "ordinary content",
+                    "2026-04-15T00:00:00Z",
+                )
+            ],
+        )
+        result = self.run_cli(
+            "search",
+            str(self.workspace),
+            "absent-marker",
+            "--history-sources",
+            str(self.manifest),
+            check=False,
+        )
+        self.assertIn("Searching 1 session(s)", result.stdout)
+        self.assertIn("No matches found.", result.stdout)
+        self.assertNotIn("No sessions found", result.stdout)
+        self.assertIn(
+            "Candidate prefilter: structured parsing required for 0/1 session(s).",
+            result.stderr,
+        )
 
     def test_repeated_copy_sizes_flags_only_actual_duplicates(self) -> None:
         """Only sizes that repeat are worth hashing — a unique size cannot
@@ -1219,6 +1302,10 @@ class RawBytePrefilterSafetyTests(unittest.TestCase):
         for keyword in ("café", "你好", "straße", "ẞ"):
             with self.subTest(keyword=keyword):
                 self.assertFalse(keywords_are_raw_byte_safe([keyword]))
+
+    def test_cjk_is_safe_for_file_prefilter_but_not_line_prefilter(self) -> None:
+        self.assertTrue(keywords_are_file_prefilter_safe(["你好"]))
+        self.assertFalse(keywords_are_raw_byte_safe(["你好"]))
 
     def test_ascii_keyword_is_raw_byte_safe(self) -> None:
         # The guard must not misfire on ordinary input — killing the speedup

--- a/daymade-claude-code/read-claude-code-history/tests/test_analyze_sessions.py
+++ b/daymade-claude-code/read-claude-code-history/tests/test_analyze_sessions.py
@@ -1085,6 +1085,59 @@ class SessionAnalyzerTests(unittest.TestCase):
         self.assertEqual(default_run.stdout, no_prefilter_run.stdout)
         self.assertIn("Found 1 session(s) with matches", default_run.stdout)
 
+    def test_candidate_final_id_expands_stable_renamed_copy(self) -> None:
+        prefix_id = "55555555-5555-4555-8555-555555555555"
+        final_id = "66666666-6666-4666-8666-666666666666"
+        active_copy = project_dir(self.active_home, self.workspace) / "changing-id.jsonl"
+        write_jsonl(
+            active_copy,
+            [
+                user_record(
+                    prefix_id,
+                    self.workspace,
+                    "early provisional identity",
+                    "2026-04-20T10:00:00Z",
+                ),
+                user_record(
+                    final_id,
+                    self.workspace,
+                    "final-id-union-marker",
+                    "2026-04-20T10:00:01Z",
+                ),
+            ],
+        )
+        archive_copy = project_dir(self.archive_home, self.workspace) / "stable-renamed.jsonl"
+        write_jsonl(
+            archive_copy,
+            [
+                {
+                    "type": "user",
+                    "sessionId": final_id,
+                    "cwd": str(self.workspace),
+                    "message": {
+                        "role": "user",
+                        "content": "untimed non-matching copy",
+                    },
+                }
+            ],
+        )
+        arguments = (
+            "search",
+            str(self.workspace),
+            "final-id-union-marker",
+            "--from-date",
+            "2026-04-01",
+            "--to-date",
+            "2026-04-30",
+            "--history-sources",
+            str(self.manifest),
+        )
+        default_run = self.run_cli(*arguments)
+        no_prefilter_run = self.run_cli(*arguments, "--no-prefilter")
+        self.assertEqual(default_run.stdout, no_prefilter_run.stdout)
+        self.assertIn("Session sources: active:main, archive:full-backup", default_run.stdout)
+        self.assertIn("excluded 1 record(s) without an internal timestamp", default_run.stdout)
+
     def test_zero_match_hint_points_at_unapplied_widenings(self) -> None:
         write_jsonl(
             project_dir(self.active_home, self.workspace)

--- a/daymade-claude-code/read-claude-code-history/tests/test_analyze_sessions.py
+++ b/daymade-claude-code/read-claude-code-history/tests/test_analyze_sessions.py
@@ -409,20 +409,16 @@ class SessionAnalyzerTests(unittest.TestCase):
     def test_candidate_prefilter_under_date_window_keeps_untimed_count_exact(self) -> None:
         """Candidate-first filtering may skip whole non-matching sessions,
         but once any copy of a session is a candidate it must parse every
-        same-named active/archive copy. Otherwise a non-matching copy's untimed
-        records disappear from the warning. Prove byte-for-byte parity with
-        --no-prefilter, not merely the keyword hit."""
+        active/archive copy with that internal sessionId, even if the files
+        were renamed. Otherwise a non-matching copy's untimed records and
+        provenance disappear. Prove byte-for-byte parity with --no-prefilter,
+        not merely the keyword hit."""
         session_id = "66666666-6666-4666-8666-666666666666"
+        active_copy = project_dir(self.active_home, self.workspace) / "renamed-active.jsonl"
         write_jsonl(
-            project_dir(self.active_home, self.workspace) / f"{session_id}.jsonl",
+            active_copy,
             [
-                user_record(session_id, self.workspace, "has the target keyword", "2026-04-15T00:00:00Z"),
-            ],
-        )
-        write_jsonl(
-            project_dir(self.archive_home, self.workspace) / f"{session_id}.jsonl",
-            [
-                {  # non-matching archived copy: still contributes untimed records
+                {  # non-matching active copy: still contributes untimed records
                     "type": "user",
                     "sessionId": session_id,
                     "cwd": str(self.workspace),
@@ -434,6 +430,13 @@ class SessionAnalyzerTests(unittest.TestCase):
                     "cwd": str(self.workspace),
                     "message": {"role": "user", "content": "another untimed filler"},
                 },
+            ],
+        )
+        archive_copy = project_dir(self.archive_home, self.workspace) / "renamed-archive.jsonl"
+        write_jsonl(
+            archive_copy,
+            [
+                user_record(session_id, self.workspace, "has the target keyword", "2026-04-15T00:00:00Z"),
             ],
         )
         default_run = self.run_cli(
@@ -448,6 +451,8 @@ class SessionAnalyzerTests(unittest.TestCase):
         )
         self.assertEqual(default_run.stdout, no_prefilter_run.stdout)
         self.assertIn("excluded 2 record(s) without an internal timestamp", default_run.stdout)
+        self.assertIn("Session sources: active:main, archive:full-backup", default_run.stdout)
+        self.assertIn(str(archive_copy), default_run.stdout)
 
     def test_candidate_first_discovery_parses_only_matching_session_metadata(self) -> None:
         module = _load_analyze_module()
@@ -521,7 +526,7 @@ class SessionAnalyzerTests(unittest.TestCase):
         self.assertIn("No matches found.", result.stdout)
         self.assertNotIn("No sessions found", result.stdout)
         self.assertIn(
-            "Candidate prefilter: structured parsing required for 0/1 session(s).",
+            "Candidate prefilter: full-session parsing required for 0/1 session(s).",
             result.stderr,
         )
 

--- a/daymade-claude-code/read-claude-code-history/tests/test_analyze_sessions.py
+++ b/daymade-claude-code/read-claude-code-history/tests/test_analyze_sessions.py
@@ -584,6 +584,10 @@ class SessionAnalyzerTests(unittest.TestCase):
         self.assertIsNone(session_id)
         self.assertEqual(loads.call_count, 0)
 
+        dangling = self.root / "dangling.jsonl"
+        dangling.symlink_to(self.root / "missing-target.jsonl")
+        self.assertIsNone(claude_core.peek_claude_session_id(dangling))
+
     def test_uncertain_identity_is_conservatively_fully_parsed(self) -> None:
         no_id = project_dir(self.active_home, self.workspace) / "legacy-no-id.jsonl"
         write_jsonl(
@@ -604,6 +608,28 @@ class SessionAnalyzerTests(unittest.TestCase):
             "Candidate prefilter: full-session parsing required for 1/1 session(s).",
             result.stderr,
         )
+
+    def test_dangling_jsonl_degrades_to_tolerant_full_scan(self) -> None:
+        dangling = project_dir(self.active_home, self.workspace) / "orphan.jsonl"
+        dangling.symlink_to(self.root / "missing-session.jsonl")
+        default_run = self.run_cli(
+            "search",
+            str(self.workspace),
+            "absent-marker",
+            "--history-sources",
+            str(self.manifest),
+        )
+        no_prefilter_run = self.run_cli(
+            "search",
+            str(self.workspace),
+            "absent-marker",
+            "--no-prefilter",
+            "--history-sources",
+            str(self.manifest),
+        )
+        self.assertEqual(default_run.stdout, no_prefilter_run.stdout)
+        self.assertIn("No matches found.", default_run.stdout)
+        self.assertNotIn("Traceback", default_run.stderr)
 
     def test_no_candidate_is_no_match_not_no_sessions(self) -> None:
         session_id = "12121212-1212-4212-8212-121212121212"
@@ -983,6 +1009,46 @@ class SessionAnalyzerTests(unittest.TestCase):
         )
         self.assertIn(target_id, completed.stdout)
         self.assertNotIn(current_id, completed.stdout)
+
+    def test_exclude_session_does_not_treat_alias_filename_as_identity(self) -> None:
+        internal_id = "22222222-2222-4222-8222-222222222222"
+        alias_stem = "11111111-1111-4111-8111-111111111111"
+        write_jsonl(
+            project_dir(self.active_home, self.workspace) / f"{alias_stem}.jsonl",
+            [
+                user_record(
+                    internal_id,
+                    self.workspace,
+                    "renamed-copy-marker",
+                    "2026-04-20T10:00:00Z",
+                )
+            ],
+        )
+        write_jsonl(
+            project_dir(self.archive_home, self.workspace) / f"{internal_id}.jsonl",
+            [
+                user_record(
+                    internal_id,
+                    self.workspace,
+                    "ordinary archive copy",
+                    "2026-04-20T10:00:01Z",
+                )
+            ],
+        )
+        arguments = (
+            "search",
+            str(self.workspace),
+            "renamed-copy-marker",
+            "--exclude-session",
+            alias_stem,
+            "--history-sources",
+            str(self.manifest),
+        )
+        default_run = self.run_cli(*arguments)
+        no_prefilter_run = self.run_cli(*arguments, "--no-prefilter")
+        self.assertEqual(default_run.stdout, no_prefilter_run.stdout)
+        self.assertIn("Found 1 session(s) with matches", default_run.stdout)
+        self.assertIn(f"{alias_stem}.jsonl", default_run.stdout)
 
     def test_zero_match_hint_points_at_unapplied_widenings(self) -> None:
         write_jsonl(

--- a/daymade-claude-code/read-claude-code-history/tests/test_analyze_sessions.py
+++ b/daymade-claude-code/read-claude-code-history/tests/test_analyze_sessions.py
@@ -549,7 +549,7 @@ class SessionAnalyzerTests(unittest.TestCase):
         self.assertEqual([ref["session_id"] for ref in sessions], [matching_id])
         self.assertEqual(scan.call_count, 1)
 
-    def test_identity_peek_is_bounded_when_session_id_is_absent(self) -> None:
+    def test_final_identity_peek_is_bounded_and_reads_from_eof(self) -> None:
         from _core import claude as claude_core
 
         no_id = self.root / "no-session-id.jsonl"
@@ -560,7 +560,7 @@ class SessionAnalyzerTests(unittest.TestCase):
         with mock.patch.object(
             claude_core.json, "loads", wraps=json.loads
         ) as loads:
-            session_id = claude_core.peek_claude_session_id(
+            session_id = claude_core.peek_final_claude_session_id(
                 no_id,
                 max_records=3,
                 max_bytes=1024 * 1024,
@@ -576,7 +576,7 @@ class SessionAnalyzerTests(unittest.TestCase):
         with mock.patch.object(
             claude_core.json, "loads", wraps=json.loads
         ) as loads:
-            session_id = claude_core.peek_claude_session_id(
+            session_id = claude_core.peek_final_claude_session_id(
                 oversized,
                 max_records=32,
                 max_bytes=128,
@@ -586,7 +586,20 @@ class SessionAnalyzerTests(unittest.TestCase):
 
         dangling = self.root / "dangling.jsonl"
         dangling.symlink_to(self.root / "missing-target.jsonl")
-        self.assertIsNone(claude_core.peek_claude_session_id(dangling))
+        self.assertIsNone(claude_core.peek_final_claude_session_id(dangling))
+
+        conflicting = self.root / "conflicting-identities.jsonl"
+        write_jsonl(
+            conflicting,
+            [
+                {"sessionId": "prefix-id", "type": "progress"},
+                {"sessionId": "final-id", "type": "progress"},
+            ],
+        )
+        self.assertEqual(
+            claude_core.peek_final_claude_session_id(conflicting),
+            "final-id",
+        )
 
     def test_uncertain_identity_is_conservatively_fully_parsed(self) -> None:
         no_id = project_dir(self.active_home, self.workspace) / "legacy-no-id.jsonl"

--- a/daymade-claude-code/read-claude-code-history/tests/test_core_text.py
+++ b/daymade-claude-code/read-claude-code-history/tests/test_core_text.py
@@ -116,7 +116,7 @@ class FilesPossiblyMatchingTests(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertIn(escaped, result)
 
-    def test_mixed_unicode_query_honors_ascii_case_after_json_decode(self) -> None:
+    def test_mixed_unicode_query_preserves_escaped_ascii_case_candidate(self) -> None:
         escaped_lower = self._write(
             "escaped-lower-ascii.jsonl",
             '{"message":"自\\u0061动"}\n',
@@ -130,7 +130,22 @@ class FilesPossiblyMatchingTests(unittest.TestCase):
         self.assertIsNotNone(insensitive)
         self.assertIn(escaped_lower, insensitive)
         self.assertIsNotNone(sensitive)
-        self.assertNotIn(escaped_lower, sensitive)
+        # A file containing any Unicode escape remains a conservative
+        # candidate because decoded full-fold equivalents can use a different
+        # code point. Structured matching still enforces case sensitivity.
+        self.assertIn(escaped_lower, sensitive)
+
+    def test_mixed_unicode_ascii_query_keeps_escaped_full_fold_candidate(self) -> None:
+        kelvin_escape = self._write(
+            "escaped-kelvin.jsonl",
+            '{"message":"自\\u212A"}\n',
+        )
+        self.assertTrue(keywords_are_file_prefilter_safe(["自k"]))
+        result = files_possibly_matching(
+            [kelvin_escape], ["自k"], case_sensitive=False
+        )
+        self.assertIsNotNone(result)
+        self.assertIn(kelvin_escape, result)
 
     def test_cased_or_multicodepoint_unicode_disables_file_prefilter(self) -> None:
         for keyword in ("café", "straße", "ẞ", "İ"):

--- a/daymade-claude-code/read-claude-code-history/tests/test_core_text.py
+++ b/daymade-claude-code/read-claude-code-history/tests/test_core_text.py
@@ -25,7 +25,11 @@ from unittest import mock
 SKILL_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(SKILL_DIR / "scripts"))
 
-from _core.text import files_possibly_matching, iter_jsonl  # noqa: E402
+from _core.text import (  # noqa: E402
+    files_possibly_matching,
+    iter_jsonl,
+    keywords_are_file_prefilter_safe,
+)
 
 
 class FilesPossiblyMatchingTests(unittest.TestCase):
@@ -64,6 +68,30 @@ class FilesPossiblyMatchingTests(unittest.TestCase):
         result = files_possibly_matching([wrong_case], ["needle"], case_sensitive=True)
         self.assertIsNotNone(result)
         self.assertNotIn(wrong_case, result)
+
+    def test_cjk_keyword_uses_file_prefilter_without_losing_escaped_json(self) -> None:
+        raw = self._write(
+            "raw.jsonl",
+            json.dumps({"message": "这里有自动主线回锚"}, ensure_ascii=False) + "\n",
+        )
+        escaped = self._write(
+            "escaped.jsonl",
+            json.dumps({"message": "这里有自动主线回锚"}, ensure_ascii=True) + "\n",
+        )
+        noise = self._write("noise.jsonl", '{"message":"unrelated"}\n')
+        self.assertTrue(keywords_are_file_prefilter_safe(["自动主线回锚"]))
+        result = files_possibly_matching(
+            [raw, escaped, noise], ["自动主线回锚"]
+        )
+        self.assertIsNotNone(result)
+        self.assertIn(raw, result)
+        self.assertIn(escaped, result)
+        self.assertNotIn(noise, result)
+
+    def test_cased_or_multicodepoint_unicode_disables_file_prefilter(self) -> None:
+        for keyword in ("café", "straße", "ẞ", "İ"):
+            with self.subTest(keyword=keyword):
+                self.assertFalse(keywords_are_file_prefilter_safe([keyword]))
 
     def test_or_semantics_across_multiple_keywords(self) -> None:
         only_second = self._write("second.jsonl", '{"message": "contains haystack only"}\n')

--- a/daymade-claude-code/read-claude-code-history/tests/test_core_text.py
+++ b/daymade-claude-code/read-claude-code-history/tests/test_core_text.py
@@ -78,15 +78,59 @@ class FilesPossiblyMatchingTests(unittest.TestCase):
             "escaped.jsonl",
             json.dumps({"message": "这里有自动主线回锚"}, ensure_ascii=True) + "\n",
         )
+        mixed_raw_then_escaped = self._write(
+            "mixed-raw-escaped.jsonl",
+            '{"message":"这里有自\\u52a8主线回锚"}\n',
+        )
+        mixed_escaped_then_raw = self._write(
+            "mixed-escaped-raw.jsonl",
+            '{"message":"这里有\\u81EA动主线回锚"}\n',
+        )
         noise = self._write("noise.jsonl", '{"message":"unrelated"}\n')
         self.assertTrue(keywords_are_file_prefilter_safe(["自动主线回锚"]))
         result = files_possibly_matching(
-            [raw, escaped, noise], ["自动主线回锚"]
+            [
+                raw,
+                escaped,
+                mixed_raw_then_escaped,
+                mixed_escaped_then_raw,
+                noise,
+            ],
+            ["自动主线回锚"],
         )
         self.assertIsNotNone(result)
         self.assertIn(raw, result)
         self.assertIn(escaped, result)
+        self.assertIn(mixed_raw_then_escaped, result)
+        self.assertIn(mixed_escaped_then_raw, result)
         self.assertNotIn(noise, result)
+
+    def test_case_sensitive_unicode_matches_uppercase_json_hex(self) -> None:
+        escaped = self._write(
+            "uppercase-hex.jsonl",
+            '{"message":"\\u81EA\\u52A8"}\n',
+        )
+        result = files_possibly_matching(
+            [escaped], ["自动"], case_sensitive=True
+        )
+        self.assertIsNotNone(result)
+        self.assertIn(escaped, result)
+
+    def test_mixed_unicode_query_honors_ascii_case_after_json_decode(self) -> None:
+        escaped_lower = self._write(
+            "escaped-lower-ascii.jsonl",
+            '{"message":"自\\u0061动"}\n',
+        )
+        insensitive = files_possibly_matching(
+            [escaped_lower], ["自A动"], case_sensitive=False
+        )
+        sensitive = files_possibly_matching(
+            [escaped_lower], ["自A动"], case_sensitive=True
+        )
+        self.assertIsNotNone(insensitive)
+        self.assertIn(escaped_lower, insensitive)
+        self.assertIsNotNone(sensitive)
+        self.assertNotIn(escaped_lower, sensitive)
 
     def test_cased_or_multicodepoint_unicode_disables_file_prefilter(self) -> None:
         for keyword in ("café", "straße", "ẞ", "İ"):

--- a/daymade-claude-code/read-claude-code-history/tests/test_core_text.py
+++ b/daymade-claude-code/read-claude-code-history/tests/test_core_text.py
@@ -87,6 +87,10 @@ class FilesPossiblyMatchingTests(unittest.TestCase):
             '{"message":"这里有\\u81EA动主线回锚"}\n',
         )
         noise = self._write("noise.jsonl", '{"message":"unrelated"}\n')
+        fold_noise = self._write(
+            "fold-noise.jsonl",
+            '{"message":"unrelated K İ ﬁ"}\n',
+        )
         self.assertTrue(keywords_are_file_prefilter_safe(["自动主线回锚"]))
         result = files_possibly_matching(
             [
@@ -95,6 +99,7 @@ class FilesPossiblyMatchingTests(unittest.TestCase):
                 mixed_raw_then_escaped,
                 mixed_escaped_then_raw,
                 noise,
+                fold_noise,
             ],
             ["自动主线回锚"],
         )
@@ -104,6 +109,7 @@ class FilesPossiblyMatchingTests(unittest.TestCase):
         self.assertIn(mixed_raw_then_escaped, result)
         self.assertIn(mixed_escaped_then_raw, result)
         self.assertNotIn(noise, result)
+        self.assertNotIn(fold_noise, result)
 
     def test_case_sensitive_unicode_matches_uppercase_json_hex(self) -> None:
         escaped = self._write(

--- a/daymade-claude-code/read-codex-history/scripts/_core/claude.py
+++ b/daymade-claude-code/read-codex-history/scripts/_core/claude.py
@@ -21,42 +21,51 @@ class ClaudeSessionSummary:
     timestamp_count: int
 
 
-def peek_claude_session_id(
+def peek_final_claude_session_id(
     path: Path,
     *,
     max_records: int = 32,
-    max_bytes: int = 256 * 1024,
+    max_bytes: int = 64 * 1024,
 ) -> Optional[str]:
-    """Read a bounded prefix for the first internal session id.
+    """Read a bounded EOF suffix for the final internal session id.
 
-    Candidate discovery needs the authoritative JSONL identity so renamed
-    active/archive copies still form one session, but it must not rescan every
-    transcript body merely to build that union. ``None`` means the prefix did
-    not prove an identity; callers must conservatively promote that file to the
-    full candidate path rather than trusting its filename stem.
+    The full metadata scanner preserves the last valid ``sessionId`` in a
+    JSONL file. Reading complete records backwards from EOF makes any ID found
+    here authoritative even when earlier records disagree, while keeping the
+    work bounded. ``None`` means the suffix did not prove an identity; callers
+    must conservatively promote that file to the full candidate path rather
+    than trusting a prefix or filename stem.
     """
-    records_read = 0
-    bytes_read = 0
     try:
         with path.open("rb") as handle:
-            for raw_line in handle:
-                if records_read >= max_records:
-                    return None
-                bytes_read += len(raw_line)
-                if bytes_read > max_bytes:
-                    return None
-                records_read += 1
-                try:
-                    record = json.loads(raw_line)
-                except (json.JSONDecodeError, UnicodeDecodeError):
-                    continue
-                if not isinstance(record, dict):
-                    continue
-                session_id = record.get("sessionId")
-                if isinstance(session_id, str) and session_id:
-                    return session_id
+            handle.seek(0, 2)
+            size = handle.tell()
+            start = max(0, size - max_bytes)
+            handle.seek(start)
+            suffix = handle.read(max_bytes)
     except (OSError, UnicodeError):
         return None
+
+    if start > 0:
+        first_newline = suffix.find(b"\n")
+        if first_newline < 0:
+            return None
+        suffix = suffix[first_newline + 1 :]
+
+    records_read = 0
+    for raw_line in reversed(suffix.splitlines()):
+        if records_read >= max_records:
+            return None
+        records_read += 1
+        try:
+            record = json.loads(raw_line)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        if not isinstance(record, dict):
+            continue
+        session_id = record.get("sessionId")
+        if isinstance(session_id, str) and session_id:
+            return session_id
     return None
 
 

--- a/daymade-claude-code/read-codex-history/scripts/_core/claude.py
+++ b/daymade-claude-code/read-codex-history/scripts/_core/claude.py
@@ -37,23 +37,26 @@ def peek_claude_session_id(
     """
     records_read = 0
     bytes_read = 0
-    with path.open("rb") as handle:
-        for raw_line in handle:
-            if records_read >= max_records:
-                return None
-            bytes_read += len(raw_line)
-            if bytes_read > max_bytes:
-                return None
-            records_read += 1
-            try:
-                record = json.loads(raw_line)
-            except (json.JSONDecodeError, UnicodeDecodeError):
-                continue
-            if not isinstance(record, dict):
-                continue
-            session_id = record.get("sessionId")
-            if isinstance(session_id, str) and session_id:
-                return session_id
+    try:
+        with path.open("rb") as handle:
+            for raw_line in handle:
+                if records_read >= max_records:
+                    return None
+                bytes_read += len(raw_line)
+                if bytes_read > max_bytes:
+                    return None
+                records_read += 1
+                try:
+                    record = json.loads(raw_line)
+                except (json.JSONDecodeError, UnicodeDecodeError):
+                    continue
+                if not isinstance(record, dict):
+                    continue
+                session_id = record.get("sessionId")
+                if isinstance(session_id, str) and session_id:
+                    return session_id
+    except (OSError, UnicodeError):
+        return None
     return None
 
 

--- a/daymade-claude-code/read-codex-history/scripts/_core/claude.py
+++ b/daymade-claude-code/read-codex-history/scripts/_core/claude.py
@@ -20,6 +20,22 @@ class ClaudeSessionSummary:
     timestamp_count: int
 
 
+def scan_claude_session_id(path: Path) -> str:
+    """Read only until the first internal session id, then stop.
+
+    Candidate discovery needs the authoritative JSONL identity so renamed
+    active/archive copies still form one session, but it must not rescan every
+    transcript body merely to build that union. Valid Claude session files use
+    one stable ``sessionId`` throughout; files without one retain the same
+    filename-stem fallback as :func:`scan_claude_session`.
+    """
+    for record in iter_jsonl(path):
+        session_id = record.get("sessionId")
+        if isinstance(session_id, str) and session_id:
+            return session_id
+    return path.stem
+
+
 def scan_claude_session(path: Path, max_title_chars: int = 120) -> ClaudeSessionSummary:
     """Scan every valid record and return internal time bounds plus title metadata.
 

--- a/daymade-claude-code/read-codex-history/scripts/_core/claude.py
+++ b/daymade-claude-code/read-codex-history/scripts/_core/claude.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -20,20 +21,40 @@ class ClaudeSessionSummary:
     timestamp_count: int
 
 
-def scan_claude_session_id(path: Path) -> str:
-    """Read only until the first internal session id, then stop.
+def peek_claude_session_id(
+    path: Path,
+    *,
+    max_records: int = 32,
+    max_bytes: int = 256 * 1024,
+) -> Optional[str]:
+    """Read a bounded prefix for the first internal session id.
 
     Candidate discovery needs the authoritative JSONL identity so renamed
     active/archive copies still form one session, but it must not rescan every
-    transcript body merely to build that union. Valid Claude session files use
-    one stable ``sessionId`` throughout; files without one retain the same
-    filename-stem fallback as :func:`scan_claude_session`.
+    transcript body merely to build that union. ``None`` means the prefix did
+    not prove an identity; callers must conservatively promote that file to the
+    full candidate path rather than trusting its filename stem.
     """
-    for record in iter_jsonl(path):
-        session_id = record.get("sessionId")
-        if isinstance(session_id, str) and session_id:
-            return session_id
-    return path.stem
+    records_read = 0
+    bytes_read = 0
+    with path.open("rb") as handle:
+        for raw_line in handle:
+            if records_read >= max_records:
+                return None
+            bytes_read += len(raw_line)
+            if bytes_read > max_bytes:
+                return None
+            records_read += 1
+            try:
+                record = json.loads(raw_line)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                continue
+            if not isinstance(record, dict):
+                continue
+            session_id = record.get("sessionId")
+            if isinstance(session_id, str) and session_id:
+                return session_id
+    return None
 
 
 def scan_claude_session(path: Path, max_title_chars: int = 120) -> ClaudeSessionSummary:

--- a/daymade-claude-code/read-codex-history/scripts/_core/text.py
+++ b/daymade-claude-code/read-codex-history/scripts/_core/text.py
@@ -441,11 +441,17 @@ def files_possibly_matching(
 
     marker_scan = [exe, "-a", "-F", "-l"]
     markers = list(_FOLDS_TO_ASCII)
-    # An ASCII query can match a non-ASCII full-fold equivalent stored as a
-    # JSON escape ("financial" vs "\\ufb01nancial"). Keep every escaped file
-    # in that case. For uncased Unicode queries, the mixed raw/escaped regex
-    # above is exact, so the broad marker would only re-admit the whole archive.
-    if any(keyword.isascii() for keyword in keyword_list):
+    # Any ASCII character in a query can match a non-ASCII full-fold
+    # equivalent stored as a JSON escape ("k" vs "\\u212a", "ss" vs
+    # "\\u00df"). This also matters inside a mixed keyword such as "自k";
+    # checking ``keyword.isascii()`` would miss that file before structured
+    # casefold matching. Pure uncased-Unicode queries use the exact mixed regex
+    # above, so they still avoid this broad archive marker.
+    if any(
+        character.isascii()
+        for keyword in keyword_list
+        for character in keyword
+    ):
         markers.append("\\u")
     for marker in markers:
         marker_scan += ["-e", marker]

--- a/daymade-claude-code/read-codex-history/scripts/_core/text.py
+++ b/daymade-claude-code/read-codex-history/scripts/_core/text.py
@@ -451,23 +451,27 @@ def files_possibly_matching(
                 ]
         mixed_scan.append("--")
 
-    marker_scan = [exe, "-a", "-F", "-l"]
-    markers = list(_FOLDS_CONTAINING_ASCII)
+    has_ascii_query_character = any(
+        character.isascii()
+        for keyword in keyword_list
+        for character in keyword
+    )
+    markers: list[str] = []
     # Any ASCII character in a query can match a non-ASCII full-fold
     # equivalent stored as a JSON escape ("k" vs "\\u212a", "ss" vs
     # "\\u00df"). This also matters inside a mixed keyword such as "自k";
     # checking ``keyword.isascii()`` would miss that file before structured
     # casefold matching. Pure uncased-Unicode queries use the exact mixed regex
     # above, so they still avoid this broad archive marker.
-    if any(
-        character.isascii()
-        for keyword in keyword_list
-        for character in keyword
-    ):
+    if has_ascii_query_character:
+        markers.extend(_FOLDS_CONTAINING_ASCII)
         markers.append("\\u")
-    for marker in markers:
-        marker_scan += ["-e", marker]
-    marker_scan.append("--")
+    marker_scan: Optional[list[str]] = None
+    if markers:
+        marker_scan = [exe, "-a", "-F", "-l"]
+        for marker in markers:
+            marker_scan += ["-e", marker]
+        marker_scan.append("--")
 
     # Batch the paths: one exec per ~half of ARG_MAX. Passing every path in a
     # single argv fails with E2BIG once the corpus is large enough — measured
@@ -550,7 +554,7 @@ def files_possibly_matching(
 
     if (
         not scan_all(kw_scan)
-        or not scan_all(marker_scan)
+        or (marker_scan is not None and not scan_all(marker_scan))
         or (mixed_scan is not None and not scan_all(mixed_scan))
     ):
         return None

--- a/daymade-claude-code/read-codex-history/scripts/_core/text.py
+++ b/daymade-claude-code/read-codex-history/scripts/_core/text.py
@@ -258,6 +258,42 @@ def keywords_are_raw_byte_safe(keywords: Iterable[str]) -> bool:
     )
 
 
+def keywords_are_file_prefilter_safe(keywords: Iterable[str]) -> bool:
+    """Can the two-pass file scanner safely rule out non-matching files?
+
+    This is intentionally broader than :func:`keywords_are_raw_byte_safe`.
+    Line-level filtering must see the keyword's literal bytes on the exact
+    physical line, so it remains ASCII-only.  File-level filtering also runs
+    the conservative ``_UNSCANNABLE_MARKERS`` pass: any file containing a
+    ``\\u`` escape or a non-ASCII character that folds to ASCII remains a
+    candidate and is fully parsed later.  That extra pass makes ordinary CJK
+    and one-codepoint Unicode folds safe without losing escaped archives.
+
+    File-level Unicode filtering is limited to uncased code points (CJK,
+    emoji, symbols).  Cased non-ASCII text such as ``café`` falls back to full
+    parsing: raw UTF-8 can be handled by ``rg -i``, but an archive may encode
+    uppercase ``É`` as ``\\u00c9`` while the query's lowercase ``é`` is
+    ``\\u00e9``.  Treating every file containing any ``\\u`` as a candidate
+    preserved correctness but destroyed the speedup on real archives.
+
+    Multi-codepoint full folds (``ß`` -> ``ss``, ligatures, dotted I) likewise
+    fall back to full parsing because ``rg -i`` performs simple folding and
+    cannot prove their absence. JSON-required/optional escape characters
+    remain unsafe for the same reason documented by
+    :func:`keywords_are_raw_byte_safe`.
+    """
+    return all(
+        bool(keyword)
+        and not _JSON_ESCAPED_CHAR_RE.search(keyword)
+        and all(len(character.casefold()) == 1 for character in keyword)
+        and all(
+            character.isascii() or character.lower() == character.upper()
+            for character in keyword
+        )
+        for keyword in keywords
+    )
+
+
 def files_possibly_matching(
     paths: Iterable[Path],
     keywords: Iterable[str],
@@ -305,7 +341,11 @@ def files_possibly_matching(
     """
     path_list = list(paths)
     keyword_list = list(keywords)
-    if not path_list or not keyword_list or not keywords_are_raw_byte_safe(keyword_list):
+    if (
+        not path_list
+        or not keyword_list
+        or not keywords_are_file_prefilter_safe(keyword_list)
+    ):
         return None
     exe = shutil.which("rg") or shutil.which("grep")
     if not exe:
@@ -333,10 +373,20 @@ def files_possibly_matching(
         kw_scan.append("-i")
     for kw in keyword_list:
         kw_scan += ["-e", kw]
+        escaped = json.dumps(kw, ensure_ascii=True)[1:-1]
+        if escaped != kw:
+            kw_scan += ["-e", escaped]
     kw_scan.append("--")
 
     marker_scan = [exe, "-a", "-F", "-l"]
-    for marker in _UNSCANNABLE_MARKERS:
+    markers = list(_FOLDS_TO_ASCII)
+    # An ASCII query can match a non-ASCII full-fold equivalent stored as a
+    # JSON escape ("financial" vs "\\ufb01nancial"). Keep every escaped file
+    # in that case. For uncased Unicode queries, the exact escaped keyword was
+    # added above, so the broad marker would only re-admit the whole archive.
+    if any(keyword.isascii() for keyword in keyword_list):
+        markers.append("\\u")
+    for marker in markers:
         marker_scan += ["-e", marker]
     marker_scan.append("--")
 

--- a/daymade-claude-code/read-codex-history/scripts/_core/text.py
+++ b/daymade-claude-code/read-codex-history/scripts/_core/text.py
@@ -246,10 +246,10 @@ def keywords_are_raw_byte_safe(keywords: Iterable[str]) -> bool:
        some writers emit ``\\/``, so it is excluded for the same reason.
 
     Falling back is always the safe direction: it costs speed, never a missed
-    match. The cost is real and worth naming — a non-ASCII query (any CJK one)
-    gets no pre-filter at all and pays the full parse. Correctness first: this
-    tool's callers are told they may conclude a topic is absent from a
-    no-match result.
+    match. This function therefore keeps non-ASCII out of the *line-level*
+    literal filter. Callers may still use the separate file-level mixed-JSON
+    regex below for uncased Unicode such as CJK. Correctness first: this tool's
+    callers are told they may conclude a topic is absent from a no-match result.
     """
     return all(
         kw.isascii()
@@ -263,11 +263,11 @@ def keywords_are_file_prefilter_safe(keywords: Iterable[str]) -> bool:
 
     This is intentionally broader than :func:`keywords_are_raw_byte_safe`.
     Line-level filtering must see the keyword's literal bytes on the exact
-    physical line, so it remains ASCII-only.  File-level filtering also runs
-    the conservative ``_UNSCANNABLE_MARKERS`` pass: any file containing a
-    ``\\u`` escape or a non-ASCII character that folds to ASCII remains a
-    candidate and is fully parsed later.  That extra pass makes ordinary CJK
-    and one-codepoint Unicode folds safe without losing escaped archives.
+    physical line, so it remains ASCII-only. File-level filtering can use an
+    exact regex whose every code point accepts either raw UTF-8 or its JSON
+    ``\\u`` representation; that covers fully escaped *and mixed* JSON strings
+    without admitting every file that happens to contain some unrelated
+    Unicode escape.
 
     File-level Unicode filtering is limited to uncased code points (CJK,
     emoji, symbols).  Cased non-ASCII text such as ``café`` falls back to full
@@ -292,6 +292,39 @@ def keywords_are_file_prefilter_safe(keywords: Iterable[str]) -> bool:
         )
         for keyword in keywords
     )
+
+
+def _json_unicode_escape(character: str) -> str:
+    """Encode one code point using JSON's ``\\u`` form, including ASCII."""
+    if character.isascii():
+        return f"\\u{ord(character):04x}"
+    return json.dumps(character, ensure_ascii=True)[1:-1]
+
+
+def _mixed_json_keyword_regex(keyword: str, *, case_sensitive: bool) -> str:
+    """Return an exact regex for every legal raw/``\\u`` mixture of keyword.
+
+    JSON permits each otherwise-safe character to appear literally or as a
+    Unicode escape, even inside one word (``自\\u52a8``). A pair of fixed-string
+    patterns for the all-raw and all-escaped forms therefore under-approximates
+    the parsed text. One linear-size regex avoids the exponential list of all
+    mixtures. Scoped ``(?i:...)`` applies only to hexadecimal escape digits so
+    ``--case-sensitive`` still governs the decoded text rather than the JSON
+    encoder's arbitrary choice of ``a-f`` versus ``A-F``.
+    """
+    pieces: list[str] = []
+    for character in keyword:
+        raw = re.escape(character)
+        codepoints = {ord(character)}
+        if not case_sensitive and character.isascii() and character.isalpha():
+            codepoints.update({ord(character.lower()), ord(character.upper())})
+        escaped_alternatives = {
+            f"(?i:{re.escape(_json_unicode_escape(chr(codepoint)))})"
+            for codepoint in codepoints
+        }
+        alternatives = [raw, *sorted(escaped_alternatives)]
+        pieces.append(f"(?:{'|'.join(alternatives)})")
+    return "".join(pieces)
 
 
 def files_possibly_matching(
@@ -350,18 +383,30 @@ def files_possibly_matching(
     exe = shutil.which("rg") or shutil.which("grep")
     if not exe:
         return None
+    has_unicode_keyword = any(
+        not character.isascii()
+        for keyword in keyword_list
+        for character in keyword
+    )
+    # The exact mixed raw/escaped matcher below relies on ripgrep's Rust regex
+    # syntax. Plain grep remains a safe ASCII fallback; Unicode degrades to the
+    # original full structured scan instead of trusting a different regex
+    # dialect.
+    if has_unicode_keyword and Path(exe).name != "rg":
+        return None
     # -a/--text: never let the binary-content heuristic skip a JSONL file that
     #   happens to contain a byte sequence that looks binary.
     # -F: keywords are literal substrings everywhere else in this codebase
     #   (Python's str.count(), not a regex) — a raw scan must match the same
     #   semantics, not treat a keyword like "a.b" as a wildcard pattern.
     # -l: list matching filenames only; we don't need line numbers here.
-    # Two scans, unioned — they need opposite case settings.
+    # Three scans are unioned; the fixed-string and structural-marker passes
+    # need opposite case settings, while the regex pass models decoded JSON.
     #
     # Pass 1 matches the keywords the way the real matcher does (folded, unless
     # the caller asked for case-sensitive).
     #
-    # Pass 2 looks for content the byte scanner cannot reason about at all
+    # Pass 3 looks for content the byte scanner cannot reason about at all
     # (fold-equivalent characters, "\u" escapes) and MUST be case-sensitive.
     # Handing those characters to a "-i" scan is self-defeating: "-i" folds the
     # *pattern* too, so `ſ` matches a plain `s` and `K` (U+212A) matches `k` —
@@ -378,12 +423,28 @@ def files_possibly_matching(
             kw_scan += ["-e", escaped]
     kw_scan.append("--")
 
+    mixed_scan: Optional[list[str]] = None
+    if has_unicode_keyword:
+        mixed_scan = [exe, "-a", "-l"]
+        if not case_sensitive:
+            mixed_scan.append("-i")
+        for keyword in keyword_list:
+            if any(not character.isascii() for character in keyword):
+                mixed_scan += [
+                    "-e",
+                    _mixed_json_keyword_regex(
+                        keyword,
+                        case_sensitive=case_sensitive,
+                    ),
+                ]
+        mixed_scan.append("--")
+
     marker_scan = [exe, "-a", "-F", "-l"]
     markers = list(_FOLDS_TO_ASCII)
     # An ASCII query can match a non-ASCII full-fold equivalent stored as a
     # JSON escape ("financial" vs "\\ufb01nancial"). Keep every escaped file
-    # in that case. For uncased Unicode queries, the exact escaped keyword was
-    # added above, so the broad marker would only re-admit the whole archive.
+    # in that case. For uncased Unicode queries, the mixed raw/escaped regex
+    # above is exact, so the broad marker would only re-admit the whole archive.
     if any(keyword.isascii() for keyword in keyword_list):
         markers.append("\\u")
     for marker in markers:
@@ -469,7 +530,11 @@ def files_possibly_matching(
             used += size
         return not batch or run_batch(scan_prefix, batch)
 
-    if not scan_all(kw_scan) or not scan_all(marker_scan):
+    if (
+        not scan_all(kw_scan)
+        or not scan_all(marker_scan)
+        or (mixed_scan is not None and not scan_all(mixed_scan))
+    ):
         return None
     return matched
 

--- a/daymade-claude-code/read-codex-history/scripts/_core/text.py
+++ b/daymade-claude-code/read-codex-history/scripts/_core/text.py
@@ -198,12 +198,24 @@ _FOLDS_TO_ASCII = tuple(
     and chr(cp).casefold().strip()
 )
 
+# A substring query needs one wider class: U+0130 casefolds to ``i`` plus a
+# combining dot, so the ASCII query ``i`` legitimately matches even though the
+# whole fold is not ASCII. Seven other code points have the same shape. Keep
+# the narrower table above as its existing contract and derive this superset
+# from Python's matcher semantics as well.
+_FOLDS_CONTAINING_ASCII = tuple(
+    chr(cp)
+    for cp in range(0x80, 0x11000)
+    if chr(cp).casefold() != chr(cp)
+    and any(character.isascii() for character in chr(cp).casefold())
+)
+
 # Any of these in a file/line means a byte scan cannot rule it out:
 #   - the fold-equivalent characters above
 #   - a "\u" escape: content written with ensure_ascii=True stores non-ASCII
 #     that way, and some writers (Go's encoding/json) escape even ASCII
 #     "<" ">" "&" as </>/&
-_UNSCANNABLE_MARKERS = _FOLDS_TO_ASCII + ("\\u",)
+_UNSCANNABLE_MARKERS = _FOLDS_CONTAINING_ASCII + ("\\u",)
 
 
 def keywords_are_raw_byte_safe(keywords: Iterable[str]) -> bool:
@@ -440,7 +452,7 @@ def files_possibly_matching(
         mixed_scan.append("--")
 
     marker_scan = [exe, "-a", "-F", "-l"]
-    markers = list(_FOLDS_TO_ASCII)
+    markers = list(_FOLDS_CONTAINING_ASCII)
     # Any ASCII character in a query can match a non-ASCII full-fold
     # equivalent stored as a JSON escape ("k" vs "\\u212a", "ss" vs
     # "\\u00df"). This also matters inside a mixed keyword such as "自k";

--- a/daymade-claude-code/read-codex-history/scripts/analyze_sessions.py
+++ b/daymade-claude-code/read-codex-history/scripts/analyze_sessions.py
@@ -2165,14 +2165,13 @@ def main():
     search_parser.add_argument(
         "--no-prefilter",
         action="store_true",
-        help="Disable the rg/grep raw-byte pre-filter and fully parse every "
-        "session file. The pre-filter is designed to be a pure speedup: it "
-        "only runs for keywords whose bytes must appear verbatim in the file "
-        "(ASCII, no '/', no control characters), and disables itself for the "
-        "rest — so a non-ASCII query (any CJK one) already parses everything "
-        "and this flag changes nothing for it. Use this to verify the "
-        "pre-filter's neutrality on an ASCII query, or to rule it out when "
-        "diagnosing a suspected missed match.",
+        help="Disable native file/line pre-filters and fully parse every "
+        "session file. The filters are conservative speedups: ordinary ASCII "
+        "uses literal matching, and uncased Unicode such as CJK uses an exact "
+        "raw/JSON-escaped file regex when ripgrep is available. Unsafe escape "
+        "characters, cased or multi-codepoint Unicode folds, missing tools, "
+        "and scanner errors already fall back to full parsing. Use this flag "
+        "to verify output neutrality or diagnose a suspected missed match.",
     )
     _add_home_flags(search_parser)
 

--- a/daymade-claude-code/read-codex-history/tests/test_analyze_sessions.py
+++ b/daymade-claude-code/read-codex-history/tests/test_analyze_sessions.py
@@ -1280,6 +1280,7 @@ class RawBytePrefilterSafetyTests(unittest.TestCase):
             ("the ﬁnancial model is attached", "financial"),
             ("DIE STRAẞE IST LANG", "strasse"),
             ("a ﬅudy of ﬆate machines", "study"),
+            ("İstanbul and 自İ", "自i"),
         ):
             with self.subTest(content=content):
                 self._assert_search_finds(content, keyword)
@@ -1295,6 +1296,15 @@ class RawBytePrefilterSafetyTests(unittest.TestCase):
         for ch in _FOLDS_TO_ASCII:
             self.assertFalse(ch.isascii(), f"{ch!r} is already ASCII")
             self.assertTrue(ch.casefold().isascii(), f"{ch!r} does not fold to ASCII")
+
+        from _core.text import _FOLDS_CONTAINING_ASCII
+
+        self.assertIn("İ", _FOLDS_CONTAINING_ASCII)
+        for ch in _FOLDS_CONTAINING_ASCII:
+            self.assertTrue(
+                any(part.isascii() for part in ch.casefold()),
+                f"{ch!r} has no ASCII substring after casefold",
+            )
 
     def _assert_search_finds(self, content: str, keyword: str,
                              ensure_ascii: bool = False) -> None:


### PR DESCRIPTION
## Outcome

- Discover Claude keyword candidates before full-session parsing, using a bounded EOF identity index and exact physical-path selection.
- Preserve renamed active/archive unions, final-ID exclusion, provenance, untimed counts, totals, and `--no-prefilter` semantics.
- Make the shared Unicode prefilter safe for raw/escaped/mixed CJK and Python casefold edge cases; keep pure CJK on the exact path.
- Scope the release note accurately: Claude gets candidate-first discovery; both readers share the Unicode fix.

## Evidence

- `read-claude-code-history`: 167 tests passed.
- `read-codex-history`: 123 tests passed.
- Shared core sync, both `quick_validate` runs, plugin validation, and both existing-skill migration audits passed.
- Representative multi-thousand-session CJK search completes in about 11 seconds with under 1% of sessions fully parsed; the prior brute-force path was interrupted after 94 seconds.
- Fresh-context final release gate: PASS, no BLOCKER/MAJOR.