### PR TITLE
feat(macos-cleaner): diagnose Chromium APFS clone leaks

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -258,7 +258,7 @@
       "description": "Apple-platform development and operations suite bundling programmatic macOS window capture, iOS/macOS app development with XcodeGen and SwiftUI, safe disk-space diagnosis and cleanup, and disciplined launchd watchdog design under one shared namespace. Install once for the complete macOS and iOS toolkit.",
       "source": "./daymade-macos",
       "strict": false,
-      "version": "1.0.0",
+      "version": "1.1.0",
       "category": "suite",
       "keywords": [
         "suite",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **macos-cleaner** (daymade-macos v1.0.0 → v1.1.0): add a targeted Chromium code-sign-clone branch and current-user-scoped analyzer that separates active, inactive, and unknown children, binds approved batches to a candidate SHA, preserves explicit exclusions across activity races, and supports a final read-only recheck while the exact-path deletion prompt waits. Rank nominal APFS path accounting separately from expected physical release, require df readback for actual reclaimed space, and stop the legacy deletion helper from silently shrinking a changed batch, labeling measured totals as physically “freed,” or continuing after the first failure.
+
 ### Fixed
 - **tunnel-doctor** v1.11.0 → v1.11.1: correct the Windows/v2rayN chain-repair note that assumed every manual exit was a residential VLESS profile and treated a fixed exit-IP range as the authority. The generic workflow now reads the exact protocol from the owning client, keeps credentials out of output and Git, discovers the live SQLite schema, independently reads back type/presence/pointers/active front, and treats IP/ASN as observation rather than proof of billing class.
 - **twitter-reader** v1.1.1 → v1.2.0: fix the single-source-of-failure on

--- a/daymade-macos/macos-cleaner/.security-scan-passed
+++ b/daymade-macos/macos-cleaner/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-08-23T18:32:03.202259+00:00
+Scanned at: 2026-08-30T22:18:33.663675+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: b3d5bd0077b7aae2064c15c5b681554cc52600ccc400c6b6ba1a386223c596d0
+Content hash: 99e85f04d18a9551282b2a3a7a84045e55053d7c803d11596ef441743f24ffc3

--- a/daymade-macos/macos-cleaner/SKILL.md
+++ b/daymade-macos/macos-cleaner/SKILL.md
@@ -5,11 +5,11 @@ description: >-
   storage, reports “Caching needs more space,” shows large Apple Content
   Caching or AssetCacheManagerUtil usage, or needs analysis of caches, logs,
   application remnants, large or duplicate files, Docker or OrbStack,
-  Homebrew, npm, pip,
-  Xcode, and other developer storage. Routes known suspects to targeted
-  read-only diagnosis before broad scans, distinguishes logical from physical
-  usage, requires an impact-and-recovery plan plus explicit confirmation before
-  state changes, and verifies disk space and co-resident services afterward.
+  Chromium code-sign clones, Homebrew, npm, pip, Xcode, and other developer
+  storage. Routes known suspects to targeted read-only diagnosis before broad
+  scans, distinguishes nominal path accounting from physical release, requires
+  an impact-and-recovery plan plus explicit confirmation before state changes,
+  and verifies disk space and co-resident services afterward.
 ---
 
 # macOS Cleaner
@@ -25,6 +25,7 @@ Choose the narrowest path that can answer the request:
 | Apple Content Caching, `AssetCacheManagerUtil`, `CacheUsed`, `ActualCacheUsed`, iCloud cache, or “Caching needs more space” | Read `references/apple_content_caching.md` completely before probing or proposing commands |
 | Docker, OrbStack, images, containers, or volumes | Read `references/docker_analysis.md`; inspect every object and never use prune-family commands |
 | Docker build cache | Measure with `docker builder du`; this skill reports it but does not delete it because Docker exposes category-wide prune controls rather than per-record intent |
+| Chrome, ChromeDriver, Playwright, Codex Computer Use, Edge, or Chromium has large `*.code_sign_clone` directories | Read `references/chromium_code_sign_clones.md` completely; use the bundled analyzer to separate active, inactive, and unknown exact children and never equate `du` with physical release |
 | A named cache, directory, application, or service is already the suspect | Inspect that target first and read the matching semantics in `references/cleanup_targets.md`; do not start a home-directory or whole-disk scan |
 | The source is genuinely unknown | Use the general analysis workflow below; Mole is optional, not the universal first step |
 
@@ -41,7 +42,7 @@ User-provided scope exclusions override every generic scan suggestion. Do not in
 7. **Avoid broad destructive shell forms.** Do not recommend or execute broad `rm -rf` or glob deletion. For exact approved ordinary files, prefer Finder Trash. The bundled legacy helper permanently deletes and has only the limited guards documented below; never treat it as equivalent to Trash.
 8. **Preserve valuable state.** Never target user documents, credentials, SSH material, active databases, application configuration, or running-service state merely to increase the reported savings. Read `references/safety_rules.md` before any file deletion.
 9. **Execution follows the user's authorization.** If the user asks only for analysis or wants to run commands personally, hand off the commands. If the user asks the agent to fix the machine and explicitly confirms the scoped plan, execute the exact approved commands and verify them. Unattended recurring deletion logic needs separate approval before it is written or enabled.
-10. **Fail fast.** A non-zero command, a mismatched postcondition, an unexpected target, or a changed dependency stops the cleanup. Report the partial state; do not improvise a fallback.
+10. **Fail fast.** An unexpected non-zero command, a mismatched postcondition, an unexpected target, or a changed dependency stops the cleanup. Interpret documented probe statuses such as `lsof` exit 1 with empty output before deciding they are failures. Report the partial state; do not improvise a fallback.
 
 ## Phase contract
 
@@ -81,6 +82,7 @@ Keep this first phase read-only. Do not run `scripts/cleanup_report.py` yet: it 
 - Query the subsystem's own status and settings.
 - Measure physical allocation with a bounded `du` on the exact data path only when permissions and user scope allow it.
 - Distinguish logical content size, sparse-file apparent size, purgeable space, and physically allocated bytes.
+- For APFS clones, label `du` as path-accounted or nominal rather than physical: shared extents can be attributed to every path, so actual release remains unknown until deletion and `df` readback.
 - For a suspected growing log, record exact file sizes at two or more timestamps. One large file or one recent mtime does not prove sustained growth.
 - Capture the current process, listeners, launch mechanism, and supported health probe of any co-resident service the user marks as critical. Re-resolve PIDs at each checkpoint.
 
@@ -89,6 +91,13 @@ If the known suspect alone can meet the user's free-space target, do not scan un
 ### General analysis when the source is unknown
 
 Run the smallest ordered sequence that can identify enough physical space to meet the target. Stop only when candidates with supported exact actions and defensible expected physical release can meet it. Raw allocation totals, logical cache sizes, shared Docker layers, Trash moves, and unverified “potential savings” do not satisfy the stop condition.
+
+Do not make the physical-confidence ranking hide the user's largest visible
+hotspot. When a nominal/path-accounted candidate is larger than the recommended
+action, show both numbers and explain why its physical release is uncertain.
+Rank by defensible physical release, safety, and effort; report nominal size as
+a separate column instead of silently treating it as either zero or fully
+reclaimable.
 
 | Order / signal | Read-only action | Stop or continue |
 |---|---|---|
@@ -139,7 +148,7 @@ Immediately before the first state-changing command:
 1. Reconfirm the target identity and current disk state.
 2. Re-query the objects or subsystem status; cleanup plans expire when live state changes.
 3. Recheck protected-service health.
-4. Compare the approved commands with the commands about to run. Any difference requires new approval.
+4. Compare the approved commands and exact target set with the commands about to run. Any wider or different target set requires new approval. A separately preserved item becoming inactive does not invalidate the plan when it remains explicitly excluded and the approved target-set hash still matches.
 
 If the approved plan includes creation of a local before/after report artifact, capture the before snapshot now, after approval and before the first cleanup command:
 
@@ -196,12 +205,14 @@ uv run scripts/cleanup_report.py --snapshot after --compare
 Load only the branch relevant to the current task:
 
 - `references/apple_content_caching.md` — Apple Content Caching diagnosis, unit interpretation, supported remote controls, confirmation plan, and post-cleanup verification.
+- `references/chromium_code_sign_clones.md` — Chrome/Chromium/Edge code-sign-clone semantics, nominal-versus-physical reporting, exact inactive-target manifests, cleanup verification, and recurrence prevention.
 - `references/cleanup_targets.md` — cache, log, application, developer, large-file, and Time Machine target semantics.
 - `references/docker_analysis.md` — per-object Docker and OrbStack analysis, database-volume safeguards, and refill root-cause diagnosis.
 - `references/mole_integration.md` — TTY workflow for interactive Mole analysis and preview.
 - `references/report_templates.md` — long-form general and Docker report templates.
 - `references/safety_rules.md` — blocked paths, confirmation, recovery, and file-deletion safety checks.
 - `scripts/analyze_caches.py` — bounded cache inventory.
+- `scripts/analyze_code_sign_clones.py` — read-only current-user code-sign-clone inventory; after approval it can revalidate an exact candidate SHA and write a non-overwriting batch manifest.
 - `scripts/find_app_remnants.py` — application-remnant candidates; reads its fixed Applications and `~/Library` roots, so require that scope first.
 - `scripts/analyze_large_files.py` — large-file discovery inside an approved path.
 - `scripts/analyze_dev_env.py` — Docker/package-manager inventory plus fixed common-project-root `.git` sizing; require that full read scope first.

--- a/daymade-macos/macos-cleaner/references/chromium_code_sign_clones.md
+++ b/daymade-macos/macos-cleaner/references/chromium_code_sign_clones.md
@@ -1,0 +1,246 @@
+# Chromium code-sign clones: targeted diagnosis and cleanup
+
+Use this reference when Chrome, ChromeDriver, Playwright, Codex Computer Use,
+Microsoft Edge, Chromium, or another Chromium-based browser leaves
+`*.code_sign_clone/code_sign_clone.*` directories under the current user's
+`/private/var/folders/.../X/` directory.
+
+## Contents
+
+- What these directories are
+- Read-only inventory
+- Interpret size and activity evidence
+- Plan an exact cleanup
+- Execute only the approved manifest
+- Verify actual release and recurrence
+- Prevent recurrence
+- Failure handling
+- Sources
+
+## What these directories are
+
+Chromium creates one temporary clone per browser instance so an in-use app
+bundle remains reachable and code-signature-valid while an installed browser
+update is staged. Chromium's implementation uses an APFS copy-on-write clone of
+the app bundle plus a hard link for the main executable. It expects the cleanup
+helper to delete that instance-specific directory after the browser exits.
+
+APFS clones share unchanged blocks. A clone can therefore present as a complete
+multi-gigabyte app tree without owning that many unique blocks. Treat `du -sk`
+as **path-accounted allocation**, not as a prediction that deleting the path
+will increase `df` by the same amount. The only authoritative result for the
+cleanup is the before/after `df -k /System/Volumes/Data` delta.
+
+The clone contains an application bundle, not the browser profile. Do not widen
+this branch to the installed browser app, `--user-data-dir`, downloads,
+credentials, or any other browser state.
+
+## Read-only inventory
+
+Run the bundled analyzer from the skill directory:
+
+```bash
+uv run scripts/analyze_code_sign_clones.py
+```
+
+The default scope is deliberately narrow. It resolves the current user's
+`DARWIN_USER_TEMP_DIR`, inspects only sibling `X/*.code_sign_clone` roots owned
+by that user, validates the expected `code_sign_clone.XXXXXX` child shape, reads
+the bundle version, measures path-accounted blocks, and performs one canonical
+root `lsof +D` scan. It does not delete, stop, or configure anything and does
+not write a manifest.
+
+For an already-known exact root, avoid discovery:
+
+```bash
+uv run scripts/analyze_code_sign_clones.py \
+  --root "/private/var/folders/<bucket>/<user>/X/<bundle-id>.code_sign_clone"
+```
+
+Use `--json` when a machine-readable evidence record is helpful. Preserve the
+command output in the report; redirecting it to a file is a local write and
+belongs in an explicitly listed plan when the phase must remain read-only.
+
+## Interpret size and activity evidence
+
+Read the analyzer's three independent signals:
+
+| Signal | Meaning | Decision use |
+|---|---|---|
+| `path-accounted total` | Blocks attributed to paths by `du`; APFS shared extents may be counted repeatedly | Surface the hotspot, but never promise this amount as physical release |
+| `active` | `lsof` named an open file below that exact child | Preserve; do not delete it |
+| `inactive` | The root scan completed and named no open file below a structurally valid, current-user-owned child | Eligible for an exact user decision, not automatically disposable |
+| `unknown` | The `lsof` scan was incomplete or structure/ownership/size evidence failed | Preserve and investigate; never convert unknown to inactive |
+
+Do not infer activity from `lsof`'s exit code alone. Apply these rules:
+
+- Treat every output record naming a target path as definitive evidence that
+  the target is active, even if the command later exits nonzero.
+- Treat exit 1 with empty stdout and stderr as the no-open-files result.
+- The bundled `lsof` 4.91 observed during validation returned 1 while printing
+  valid `+D` matches. Treat exit 0 or 1 with empty stderr as a completed scan;
+  named paths are active and unmatched validated children are inactive.
+- Treat a timeout, stderr, or an exit outside 0/1 as an incomplete scan. Named
+  paths remain active; unmatched paths become unknown rather than inactive.
+- Canonicalize `/var` to `/private/var` before matching. Otherwise the same file
+  can appear under two spellings and produce misleading selection behavior.
+
+Also capture browser and launcher process command lines. A running browser is
+not itself proof that every old child is active; the path-level open-file result
+decides each child. Conversely, an empty process-name search does not replace
+the path-level scan.
+
+### Rank this hotspot honestly
+
+Show both columns whenever this hotspot competes with Docker, package caches,
+or other large candidates:
+
+1. **Observed path-accounted size** — the large number the user can see.
+2. **Expected physical release and confidence** — `unknown` for APFS clone
+   sets until deletion and `df` readback.
+
+Rank executable cleanup candidates by defensible expected physical release,
+safety, and effort, but never hide or silently demote the largest nominal
+hotspot. Explain the uncertainty before choosing a smaller candidate. A path
+that looks ten times larger may physically release less than a smaller cache;
+that is a measurement boundary, not a reason to omit the path from the report.
+
+## Plan an exact cleanup
+
+Before asking for approval, report:
+
+- the exact canonical clone root;
+- each exact inactive candidate, or the candidate count plus SHA-256 and an
+  attached/displayed exact path list;
+- every active, unknown, or otherwise preserved child;
+- the path-accounted total, clearly labeled as nominal;
+- expected physical release as unknown until `df` readback;
+- permanent-deletion impact and recovery: the browser can recreate its clone,
+  but the deleted directories do not go to Trash;
+- the exact manifest-creation and dedicated deletion commands;
+- protected browser/automation process invariants;
+- postconditions and a bounded refill observation.
+
+For a nominal batch above 10 GiB, recommend a current backup before permanent
+deletion even though the content is reconstructible. Do not describe it as
+“absolutely safe”; a mistaken target is still permanent.
+
+If one child is active or unknown, explicitly preserve it in the approved plan.
+Its later transition to inactive does not expand the approved target set.
+
+## Execute only the approved manifest
+
+After explicit approval, create the content-bound manifest by repeating every
+read-only check. Pass every preserved child through `--exclude`, even if it may
+have exited since the plan was shown:
+
+```bash
+uv run scripts/analyze_code_sign_clones.py \
+  --root "/private/var/folders/<bucket>/<user>/X/<bundle-id>.code_sign_clone" \
+  --exclude "/private/var/folders/<bucket>/<user>/X/<bundle-id>.code_sign_clone/code_sign_clone.<kept>" \
+  --expect-candidate-sha "<approved-sha256>" \
+  --write-manifest "/private/tmp/macos-cleaner-code-sign-clones.txt"
+```
+
+The analyzer refuses to overwrite a manifest, rejects a changed candidate hash,
+and emits no active or unknown child. A newly active approved target disappears
+from the candidate set and changes the hash, so execution stops. A preserved
+active child that has since become inactive remains excluded and does **not**
+cause a false plan-expiry failure.
+
+If the command stops, do not weaken the check or regenerate a wider manifest.
+Re-run the read-only report and ask again only when the exact approved target
+set must change.
+
+Start the generic exact-path helper only after the manifest count and SHA are
+read back:
+
+```bash
+/usr/bin/wc -l /private/tmp/macos-cleaner-code-sign-clones.txt
+/usr/bin/shasum -a 256 /private/tmp/macos-cleaner-code-sign-clones.txt
+uv run scripts/safe_delete.py \
+  --batch /private/tmp/macos-cleaner-code-sign-clones.txt
+```
+
+When `safe_delete.py` reaches its interactive selection prompt, leave that
+prompt waiting. In another shell, repeat the analyzer command with the same
+`--root`, every approved `--exclude`, and `--expect-candidate-sha`, but omit
+`--write-manifest`. Enter `all` only if that final read-only check passes. If it
+fails, enter `none` or cancel; do not regenerate a different list inside the
+approved execution phase.
+
+This is a normal local-maintenance guard, not an adversarial deletion engine. It
+assumes no hostile same-user or privileged process is replacing clone paths or
+changing mount topology in the gap between the final check and deletion. If
+automation is actively relaunching browsers, a privileged maintenance process
+is changing mounts, or that assumption is otherwise false, stop: quit the
+owning browser/launcher or reboot, then restart diagnosis from a stable state.
+
+The helper rejects a changed manifest with missing paths and stops after the
+first deletion failure, leaving later targets untouched. Its measured total is
+still `du` path accounting rather than physical release. Never replace the
+manifest with the clone root, a wildcard, `find -delete`, or a recursive shell
+deletion.
+
+## Verify actual release and recurrence
+
+Independently verify all clauses:
+
+1. Confirm every manifest path is absent by reading the manifest one exact line
+   at a time. Do not use a shell glob.
+2. Confirm preserved paths were not deleted by this operation. Record if the
+   browser's own cleanup removed one naturally.
+3. Re-run the analyzer and record remaining/new clone counts and statuses.
+4. Re-read `df -k` and `df -h` on `/System/Volumes/Data`. Calculate actual
+   physical release from the `Available` KiB delta, not from `du` or the delete
+   helper.
+5. Re-resolve protected Chrome/Chromium/Edge and automation processes. Confirm
+   the user-visible browser and required sessions remain healthy.
+6. Observe at 0, 15, and 30 seconds. A new clone associated with a currently
+   running browser may be legitimate; repeated inactive growth means the
+   launcher/lifecycle source remains unfixed.
+
+Report nominal reduction and physical release side by side. A large nominal
+reduction with little `df` movement is a valid result that demonstrates block
+sharing; do not relabel it as a large physical cleanup.
+
+## Prevent recurrence
+
+Trace the current launcher and executable before changing configuration. For
+automation that supports an explicit browser executable, prefer Chrome for
+Testing when it meets the user's compatibility needs: current Chromium source
+disables this auto-update-specific clone feature in Chrome for Testing because
+that build does not support auto-updates. Verify the configured executable and
+the next real process command line; a configuration edit alone is not proof.
+
+If the workflow must use an installed auto-updating Chromium browser, fix the
+source by reusing the managed browser where appropriate and awaiting graceful
+browser shutdown so Chromium's cleanup helper can run. Do not kill a user's
+interactive browser, change their default browser, install another runtime, or
+enable unattended recurring deletion without a separate explicit plan and
+approval.
+
+## Failure handling
+
+| Observation | Response |
+|---|---|
+| No clone root exists | Report no current target; do not create one |
+| `lsof` incomplete | Preserve unmatched children as unknown; retry read-only or stop |
+| Candidate SHA changed | Plan expired; do not write or delete from a regenerated wider list |
+| An approved candidate became active | Stop; preserve it and obtain a new decision for the reduced set if cleanup should continue |
+| A preserved child became inactive | Keep it excluded; proceed only if the approved candidate SHA still matches |
+| Final analyzer recheck fails while the delete prompt waits | Cancel the prompt; return to read-only diagnosis and do not widen the manifest |
+| A manifest target disappears before the helper prepares the batch | The helper stops before confirmation; record the changed state and re-plan if needed |
+| A deletion fails after the batch starts | The helper stops after that first failure; verify the failing and completed paths before any retry |
+| Browser automation or privileged mount changes can continue during deletion | Stop; stabilize or reboot the owning environment before restarting diagnosis |
+| Delete helper reports tens of GiB but `df` moves little | Report nominal vs physical truth; do not claim the helper's number |
+| Clone count refills quickly | Diagnose the launcher and shutdown lifecycle before another cleanup |
+
+## Sources
+
+Verified 2026-08-31:
+
+- Apple, [About Apple File System](https://developer.apple.com/documentation/foundation/about-apple-file-system): clones share unchanged blocks; APFS volumes share container free space.
+- Chromium, [`code_sign_clone_manager.h`](https://chromium.googlesource.com/chromium/src/+/main/chrome/browser/mac/code_sign_clone_manager.h): lifecycle, per-instance clone purpose, expected cleanup, and copy-on-write behavior.
+- Chromium, [`code_sign_clone_manager.mm`](https://chromium.googlesource.com/chromium/src/+/main/chrome/browser/mac/code_sign_clone_manager.mm): current implementation, clone-count telemetry, and Chrome for Testing exclusion.
+- Chromium issue [379125944](https://issues.chromium.org/issues/379125944): ChromeDriver cleanup defect tracked by the implementation.

--- a/daymade-macos/macos-cleaner/references/cleanup_targets.md
+++ b/daymade-macos/macos-cleaner/references/cleanup_targets.md
@@ -180,6 +180,7 @@ Do not reopen a broad Mole scan for a named developer cache. Resolve one exact p
 
 | Target | Authority for the exact live path | Default candidate only when no override is found | Supported/narrow next step |
 |---|---|---|---|
+| Chromium code-sign clones | `scripts/analyze_code_sign_clones.py` resolves the current user's `DARWIN_USER_TEMP_DIR` sibling `X` directory and validates exact owned roots | None; do not scan every user's `/private/var/folders` tree | Read `chromium_code_sign_clones.md`; preserve active/unknown children and bind any inactive batch to the analyzer's exact candidate SHA |
 | Xcode DerivedData | Xcode **Settings → Locations → Derived Data** | `~/Library/Developer/Xcode/DerivedData` | Quit Xcode; prefer removing an exact inactive project child. Whole-root Trash requires explicit rebuild-cost approval. |
 | npm `_cacache` / `_npx` | `npm config get cache`, then append the exact child name | None; do not guess around npm's returned root | `_npx` may go to Trash after confirming no `npx` process. Keep `_cacache` by default; whole-cache removal requires explicit redownload approval. |
 | uv cache | `uv cache dir` (honors `--cache-dir`, `UV_CACHE_DIR`, and uv config) | `$XDG_CACHE_HOME/uv` or `~/.cache/uv` only as a candidate | Prefer `uv cache clean <exact-package>` for a named obsolete package, or `uv cache clean` only when the whole cache is approved. Do not edit uv's internal cache by hand. |
@@ -190,14 +191,24 @@ Do not reopen a broad Mole scan for a named developer cache. Resolve one exact p
 | JetBrains caches | **Help → Diagnostic Tools → Special Files and Folders** or `idea.system.path` | `~/Library/Caches/JetBrains/<product><version>` | Quit the IDE; prefer its cache invalidation UI. An exact cache for an uninstalled/retired product version may go to Trash. Never target config/plugins/local history by assuming every JetBrains directory is cache. |
 | Stopped Docker container | `docker inspect <exact-name-or-id>` plus `docker ps -a` | None | Use `references/docker_analysis.md`; stopped status alone never authorizes removal. |
 
-For the resolved `<exact-cache-path>`, use allocated blocks and an in-use check:
+For an ordinary resolved `<exact-cache-path>`, use path-accounted blocks and an
+in-use check. APFS code-sign clones use their dedicated analyzer/reference
+instead because shared extents and multi-child activity need separate handling:
 
 ```bash
 /usr/bin/du -sk "<exact-cache-path>"
 /usr/sbin/lsof +D "<exact-cache-path>"
 ```
 
-`lsof` exit 0 means the target is in use. Exit 1 with empty stdout/stderr is the no-open-files result; timeout, permission errors, or any other output leave the check incomplete. Combine this with the live owning-process check—an empty `lsof` result alone does not prove an application is inactive.
+Canonicalize the target path before interpreting `lsof`. Any output record
+naming the target or one of its descendants proves it is in use. Exit 1 with
+empty stdout/stderr is the no-open-files result. The bundled `lsof` 4.91
+observed during validation also returned 1 while printing valid `+D` matches,
+so treat exit 0 or 1 with empty stderr as a completed scan. A timeout, stderr,
+or an exit outside 0/1 leaves
+unmatched paths unknown; do not convert an incomplete scan into “not in use.”
+Combine this with the live owning-process check—an empty process-name search
+alone does not prove a path is inactive.
 
 The plan must name the exact supported command or exact Finder Trash target, rebuild/redownload impact, and a postcondition. After action, re-resolve the configured path, re-run `du -sk`, and read target-volume `df -k/-h`. Trash is a recovery step, not physical reclamation; do not claim freed bytes until the separately approved removal from Trash is reflected in `df`.
 

--- a/daymade-macos/macos-cleaner/references/report_templates.md
+++ b/daymade-macos/macos-cleaner/references/report_templates.md
@@ -21,6 +21,16 @@ Use these templates after the read-only evidence phase. They implement the main 
 |---|---:|---|---|---|
 | <subsystem/path> | <value + unit> | <logical/physical> | `<command>` | <complete/partial> |
 
+## Ranked candidates
+
+Keep nominal/path-accounted size separate from expected physical release so a
+large APFS clone or shared-layer hotspot remains visible without becoming a
+false savings promise.
+
+| Rank | Exact candidate | Nominal/path-accounted size | Expected physical release | Confidence | Why this rank |
+|---:|---|---:|---:|---|---|
+| 1 | <exact target> | <observed or n/a> | <estimate or unknown> | <high/medium/low> | <safety + evidence + effort> |
+
 State permission errors and incomplete scans. Never present a partial `du` total as the complete category size.
 
 ## Protected-service baseline

--- a/daymade-macos/macos-cleaner/references/safety_rules.md
+++ b/daymade-macos/macos-cleaner/references/safety_rules.md
@@ -48,7 +48,7 @@ These paths and their descendants are blocked even when the user selects `all` i
 
 ### Rule 5: Suggest Backups for Large Deletions
 
-Before deleting >10 GB, recommend Time Machine backup.
+Before deleting >10 GiB, recommend Time Machine backup.
 
 ### Rule 6: Docker Prune Prohibition
 
@@ -152,7 +152,7 @@ uv run scripts/safe_delete.py "/exact/approved/path"
 
 ### Large Deletions
 
-**Threshold**: >10 GB
+**Threshold**: >10 GiB
 
 **Action**: Warn user and suggest Time Machine backup
 
@@ -285,24 +285,34 @@ for data_path in user_data_paths:
 ### Check 4: Not in Use
 
 ```python
-def is_in_use(path):
-    """Check if file/directory is in use."""
+def open_file_state(path):
+    """Return 'active', 'inactive', or 'unknown'; never fail open."""
+    canonical = os.path.realpath(path)
     try:
         result = subprocess.run(
-            ['lsof', path],
+            ['/usr/sbin/lsof', '-Fn', '+D', canonical],
             capture_output=True,
-            text=True
+            text=True,
+            timeout=120,
         )
-        # If lsof finds processes using the file, returncode is 0
-        if result.returncode == 0:
-            return True
-        return False
-    except:
-        return False  # Assume not in use if check fails
+    except (OSError, subprocess.TimeoutExpired):
+        return 'unknown'
 
-if is_in_use(path):
-    print(f"⚠️ Warning: {path} is currently in use")
-    print("   Close the application first, then try again.")
+    names = [os.path.realpath(line[1:]) for line in result.stdout.splitlines()
+             if line.startswith('n')]
+    prefix = canonical + os.sep
+    if any(name == canonical or name.startswith(prefix) for name in names):
+        return 'active'
+    if result.stderr.strip():
+        return 'unknown'
+    if result.returncode in (0, 1):
+        return 'inactive'
+    return 'unknown'
+
+state = open_file_state(path)
+if state != 'inactive':
+    print(f"⚠️ Refusing deletion because inactivity is not proven: {path}")
+    print(f"   Open-file state: {state}; refuse deletion until inactive is proven.")
     return False
 ```
 
@@ -357,7 +367,7 @@ def safe_delete(path, size, description):
         return (False, "No permission")
 
     # Backup warning for large deletions
-    if size > 10 * 1024 * 1024 * 1024:  # 10 GB
+    if size > 10 * 1024 * 1024 * 1024:  # 10 GiB
         if not confirm_large_deletion(size):
             return (False, "User cancelled")
 
@@ -438,7 +448,7 @@ tmutil browse
 ### Preventing Accidents
 
 1. **Use Trash instead of rm** when possible
-2. **Require Time Machine backup** for >10 GB deletions
+2. **Require Time Machine backup** for >10 GiB deletions
 3. **Test on small items first** before batch operations
 4. **Show dry-run results** before actual deletion
 

--- a/daymade-macos/macos-cleaner/scripts/analyze_code_sign_clones.py
+++ b/daymade-macos/macos-cleaner/scripts/analyze_code_sign_clones.py
@@ -1,0 +1,498 @@
+#!/usr/bin/env python3
+"""Inventory inactive macOS Chromium code-sign clones without deleting them.
+
+The default scope is the current user's ``DARWIN_USER_TEMP_DIR`` sibling ``X``
+directory. Explicit roots must still be current-user-owned ``*.code_sign_clone``
+directories below ``/private/var/folders``.
+
+Use ``--write-manifest`` only after the user approves the exact candidate hash.
+The command re-runs every check and refuses to write when the approved candidate
+set changed or any candidate is active/unknown.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import plistlib
+import re
+import subprocess
+import sys
+import tempfile
+from datetime import datetime
+from pathlib import Path
+
+
+VAR_FOLDERS_ROOT = Path("/private/var/folders")
+DATA_VOLUME = "/System/Volumes/Data"
+ROOT_NAME_RE = re.compile(r"^[A-Za-z0-9._-]+\.code_sign_clone$")
+CHILD_NAME_RE = re.compile(r"^code_sign_clone\.[A-Za-z0-9]{6}$")
+
+
+class AnalysisError(RuntimeError):
+    """Raised when a clone root or evidence command cannot be trusted."""
+
+
+def canonical_path(path):
+    return Path(os.path.realpath(os.path.expanduser(str(path))))
+
+
+def is_relative_to(path, parent):
+    try:
+        path.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def format_kib(kib):
+    if kib is None:
+        return "unknown"
+    value = float(kib)
+    for unit in ("KiB", "MiB", "GiB", "TiB"):
+        if value < 1024 or unit == "TiB":
+            return f"{value:.2f} {unit}"
+        value /= 1024
+    return f"{value:.2f} TiB"
+
+
+def run_command(argv, timeout=120):
+    try:
+        return subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise AnalysisError(f"command failed: {' '.join(argv)}: {exc}") from exc
+
+
+def get_current_user_x_dir():
+    result = run_command(["/usr/bin/getconf", "DARWIN_USER_TEMP_DIR"], timeout=10)
+    if result.returncode != 0 or not result.stdout.strip():
+        detail = result.stderr.strip() or f"exit {result.returncode}"
+        raise AnalysisError(f"cannot resolve DARWIN_USER_TEMP_DIR: {detail}")
+    temp_dir = canonical_path(result.stdout.strip())
+    return canonical_path(temp_dir.parent / "X")
+
+
+def validate_root(path):
+    original = Path(os.path.expanduser(str(path)))
+    if original.is_symlink():
+        raise AnalysisError(f"clone root must not be a symlink: {original}")
+    root = canonical_path(original)
+    if not root.is_dir():
+        raise AnalysisError(f"clone root is not a directory: {root}")
+    if not ROOT_NAME_RE.fullmatch(root.name):
+        raise AnalysisError(f"unexpected clone-root name: {root.name}")
+    if root.parent.name != "X" or not is_relative_to(root, VAR_FOLDERS_ROOT):
+        raise AnalysisError(
+            f"clone root must be below /private/var/folders/.../X: {root}"
+        )
+    if root.stat().st_uid != os.getuid():
+        raise AnalysisError(f"clone root is not owned by the current user: {root}")
+    return root
+
+
+def discover_roots(explicit_roots):
+    if explicit_roots:
+        roots = [validate_root(path) for path in explicit_roots]
+    else:
+        x_dir = get_current_user_x_dir()
+        if not x_dir.is_dir():
+            return []
+        roots = [validate_root(path) for path in x_dir.glob("*.code_sign_clone")]
+    return sorted(set(roots), key=str)
+
+
+def du_kib(path):
+    result = run_command(["/usr/bin/du", "-sk", str(path)])
+    if result.returncode != 0:
+        return None, result.stderr.strip() or f"du exit {result.returncode}"
+    try:
+        return int(result.stdout.split()[0]), None
+    except (IndexError, ValueError):
+        return None, "du returned an unreadable size"
+
+
+def df_available_kib(volume=DATA_VOLUME):
+    result = run_command(["/bin/df", "-k", volume], timeout=10)
+    if result.returncode != 0:
+        return None
+    lines = [line for line in result.stdout.splitlines() if line.strip()]
+    if len(lines) < 2:
+        return None
+    try:
+        return int(lines[-1].split()[3])
+    except (IndexError, ValueError):
+        return None
+
+
+def parse_lsof_fields(stdout):
+    records = []
+    process = {"pid": None, "command": None}
+    for line in stdout.splitlines():
+        if len(line) < 2:
+            continue
+        field, value = line[0], line[1:]
+        if field == "p":
+            process = {"pid": value, "command": None}
+        elif field == "c":
+            process["command"] = value
+        elif field == "n":
+            records.append(
+                {
+                    "pid": process["pid"],
+                    "command": process["command"],
+                    "path": value,
+                }
+            )
+    return records
+
+
+def scan_open_files(root):
+    result = run_command(["/usr/sbin/lsof", "-Fpcn", "+D", str(root)])
+    records = parse_lsof_fields(result.stdout)
+    stderr = result.stderr.strip()
+    # Apple's bundled lsof 4.91 has been observed returning 1 even when +D
+    # prints complete matching records. Treat 0/1 as expected statuses and use
+    # stderr as the completeness boundary; any named target remains active.
+    complete = not stderr and result.returncode in (0, 1)
+    return {
+        "complete": complete,
+        "returncode": result.returncode,
+        "stderr": stderr,
+        "records": records,
+    }
+
+
+def find_app_metadata(child):
+    try:
+        bundles = sorted(
+            path
+            for path in child.iterdir()
+            if path.is_dir()
+            and not path.is_symlink()
+            and (path.name.endswith(".app") or path.name.endswith(".app.bundle"))
+        )
+    except OSError as exc:
+        return None, f"cannot list clone child: {exc}"
+    if len(bundles) != 1:
+        return None, f"expected one app bundle, found {len(bundles)}"
+    plist_path = bundles[0] / "Contents" / "Info.plist"
+    if not plist_path.is_file() or plist_path.is_symlink():
+        return None, "missing regular Contents/Info.plist"
+    try:
+        with plist_path.open("rb") as handle:
+            plist = plistlib.load(handle)
+    except (OSError, plistlib.InvalidFileException) as exc:
+        return None, f"cannot read Info.plist: {exc}"
+    return {
+        "app_bundle": str(bundles[0]),
+        "bundle_id": plist.get("CFBundleIdentifier"),
+        "version": plist.get("CFBundleShortVersionString"),
+        "executable": plist.get("CFBundleExecutable"),
+    }, None
+
+
+def match_records_to_children(root, children, records):
+    matched = {str(child): [] for child in children}
+    root_prefix = str(root) + os.sep
+    for record in records:
+        name = record.get("path") or ""
+        canonical_name = os.path.realpath(name)
+        if not canonical_name.startswith(root_prefix):
+            continue
+        for child in children:
+            child_prefix = str(child) + os.sep
+            if canonical_name == str(child) or canonical_name.startswith(child_prefix):
+                matched[str(child)].append(record)
+                break
+    return matched
+
+
+def inventory_root(root):
+    standard_children = []
+    unexpected_children = []
+    try:
+        root_children = sorted(root.iterdir(), key=lambda item: item.name)
+    except OSError as exc:
+        raise AnalysisError(f"cannot list clone root {root}: {exc}") from exc
+    for path in root_children:
+        if (
+            path.is_dir()
+            and not path.is_symlink()
+            and CHILD_NAME_RE.fullmatch(path.name)
+        ):
+            standard_children.append(canonical_path(path))
+        else:
+            unexpected_children.append(str(path))
+
+    lsof = scan_open_files(root)
+    open_by_child = match_records_to_children(
+        root, standard_children, lsof["records"]
+    )
+    entries = []
+    for child in standard_children:
+        reasons = []
+        try:
+            owner_uid = child.stat().st_uid
+        except OSError as exc:
+            owner_uid = None
+            reasons.append(f"cannot stat clone child: {exc}")
+        if owner_uid is not None and owner_uid != os.getuid():
+            reasons.append("not owned by current user")
+        metadata, metadata_error = find_app_metadata(child)
+        if metadata_error:
+            reasons.append(metadata_error)
+        size_kib, size_error = du_kib(child)
+        if size_error:
+            reasons.append(size_error)
+        open_records = open_by_child[str(child)]
+        if open_records:
+            status = "active"
+        elif not lsof["complete"]:
+            status = "unknown"
+            reasons.append(
+                "lsof scan incomplete; unmatched paths cannot be called inactive"
+            )
+        elif reasons:
+            status = "unknown"
+        else:
+            status = "inactive"
+        entries.append(
+            {
+                "path": str(child),
+                "status": status,
+                "path_accounted_kib": size_kib,
+                "metadata": metadata,
+                "open_records": open_records,
+                "reasons": reasons,
+            }
+        )
+
+    root_kib, root_size_error = du_kib(root)
+    return {
+        "root": str(root),
+        "path_accounted_kib": root_kib,
+        "root_size_error": root_size_error,
+        "lsof": lsof,
+        "unexpected_children": unexpected_children,
+        "entries": entries,
+    }
+
+
+def candidate_hash(paths):
+    payload = "".join(f"{path}\n" for path in sorted(paths))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def build_report(roots, excluded_paths):
+    inventories = [inventory_root(root) for root in roots]
+    entries = [entry for item in inventories for entry in item["entries"]]
+    known_paths = {entry["path"] for entry in entries}
+    excluded = {str(canonical_path(path)) for path in excluded_paths}
+    missing_exclusions = sorted(excluded - known_paths)
+    if missing_exclusions:
+        raise AnalysisError(
+            "excluded path is not a current standard clone child: "
+            + ", ".join(missing_exclusions)
+        )
+    candidates = sorted(
+        entry["path"]
+        for entry in entries
+        if entry["status"] == "inactive" and entry["path"] not in excluded
+    )
+    return {
+        "generated_at": datetime.now().astimezone().isoformat(timespec="seconds"),
+        "data_volume": DATA_VOLUME,
+        "data_volume_available_kib": df_available_kib(),
+        "roots": inventories,
+        "excluded_paths": sorted(excluded),
+        "candidate_paths": candidates,
+        "candidate_sha256": candidate_hash(candidates),
+        "physical_release": "unknown until deletion and df readback",
+    }
+
+
+def write_manifest(path, report, expected_sha):
+    actual_sha = report["candidate_sha256"]
+    if actual_sha != expected_sha:
+        raise AnalysisError(
+            f"candidate hash changed: expected {expected_sha}, observed {actual_sha}"
+        )
+    candidates = report["candidate_paths"]
+    if not candidates:
+        raise AnalysisError("no inactive approved candidates to write")
+    by_path = {
+        entry["path"]: entry
+        for root in report["roots"]
+        for entry in root["entries"]
+    }
+    unsafe = [
+        candidate
+        for candidate in candidates
+        if by_path[candidate]["status"] != "inactive"
+    ]
+    if unsafe:
+        raise AnalysisError("candidate is no longer inactive: " + ", ".join(unsafe))
+
+    output = canonical_path(path)
+    parent = output.parent
+    if not parent.is_dir():
+        raise AnalysisError(f"manifest parent does not exist: {parent}")
+    if output.exists() or output.is_symlink():
+        raise AnalysisError(f"refusing to overwrite manifest: {output}")
+
+    temp_name = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=parent,
+            prefix=f".{output.name}.",
+            delete=False,
+        ) as handle:
+            temp_name = handle.name
+            for candidate in candidates:
+                handle.write(candidate + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temp_name, 0o600)
+        os.link(temp_name, output)
+    except FileExistsError as exc:
+        raise AnalysisError(f"refusing to overwrite manifest: {output}") from exc
+    finally:
+        if temp_name:
+            try:
+                os.unlink(temp_name)
+            except FileNotFoundError:
+                pass
+    return output
+
+
+def print_human(report):
+    print("Chromium code-sign clone inventory")
+    print("=" * 78)
+    print(
+        "Path-accounted sizes are nominal APFS clone accounting, not guaranteed "
+        "physical savings."
+    )
+    print(
+        f"Data-volume available: {format_kib(report['data_volume_available_kib'])}"
+    )
+    for root in report["roots"]:
+        print(f"\nRoot: {root['root']}")
+        print(f"Path-accounted total: {format_kib(root['path_accounted_kib'])}")
+        print(
+            "lsof: "
+            f"exit={root['lsof']['returncode']} "
+            f"complete={'yes' if root['lsof']['complete'] else 'no'}"
+        )
+        if root["lsof"]["stderr"]:
+            print(f"lsof stderr: {root['lsof']['stderr']}")
+        if root["unexpected_children"]:
+            print("Unexpected children (preserved):")
+            for path in root["unexpected_children"]:
+                print(f"  - {path}")
+        for entry in root["entries"]:
+            version = (entry["metadata"] or {}).get("version") or "unknown-version"
+            print(
+                f"  {entry['status']:<8} {format_kib(entry['path_accounted_kib']):>12} "
+                f"{version:<18} {entry['path']}"
+            )
+            for record in entry["open_records"]:
+                print(
+                    "    open: "
+                    f"pid={record.get('pid') or '?'} "
+                    f"command={record.get('command') or '?'} "
+                    f"path={record.get('path') or '?'}"
+                )
+            for reason in entry["reasons"]:
+                print(f"    evidence gap: {reason}")
+    print("\nExact inactive candidates:", len(report["candidate_paths"]))
+    print("Candidate SHA-256:", report["candidate_sha256"])
+    if report["excluded_paths"]:
+        print("Explicitly preserved paths:")
+        for path in report["excluded_paths"]:
+            print(f"  - {path}")
+    print("Expected physical release: unknown until deletion and df readback")
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Inventory current-user Chromium code-sign clones and identify exact "
+            "inactive candidates without deleting them."
+        )
+    )
+    parser.add_argument(
+        "--root",
+        action="append",
+        default=[],
+        help=(
+            "Exact *.code_sign_clone root; repeat for multiple roots. Defaults "
+            "to current-user roots beside DARWIN_USER_TEMP_DIR."
+        ),
+    )
+    parser.add_argument(
+        "--exclude",
+        action="append",
+        default=[],
+        help="Exact clone child to preserve even if it becomes inactive; repeatable.",
+    )
+    parser.add_argument("--json", action="store_true", help="Print JSON evidence.")
+    parser.add_argument(
+        "--expect-candidate-sha",
+        help="Require the exact current inactive candidate set to match this SHA-256.",
+    )
+    parser.add_argument(
+        "--write-manifest",
+        help=(
+            "Write exact inactive candidate paths to a new file. Requires "
+            "--expect-candidate-sha and must be used only after approval."
+        ),
+    )
+    return parser
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+    if args.write_manifest and not args.expect_candidate_sha:
+        print(
+            "ERROR: --write-manifest requires --expect-candidate-sha",
+            file=sys.stderr,
+        )
+        return 2
+    try:
+        roots = discover_roots(args.root)
+        report = build_report(roots, args.exclude)
+        if args.expect_candidate_sha:
+            observed = report["candidate_sha256"]
+            if observed != args.expect_candidate_sha:
+                raise AnalysisError(
+                    "candidate hash changed: "
+                    f"expected {args.expect_candidate_sha}, observed {observed}"
+                )
+        if args.json:
+            print(json.dumps(report, indent=2, sort_keys=True))
+        else:
+            print_human(report)
+        if args.write_manifest:
+            output = write_manifest(
+                args.write_manifest, report, args.expect_candidate_sha
+            )
+            print(
+                f"Manifest written: {output}",
+                file=sys.stderr if args.json else sys.stdout,
+            )
+        return 0
+    except AnalysisError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/daymade-macos/macos-cleaner/scripts/safe_delete.py
+++ b/daymade-macos/macos-cleaner/scripts/safe_delete.py
@@ -152,7 +152,7 @@ def confirm_delete(path, size, description):
     print(f"\n🗑️  Confirm Deletion")
     print("━" * 50)
     print(f"Path:        {path}")
-    print(f"Size:        {format_size(size)}")
+    print(f"Measured size: {format_size(size)} (not a physical-release promise)")
     print(f"Description: {description}")
 
     # Additional safety check for important paths
@@ -194,7 +194,7 @@ def batch_confirm(items):
 
     total_size = sum(item[1] for item in items)
     print("-" * 70)
-    print(f"{'Total':<4} {format_size(total_size):<12}")
+    print(f"{'Measured total':<14} {format_size(total_size):<12}")
 
     print("\nOptions:")
     print("  'all'      - Delete all items")
@@ -316,15 +316,21 @@ def main():
 
     paths = allowed_paths
 
+    # A missing requested target means the approved set changed. Do not
+    # silently shrink a batch and present the remainder as the original plan.
+    missing_paths = [path for path in paths if not Path(path).exists()]
+    if missing_paths:
+        print("❌ Requested target set changed; missing paths:")
+        for path in missing_paths:
+            print(f"   {path}")
+        return 1
+
     # Prepare items
     items = []
     for path in paths:
         size = get_size(path)
         description = get_description(path)
         items.append((path, size, description))
-
-    # Remove non-existent paths
-    items = [(p, s, d) for p, s, d in items if Path(p).exists()]
 
     if not items:
         print("❌ No valid paths to delete")
@@ -341,7 +347,8 @@ def main():
         success, message = delete_path(path)
         if success:
             print(f"\n✅ {message}")
-            print(f"   Freed: {format_size(size)}")
+            print(f"   Measured size removed: {format_size(size)}")
+            print("   Physical release: verify with before/after df -k")
             return 0
         else:
             print(f"\n❌ {message}")
@@ -370,11 +377,15 @@ def main():
             if success:
                 success_count += 1
                 total_freed += size
+            else:
+                print("⛔ Stopping batch after the first failure.")
+                break
 
         print("━" * 50)
         print(f"\n📊 Results:")
         print(f"   Successfully deleted: {success_count}/{len(selected)}")
-        print(f"   Total freed:          {format_size(total_freed)}")
+        print(f"   Measured size removed: {format_size(total_freed)}")
+        print("   Physical release:      verify with before/after df -k")
 
         return 0 if success_count == len(selected) else 1
 

--- a/daymade-macos/macos-cleaner/tests/test_analyze_code_sign_clones.py
+++ b/daymade-macos/macos-cleaner/tests/test_analyze_code_sign_clones.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import io
+import plistlib
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "analyze_code_sign_clones.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "analyze_code_sign_clones", SCRIPT_PATH
+)
+ANALYZER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(ANALYZER)
+
+
+class LsofParsingTests(unittest.TestCase):
+    def test_parses_process_and_path_fields(self):
+        records = ANALYZER.parse_lsof_fields(
+            "p123\ncGoogle Chrome\nntmp/root/code_sign_clone.ABC123/app\n"
+        )
+        self.assertEqual(
+            [
+                {
+                    "pid": "123",
+                    "command": "Google Chrome",
+                    "path": "tmp/root/code_sign_clone.ABC123/app",
+                }
+            ],
+            records,
+        )
+
+    @patch.object(ANALYZER, "run_command")
+    def test_empty_exit_one_is_complete_no_open_files(self, run_command):
+        run_command.return_value.returncode = 1
+        run_command.return_value.stdout = ""
+        run_command.return_value.stderr = ""
+        result = ANALYZER.scan_open_files(Path("/private/var/folders/a/b/X/root"))
+        self.assertTrue(result["complete"])
+        self.assertEqual([], result["records"])
+
+    @patch.object(ANALYZER, "run_command")
+    def test_exit_one_with_records_is_complete_on_bundled_macos_lsof(
+        self, run_command
+    ):
+        run_command.return_value.returncode = 1
+        run_command.return_value.stdout = "p123\ncChrome\nn/private/path\n"
+        run_command.return_value.stderr = ""
+        result = ANALYZER.scan_open_files(Path("/private/path"))
+        self.assertTrue(result["complete"])
+        self.assertEqual("/private/path", result["records"][0]["path"])
+
+    @patch.object(ANALYZER, "run_command")
+    def test_unexpected_exit_with_records_marks_scan_incomplete(self, run_command):
+        run_command.return_value.returncode = 2
+        run_command.return_value.stdout = "p123\ncChrome\nn/private/path\n"
+        run_command.return_value.stderr = ""
+        result = ANALYZER.scan_open_files(Path("/private/path"))
+        self.assertFalse(result["complete"])
+        self.assertEqual("/private/path", result["records"][0]["path"])
+
+
+class InventoryTests(unittest.TestCase):
+    def make_clone(self, root, name, version="152.0.0.0"):
+        child = root / name
+        plist_path = child / "Browser.app.bundle" / "Contents" / "Info.plist"
+        plist_path.parent.mkdir(parents=True)
+        with plist_path.open("wb") as handle:
+            plistlib.dump(
+                {
+                    "CFBundleIdentifier": "org.example.Browser",
+                    "CFBundleShortVersionString": version,
+                    "CFBundleExecutable": "Browser",
+                },
+                handle,
+            )
+        return child
+
+    @patch.object(ANALYZER, "df_available_kib", return_value=5000)
+    @patch.object(ANALYZER, "du_kib", return_value=(100, None))
+    @patch.object(ANALYZER, "scan_open_files")
+    def test_active_child_excluded_and_inactive_child_hashed(
+        self, scan_open_files, _du_kib, _df
+    ):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "org.example.Browser.code_sign_clone"
+            root.mkdir()
+            active = self.make_clone(root, "code_sign_clone.ACT123")
+            inactive = self.make_clone(root, "code_sign_clone.INA123")
+            scan_open_files.return_value = {
+                "complete": True,
+                "returncode": 0,
+                "stderr": "",
+                "records": [
+                    {
+                        "pid": "42",
+                        "command": "Browser",
+                        "path": str(active / "Browser.app.bundle/Contents/MacOS/Browser"),
+                    }
+                ],
+            }
+
+            report = ANALYZER.build_report([root.resolve()], [active])
+
+            self.assertEqual([str(inactive.resolve())], report["candidate_paths"])
+            self.assertEqual(
+                ANALYZER.candidate_hash([str(inactive.resolve())]),
+                report["candidate_sha256"],
+            )
+            statuses = {
+                entry["path"]: entry["status"]
+                for entry in report["roots"][0]["entries"]
+            }
+            self.assertEqual("active", statuses[str(active.resolve())])
+            self.assertEqual("inactive", statuses[str(inactive.resolve())])
+
+    @patch.object(ANALYZER, "df_available_kib", return_value=5000)
+    @patch.object(ANALYZER, "du_kib", return_value=(100, None))
+    @patch.object(ANALYZER, "scan_open_files")
+    def test_incomplete_lsof_never_emits_inactive_candidate(
+        self, scan_open_files, _du_kib, _df
+    ):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "org.example.Browser.code_sign_clone"
+            root.mkdir()
+            child = self.make_clone(root, "code_sign_clone.UNK123")
+            scan_open_files.return_value = {
+                "complete": False,
+                "returncode": 1,
+                "stderr": "partial scan",
+                "records": [],
+            }
+
+            report = ANALYZER.build_report([root.resolve()], [])
+
+            self.assertEqual([], report["candidate_paths"])
+            entry = report["roots"][0]["entries"][0]
+            self.assertEqual(str(child.resolve()), entry["path"])
+            self.assertEqual("unknown", entry["status"])
+
+    @patch.object(ANALYZER, "df_available_kib", return_value=5000)
+    @patch.object(ANALYZER, "du_kib", return_value=(100, None))
+    @patch.object(ANALYZER, "scan_open_files")
+    def test_preserved_active_child_can_exit_without_expiring_candidate_hash(
+        self, scan_open_files, _du_kib, _df
+    ):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "org.example.Browser.code_sign_clone"
+            root.mkdir()
+            kept = self.make_clone(root, "code_sign_clone.KEP123")
+            candidate = self.make_clone(root, "code_sign_clone.CAN123")
+            scan_open_files.return_value = {
+                "complete": True,
+                "returncode": 1,
+                "stderr": "",
+                "records": [
+                    {
+                        "pid": "42",
+                        "command": "Browser",
+                        "path": str(kept / "Browser.app.bundle/Contents/MacOS/Browser"),
+                    }
+                ],
+            }
+            before = ANALYZER.build_report([root.resolve()], [kept])
+
+            scan_open_files.return_value = {
+                "complete": True,
+                "returncode": 1,
+                "stderr": "",
+                "records": [],
+            }
+            after = ANALYZER.build_report([root.resolve()], [kept])
+
+            self.assertEqual([str(candidate.resolve())], before["candidate_paths"])
+            self.assertEqual(before["candidate_paths"], after["candidate_paths"])
+            self.assertEqual(before["candidate_sha256"], after["candidate_sha256"])
+
+    @patch.object(ANALYZER, "df_available_kib", return_value=5000)
+    @patch.object(ANALYZER, "du_kib", return_value=(100, None))
+    @patch.object(ANALYZER, "scan_open_files")
+    def test_candidate_becoming_active_expires_candidate_hash(
+        self, scan_open_files, _du_kib, _df
+    ):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "org.example.Browser.code_sign_clone"
+            root.mkdir()
+            candidate = self.make_clone(root, "code_sign_clone.CAN123")
+            scan_open_files.return_value = {
+                "complete": True,
+                "returncode": 1,
+                "stderr": "",
+                "records": [],
+            }
+            before = ANALYZER.build_report([root.resolve()], [])
+
+            scan_open_files.return_value = {
+                "complete": True,
+                "returncode": 1,
+                "stderr": "",
+                "records": [
+                    {
+                        "pid": "42",
+                        "command": "Browser",
+                        "path": str(candidate / "Browser.app.bundle/Contents/MacOS/Browser"),
+                    }
+                ],
+            }
+            after = ANALYZER.build_report([root.resolve()], [])
+
+            self.assertNotEqual(before["candidate_sha256"], after["candidate_sha256"])
+            self.assertEqual([], after["candidate_paths"])
+
+
+class ManifestTests(unittest.TestCase):
+    def report(self, candidate):
+        return {
+            "candidate_sha256": ANALYZER.candidate_hash([candidate]),
+            "candidate_paths": [candidate],
+            "roots": [
+                {
+                    "entries": [
+                        {
+                            "path": candidate,
+                            "status": "inactive",
+                        }
+                    ]
+                }
+            ],
+        }
+
+    def test_manifest_requires_matching_hash_and_refuses_overwrite(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            candidate = "/private/var/folders/a/b/X/root/code_sign_clone.ABC123"
+            report = self.report(candidate)
+            output = Path(temp_dir) / "approved.txt"
+
+            with self.assertRaisesRegex(ANALYZER.AnalysisError, "hash changed"):
+                ANALYZER.write_manifest(output, report, "wrong")
+
+            written = ANALYZER.write_manifest(
+                output, report, report["candidate_sha256"]
+            )
+            self.assertEqual(output.resolve(), written)
+            self.assertEqual(candidate + "\n", output.read_text())
+            self.assertEqual(0o600, output.stat().st_mode & 0o777)
+
+            with self.assertRaisesRegex(ANALYZER.AnalysisError, "overwrite"):
+                ANALYZER.write_manifest(
+                    output, report, report["candidate_sha256"]
+                )
+
+
+class SafetyBoundaryTests(unittest.TestCase):
+    def test_manifest_cli_requires_expected_candidate_hash(self):
+        errors = io.StringIO()
+        with redirect_stderr(errors):
+            exit_code = ANALYZER.main(["--write-manifest", "/private/tmp/list"])
+        self.assertEqual(2, exit_code)
+        self.assertIn("requires --expect-candidate-sha", errors.getvalue())
+
+    def test_explicit_root_outside_var_folders_is_rejected(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "org.example.Browser.code_sign_clone"
+            root.mkdir()
+            with self.assertRaisesRegex(
+                ANALYZER.AnalysisError,
+                "must be below /private/var/folders",
+            ):
+                ANALYZER.validate_root(root)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/daymade-macos/macos-cleaner/tests/test_safe_delete.py
+++ b/daymade-macos/macos-cleaner/tests/test_safe_delete.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import io
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "safe_delete.py"
+SPEC = importlib.util.spec_from_file_location("safe_delete", SCRIPT_PATH)
+SAFE_DELETE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(SAFE_DELETE)
+
+
+class OutputTruthTests(unittest.TestCase):
+    def test_single_delete_never_calls_measured_size_freed_space(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target = Path(temp_dir) / "candidate"
+            target.mkdir()
+            output = io.StringIO()
+            with (
+                patch("sys.argv", ["safe_delete.py", str(target)]),
+                patch.object(SAFE_DELETE, "confirm_delete", return_value=True),
+                patch.object(
+                    SAFE_DELETE,
+                    "delete_path",
+                    return_value=(True, "Deleted successfully"),
+                ),
+                redirect_stdout(output),
+            ):
+                exit_code = SAFE_DELETE.main()
+
+            self.assertEqual(0, exit_code)
+            self.assertIn("Measured size removed:", output.getvalue())
+            self.assertIn("verify with before/after df -k", output.getvalue())
+            self.assertNotIn("Freed:", output.getvalue())
+
+    def test_batch_delete_labels_sum_as_measured_not_physical(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            first = Path(temp_dir) / "first"
+            second = Path(temp_dir) / "second"
+            first.mkdir()
+            second.mkdir()
+            output = io.StringIO()
+
+            def approve_all(items):
+                return items
+
+            with (
+                patch("sys.argv", ["safe_delete.py", str(first), str(second)]),
+                patch.object(SAFE_DELETE, "batch_confirm", side_effect=approve_all),
+                patch.object(
+                    SAFE_DELETE,
+                    "delete_path",
+                    return_value=(True, "Deleted successfully"),
+                ),
+                redirect_stdout(output),
+            ):
+                exit_code = SAFE_DELETE.main()
+
+            self.assertEqual(0, exit_code)
+            self.assertIn("Measured size removed:", output.getvalue())
+            self.assertIn("Physical release:", output.getvalue())
+            self.assertNotIn("Total freed:", output.getvalue())
+
+    def test_missing_manifest_target_stops_before_confirmation(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            missing = Path(temp_dir) / "missing"
+            output = io.StringIO()
+            with (
+                patch("sys.argv", ["safe_delete.py", str(missing)]),
+                patch.object(SAFE_DELETE, "confirm_delete") as confirm_delete,
+                redirect_stdout(output),
+            ):
+                exit_code = SAFE_DELETE.main()
+
+            self.assertEqual(1, exit_code)
+            confirm_delete.assert_not_called()
+            self.assertIn("target set changed", output.getvalue())
+
+    def test_batch_stops_after_first_delete_failure(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            first = Path(temp_dir) / "first"
+            second = Path(temp_dir) / "second"
+            first.mkdir()
+            second.mkdir()
+            output = io.StringIO()
+
+            with (
+                patch("sys.argv", ["safe_delete.py", str(first), str(second)]),
+                patch.object(
+                    SAFE_DELETE,
+                    "batch_confirm",
+                    side_effect=lambda items: items,
+                ),
+                patch.object(
+                    SAFE_DELETE,
+                    "delete_path",
+                    side_effect=[(False, "first failed"), (True, "should not run")],
+                ) as delete_path,
+                redirect_stdout(output),
+            ):
+                exit_code = SAFE_DELETE.main()
+
+            self.assertEqual(1, exit_code)
+            self.assertEqual(1, delete_path.call_count)
+            self.assertIn("Stopping batch after the first failure", output.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test-suites.txt
+++ b/scripts/ci/test-suites.txt
@@ -61,6 +61,7 @@ python-unittest  daymade-claude-code/claude-switch-models-setup/tests
 python-unittest  daymade-skill/skill-governance/tests
 python-unittest  daymade-codex/codex-1m-context-window-setup/tests
 python-unittest  daymade-codex/interaction-design-board/tests
+python-unittest  daymade-macos/macos-cleaner/tests
 python-unittest  daymade-audio/asr-transcribe-to-text/tests
 python-unittest  daymade-audio/transcript-fixer/tests
 python-unittest  feishu-doc-scraper/tests


### PR DESCRIPTION
## Description

Teach macos-cleaner to treat Chromium code-sign clones as a first-class disk-pressure suspect without confusing APFS path accounting with physically reclaimable space.

## Type of Change

- [x] Enhancement to existing skill
- [x] Bug fix
- [x] Infrastructure/tooling improvement

## Changes Made

- add a current-user-scoped analyzer for Chrome/Chromium/Edge code-sign clone roots
- classify exact children as active, inactive, or unknown from structure, ownership, size, and canonical lsof evidence
- bind approved inactive sets to a candidate SHA while preserving explicitly excluded active paths
- keep the largest nominal hotspot visible while ranking expected physical release separately
- make safe_delete stop on missing requested paths or the first deletion failure and stop calling measured path size physically freed
- add a final analyzer recheck at the waiting deletion prompt and document the normal local-maintenance boundary
- register the macos-cleaner unittest suite and bump daymade-macos to v1.1.0

## Testing Done

- [x] Tested on macOS
- [x] Tested on Linux
- [x] Automated tests added/updated
- [x] Validated with skill-creator validation script

- 24/24 macOS unit tests pass
- 24/24 Linux tests pass in a no-network, read-only Python 3.12 container
- live read-only replay correctly preserves the remaining active Chrome clone
- quick_validate, verbose security scan, existing-skill regression audit, version progression, and package creation pass
- regression audit records 882 exact preservations and 8 classified runtime corrections

## Scope Boundary

This workflow is for stable local maintenance, not adversarial same-user/root mutation. If browser automation keeps relaunching or privileged mount topology is changing, it stops and requires stabilizing or rebooting the environment before diagnosis restarts.

## Quality Checklist

- [x] Code follows the project style
- [x] Documentation updated
- [x] No sensitive information exposed
- [x] Existing Docker, Apple Content Caching, Mole, duplicate-file, confirmation, recovery, and df-verification routes remain reachable
