### PR TITLE
docs(claude-code-hooks): heredoc 有 cheap middle ground（推翻本文件旧断言）+ 两个软链/路径盲区

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -104,7 +104,7 @@
       "description": "Claude Code operations suite that bundles cross-project prior-work retrieval across code, docs, Skills, meetings, WeChat archives, and conversation history; provider-separated Claude Code and Codex history readers; identity- and lineage-gated continuation workflows; plugin/skill troubleshooting; CLAUDE.md progressive disclosure optimization; version-synced Lark CLI routing; statusline configuration; exported .txt repair; full claude.ai conversation extraction with tool-call rendering and file download; plugin marketplace development and suite consolidation; writing/testing/debugging Claude Code hooks; multi-provider profile isolation; personal-memory migration into tool-agnostic AGENTS.md reference docs; one-shot local timers that ping Claude right after subscription quota reset to start a fresh 5-hour usage window; and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
       "source": "./daymade-claude-code",
       "strict": false,
-      "version": "3.7.6",
+      "version": "3.7.7",
       "category": "suite",
       "keywords": [
         "suite",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **claude-code-hooks** (`daymade-claude-code` v3.7.7): the skill asserted that a non-git
+  heredoc whose body carries trigger-looking data leaves a fail-closed guard with "no cheap
+  middle ground" — only declare-it-fail-open or a real shell grammar. That is now shown to be
+  wrong, with the middle ground and its contract: **strip heredoc bodies by sink**. A body
+  feeding a data consumer (`git commit -F -`, `python3 - <<'PY'`) is data and comes out; a body
+  feeding a shell (`cat > x.sh <<'EOS'`, `bash <<'EOS'`, `ssh host <<'EOS'`) *is* command text
+  and stays in. The `keep` branch is the half a first cut omits, and omitting it is not
+  cosmetic: on an 852-command replay the wholesale-strip version passed its fixtures and then
+  missed that shape's only true positive in the corpus, which lived inside a `cat > … <<'EOS'`
+  that was executed two lines later. The published contract states the failure direction (an
+  unnamed sink means the body is stripped — a miss, never a false block, per rule 1), that it
+  does not raise pitfall #11's grammar ceiling, and that the sink list is the only side safe to
+  extend. The same walker section carried the overturned claim a second time — its
+  false-block-direction list headed with "non-git heredoc bodies (declared, not patched)" and a
+  blanket "each block-side entry is declared because fixing it takes real shell grammar." Both
+  were corrected in place; leaving them would have had the file assert "only a grammar fixes
+  this" and "a heuristic fixes most of this" about one category within twenty lines.
+  Recipe smoke-run verbatim (11 shapes, including the three the prose names as genuine misses).
+
+  Two new pitfalls, both measured while writing a guard under this skill's own rules:
+  **#42** — a hook that locates a sibling file with `dirname "${BASH_SOURCE[0]}"` looks in the
+  wrong directory, because rule 3 requires `~/.claude/hooks/<name>.sh` to be a symlink and
+  `BASH_SOURCE` is the *invocation* path. The sibling lookup exits 127, and the SessionStart
+  health check renders that as `selftest failed` for a completely healthy guard — a permanent
+  false alarm, the direction that trains operators to ignore the whole line. Same root as #41
+  (unresolved symlink), different victim (locates from the link vs stats the link); the two now
+  cross-reference. Fix is the portable link-walk loop, plus the calibration that catches it:
+  exercise the selftest through the *registered* path, not only the SSOT path.
+  **#43** — `settings.json` hook paths come in three spellings (measured in one active profile:
+  45 `~/…`, 8 absolute, 5 `$HOME/…`; all three fire). A consumer that expands only `~` leaves
+  `$HOME` literal, the path fails `[ -r ]`, and the tool files live guards under "can't check
+  this one" — four registered PreToolUse guards had never actually been audited. One-way
+  silent, and toward false *unknown*, which reads as noise. Fix expands both; the calibration
+  is asserting targets-found equals entries-registered.
+
+  Rule 9 (corpus replay) gains the false-positive family that is structural rather than
+  incidental: for a guard whose detector is a text pattern, **documenting the anti-pattern
+  reproduces its own trigger**. Of the 4 corpus commands matching that guard's headline shape,
+  3 were healthy — a commit message about the guard, a doc write embedding the pattern, and the
+  calibration command that runs the bad form beside the good one. A naive detector would have
+  been 75% wrong on its own signature shape, blocking its author mid-sentence. Retired by the
+  sink-discriminating stripper plus a "correct form present in the same command" exemption,
+  the same shape as a `pipefail` escape hatch.
 - **daymade-audio / asr-transcribe-to-text** (`daymade-audio` v1.32.4): prevent single-character or degenerate aligned turns from emitting `start == end` and `duration == 0`. The Qwen aligner and Whisper.cpp late-fusion producer now share one half-up integer-millisecond contract for direct and interpolated lattice points, turn fields, TXT, CSV, and alignment JSON; degenerate turns receive only the smallest 1 ms interval and never borrow a later timestamp across a speaker change or long silence. Both speaker-bundle producers record their reviewed edge-inheritance tolerance in the final receipt (Qwen 1 s; overlap-only fusion 0 s), and the shared time-contract module is covered by each pipeline hash. This keeps identically named artifacts semantically consistent without weakening downstream positive-duration or diarization-support checks; the receipt-less legacy cascade remains outside the strict bundle contract.
 - **pdf-creator** (`daymade-docs` v1.13.0): the table-border check could clear the defect it
   exists to catch, and separately failed most healthy documents. Both were found by calibrating

--- a/daymade-claude-code/claude-code-hooks/.security-scan-passed
+++ b/daymade-claude-code/claude-code-hooks/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-08-25T12:02:35.358857+00:00
+Scanned at: 2026-08-30T12:46:44.891001+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 141499a4a63982ec033db0e4846567273e2d0caa49ae55f3340ac2581e3925a7
+Content hash: c03c790a2f86c0bf009eb4bf349695c0ef885915f218e21f8d3a11264cde7317

--- a/daymade-claude-code/claude-code-hooks/SKILL.md
+++ b/daymade-claude-code/claude-code-hooks/SKILL.md
@@ -990,6 +990,30 @@ blind spot one step short of self-lockout. Once a guard HAS locked you out, the 
 routes are in **#3**'s list (edit `settings.json` with the Edit/Write tool, which never
 fires a `Bash` matcher; or start a session with a different `CLAUDE_CONFIG_DIR`).
 
+That clustering is a tendency. For a guard whose detector is a **text pattern**, one
+family of it is a certainty instead: **documenting the anti-pattern reproduces its own
+trigger.** The commit message explaining the guard, the doc example, the note you write
+into your own knowledge base — each carries the banned shape verbatim, as data, and each
+lands in the corpus. Measured 2026-08-30 on an 852-command replay: of the 4 commands
+matching the guard's headline shape, **3 were healthy** — a commit message about the
+guard, a doc write embedding the pattern, and the calibration command that deliberately
+runs the bad form beside the good one to show the difference. A detector taking the
+pattern at face value would have been **75% wrong on its own signature shape**, and every
+one of those blocks would have landed on the author mid-sentence, while writing the guard
+up. Two exemptions retire the family, and neither is a special case: **data-sink heredoc
+bodies** (`references/hook_patterns.md`, under the command-position walker's heredoc
+limits — the sink-discriminating stripper), which covers the commit message and the doc
+write; and **the correct form present in the same command**, which covers the calibration
+— an author who wrote the fix beside the bug is demonstrating it, not committing it. The
+second is the same shape as the `pipefail` escape hatch a pipe-fallback guard uses: the
+command carries evidence that its author already knows, so stop arguing with them. Its
+mechanism is one more literal test, run **before** the detector and short-circuiting it —
+for `pipe-fallback-guard` that is the substring set `pipefail`/`PIPESTATUS`/`pipestatus`
+(rule 4); for a detector with a canonical fix, it is that fix's distinctive fragment.
+Keep it narrow and literal: a *pattern* for the correct form re-opens the whole guessing
+problem, whereas a fixed string an author had to type on purpose is hard to hit by
+accident, and its failure direction is a miss.
+
 Sizing, so this doesn't read as a research project: one harvest plus one loop, minutes of
 wall time.
 

--- a/daymade-claude-code/claude-code-hooks/references/hook_patterns.md
+++ b/daymade-claude-code/claude-code-hooks/references/hook_patterns.md
@@ -539,15 +539,19 @@ variables-as-commands (`CMD=TRIGGER; $CMD -t x`); and mid-word `#` in the
 *miss* direction (`foo=#x TRIGGER` — bash treats it as an assignment and DOES
 run TRIGGER, shlex's commenter eats the line instead).
 
-**False-block-direction (currently blocks — declared, not patched):** non-git
-heredoc bodies (the residual below); multiline `case` patterns (`TRIGGER)` at a
-line head is a pattern, not a call); and `TRIGGER#frag` (shlex's posix lexer
-starts a comment at the mid-word `#`, bash doesn't — though in that shape bash
-itself errors command-not-found, so the practical harm is low).
+**False-block-direction (currently blocks — declared, not patched):** multiline
+`case` patterns (`TRIGGER)` at a line head is a pattern, not a call); and
+`TRIGGER#frag` (shlex's posix lexer starts a comment at the mid-word `#`, bash
+doesn't — though in that shape bash itself errors command-not-found, so the
+practical harm is low). **Non-git heredoc bodies used to head this list; they are
+now largely patchable** — see the sink-discriminating stripper below, which cuts
+the false-block surface without a grammar, at the cost of a bounded miss.
 
-Each miss-side entry is declared rather than patched per bias-to-under; each
-block-side entry is declared because fixing it takes real shell grammar, not
-more heuristics. Production qlmanage-guard shares most of these.
+Each miss-side entry is declared rather than patched per bias-to-under. The
+block-side entries left in that list are declared because fixing *them* takes
+real shell grammar rather than more heuristics — a claim worth stating per entry
+instead of as a rule about the whole side, since the heredoc entry disproved the
+general form. Production qlmanage-guard shares most of these.
 
 **What it splits but cannot fully parse:** a newline **inside a heredoc body** —
 a heredoc is not quote syntax, so `git commit -F - <<'MSG'` whose body quotes a
@@ -561,9 +565,77 @@ reminder, declare it and move on; for a fail-closed blocker, lift the git-write
 exemption (pitfall #7) to the whole command BEFORE this walk — exactly the
 order Pattern A shows. But note the exemption's name: it rescues **git**
 heredocs only. A non-git one (`cat <<'EOF'` whose body contains
-trigger-looking data) still false-blocks a fail-closed guard, and for that
-shape the honest options are declare-it-fail-open or a real shell grammar —
-there is no cheap middle ground.
+trigger-looking data) still false-blocks a fail-closed guard.
+
+**Generalizing the exemption: strip heredoc bodies by SINK, not wholesale.**
+The git-write exemption works because `git commit -F -` consumes its heredoc as
+*data*. That property is not specific to git, and it is decidable from the
+introducing line alone — which makes a cheap middle ground available after all,
+provided you take its contract with it.
+
+```python
+import re
+
+# Heredoc bodies whose sink is a DATA consumer are stripped; bodies whose sink is
+# a SHELL are kept, because there the body IS command text.
+SHELL_SINK = re.compile(
+    r">\s*\S+\.(?:sh|bash|zsh)\b"                    # cat > install.sh <<'EOS'
+    r"|(?:^|[|;&]|\$\()\s*(?:bash|sh|zsh|ssh)\b")    # bash <<'EOS' / ssh host <<'EOS'
+
+def strip_heredocs(cmd):
+    lines, out, i = cmd.split("\n"), [], 0
+    while i < len(lines):
+        intro = lines[i]
+        out.append(intro)
+        tags = [(a or b or c) for a, b, c in re.findall(
+            r"<<-?[ \t]*(?:'([^']*)'|\"([^\"]*)\"|([A-Za-z_][A-Za-z0-9_]*))", intro)]
+        keep = bool(SHELL_SINK.search(intro))        # this line decides
+        i += 1
+        for tag in tags:
+            if not tag:
+                continue
+            while i < len(lines) and lines[i].strip() != tag:
+                if keep:
+                    out.append(lines[i])             # shell source — still inspected
+                i += 1
+            i += 1                                   # eat the terminator line
+    return "\n".join(out)
+```
+
+The `keep` branch is the half a first cut gets wrong, and it is not a corner
+case: `cat > <file>.sh <<'EOS' … EOS` followed by executing that file is how
+agents routinely write scripts, so a stripper without it goes blind to exactly
+the commands most worth inspecting. Measured 2026-08-30, on the 852 real
+commands of the session that wrote the guard: the wholesale-strip version passed
+its fixtures and then **missed that shape's only true positive in the whole
+corpus**, because it lived inside `cat > watcher.sh <<'EOS'` and was executed
+two lines later. Swapping in the sink-discriminating version recovered it, and
+across all four of that guard's detectors the replay ended at **10 blocks, 0
+false blocks over 852 commands** — with three near-miss commands correctly
+*allowed*, all three of which quoted the guard's own target pattern verbatim as
+prose (see rule 9 in SKILL.md for why a text-pattern guard's corpus always
+contains those).
+
+Take the contract with the code, because this is a heuristic with a direction,
+not a parser:
+
+- **Failure direction is toward the miss.** A shell sink the regex does not name
+  means the body gets stripped and its contents go uninspected. Three real shapes,
+  all verified against the code above rather than assumed: an interpreter not in the
+  alternation (`fish <<EOS`), one reached **through a wrapper** (`timeout 5 bash
+  <<EOS`), and one **invoked by path** (`/bin/zsh <<EOS`) — the second branch anchors
+  the shell name at a command position (`^`, after `|;&`, or after `$(`), so a leading
+  `/bin/` or a wrapper token puts it out of reach. Missing them is rule 1's preferred
+  direction — a miss, never a false block — and it is why this is honest rather than
+  complete. Check your own additions the same way: run the function on the shape and
+  look at whether the body survived, because the alternation reads as if it covers
+  more than it does.
+- **It does not make the guard grammar-correct.** A command you genuinely want
+  blocked, sitting in a heredoc fed to an unlisted sink, still passes. If you need
+  that, you still need a real shell grammar; nothing here changes #11's ceiling.
+- **Extend the sink list, never the strip list.** Adding a sink to `SHELL_SINK`
+  can only turn a miss into a block on *executed* text. Loosening in the other
+  direction — stripping more bodies — is what re-opens the blind spot above.
 
 ---
 

--- a/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
+++ b/daymade-claude-code/claude-code-hooks/references/hook_pitfalls.md
@@ -2103,3 +2103,100 @@ this list and describe defects you reach by asking a different question):
   has to exercise the link: a case that **edits the SSOT without touching the
   symlink** and asserts the expensive path fires. A suite that stats a real file
   passes with `-L` missing, which is why the bug shipped in the first cut.
+- **Sibling:** #42 is the same root (rule 3's symlink, left unresolved) with a
+  different victim — that one **locates** a sibling file from the link's directory
+  instead of stat-ing the link. When you fix either, grep the hook for every other
+  use of its own path.
+
+## 42. A symlinked hook that locates a sibling file with `dirname "${BASH_SOURCE[0]}"` looks in the wrong directory — and the miss is reported as "selftest failed"
+
+- **Symptom:** the hook's `--selftest` passes when you run it by its SSOT path, and
+  the SessionStart health check reports `selftest failed: <hook>` for the same file
+  on every session. Nothing else is wrong: `bash -n` is clean, the detector blocks
+  and allows correctly, the registration is present. Only the health check disagrees,
+  and only ever in one direction.
+- **Precondition (or you will not see this at all):** the health check has to actually
+  run the selftest. Pattern C as printed in `hook_patterns.md` does **not** — it does
+  `bash -n` plus a registration `grep`. It is SKILL.md's **build order step 4** that
+  extends that same loop with `bash "$h" "$mode"` over the registered-hooks path. So
+  this pitfall bites the design this skill prescribes in full, not the compact skeleton
+  alone; if your health check only syntax-checks, a broken sibling lookup stays invisible
+  until the day you need the battery.
+- **Cause:** the same two prescriptions as #41, composing through a different
+  mechanism. Rule 3 requires `~/.claude/hooks/<name>.sh` to be a **symlink** into the
+  SSOT; that build-order health check invokes hooks by that path. `${BASH_SOURCE[0]}` is the path
+  bash was **invoked with**, not the resolved file — so inside the hook
+  `dirname "${BASH_SOURCE[0]}"` is `~/.claude/hooks`, and a sibling lookup such as
+  `exec bash "$(dirname "${BASH_SOURCE[0]}")/<name>.test.sh"` finds nothing and exits
+  **127**. To the health check 127 is simply non-zero, so a fully healthy guard is
+  advertised as broken at every session start — which is the expensive direction:
+  a permanent false alarm trains the operator to ignore that whole line of output.
+  Where #41 **stats** the link instead of the target, this one **locates from** it.
+  Anything that resolves a path out of `$0`/`BASH_SOURCE` is in this family:
+  a bundled library it sources, a fixture directory, a template.
+- **Fix:** walk the link chain before taking `dirname`. What you need is *resolve
+  every hop, then take the directory* — name the behavior rather than a flag, because
+  the flag's availability is exactly the thing that varies. `readlink -f` does it in
+  one call and **current macOS does ship it** (verified on Darwin 25.5: `/usr/bin/readlink`
+  is a real BSD binary and `-f` resolves a two-hop chain), but it is not in POSIX and
+  older BSDs omit it, and a hook runs on whatever machine installed it. The loop below
+  depends on no flag at all:
+  ```bash
+  _self="${BASH_SOURCE[0]}"
+  while [ -L "$_self" ]; do
+    _link=$(readlink "$_self")
+    case "$_link" in
+      /*) _self="$_link" ;;                          # absolute target
+      *)  _self="$(dirname "$_self")/$_link" ;;      # relative to the link's dir
+    esac
+  done
+  _dir=$(cd "$(dirname "$_self")" && pwd)
+  ```
+- **The calibration that catches it, and the reason it shipped:** the author tests
+  the hook the way the author invokes it — by the SSOT path, where `dirname` is
+  accidentally right. **Run the selftest through the registered path too**
+  (`bash ~/.claude/hooks/<name>.sh --selftest-full`), because that is the path the
+  harness will use. The general form: a hook reached through more than one path is a
+  hook that must be exercised through each of them. Same lesson as #41's
+  "the regression test has to exercise the link".
+- **Diagnosing it from the outside** (you see only `selftest failed`): run the two
+  paths side by side and compare — identical output means the fault is real, an
+  exit 127 from the registered path means it is this pitfall.
+
+## 43. `settings.json` hook paths come in three spellings, and a consumer that expands only `~` silently rates live guards "unreadable"
+
+- **Symptom:** an auditor, health check, or migration script that iterates the
+  **registered** hooks reports a subset as unreadable / unauditable / not found, and
+  therefore skips them. Those hooks are live and firing. The report is not empty and
+  not obviously wrong — it just quietly has a hole with a plausible-looking label.
+- **Cause:** a hook's `command` is a shell-ish string, and real settings files mix
+  spellings, because they accumulate over months from different sessions and
+  installers. One active profile, measured 2026-08-30: **45** entries as
+  `~/.claude/hooks/<name>.sh`, **8** fully absolute, **5** as
+  `$HOME/.claude/hooks/<name>.sh`. All three fire (verified live in both the `~` and
+  the `$HOME` form). Python's `os.path.expanduser` resolves `~` and passes absolute
+  paths through, but leaves `$HOME` **literal**; the path then fails `[ -r ]` /
+  `os.path.exists` and the consumer files it under "can't check this one". The tool
+  that surfaced this enumerates `PreToolUse` only (the one event where `exit 2` has
+  blocking semantics), and **4 of those 5 `$HOME`-spelled entries are `PreToolUse`** —
+  so four registered blocking guards had never actually been audited by it, which is
+  exactly the population it existed to cover. Quote the scope with the count, or the
+  two numbers look like they should match and don't.
+- **Direction:** one-way and silent. It never rates a broken guard healthy; it rates
+  **healthy guards unknown** — and "unknown" in an audit output reads as noise, so
+  nobody chases it. A checker with a blind spot is worse than a missing checker,
+  because its green covers the gap.
+- **Fix:** expand both, in either language.
+  ```python
+  p = os.path.expanduser(os.path.expandvars(cmd.split()[0]))   # $HOME then ~
+  ```
+  ```bash
+  p="${cmd%% *}"; p="${p/#\$HOME/$HOME}"; p="${p/#\~/$HOME}"   # no eval — the
+  # command string is config data, and `eval` on it turns a settings file into
+  # code execution
+  ```
+- **Calibration (the check that would have caught it in one line):** before trusting
+  any sweep over registered hooks, assert **targets found == entries registered**.
+  A sweep that silently drops 5 of 58 is indistinguishable from one that covers
+  everything, unless you compare the two counts. Same instrument discipline as
+  rule 9's "a replay returning zero blocks makes the harness a suspect".


### PR DESCRIPTION
## 这次改动推翻了本 skill 自己的一条显式断言

`references/hook_patterns.md` 原文写着：非 git 的 heredoc 体带着 trigger 样文本时会误伤
fail-closed guard，而 *"the honest options are declare-it-fail-open or a real shell grammar —
**there is no cheap middle ground**"*。

**中间地带存在**，配方与合同一起发布：**按 sink 剥离 heredoc 体，不是一刀切**。
喂给数据消费者的体（`git commit -F -`、`python3 - <<'PY'`）是数据，剥掉；喂给 shell 的体
（`cat > x.sh <<'EOS'`、`bash <<'EOS'`、`ssh host <<'EOS'`）**就是命令文本**，留下受检。

`keep` 那一半是第一版必然写漏的，而漏掉它不是小事：852 条真实命令回放里，一刀切版本
通过了自己的 fixture，然后漏掉了那个形状在全语料里唯一的真阳性——它就写在
`cat > … <<'EOS'` 里，两行之后被执行。

合同随代码一起给：失败方向朝漏（未命名的 sink → 体被剥 → 漏拦，不是误杀，合 rule 1 的
方向）、不抬高 pitfall #11 的语法天花板、只有 sink 名单这一侧可以扩。

**同一小节里那条断言还有第二处副本**（false-block-direction 清单把非 git heredoc 列为
「已声明、未修补」+ 一句「each block-side entry 需要真语法」的概括），一并就地修正。
留着它，本文件会在 20 行内同时断言「只有真语法能修」和「启发式能修大部分」。

## 两个新 pitfall

都是在本 skill 自己的规则下写一个 guard 时实测撞到的。

**#42 — 软链下 `dirname "${BASH_SOURCE[0]}"` 找错目录。** rule 3 要求
`~/.claude/hooks/<name>.sh` 是软链，而 `BASH_SOURCE` 是**调用路径**不是解析后的文件。
兄弟文件查找 exit 127，SessionStart 健康检查把它渲染成 `selftest failed`——一个完全健康的
guard 被永久误报，而这是最贵的方向：它训练操作者忽略整行输出。与 #41 同根（软链未解析）
异 victim（从软链定位 vs stat 软链），两条已互引。修法是不依赖任何 flag 的解链循环。

**#43 — `settings.json` 的 hook 路径有三种写法。** 实测某活跃 profile：45 个 `~/…`、
8 个绝对路径、5 个 `$HOME/…`，三种都会触发。只展 `~` 的消费者会把 `$HOME` 原样留着，
路径过不了 `[ -r ]`，于是把活着的 guard 归进「这个查不了」——那 5 个里 4 个是 PreToolUse，
即四个注册在案的阻断型 guard 从未被真正审计过，而那正是该工具存在的目标人群。

## rule 9 补一个结构性误杀家族

检测器是文本模式的 guard，**给它写文档就会复现它自己的触发条件**。语料里命中该 guard
头号形状的 4 条命令，3 条是健康的：讲这个 guard 的 commit message、把该模式写进文档、
以及故意把坏写法和正解并排跑的标定命令本身。照单全收的检测器会在自己的签名形状上错
75%，且每次都拦在作者写它的当口。

## 验证

- 文档 python 代码块**逐字抠出、不补任何字符**跑 11 个形状全过，含散文点名的三个
  「确实会漏」的形状（`fish` / `timeout` 包装 / 按路径调用）
- #42 的 bash 代码块造真实软链跑，双向：坏写法经软链复现症状；修法在 SSOT / 一级软链 /
  二级链式软链三种路径全通
- 回归审计：915 精确保留 / 3 候选全部裁定 → verify 通过
- 每条散文指针开目标核对（rule 1 正文确实排序了失败方向；逃生口原文落在 rule 4 区间内；
  `bash "$h" "$mode"` 落在 build order step 4 区间内）
- `quick_validate` / `security_scan` 通过；registry diff 恰好一行；CHANGELOG +43/-0 纯增量
- **fresh-context 独立审阅**（轴 = 可执行性 + 对基线的忠实度），8 条发现 7 条落地。
  最值得说的两条：① 代码块缺 `import re`，照文档粘贴即 `NameError`——**我原来的 smoke
  脚本自己拼了 `import re` 才没测出来**，正是本 skill 要教的病出现在验证它的仪器上；
  ② 上面那处「第二副本」的自相矛盾，是我自查漏掉、审阅抓到的。

🤖 Generated with [Claude Code](https://claude.com/claude-code)