### PR TITLE
docs(claude-md): read the full staged set before bare commits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,6 +184,7 @@ the same worktree — a blanket stage piggybacks their work into your commit:
 ```bash
 git status
 git add path/to/file1 path/to/file2   # specific files only
+git diff --cached --name-status       # every staged entry (`D` lines included) must be one you intended; a `D` you never made = drift from a parallel session's index-bypassing commit — see git-safety-net Mode D
 git commit -m "message"
 git push
 ```


### PR DESCRIPTION
## What

The Git Operations example in repo CLAUDE.md staged explicit paths but committed blind. One added line:

```bash
git diff --cached --name-status       # every staged entry (`D` lines included) must be one you intended; a `D` you never made = drift from a parallel session's index-bypassing commit — see git-safety-net Mode D
```

## Why

A bare `git commit` snapshots the whole shared index — a parallel session's staged work, or phantom deletions left by an index-bypassing commit (`commit-tree` + `update-ref`, temp `GIT_INDEX_FILE`). Both were observed on this repo's shared checkout the same day: a 320-file staged pile sat in the index, and later a 24-file delivered directory showed as staged deletions. The rule's SSOT is git-safety-net Mode D (v1.13.0); this is the operational step in the repo's own quick reference, per its "high-frequency steps" role — no rule text is duplicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)