### PR TITLE
docs(tibo-reset-codex): fold 2026-08-31 live-run evidence (v1.2.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1154,7 +1154,7 @@
       "description": "查询 ChatGPT/Codex 额度重置时间，区分 Tibo 官宣、未官宣的平台静默重置、banked reset 与账户级周期重置。Use when 用户问「什么时候重置」「额度什么时候恢复」「下次全员重置几点」 「banked reset 到了吗」「Tibo 说了什么」「usage limit when reset」，或说「额度突然回到 100%」「好像/肯定又重置了」。必须用实时产品状态、独立用户实测与公告交叉核验；禁止因 Tibo Radar 没有新条目就否定已经发生的重置，并须把太平洋时间当场换算为北京时间。",
       "source": "./tibo-reset-codex",
       "strict": false,
-      "version": "1.2.1",
+      "version": "1.2.2",
       "category": "utilities",
       "keywords": [
         "chatgpt",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **macos-cleaner** (daymade-macos v1.0.0 → v1.1.0): add a targeted Chromium code-sign-clone branch and current-user-scoped analyzer that separates active, inactive, and unknown children, binds approved batches to a candidate SHA, preserves explicit exclusions across activity races, and supports a final read-only recheck while the exact-path deletion prompt waits. Rank nominal APFS path accounting separately from expected physical release, require df readback for actual reclaimed space, and stop the legacy deletion helper from silently shrinking a changed batch, labeling measured totals as physically “freed,” or continuing after the first failure.
+- **tibo-reset-codex** v1.2.1 → v1.2.2: fold in the 2026-08-31 live run.
+  The Radar timeline command now prints each event's `url` inline, removing
+  the second lookup before reading the original post; the
+  celebration-as-reset rule gains its full next-day fulfillment chain
+  (8-29 "moved to tomorrow" → 8-30 12:24 PT "will land at 6pm PST" →
+  19:34 PT "hit 25M active users…we have now reset usage for all paid
+  subscriptions"), and 25M joins the milestone list; landed-confirmation
+  evidence now lists both observed phrasings ("has landed" and "we have
+  now reset usage…"). Independent review caught two first-draft defects —
+  an invented "<24h" duration contradicting the measured 29h10m span, and
+  an order-inverted stitched quote — both fixed and re-verified pre-ship.
 
 ### Fixed
 - **peer-message** v1.0.0 → v1.0.1: make documentation ownership executable instead of duplicative. `SKILL.md` keeps only routing, stable prerequisites, safety, and owner pointers; `peer.py --help` owns CLI syntax; the protocol reference owns addressing, envelopes, receipt, exit, transport, and verification semantics; the official-feature reference owns volatile product interfaces and inbound mechanics. README/README.zh-CN and `CLAUDE.md` point to those owners, while the changelog and private review stop persisting derived test, session, reachability, and file totals.

--- a/tibo-reset-codex/SKILL.md
+++ b/tibo-reset-codex/SKILL.md
@@ -63,14 +63,15 @@ import json,sys
 for e in json.load(sys.stdin)['events'][:5]:
     print(e['announced_at'], '|', e.get('type'), '|', str(e.get('summary'))[:100])
     ow = e.get('official_window')
-    if ow: print('   窗口:', ow.get('label'), '=', ow.get('start_at'), '→', ow.get('end_at'), 'UTC')"
+    if ow: print('   窗口:', ow.get('label'), '=', ow.get('start_at'), '→', ow.get('end_at'), 'UTC')
+    print('   url:', e.get('url'))"
 ```
 
 新条目在前。关键字段：`announced_at`（UTC ISO）、`summary`（可能截断）、`url`（原帖）、
 `official_window`、`reset_verification_status`。`type` 是内部小写值：`reset` = 广域
 重置公告、`credits` = banked/额度包、`boost`/`promo` = 消耗规则类。
 
-拿到 `url` 后优先读原帖。X 帖正文的制胜通道是 **fxtwitter 公开镜像 API**（2026-08-30 实测：
+`url` 已在上面命令的输出里（2026-08-31 起直接打印，免去二次查询），拿到后优先读原帖。X 帖正文的制胜通道是 **fxtwitter 公开镜像 API**（2026-08-30 实测：
 免登录、直连即可、返回完整 JSON；**完整正文在 `tweet.text` 字段——不是 `full_text`**，该键
 不存在、照抄会 KeyError；note_tweet 长文全文也给，8-29 官宣长文实测 2324 字符完整拿到、以
 自然结尾收束）：
@@ -187,12 +188,15 @@ TZ=America/Los_Angeles date "+%F %T %Z(%z)"
   8-23 那条预告打了「Reset confirmed」——预告未落地也标 confirmed；Radar 历史上也有）。判「已到账」
   只看落地后的实际信号，不看标签：API 的 `reset_verification_status` 只有 pending/rejected/null
   （2026-08-23 全量 51 条实测：落地两天的「has landed」条目仍是 pending）——**结构上不提供
-  「已到账」正向信号**，别去等一个永不触发的字段翻转。到账证据 = Tibo 后续「has landed」类
-  推文（会作为新 event 出现），或产品内余额实测。
+  「已到账」正向信号**，别去等一个永不触发的字段翻转。到账证据 = Tibo 后续确认推
+  （会作为新 event 出现；实测两种措辞：「has landed」类，以及 2026-08-31 的「we have
+  now reset usage for all paid subscriptions…」），或产品内余额实测。
 - **「celebration」在他的语义里 = 重置动作本身，不是发帖庆祝**（2026-08-30 实战教训：把
   「This celebration is moved to tomorrow as the button was already pressed today」读成
-  「只是庆祝帖、无重置」，被两个独立源当场证伪）。他固定把重置绑在用户里程碑庆祝上——
-  7M/8M/20M 里程碑均以 banked/reset 兑现，8M 时原话「Tomorrow might be 8M active user
+  「只是庆祝帖、无重置」，被两个独立源当场证伪；次日完整兑现——12:24 PT 发「reset will
+  land at 6pm PST」预告，19:34 PT 发「hit 25M active users…we have now reset usage
+  for all paid subscriptions」落地确认）。他固定把重置绑在用户里程碑庆祝上——
+  7M/8M/20M/25M 里程碑均以 banked/reset 兑现，8M 时原话「Tomorrow might be 8M active user
   celebration day」，逼近 9M 时发起过「要不要再重置」的投票（poll 本体
   x.com/thsottiaux/status/2077271889626706300）。所以「celebration 改期到明天」应读作**预告
   明天有一次重置**。


### PR DESCRIPTION
## 变更

三条来自 2026-08-31 两次实战查询的证据型微改（纯追加，无旧合同变更）：

1. **Radar 罐装命令直接打印 `url`** — 消除「拿到 url 再读原帖」的断点
2. **celebration 规则补完整兑现链** — 8-29「moved to tomorrow」→ 8-30 12:24 PT「will land at 6pm PST」→ 19:34 PT「hit 25M active users…we have now reset usage for all paid subscriptions」；25M 并入里程碑清单
3. **到账确认措辞补第二实例** — 「we have now reset usage…」与「has landed」同类

## 验证

- `quick_validate` ✓；`audit_skill_regression` 3 候选全部 preserved_or_moved、verify 通过 ✓；`reference_net` 无新指针 ✓；文档命令原样冒烟跑通 ✓
- **两轮独立审阅**：第一轮抓 2 条（虚构的「<24h」时长断言——实测 29h10m；拼接引语倒置原序），均修复；第二轮 zero findings。档案在 PKM `next/_meta/skill-reviews/tibo-reset-codex/`（已提交 56b960851）
- marketplace 1.2.1 → 1.2.2 + CHANGELOG 同 commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)