### PR TITLE
feat(git-safety-net): name shared-index drift trap, upgrade commit-scope check

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -471,7 +471,7 @@
       "description": "Audits, preserves, recovers, and safely retires local Git state: unpushed or wrong-branch commits, dirty or detached worktrees, forgotten duplicate clones of the same repo, untracked work no bundle can back up, orphaned stashes, dangling commits, stale branches, and squash/rebase merge uncertainty. Use when the user fears work was lost; asks to recover a commit or branch; asks whether a worktree, clone, or scratch directory can be deleted; wants everything converged onto one main branch; or needs proof that cleanup will not drop work. Use it even after an audit reported clean — the usual gap is scope: every in-repo command is blind to a second clone elsewhere on disk. Triggers on \"did I lose work\", \"is everything merged\", \"is anything else lost\", \"safe to delete this clone\", \"clean up old branches/stashes\", \"only keep one main branch\", \"git reflog\", \"dangling commits\", \"分支灾难\", \"误删分支/commit\", \"worktree 能删吗\", \"还有没有丢的东西\", \"只保留一个主分支\". Covers local-Git forensics, not GitHub PR/API operations or routine sync.",
       "source": "./git-safety-net",
       "strict": false,
-      "version": "1.12.0",
+      "version": "1.13.0",
       "category": "developer-tools",
       "keywords": [
         "git",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   available throughout long sessions and prove long-horizon liveness;
   per-session ceilings are reserved for blocking loops whose capped exit
   explicitly leaves work blocked, unshipped, or pending.
+- **git-safety-net** (`git-safety-net` v1.13.0): Mode D now names the shared-index drift trap
+  that index-bypassing commits leave behind, and the prevention reference's commit-scope hygiene
+  check is upgraded to match. A bare `git commit` snapshots the *whole* index, not just what you
+  staged — but the skill never said so, and nothing warned that `commit-tree` + `update-ref` (or
+  a temporary `GIT_INDEX_FILE` commit) advances HEAD while the shared index stays on its old
+  baseline, so the commit's own files show as staged deletions (`D ` + `??` in `git status`) that
+  anyone's next bare commit turns real. Verified mechanically on throwaway repos: the drift
+  produces exactly those status pairs; a bare commit deletes the delivered files from HEAD while
+  the working tree looks untouched; `git restore --staged -- <paths>` re-syncs; and
+  `git commit -- <path>` neither creates nor repairs the drift. The new Mode D bullet assigns
+  the two obligations — whoever advanced the branch past the index re-syncs immediately, and
+  whoever commits bare on a shared tree reads `git diff --cached --name-status` as the blast
+  radius and stops on any entry they don't recognize. The hygiene section's pre-commit check
+  moves from `--name-only` to `--name-status`, because the status letter is what exposes a
+  phantom `D` for a file you never deleted. Real incident: a 24-file delivered directory sat in
+  the drift window with `D ` lines as the only sign; one bare commit by a parallel session would
+  have deleted it from the branch tip.
 - **claude-code-hooks** (`daymade-claude-code` v3.7.7): the skill asserted that a non-git
   heredoc whose body carries trigger-looking data leaves a fail-closed guard with "no cheap
   middle ground" — only declare-it-fail-open or a real shell grammar. That is now shown to be

--- a/git-safety-net/.security-scan-passed
+++ b/git-safety-net/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-08-29T08:08:10.432152+00:00
+Scanned at: 2026-08-30T16:16:34.478783+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 676bbc2be88bbbe7675604c3d6110e5a9ca5a2a0b46a3b14e2d290eff17fa195
+Content hash: 2ea4e41633c9c742214641d281c779b59c8f6a51433de58845394b96d073df49

--- a/git-safety-net/SKILL.md
+++ b/git-safety-net/SKILL.md
@@ -359,6 +359,24 @@ The habits that keep a branch tangle from ever stranding work:
   does not run the normal `git commit` hook path: execute the repository's exact pre-commit/security
   gates against the candidate before push, and still let pre-push run. This is the escape hatch for
   when commit-then-switch is off the table because someone else holds the tree.
+- **A bare `git commit` snapshots the *whole* index, not just what you staged — and a commit that
+  bypassed the index leaves a trap in it.** Moving the **current** branch without updating the
+  shared index advances HEAD while the index stays on its old baseline — via `commit-tree` +
+  `update-ref` on that branch, or a `git commit` through a temporary `GIT_INDEX_FILE`. (The
+  push-to-another-branch escape hatch above moves no *local* ref, so it leaves no drift.) Every
+  file the new commit introduced then shows as a *staged deletion* (`git status` prints `D `
+  lines plus matching `??` untracked entries). `git commit -- <path>` neither creates nor repairs
+  this drift — it only updates its own paths. The drift detonates on anyone's next bare
+  `git commit`: that commit snapshots the entire index, turning the phantom deletions real —
+  delivered files vanish from HEAD while the working tree looks untouched. Real incident:
+  a 24-file delivered directory sat in that window after a temporary-index commit; one bare commit
+  by a parallel session would have deleted it from the branch tip, and the only sign anywhere was
+  `D ` lines in `git status`. Two obligations follow. **Whoever advanced the branch past the index
+  re-syncs immediately** — `git diff --cached --name-status`, then `git restore --staged --
+  <the paths the commit touched>` until those paths no longer appear in the diff (a parallel
+  session's own staged entries are theirs, not yours to clear). **And before any bare commit on a
+  shared tree, read that same diff as your blast radius** — every entry, `D` lines included, must
+  be one you intended; an entry you don't recognize means stop, not commit.
 - **Before any rebase or branch-delete, run the applicable Mode B evidence path.** Use the full
   loss audit only when every worktree/ref/tag/stash/dangler it enumerates is in evidence scope;
   otherwise use the authorized checkout/ref's scoped checks and limit the safety claim accordingly.

--- a/git-safety-net/references/prevention_practices.md
+++ b/git-safety-net/references/prevention_practices.md
@@ -206,14 +206,28 @@ If a collision already merged, fix it by bumping again above the collided value 
 
 **Failure mode:** `git add .` or `git commit -a` sweeps unrelated changes (another task's edits,
 generated files) into a commit; later that commit gets reverted/reset and takes the unrelated work
-with it.
+with it. On a shared tree the blast radius is wider than your own staging: a bare `git commit`
+snapshots the *entire* index, which may hold a parallel session's staged work — or phantom `D`
+entries left behind when a commit advanced the branch past the index (`commit-tree` +
+`update-ref`), so the files that commit delivered show as staged deletions. Committing then folds
+the collaborator's work into your commit, or turns the phantom deletions into real ones — the
+delivered files vanish from HEAD while the working tree looks untouched.
 
-**Prevention:** stage explicit paths, and verify the staged set before committing:
+**Prevention:** stage explicit paths, then read the *whole* staged set against your intent —
+including the lines you did not add:
 
 ```bash
 git add <the specific paths for THIS change>
-git diff --cached --name-only        # confirm ONLY the intended files are staged
+git diff --cached --name-status      # FULL staged set == your intent? `D` lines included
 ```
+
+Use `--name-status` here, not `--name-only`: the status letter is what exposes a phantom `D` for a
+file you never deleted. Any entry you don't recognize — a collaborator's staged file, a deletion
+you never made — means stop, not commit. And if it was *your* commit that advanced the branch past
+the index (plumbing, a temporary `GIT_INDEX_FILE`), re-sync immediately after:
+`git restore --staged -- <the paths your commit touched>` until those paths no longer appear in
+`git diff --cached` (a parallel session's own staged entries are theirs, not yours to clear).
+Leaving the drift in place hands the next bare commit a loaded gun.
 
 ## Set a wider reflog safety window once
 


### PR DESCRIPTION
## What

Mode D gains the rule that a bare \`git commit\` snapshots the **whole** index, not just what you staged — and that commits bypassing the shared index (\`commit-tree\` + \`update-ref\`, a temporary \`GIT_INDEX_FILE\` commit) leave a trap in it: the commit's own files show as **phantom staged deletions** (\`D \` + \`??\` in \`git status\`), which anyone's next bare commit turns into real deletions from HEAD while the working tree looks untouched. \`git commit -- <path>\` neither creates nor repairs this drift.

Two obligations follow: whoever advanced the branch past the index **re-syncs immediately** (\`git restore --staged -- <paths>\` until those paths no longer appear in \`git diff --cached\` — path-scoped, never unstage a parallel session's entries); and whoever commits bare on a shared tree **reads \`git diff --cached --name-status\` as the blast radius** and stops on any entry they don't recognize.

The prevention reference's commit-scope hygiene check moves from \`--name-only\` to \`--name-status\` (the status letter is what exposes a phantom \`D\`), with the success condition scoped to your own paths.

## Why

Real incident (2026-08-30): a 24-file delivered directory sat in the drift window after a temporary-index commit; one bare commit by a parallel session would have deleted it from the branch tip, and the only sign anywhere was \`D \` lines in \`git status\`.

## Evidence

- **Mechanism mechanically reproduced** on throwaway repos (4 scenarios): drift → \`D \`/\`??\` pairs → bare commit deletes delivered files from HEAD; \`restore --staged\` re-syncs; pathspec commit neither creates nor repairs.
- **2 with-skill behavior replays passed** (drift-state commit; post-plumbing cleanup), end states independently machine-verified.
- **Independent fresh-context review passed**: 1 concern + 3 nits, all fixed and re-checked; all three mechanism claims independently reproduced (reviewer could not falsify them).
- \`quick_validate\` ✅ · regression audit (3 candidates, all \`preserved_or_moved\`) ✅ · \`reference_net\` ✅ · security scan ✅.
- Review archive: PKM \`next/_meta/skill-reviews/git-safety-net/independent-review-shared-index-drift-20260830.md\`.

## Version

\`git-safety-net\` 1.12.0 → 1.13.0 + CHANGELOG entry (Unreleased → Fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)