### PR TITLE
docs(tibo-reset-codex): complete the release bookkeeping #435 skipped

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1155,7 +1155,7 @@
       "description": "查询 ChatGPT/Codex 额度重置时间，区分 Tibo 官宣、未官宣的平台静默重置、banked reset 与账户级周期重置。Use when 用户问「什么时候重置」「额度什么时候恢复」「下次全员重置几点」 「banked reset 到了吗」「Tibo 说了什么」「usage limit when reset」，或说「额度突然回到 100%」「好像/肯定又重置了」。必须用实时产品状态、独立用户实测与公告交叉核验；禁止因 Tibo Radar 没有新条目就否定已经发生的重置，并须把太平洋时间当场换算为北京时间。",
       "source": "./tibo-reset-codex",
       "strict": false,
-      "version": "1.3.0",
+      "version": "1.3.1",
       "category": "utilities",
       "keywords": [
         "chatgpt",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **peer-message** v1.0.0 (marketplace v3.6.0): restore the previously uncommitted Claude UDS messenger from its source session and extend it into a local Claude Code ↔ Codex coordination layer. The bundled stdlib CLI discovers `claude:` and `codex:` targets across isolated standard Claude profiles, preserves the original authenticated UDS fallback, routes Codex through the first-party `codex queue --thread` command, supports explicitly counted cross-provider broadcasts, adds source/reply envelopes with explicit provenance strength, and verifies delivery from Claude transcripts or Codex queue/thread history without writing either product's SQLite stores. Claude uses a host-recognized peer wrapper; Codex provenance remains advisory text enforced by receiver-side governing instructions. The Skill-local official-feature reference owns the corrected availability and inbound-policy boundaries. The registered test suite, live Codex queue acceptance, and subsequent thread-history consumption were independently verified.
 
 ### Changed
+- **tibo-reset-codex** v1.2.2 → v1.3.1: add the missing local-account
+  forensics leg and close the announcement path's structural blind spot,
+  both exposed by the 2026-09-01 live run. The skill previously could only
+  point the user at the product usage page or `/status`; it now reads the
+  `rate_limits` snapshots in `~/.codex/sessions/**/rollout-*.jsonl`, which
+  are the same evidence tier but scriptable, historical, and precise enough
+  to bound a reset to a minutes-wide interval. Three traps that return
+  plausible wrong answers without erroring are documented with the filters
+  that defeat them: `primary` does not always denote the weekly window,
+  `limit_id` includes a permanently-zero decoy bucket that manufactures
+  dozens of phantom resets, and `resets_at` drifts by seconds on every
+  snapshot so it cannot be used as a reset predicate. Window-anchor shape
+  now distinguishes a button-press reset (clean +7d) from a quota
+  reconfiguration (anchor moved into the past), and concurrent sessions are
+  noted as emitting the same reset twice. On the announcement side, Radar
+  indexes only @thsottiaux and therefore cannot see @ChatGPT or
+  status.openai.com — half the predictive signal, since resets fire on
+  outage compensation as well as milestones — so the outage line and
+  codexrunway.com join the channel list. Both new scripts were executed
+  verbatim as a reader would paste them; that is how the status-page command
+  was found to need built-in retries rather than a bare call.
 - **peer-message** v1.0.1 → v1.1.0: add an operational coordination and learning contract distilled from post-release Claude/Codex use. A read-only `whoami` command gives parent tasks an exact reply address before delegation; worker reports correlate the incoming task through `in_reply_to`; multiline or data-rich reports use the CLI's UTF-8 message-file entry; and bounded verification stops at transport, receiver queue/history, explicit reply, or independently verified task completion instead of collapsing them into “delivered.” The evidence-gated improvement loop admits layer-bounded sender errors as well as receiver records, task outcomes, deterministic tests, and user corrections, routes each failure to its owner, requires executable When/Do/Evidence/Missing/Do-not-infer/Stop rules, and separates bounded Skill evolution from unsupported autonomous RSI. Existing transports, receipts, exit codes, and authorization boundaries are unchanged.
 - **terraform-skill** v1.0.1 → v1.1.0: replace deploy-and-pray advice with a release-safety contract grounded in current Terraform, Docker Compose, Caddy, and Cloudflare behavior. Staging and production now share one required-key schema; every runtime writer must validate the exact candidate bytes, full Compose-rendered environment, and immutable image before live mutation. Saved plans are bound to source/artifact provenance, staging receipts follow live verification, and production authorization remains a distinct last-reversible-point decision. Correct the prior claims that Compose ignores shell overrides, `terraform validate` proves environment/runtime behavior, token shape proves Cloudflare capability, and disabling `set -e` is the right way to preserve failure diagnostics.
 - **macos-cleaner** (daymade-macos v1.0.0 → v1.1.0): add a targeted Chromium code-sign-clone branch and current-user-scoped analyzer that separates active, inactive, and unknown children, binds approved batches to a candidate SHA, preserves explicit exclusions across activity races, and supports a final read-only recheck while the exact-path deletion prompt waits. Rank nominal APFS path accounting separately from expected physical release, require df readback for actual reclaimed space, and stop the legacy deletion helper from silently shrinking a changed batch, labeling measured totals as physically “freed,” or continuing after the first failure.

--- a/README.md
+++ b/README.md
@@ -3542,6 +3542,8 @@ they become load-bearing data.
 - 公告索引 Tibo Radar JSON API 现查；读 X 原帖走 fxtwitter 镜像拿完整长文（30 秒出结果）
 - 解读 Tibo 糙时间写法（「14pm PST」混用 24 小时制、常年写 PST 实为 PDT）
 - 太平洋时间→北京时间当场实测换算命令，含夏令时跨时令处理
+- 本机 `~/.codex` rollout 快照取证：重建周额度曲线、把重置定位到分钟级区间，不必让用户去截图
+- 同时查官方故障线（@ChatGPT / status.openai.com）——重置有里程碑与故障补偿两个触发，Radar 只索引前者
 - 证据纪律：tracker 标签 ≠ 已到账，官宣 ≠ 你的账户已到账；celebration 帖 = 里程碑重置预告
 
 **Example usage:**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -3526,7 +3526,9 @@ A 股行业投研工作流：全板块成分股 Top N 涨幅计算、公告窗�
 不要凭记忆回答“什么时候恢复额度”，应通过权威追踪通道现查并换算北京时间。
 
 **核心能力：**
-- Tibo Radar JSON API 与 codexlimitwatch 双源核对
+- Tibo Radar JSON API 现查公告；Radar 与 codexlimitwatch 属同一来源家族，只能互查解析一致，不作独立双源
+- 另查官方故障线（@ChatGPT / status.openai.com）：重置有里程碑与故障补偿两个触发，Radar 只索引前者
+- 本机 `~/.codex` rollout 快照取证：重建周额度曲线、把重置定位到分钟级区间
 - 识别公告中的混合时间写法和 PST/PDT 夏令时差异
 - 太平洋时间到北京时间的当场实测换算
 - 区分 tracker 标签、官方公告与用户账户实际到账状态

--- a/tibo-reset-codex/SKILL.md
+++ b/tibo-reset-codex/SKILL.md
@@ -258,7 +258,7 @@ PY
 
 ### 5. 通道失败时
 
-Radar API 挂 → fxtwitter 读原帖（上节命令）→ syndication 官方端点（截断 276 字符，只够核对元数据）→
+Radar API 挂 → fxtwitter 读原帖（§1 的命令）→ syndication 官方端点（截断 276 字符，只够核对元数据）→
 codexlimitwatch 单源（标注同源镜像）+ LunarWerx（仅 Tibo 信号解读交叉验证，非独立观测第二源）→
 WebSearch `thsottiaux reset`
 找转录。用户报告产品已变化时，公告通道全空仍要走静默重置路径；全部产品/社区


### PR DESCRIPTION
## 起因

#435 把 tibo-reset-codex bump 到 1.3.0，但**跳过了本仓自己的发布清单**（`CLAUDE.md` → "Files to update"）要求的配套项：CHANGELOG 条目与 README 同步。本 PR 补齐，并修掉核对过程中发现的两处与 SSOT 冲突的内容。

## 发现的不一致

| 项 | 权威来源 | 问题 |
|---|---|---|
| CHANGELOG 缺条目 | `CHANGELOG.md`（发布记录 SSOT） | marketplace.json 版本动了，但唯一记录发布历史的地方看不到它 |
| `（上节命令）`指错节 | `tibo-reset-codex/SKILL.md` | 命令在 §1，而 #435 的重编号（旧 §2/3/4 → §3/4/5）把这个**相对**指针又推远了一节 |
| 「双源核对」 | 同上，§1 证据纪律 | README.zh-CN 称 Radar 与 codexlimitwatch 为「双源核对」，而 skill 明写二者**同一来源家族、不能称独立双源** |
| README 未反映新能力 | 同上 | #435 加的本机取证腿与官方故障线没进用户可见目录 |

## 修改

- **CHANGELOG.md** — 补 `v1.2.2 → v1.3.1` 条目。
- **tibo-reset-codex/SKILL.md** — `（上节命令）` → `（§1 的命令）`。改成**绝对**引用，以后再重编号也不会断。
- **README.zh-CN.md** — 「双源核对」改为与 SSOT 一致的措辞；补两条新能力。
- **README.md** — 补两条新能力。
- **marketplace.json** — 1.3.0 → 1.3.1（SKILL.md 变了就必须 bump，`check_version_progression.py` 强制）。

## 刻意不动的

- **`CLAUDE.md`**：本仓自己的规则写明它「只承载 manifest/README 权威指针，不得重新引入按 skill 的快照」。本次变更不改任何流程、命令、路径或校验方式，所以正确动作是不动它。
- **两个 README 不持久化版本号 / skill 计数 / 目录位置**（本仓已有的反派生值规则），本次继续遵守——版本只存在于 marketplace.json，CHANGELOG 里的是事件记录。

## 验证

五个检查器全过：`check_marketplace.py` ✅ `check_shell_syntax.sh` ✅ `check_version_progression.py` ✅ `check_doc_skill_lists.py` ✅ `check_marketplace.sh` ✅ `validate_changed_skills.sh` ✅（1 touched skill）。

关键事实全文检索无残留冲突：仓内其余「双源」命中全部属于 daymade-sector-research（巨潮 + 东财，确为独立双源，无关）；SKILL.md 已无相对章节指针；`§1`/`§2` 引用均指向存在的节。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USvDWkeQZGbTMayut9o5Tw
