### PR TITLE
chore(claude-code-hooks): refresh security attestation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -104,7 +104,7 @@
       "description": "Claude Code operations suite that bundles cross-project prior-work retrieval across code, docs, Skills, meetings, WeChat archives, and conversation history; provider-separated Claude Code and Codex history readers; identity- and lineage-gated continuation workflows; plugin/skill troubleshooting; CLAUDE.md progressive disclosure optimization; version-synced Lark CLI routing; statusline configuration; exported .txt repair; full claude.ai conversation extraction with tool-call rendering and file download; plugin marketplace development and suite consolidation; writing/testing/debugging Claude Code hooks; multi-provider profile isolation; personal-memory migration into tool-agnostic AGENTS.md reference docs; one-shot local timers that ping Claude right after subscription quota reset to start a fresh 5-hour usage window; and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
       "source": "./daymade-claude-code",
       "strict": false,
-      "version": "3.7.8",
+      "version": "3.7.9",
       "category": "suite",
       "keywords": [
         "suite",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **claude-code-hooks** (`daymade-claude-code` v3.7.9): refresh the tracked
+  security-scan attestation against the v3.7.8 content so a fresh checkout can
+  package the reviewed Skill without first regenerating derived evidence.
 - **claude-code-hooks** (`daymade-claude-code` v3.7.8): distinguish recurring
   advisory cadence from blocking remediation budgets. Advisory injectors remain
   available throughout long sessions and prove long-horizon liveness;

--- a/daymade-claude-code/claude-code-hooks/.security-scan-passed
+++ b/daymade-claude-code/claude-code-hooks/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-08-30T12:46:44.891001+00:00
+Scanned at: 2026-08-30T14:18:28.623123+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: c03c790a2f86c0bf009eb4bf349695c0ef885915f218e21f8d3a11264cde7317
+Content hash: e9e7b24b3e2854a71df21e1755a20c4c71373fc394eef6597e0931e5e123196c


### PR DESCRIPTION
## What changed

- refresh the tracked `.security-scan-passed` receipt against the v3.7.8 Skill content
- bump `daymade-claude-code` to v3.7.9 and record the derived-evidence repair

## Why

PR #414 passed security scanning and packaging in an isolated candidate directory, but the generated content-bound receipt was not included in the merged source tree. A fresh main checkout therefore could not package directly without regenerating evidence.

## Verification

- independent fresh scan reproduced content hash `e9e7b24b3e2854a71df21e1755a20c4c71373fc394eef6597e0931e5e123196c`
- fresh candidate checkout packages successfully without rerunning the scan
- version progression and PII pre-push guards pass
- diff is limited to the attestation, suite patch version, and CHANGELOG