### PR TITLE
fix(twitter-reader): fxtwitter-first routing + Jina risk profile; tibo 1.2.1 precision

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -777,7 +777,7 @@
       "description": "Fetch Twitter/X post content including long-form Articles with full images and metadata. Use when Claude needs to retrieve tweet/article content, author info, engagement metrics (likes, retweets, bookmarks), and embedded media. Supports individual posts and X Articles (long-form content). Automatically downloads all images to local attachments folder and generates complete Markdown with proper image references. Preferred over Jina for X Articles with images.",
       "source": "./twitter-reader",
       "strict": false,
-      "version": "1.1.1",
+      "version": "1.2.0",
       "category": "utilities",
       "keywords": [
         "twitter",
@@ -1134,7 +1134,7 @@
       "description": "查询 ChatGPT/Codex 额度重置时间，区分 Tibo 官宣、未官宣的平台静默重置、banked reset 与账户级周期重置。Use when 用户问「什么时候重置」「额度什么时候恢复」「下次全员重置几点」 「banked reset 到了吗」「Tibo 说了什么」「usage limit when reset」，或说「额度突然回到 100%」「好像/肯定又重置了」。必须用实时产品状态、独立用户实测与公告交叉核验；禁止因 Tibo Radar 没有新条目就否定已经发生的重置，并须把太平洋时间当场换算为北京时间。",
       "source": "./tibo-reset-codex",
       "strict": false,
-      "version": "1.2.0",
+      "version": "1.2.1",
       "category": "utilities",
       "keywords": [
         "chatgpt",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **twitter-reader** v1.1.1 → v1.2.0: fix the single-source-of-failure on
+  Jina exposed by live tests. Single-post text now routes through the
+  fxtwitter mirror API first (login-free, key-free, direct connection,
+  full note_tweet body in `tweet.text` — 2,324-char long-form verified);
+  X Articles with images keep `fetch_article.py`. The Jina path is
+  demoted to fallback with its real reliability profile recorded: the
+  anonymous `r.jina.ai` lane gets 403-globally-banned for hours when
+  *third-party* users abuse x.com, then recovers (verified live — ban
+  expired and anonymous fetch returned post text), so it is intermittent,
+  never load-bearing; and `fetch_tweets.sh` hard-requires `JINA_API_KEY`,
+  which is currently 402 out of balance and blocks the batch script
+  until recharged. README facet updated to match.
+- **tibo-reset-codex** v1.2.0 → v1.2.1: precision pass on the Jina
+  verdict after re-test — the ban is *intermittent* (expired after hours;
+  anonymous fetch then returned the post body), not "dead". Jina is
+  usable-but-unreliable backup; fxtwitter stays primary.
 - **tibo-reset-codex** v1.1.0 → v1.2.0: replace the dead Jina fallback for
   reading Tibo's X posts with the fxtwitter mirror API — login-free, works
   direct, and returns the full note_tweet body in `tweet.text` (**not**

--- a/README.md
+++ b/README.md
@@ -1197,15 +1197,19 @@ xcodebuild -destination 'platform=iOS Simulator,name=iPhone 17' build
 
 ### **twitter-reader** - Twitter/X Content Fetching
 
-Fetch Twitter/X post content using Jina.ai API to bypass JavaScript restrictions without authentication.
+Fetch Twitter/X post and article content. Single-post text goes through the
+fxtwitter mirror API (login-free, key-free, full long-form body); X Articles
+with images go through `fetch_article.py`; the Jina API path remains as a
+fallback with a known intermittent-ban risk.
 
 **When to use:**
 - Retrieving tweet content for analysis or documentation
-- Fetching thread replies and conversation context
+- Fetching X Articles (long-form) with all images downloaded locally
 - Extracting images and media from posts
 - Batch downloading multiple tweets for reference
 
 **Key features:**
+- Single posts: fxtwitter mirror — no key, no login, full `tweet.text` body including note_tweet long-form
 - No JavaScript rendering or browser automation needed
 - No Twitter authentication required
 - Returns markdown-formatted content with metadata
@@ -1215,10 +1219,16 @@ Fetch Twitter/X post content using Jina.ai API to bypass JavaScript restrictions
 
 **Example usage:**
 ```bash
-# Set your Jina API key (get from https://jina.ai/)
-export JINA_API_KEY="your_api_key_here"
+# Single post text (preferred): fxtwitter mirror, no key needed
+curl -sS "https://api.fxtwitter.com/USER/status/TWEET_ID" \
+  | python3 -c "import json,sys; t=json.load(sys.stdin)['tweet']; print(t['text'])"
 
-# Fetch a single tweet
+# X Article with images (full mode)
+uv run --with pyyaml python scripts/fetch_article.py \
+  "https://x.com/USER/status/TWEET_ID" ./Clippings
+
+# Jina fallback (intermittent — see SKILL.md risk note)
+export JINA_API_KEY="your_api_key_here"
 curl "https://r.jina.ai/https://x.com/USER/status/TWEET_ID" \
   -H "Authorization: Bearer ${JINA_API_KEY}"
 
@@ -1238,9 +1248,9 @@ python scripts/fetch_tweet.py https://x.com/user/status/123 output.md
 📚 **Documentation**: See [twitter-reader/SKILL.md](./twitter-reader/SKILL.md) for full details and URL format support.
 
 **Requirements**:
-- **Jina.ai API key** (get from https://jina.ai/ - free tier available)
-- **curl** (pre-installed on most systems)
-- **Python 3.6+** (for Python script)
+- **curl** (pre-installed on most systems) — single-post path needs nothing else
+- **Python 3.6+** (for Python scripts)
+- **Jina.ai API key** (only for the Jina fallback; intermittent-ban risk, and the shared repo key is currently out of balance / 402)
 
 ---
 

--- a/tibo-reset-codex/SKILL.md
+++ b/tibo-reset-codex/SKILL.md
@@ -86,8 +86,9 @@ curl -sS --max-time 20 "https://api.fxtwitter.com/<user>/status/<status-id>" \
 - `publish.twitter.com/oembed`：301 落到 `publish.x.com` 后（加 `-L`）返回 200+JSON，但可见
   文本同样截断（~273 字符、以省略号收尾，截断点与 syndication 相同）——**与 syndication
   同一档**，够核对开头与元数据，拿不到 note_tweet 全文。
-- ~~Jina Reader~~ **已不可靠**：匿名访问 x.com 会因他人滥用被**全局封禁**（403，封禁窗口数小时、
-  错误信息点名第三方账号）；本仓 jina key 已 402 余额尽。别再把它当 X 的 fallback。
+- ~~Jina Reader~~ **可用但间歇，不作主通道依赖**：匿名访问 x.com 会因他人滥用被**间歇性全局
+  封禁**（403，2026-08-30 实测：封禁数小时后解除，解除后匿名仍能拿到帖子正文；错误信息点名
+  触发滥用的第三方账号）；本仓 jina key 已 402 余额尽。fxtwitter 优先，Jina 只作它的备用。
 - fxtwitter 不返回回复内容（`replies` 字段只是数值计数）；帖子下的 Tibo 澄清需要 WebSearch
   找转录源补充。
 

--- a/twitter-reader/SKILL.md
+++ b/twitter-reader/SKILL.md
@@ -7,6 +7,21 @@ description: Fetch Twitter/X post content including long-form Articles with full
 
 Fetch Twitter/X post and article content with full media support.
 
+## Reading a single post's text: fxtwitter first (2026-08-30)
+
+For plain post text, prefer the fxtwitter mirror API — login-free, key-free,
+works direct, and returns the **full note_tweet body in `tweet.text`** (the
+`full_text` key does not exist; a 2,324-char long-form announcement came back
+complete):
+
+```bash
+curl -sS --max-time 20 "https://api.fxtwitter.com/<user>/status/<id>" \
+  | python3 -c "import json,sys; t=json.load(sys.stdin)['tweet']; print(t['created_at']); print(t['text'])"
+```
+
+`replies` is a count, not the reply thread. For X Articles with images, use
+`fetch_article.py` below — fxtwitter does not carry article bodies.
+
 ## Quick Start (Recommended)
 
 For X Articles with images, use the new fetch_article.py script:
@@ -53,7 +68,16 @@ Downloading 15 images...
 
 ## Alternative: Jina API (Text-only)
 
-For simple text-only fetching without authentication:
+⚠️ **Known reliability risk (2026-08-30 live tests)**: anonymous `r.jina.ai`
+access to x.com gets **403-globally-banned for hours** when *third-party*
+users abuse the domain — the ban blocks every anonymous caller, then
+expires. Verified working again after expiry (anonymous fetch then returns
+post text), so treat Jina as **intermittent**, never a load-bearing path.
+The shared key in this repo is also currently out of balance (402
+InsufficientBalanceError), which makes `fetch_tweets.sh` — it hard-requires
+`JINA_API_KEY` — unusable until recharged.
+
+For simple text-only fetching:
 
 ```bash
 # Single tweet
@@ -75,8 +99,8 @@ scripts/fetch_tweets.sh url1 url2 url3
 
 ### Simple Mode (Jina API)
 - Text-only content
-- No authentication required beyond Jina API key
-- Good for quick text extraction
+- Intermittent availability (see risk note above); batch script hard-requires `JINA_API_KEY`
+- Good for quick text extraction when it's up
 
 ## Prerequisites
 


### PR DESCRIPTION
Closes the residual risk from #418: twitter-reader's docs put all text-fetching on Jina, whose anonymous lane is intermittently 403-globally-banned by third-party abuse (verified live, then recovered) and whose shared key is 402 out of balance. Now: fxtwitter first for single posts, fetch_article.py keeps the Articles+images lane, Jina documented as intermittent fallback. tibo-reset-codex gets a matching precision pass (intermittent, not dead) after re-test. Both bumped + CHANGELOGged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)