### PR TITLE
docs: route hook reminder semantics through rule 7

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,15 @@ Behavior evaluation is risk-scaled by `daymade-skill:skill-creator`: bounded fix
 
 Treat `daymade-skill/skill-creator/scripts/packaging_policy.py` as the shipping-policy SSOT. Add or remove shipping exclusions only there, require every consumer to import it, and do not copy its directory list into documentation or consumer-specific filters.
 
+For hook loop and reminder semantics, load
+`daymade-claude-code:claude-code-hooks` and follow rule 7. Keep recurring
+advisory injectors available for the whole session, using cadence/hysteresis
+and reset semantics to limit frequency; never add a lifetime session cap.
+Reserve repetition budgets for blocking remediation loops whose capped exit is
+explicitly blocked, unshipped, or pending. Test advisory liveness across later
+fully-due windows, and leave current thresholds in the owning implementation
+rather than copying them into this file.
+
 Treat `daymade-skill/skill-creator` as a locked uv project. Run its bundled Python tools from that directory with `uv run --frozen`; the project-local `.venv` is isolated from caller projects while uv's shared cache supplies the pinned packages. Do not reintroduce per-call `--with` overlays for dependencies already in its `pyproject.toml`.
 
 ```bash


### PR DESCRIPTION
## Description

Documents the stable boundary between recurring advisory delivery and bounded blocking remediation in the Claude Code project entrypoint. The root instructions route detailed behavior to claude-code-hooks rule 7 and intentionally do not copy live thresholds.

## Type of Change

- [x] Documentation update

## Changes Made

- Add the advisory-versus-blocking boundary to root CLAUDE.md.
- Require later fully-due liveness checks for recurring advisories.
- Keep current thresholds in implementation rather than resident docs.
- Preserve AGENTS.md as the tracked symlink to CLAUDE.md.

## Affected Skills

- [x] Documentation only

## Testing Done

- [x] Manual testing performed

Test description:

1. Marketplace manifest validation passed.
2. Documentation skill-list validation passed.
3. All 49 shell scripts passed the repository shell syntax check.
4. A fresh-context reviewer found no BLOCKER or MAJOR issue in immutable commit c04de5d.

## Quality Checklist

- [x] Documentation updated
- [x] No new warnings generated
- [x] Changes do not break existing functionality
- [x] Commit message is clear and descriptive
- [x] Checked for typos and grammar
- [x] Links are working
- [x] Code examples are tested
