### PR TITLE
fix(git-safety-net): detect a foreign commit adopted onto your branch (v1.15.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -491,7 +491,7 @@
       "description": "Audits, preserves, recovers, and safely retires local Git state: unpushed or wrong-branch commits, dirty or detached worktrees, forgotten duplicate clones of the same repo, untracked work no bundle can back up, orphaned stashes, dangling commits, stale branches, and squash/rebase merge uncertainty. Use when the user fears work was lost; asks to recover a commit or branch; asks whether a worktree, clone, or scratch directory can be deleted; wants everything converged onto one main branch; or needs proof that cleanup will not drop work. Use it even after an audit reported clean — the usual gap is scope: every in-repo command is blind to a second clone elsewhere on disk. Triggers on \"did I lose work\", \"is everything merged\", \"is anything else lost\", \"safe to delete this clone\", \"clean up old branches/stashes\", \"only keep one main branch\", \"git reflog\", \"dangling commits\", \"分支灾难\", \"误删分支/commit\", \"worktree 能删吗\", \"还有没有丢的东西\", \"只保留一个主分支\". Covers local-Git forensics, not GitHub PR/API operations or routine sync.",
       "source": "./git-safety-net",
       "strict": false,
-      "version": "1.14.0",
+      "version": "1.15.0",
       "category": "developer-tools",
       "keywords": [
         "git",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,11 +35,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `merge-base --is-ancestor` answers only where the merge preserved the commit, so
   under squash merges its exit 1 means "not this object", not "not landed" — the
   probe that survives either strategy is a content grep carrying a known-absent
-  control line. Troubleshooting also gains the lost-receipt entry (a moved remote
+  control line; `--is-ancestor` also has a third exit code, 128, for a SHA this
+  repository does not have — a different answer from 1. The prescribed rebase is
+  `--onto "<foreign-sha>^"`, never `--onto "$base"`: the latter replays
+  `<foreign-sha>..<branch>` and so discards the author's *own* earlier commits when
+  the foreign one is not first after the base, silently and with exit 0 (measured
+  on an `A(yours) → F(foreign) → C(yours)` branch: `A` vanished). Because a rebase
+  exit code cannot report that, re-running the detection is now a required step,
+  and the already-pushed case routes to the existing force-push contract instead of
+  inventing one. Troubleshooting also gains the lost-receipt entry (a moved remote
   ref is not proof *your* write landed when concurrent sessions are merging) and a
-  probe-shape entry (`git ls-remote > f; [ -s f ]` reports "still exists" for a
-  deleted branch because network error text makes the file non-empty;
-  `--exit-code` separates matched (0), no match (2), and probe failure (128)). The
+  probe-shape entry: `git ls-remote > f; [ -s f ]` is wrong in **both** directions
+  depending on one redirection detail — bare `> f` leaves 0 bytes because Git
+  writes the failure to stderr, so a live branch reads as "already gone", while
+  `2>&1` writes 155 bytes and a deleted branch reads as "still there";
+  `--exit-code` separates matched (0), no match (2), and probe failure (128). The
   `rebase.autoStash` hazard is documented from measurement: on a conflicted rebase
   a sibling session's uncommitted work leaves the working tree while
   `git stash list` shows nothing, because an autostash is not a stash entry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `rebase.autoStash` hazard is documented from measurement: on a conflicted rebase
   a sibling session's uncommitted work leaves the working tree while
   `git stash list` shows nothing, because an autostash is not a stash entry.
+  Every probe that ships carries the guard that stops it failing green: an
+  unresolvable base turns `"$base"..HEAD` into `HEAD..HEAD` and prints nothing at
+  exit 0, indistinguishable from "clean", so the base is verified first; Git cannot
+  attribute commits in a shared checkout (both sessions write the same author), so
+  "which are mine" is a recorded fact and a stop condition, not a query; the
+  content grep needs its diff `+` stripped and its path checked, since a renamed
+  file and an unstripped needle both return 0 with the control line passing;
+  `--contains` stops reporting zero the moment the rescue ref exists, so the
+  reading must exclude it; `ls-remote` takes a fully-qualified `refs/heads/<branch>`
+  because a bare name also matches a same-named tag; and `cat-file -e` returns 128
+  for a mistyped branch and a symlinked path as well as a missing file.
   Every exit code, both failure directions, and each of the three wrong
   instruments were measured, not recalled.
 - **tibo-reset-codex** v1.2.2 → v1.3.1: add the missing local-account

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **peer-message** v1.0.0 (marketplace v3.6.0): restore the previously uncommitted Claude UDS messenger from its source session and extend it into a local Claude Code ↔ Codex coordination layer. The bundled stdlib CLI discovers `claude:` and `codex:` targets across isolated standard Claude profiles, preserves the original authenticated UDS fallback, routes Codex through the first-party `codex queue --thread` command, supports explicitly counted cross-provider broadcasts, adds source/reply envelopes with explicit provenance strength, and verifies delivery from Claude transcripts or Codex queue/thread history without writing either product's SQLite stores. Claude uses a host-recognized peer wrapper; Codex provenance remains advisory text enforced by receiver-side governing instructions. The Skill-local official-feature reference owns the corrected availability and inbound-policy boundaries. The registered test suite, live Codex queue acceptance, and subsequent thread-history consumption were independently verified.
 
 ### Changed
+- **git-safety-net** v1.14.0 → v1.15.0: add the inverse of the shared-checkout
+  failure the previous release covered. v1.14.0 handles *your uncommitted work*
+  being stranded on *another session's* branch; this adds *their commit* landing
+  in *your branch's history* — which every check the skill already prescribes
+  reports green on, because the foreign work left both the working tree and the
+  index at the moment it was committed. Only the branch's cumulative range
+  against its base reveals it, so that comparison becomes a pre-push/pre-PR step,
+  with the accidental tell named: a validator or CI job reporting a wider blast
+  radius than you worked on. Repair anchors the foreign commit on a rescue ref
+  before the rebase, so being wrong about the next step costs nothing. Two
+  instruments for "did that work survive anywhere else?" are documented as
+  measured wrong: `--contains` reports zero refs for a commit whose work already
+  merged under a squash-rewritten SHA, and whole-file comparison against the
+  integration branch reports differences as soon as the branch moves on. The
+  calibrated probe greps the integration branch for a string the commit added,
+  with a known-absent control line that is not optional. Troubleshooting gains
+  two receipt/probe entries: a moved remote ref is not proof *your* write landed
+  when concurrent sessions are merging, and `git ls-remote > f; [ -s f ]` reports
+  "still exists" for a branch that is long gone, because network error text makes
+  the file non-empty — `--exit-code` distinguishes matched (0), no match (2), and
+  probe failure (128). Every exit code and both failure directions were measured
+  in this repository, not recalled.
 - **tibo-reset-codex** v1.2.2 → v1.3.1: add the missing local-account
   forensics leg and close the announcement path's structural blind spot,
   both exposed by the 2026-09-01 live run. The skill previously could only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,25 +14,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **git-safety-net** v1.14.0 → v1.15.0: add the inverse of the shared-checkout
   failure the previous release covered. v1.14.0 handles *your uncommitted work*
   being stranded on *another session's* branch; this adds *their commit* landing
-  in *your branch's history* — which every check the skill already prescribes
-  reports green on, because the foreign work left both the working tree and the
-  index at the moment it was committed. Only the branch's cumulative range
-  against its base reveals it, so that comparison becomes a pre-push/pre-PR step,
-  with the accidental tell named: a validator or CI job reporting a wider blast
-  radius than you worked on. Repair anchors the foreign commit on a rescue ref
-  before the rebase, so being wrong about the next step costs nothing. Two
-  instruments for "did that work survive anywhere else?" are documented as
-  measured wrong: `--contains` reports zero refs for a commit whose work already
-  merged under a squash-rewritten SHA, and whole-file comparison against the
-  integration branch reports differences as soon as the branch moves on. The
-  calibrated probe greps the integration branch for a string the commit added,
-  with a known-absent control line that is not optional. Troubleshooting gains
-  two receipt/probe entries: a moved remote ref is not proof *your* write landed
-  when concurrent sessions are merging, and `git ls-remote > f; [ -s f ]` reports
-  "still exists" for a branch that is long gone, because network error text makes
-  the file non-empty — `--exit-code` distinguishes matched (0), no match (2), and
-  probe failure (128). Every exit code and both failure directions were measured
-  in this repository, not recalled.
+  in *your branch's history*, where it ships inside your PR. Every check the skill
+  already prescribes reports green on it, because the foreign work left both the
+  working tree and the index the moment it was committed; only the branch's
+  cumulative range against its recorded base reveals it, so that read-only
+  comparison becomes a pre-push/pre-PR step, with the accidental tell named — a
+  validator or CI job reporting a wider blast radius than you worked on. Repair
+  is routed through the contracts this Skill already carries rather than restated
+  inline: finding a foreign commit is itself evidence another writer was in the
+  checkout, so the standing quiesce/ownership rules apply before anything else,
+  and the sequence that follows is the existing one — Mode B evidence path,
+  `backup/pre-rewrite` at your own tip per "Snapshot before any history rewrite",
+  a separate rescue ref for their commit, then the rebase, with either ref retired
+  only under Mode C/E deletion-grade evidence. The base SHA is recorded at branch
+  creation because recovering it later reads a cached remote ref whose refresh is
+  a gated fetch. Three measured instrument corrections ship with it: `--contains`
+  reports zero refs for a commit whose work already merged under a
+  squash-rewritten SHA; hash-equality comparison of whole files against the
+  integration branch reports differences as soon as the branch moves on; and
+  `merge-base --is-ancestor` answers only where the merge preserved the commit, so
+  under squash merges its exit 1 means "not this object", not "not landed" — the
+  probe that survives either strategy is a content grep carrying a known-absent
+  control line. Troubleshooting also gains the lost-receipt entry (a moved remote
+  ref is not proof *your* write landed when concurrent sessions are merging) and a
+  probe-shape entry (`git ls-remote > f; [ -s f ]` reports "still exists" for a
+  deleted branch because network error text makes the file non-empty;
+  `--exit-code` separates matched (0), no match (2), and probe failure (128)). The
+  `rebase.autoStash` hazard is documented from measurement: on a conflicted rebase
+  a sibling session's uncommitted work leaves the working tree while
+  `git stash list` shows nothing, because an autostash is not a stash entry.
+  Every exit code, both failure directions, and each of the three wrong
+  instruments were measured, not recalled.
 - **tibo-reset-codex** v1.2.2 → v1.3.1: add the missing local-account
   forensics leg and close the announcement path's structural blind spot,
   both exposed by the 2026-09-01 live run. The skill previously could only

--- a/README.md
+++ b/README.md
@@ -3284,6 +3284,8 @@ additive until a step is explicitly labeled destructive.
 - Verifies a branch is merged by CONTENT — defeating the squash-merge "100 commits ahead" illusion
 - Proves a linked worktree safe before non-forced removal and exports all refs in one verified bundle
 - Optional adversarial multi-agent verification for a high-stakes "is everything merged?" call
+- Catches another session's commit adopted onto your branch before it ships inside your PR
+- Settles "did my push/merge actually land?" by content when the receipt was lost to a flaky network
 - Prevention habits: commit before switching, push WIP early, audit every checkout before deletion
 
 **Example usage:**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -3285,6 +3285,8 @@ Codex 上次做到一半中断了，读取 rollout 后把工作做完
 - 按内容验证分支是否已合并，破解 squash-merge 后“100 commits ahead”的幻觉
 - 删除 linked worktree 前证明其 HEAD 已被吸收，并把全部 refs 导出为校验过的 bundle
 - 高风险“是否真的全部合并了”场景可选对抗性多 agent 验证
+- 在开 PR 前抓出并行 session 的提交混入自己分支——分支级检查全绿也照样发生
+- 网络吞掉 push/merge 回执时，按内容而不是「远端 ref 动了」判定自己的写入是否落地
 - 预防习惯：切分支前先提交、尽早 push WIP、删除前审计每一个 checkout
 
 **示例：**

--- a/git-safety-net/.security-scan-passed
+++ b/git-safety-net/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-09-01T17:08:37.265263+00:00
+Scanned at: 2026-09-02T05:20:50.644560+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 6f1f1aa202f59021bfa7cf1415aab6b57dcff8434b393e6415da9c8bee52e93a
+Content hash: 48f493f40c910d0398dd8ffafa9121865fe625f821f8fa886510bdbfd2d8c4fe

--- a/git-safety-net/.security-scan-passed
+++ b/git-safety-net/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-09-02T05:58:03.726724+00:00
+Scanned at: 2026-09-02T06:00:43.764328+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 6e34ed8dc9065827279577f07ba31d010b3f90cc53a72350fbd8fdfd8f6e43eb
+Content hash: 1f12755528cb5c6884ec97b6aea5f2e36a5d0c6df8dd3034b798ed8d2d804ebd

--- a/git-safety-net/.security-scan-passed
+++ b/git-safety-net/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-09-02T05:47:10.781112+00:00
+Scanned at: 2026-09-02T05:58:03.726724+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 5eb5bdf87174b03ee3795d3d4b54aa3a4e66d0d8575465a6e91baf0da95e9d0e
+Content hash: 6e34ed8dc9065827279577f07ba31d010b3f90cc53a72350fbd8fdfd8f6e43eb

--- a/git-safety-net/.security-scan-passed
+++ b/git-safety-net/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-09-02T05:37:47.400078+00:00
+Scanned at: 2026-09-02T05:43:20.619402+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 1a79d689617dcbc281dbdd0a38860cbe8acb73414f63ea64451dd249c72387a9
+Content hash: e55565a43399a78b49d190fc69a15b9e0cc4d1e60ff244d485f33a731440b46e

--- a/git-safety-net/.security-scan-passed
+++ b/git-safety-net/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-09-02T05:20:50.644560+00:00
+Scanned at: 2026-09-02T05:37:47.400078+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 48f493f40c910d0398dd8ffafa9121865fe625f821f8fa886510bdbfd2d8c4fe
+Content hash: 1a79d689617dcbc281dbdd0a38860cbe8acb73414f63ea64451dd249c72387a9

--- a/git-safety-net/.security-scan-passed
+++ b/git-safety-net/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-09-02T05:43:20.619402+00:00
+Scanned at: 2026-09-02T05:47:10.781112+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: e55565a43399a78b49d190fc69a15b9e0cc4d1e60ff244d485f33a731440b46e
+Content hash: 5eb5bdf87174b03ee3795d3d4b54aa3a4e66d0d8575465a6e91baf0da95e9d0e

--- a/git-safety-net/SKILL.md
+++ b/git-safety-net/SKILL.md
@@ -339,27 +339,34 @@ The habits that keep a branch tangle from ever stranding work:
   back. Branch deletion remains a separately authorized Mode E action.
 - **The inverse case: another session's *commit* lands on your branch, and every check you already
   run stays green.** In a shared checkout, a commit a sibling session makes while `HEAD` sits on
-  your branch becomes a parent of yours, and ships inside your PR. `git branch --show-current`
-  names your branch, the tree is clean, and `git diff --cached --name-status` shows exactly your
-  paths — all true, all blind, because their work left the index the moment they committed. It is
-  visible only in the branch's cumulative range against the base you branched from, so read that
-  before you push or open a PR:
+  your branch becomes a parent of yours and ships inside your PR. `git branch --show-current` names
+  your branch, the tree is clean, and `git diff --cached --name-status` shows exactly your paths —
+  all true, all blind, because their work left the index the moment they committed. It appears only
+  in the branch's cumulative range against the base you branched from. Detection is read-only, so
+  run it before every push and before opening any PR:
   ```bash
-  base=$(git merge-base origin/main HEAD)
+  base=<the base SHA you recorded when you created the branch>
   git log  --oneline "$base"..HEAD     # every commit here must be yours
   git diff --name-only "$base" HEAD    # every path here must be yours
   ```
-  To repair, **anchor the foreign commit before dropping it** — one free ref makes the rebase
-  reversible whatever your analysis concludes:
-  ```bash
-  git branch rescue/foreign-<short-sha> <foreign-sha>     # unconditionally, first
-  git rebase --onto "$base" <foreign-sha> <your-branch>   # replays only the commits after it
-  ```
-  Whether that rescue ref is still needed is a *content* question, and the two obvious instruments
-  (`--contains`, whole-file comparison) were both measured answering it wrongly — the calibrated
-  probe is in the prevention reference. Real incident: a sibling session committed while `HEAD` sat
-  on a freshly created branch; the PR carried that session's in-progress work, and the only signal
-  was a repo validator reporting two changed components when the author had touched one.
+  Record that base SHA when you branch. Recovering it later with `git merge-base origin/main HEAD`
+  reads a *cached* remote ref, and the fetch that would refresh it is itself gated on exclusive
+  ownership — so on a contended checkout the derived base is the one input you cannot safely
+  recompute at the moment you need it.
+  **A foreign commit in that range is evidence another writer was in this checkout, so repair is
+  not yours to start.** Stop; the ownership rules above apply unchanged. Once ownership has
+  transferred, repair is a history rewrite of *your* branch — `git rebase --onto` checks out the
+  branch it rewrites — so it runs the existing sequence rather than a shortcut: the Mode B evidence
+  path, then `git branch backup/pre-rewrite <your-branch>` (**Snapshot before any history rewrite**
+  — this is what makes the rebase reversible), then `git branch rescue/foreign-<sha> <foreign-sha>`
+  (this preserves *their* work, a separate obligation and a different ref), then the rebase.
+  Retiring either ref afterwards is Mode C/E deletion-grade evidence, not a guess. Full procedure,
+  and why the two obvious "did their work survive?" probes return the wrong answer, in **A foreign
+  commit adopted onto your branch** in
+  [references/prevention_practices.md](references/prevention_practices.md). Real incident: a
+  sibling session committed while `HEAD` sat on a freshly created branch; the PR carried that
+  session's in-progress work, and the only signal was a repo validator reporting two changed
+  components when the author had touched one.
 - **If a parallel session is *actively* writing the shared tree, all repository mutation stops.**
   Do not `switch`, `add`, `reset`, create commits with a temporary index, update refs, or push. Use
   the repository's coordination system to quiesce that writer and transfer exclusive ownership; if
@@ -623,12 +630,20 @@ the helpers authorizes `checkout`, `reset`, `push`, `stash drop`, `branch -d`, o
 - **A push or merge command lost its receipt (timeout, TLS error, EOF) and the remote ref has
   moved** — a moved ref is not proof *your* write landed. On a repo with concurrent sessions the new
   tip can be someone else's merge, and retrying on that assumption either double-applies your change
-  or reports success for work that never shipped. Decide by content, never by movement: `git fetch`,
-  then confirm your exact object is an ancestor (`git merge-base --is-ancestor <your-sha>
-  origin/<branch>`; exit 0 = yes, 1 = no) or grep the remote-side file for a string only your version
-  contains (`git show origin/<branch>:<path>`). Real incident: three merge attempts failed at the
-  network layer while `origin/main` advanced twice — once for this author's merge, once for a
-  parallel session's.
+  or reports success for work that never shipped. Settle it by content — with two cautions first.
+  Refreshing remote-tracking refs is a fetch, which Mode C gates on exclusive ownership: on a
+  contended checkout, report the verdict as unavailable rather than fetching. And
+  `git merge-base --is-ancestor <your-sha> origin/<branch>` answers only where the merge preserved
+  your commit — a squash or rebase merge re-writes it, so exit 1 there means "not this object", not
+  "not landed", and acting on it produces exactly the double-apply this entry warns about (measured
+  in one repository on one day: one merged PR's commit was an ancestor, another's was not, and both
+  had landed). The probe that survives either merge strategy is content, with its control line:
+  ```bash
+  git show origin/<branch>:<path> | grep -cF '<a string only your version contains>'
+  git show origin/<branch>:<path> | grep -cF 'string-that-cannot-exist'  # must be 0, or the probe is broken
+  ```
+  Real incident: three merge attempts failed at the network layer while `origin/main` advanced
+  twice — once for this author's merge, once for a parallel session's.
 - **A "did that branch get deleted?" probe says it still exists** — check the shape of the probe
   before believing it. `git ls-remote <remote> <ref> > f` writes *error text* into that file when the
   network fails, so a following `[ -s f ]` reads non-empty and reports "still there" for a branch

--- a/git-safety-net/SKILL.md
+++ b/git-safety-net/SKILL.md
@@ -364,15 +364,15 @@ The habits that keep a branch tangle from ever stranding work:
   **A foreign commit in that range is evidence another writer was in this checkout, so repair is
   not yours to start.** Stop; the ownership rules above apply unchanged. Once ownership has
   transferred, repair is a history rewrite of *your* branch — `git rebase --onto` checks out the
-  branch it rewrites — so it runs the existing sequence rather than a shortcut: the Mode B evidence
-  path, then `git branch backup/pre-rewrite <your-branch>` (**Snapshot before any history rewrite**
+  branch it rewrites — so it runs the existing sequence rather than a shortcut: the applicable Mode B
+  evidence path, then `git branch backup/pre-rewrite <your-branch>` (**Snapshot before any history rewrite**
   — this is what makes the rebase reversible), then `git branch rescue/foreign-<sha> <foreign-sha>`
   (this preserves *their* work, a separate obligation and a different ref), then
   `git rebase --onto "<foreign-sha>^" "<foreign-sha>" <your-branch>` — **onto the foreign commit's
   parent, never onto the base**, because `--onto "$base"` discards everything before the foreign
   commit, your own earlier commits included, and exits 0. Then re-run the detection above: the
   rebase's exit code does not tell you whether it took something of yours with it. Retiring either
-  ref afterwards is Mode C/E deletion-grade evidence, not a guess. Full procedure,
+  ref afterwards requires Mode C/E deletion-grade evidence, not a guess. Full procedure,
   and why the two obvious "did their work survive?" probes return the wrong answer, in **A foreign
   commit adopted onto your branch** in
   [references/prevention_practices.md](references/prevention_practices.md). Real incident: a
@@ -643,8 +643,12 @@ the helpers authorizes `checkout`, `reset`, `push`, `stash drop`, `branch -d`, o
   moved** — a moved ref is not proof *your* write landed. On a repo with concurrent sessions the new
   tip can be someone else's merge, and retrying on that assumption either double-applies your change
   or reports success for work that never shipped. Settle it by content — with two cautions first.
-  Refreshing remote-tracking refs is a fetch, which Mode C gates on exclusive ownership: on a
-  contended checkout, report the verdict as unavailable rather than fetching. And
+  Refreshing remote-tracking refs is a fetch, which Mode C gates on exclusive ownership — which
+  cuts both ways. **Once you are the sole writer, fetch before you read**: rule 1 above applies to
+  this question specifically, because a stale `origin/<branch>` makes work the remote already has
+  read as unique, which is the double-apply this entry opened with. **On a contended checkout you
+  may not fetch**, and a verdict read off a cached ref is not a verdict — report it as unavailable.
+  And
   `git merge-base --is-ancestor <your-sha> origin/<branch>` answers only where the merge preserved
   your commit — a squash or rebase merge re-writes it, so exit 1 there means "not this object", not
   "not landed", and acting on it produces exactly the double-apply this entry warns about (measured

--- a/git-safety-net/SKILL.md
+++ b/git-safety-net/SKILL.md
@@ -350,9 +350,12 @@ The habits that keep a branch tangle from ever stranding work:
   git log  --oneline "$base"..HEAD     # every commit here must be yours
   git diff --name-only "$base" HEAD    # every path here must be yours
   ```
-  **The verify line is load-bearing.** If `$base` is empty or unresolvable, `"$base"..HEAD` becomes
-  `HEAD..HEAD` and the `git log` prints nothing with exit 0 — indistinguishable from "no foreign
-  commits". The check fails green, which is the direction that matters. And **"yours" is not
+  **The verify line is load-bearing, for one input in particular.** If `$base` is **empty** —
+  unset variable, a command substitution that failed — `"$base"..HEAD` becomes `HEAD..HEAD`, and the
+  `git log` prints nothing at exit 0, indistinguishable from "no foreign commits". A non-empty but
+  unresolvable base is not this problem: it fails loudly (`fatal: Invalid revision range`, exit
+  128). Measured — so the case the guard is there for is the quiet one, and it is the only one you
+  would otherwise miss. And **"yours" is not
   derivable from Git**: in a shared checkout both sessions write the same author and committer, so
   no flag separates them. It comes from the SHAs you recorded as you committed. If you cannot say
   which commits are yours, stop and ask — the repair deletes a commit, so a guess here is the loss
@@ -366,7 +369,7 @@ The habits that keep a branch tangle from ever stranding work:
   transferred, repair is a history rewrite of *your* branch — `git rebase --onto` checks out the
   branch it rewrites — so it runs the existing sequence rather than a shortcut: the applicable Mode B
   evidence path, then `git branch backup/pre-rewrite <your-branch>` (**Snapshot before any history rewrite**
-  — this is what makes the rebase reversible), then `git branch rescue/foreign-<sha> <foreign-sha>`
+  — this is what makes the rebase reversible), then `git branch rescue/foreign-<short-sha> <foreign-sha>`
   (this preserves *their* work, a separate obligation and a different ref), then
   `git rebase --onto "<foreign-sha>^" "<foreign-sha>" <your-branch>` — **onto the foreign commit's
   parent, never onto the base**, because `--onto "$base"` discards everything before the foreign
@@ -673,6 +676,9 @@ the helpers authorizes `checkout`, `reset`, `push`, `stash drop`, `branch -d`, o
   exactly this: `git ls-remote --exit-code <remote> refs/heads/<branch>` returns **0** when the ref
   matched, **2** when it did not, and anything else (**128** for an unreachable remote) means the
   probe itself failed — three outcomes the file-size test collapses into two, differently each time.
+  On 128 the branch's fate is unknown, which is not the same as gone: keep whatever preserves it,
+  retire nothing on this reading, and either retry once the remote is reachable or hand the question
+  to a human. An unreachable remote is a reason to wait, never a reason to clean up.
   Pass the **fully-qualified** ref: `ls-remote` matches on the tail of the name across all
   namespaces, so a bare branch name also matches a same-named tag and returns 0 for a branch that
   was deleted (measured — a common shape after a release tags its branch name). Same trap in the working tree: `[ -e <path> ]` cannot tell a tracked-and-clean

--- a/git-safety-net/SKILL.md
+++ b/git-safety-net/SKILL.md
@@ -346,9 +346,17 @@ The habits that keep a branch tangle from ever stranding work:
   run it before every push and before opening any PR:
   ```bash
   base=<the base SHA you recorded when you created the branch>
+  git rev-parse --verify "$base^{commit}"   # must print a SHA — see below before trusting the rest
   git log  --oneline "$base"..HEAD     # every commit here must be yours
   git diff --name-only "$base" HEAD    # every path here must be yours
   ```
+  **The verify line is load-bearing.** If `$base` is empty or unresolvable, `"$base"..HEAD` becomes
+  `HEAD..HEAD` and the `git log` prints nothing with exit 0 — indistinguishable from "no foreign
+  commits". The check fails green, which is the direction that matters. And **"yours" is not
+  derivable from Git**: in a shared checkout both sessions write the same author and committer, so
+  no flag separates them. It comes from the SHAs you recorded as you committed. If you cannot say
+  which commits are yours, stop and ask — the repair deletes a commit, so a guess here is the loss
+  this skill exists to prevent.
   Record that base SHA when you branch. Recovering it later with `git merge-base origin/main HEAD`
   reads a *cached* remote ref, and the fetch that would refresh it is itself gated on exclusive
   ownership — so on a contended checkout the derived base is the one input you cannot safely
@@ -658,11 +666,17 @@ the helpers authorizes `checkout`, `reset`, `push`, `stash drop`, `branch -d`, o
   so the test reports "already gone" for a branch whose fate is unknown — and you stop preserving
   it. Merge the streams (`> f 2>&1`, `&> f`) and the same failure writes 155 bytes, so the test
   reports "still there" for a branch that is long gone. Use the exit code the command has for
-  exactly this: `git ls-remote --exit-code <remote> <ref>` returns **0** when the ref matched, **2**
-  when it did not, and anything else (**128** for an unreachable remote) means the probe itself
-  failed — three outcomes the file-size test collapses into two, differently each time. Same trap in the working tree: `[ -e <path> ]` cannot tell a tracked-and-clean
-  file from an untracked collision. Ask Git instead — `git cat-file -e <branch>:<path>` (0 = the
-  branch has it, non-zero = it does not).
+  exactly this: `git ls-remote --exit-code <remote> refs/heads/<branch>` returns **0** when the ref
+  matched, **2** when it did not, and anything else (**128** for an unreachable remote) means the
+  probe itself failed — three outcomes the file-size test collapses into two, differently each time.
+  Pass the **fully-qualified** ref: `ls-remote` matches on the tail of the name across all
+  namespaces, so a bare branch name also matches a same-named tag and returns 0 for a branch that
+  was deleted (measured — a common shape after a release tags its branch name). Same trap in the working tree: `[ -e <path> ]` cannot tell a tracked-and-clean
+  file from an untracked collision. Ask Git instead — `git cat-file -e <branch>:<path>`, where 0 means the
+  branch has it. Do not read non-zero as "it does not": 128 also covers a mistyped branch name and a
+  path that traverses a tracked symlink, and Git distinguishes them only in the stderr text — so
+  read that text rather than the code alone, or you have rebuilt the very defect this entry opened
+  with.
 - **You're on a detached HEAD after checking out a commit** — that commit is safe as long as you
   `git switch -c <branch> HEAD` (or the reflog remembers it for ~90 days). Don't leave important
   new work on a detached HEAD across a `gc`.

--- a/git-safety-net/SKILL.md
+++ b/git-safety-net/SKILL.md
@@ -337,6 +337,29 @@ The habits that keep a branch tangle from ever stranding work:
   follow the incident-only relocation procedure in the prevention reference: prove your files match
   across bases, commit only explicit paths, and restore the prior branch before handing ownership
   back. Branch deletion remains a separately authorized Mode E action.
+- **The inverse case: another session's *commit* lands on your branch, and every check you already
+  run stays green.** In a shared checkout, a commit a sibling session makes while `HEAD` sits on
+  your branch becomes a parent of yours, and ships inside your PR. `git branch --show-current`
+  names your branch, the tree is clean, and `git diff --cached --name-status` shows exactly your
+  paths — all true, all blind, because their work left the index the moment they committed. It is
+  visible only in the branch's cumulative range against the base you branched from, so read that
+  before you push or open a PR:
+  ```bash
+  base=$(git merge-base origin/main HEAD)
+  git log  --oneline "$base"..HEAD     # every commit here must be yours
+  git diff --name-only "$base" HEAD    # every path here must be yours
+  ```
+  To repair, **anchor the foreign commit before dropping it** — one free ref makes the rebase
+  reversible whatever your analysis concludes:
+  ```bash
+  git branch rescue/foreign-<short-sha> <foreign-sha>     # unconditionally, first
+  git rebase --onto "$base" <foreign-sha> <your-branch>   # replays only the commits after it
+  ```
+  Whether that rescue ref is still needed is a *content* question, and the two obvious instruments
+  (`--contains`, whole-file comparison) were both measured answering it wrongly — the calibrated
+  probe is in the prevention reference. Real incident: a sibling session committed while `HEAD` sat
+  on a freshly created branch; the PR carried that session's in-progress work, and the only signal
+  was a repo validator reporting two changed components when the author had touched one.
 - **If a parallel session is *actively* writing the shared tree, all repository mutation stops.**
   Do not `switch`, `add`, `reset`, create commits with a temporary index, update refs, or push. Use
   the repository's coordination system to quiesce that writer and transfer exclusive ownership; if
@@ -597,6 +620,24 @@ the helpers authorizes `checkout`, `reset`, `push`, `stash drop`, `branch -d`, o
   many hours old by the end. Symptom to recognise: a change you know you committed appears absent
   upstream, so you prepare to re-ship it. Fetch first, then compare by content; if it did land,
   check whether anyone improved it before re-applying your version over theirs.
+- **A push or merge command lost its receipt (timeout, TLS error, EOF) and the remote ref has
+  moved** — a moved ref is not proof *your* write landed. On a repo with concurrent sessions the new
+  tip can be someone else's merge, and retrying on that assumption either double-applies your change
+  or reports success for work that never shipped. Decide by content, never by movement: `git fetch`,
+  then confirm your exact object is an ancestor (`git merge-base --is-ancestor <your-sha>
+  origin/<branch>`; exit 0 = yes, 1 = no) or grep the remote-side file for a string only your version
+  contains (`git show origin/<branch>:<path>`). Real incident: three merge attempts failed at the
+  network layer while `origin/main` advanced twice — once for this author's merge, once for a
+  parallel session's.
+- **A "did that branch get deleted?" probe says it still exists** — check the shape of the probe
+  before believing it. `git ls-remote <remote> <ref> > f` writes *error text* into that file when the
+  network fails, so a following `[ -s f ]` reads non-empty and reports "still there" for a branch
+  that is long gone. Use the exit code the command has for exactly this: `git ls-remote --exit-code
+  <remote> <ref>` returns **0** when the ref matched, **2** when it did not, and anything else (128
+  for an unreachable remote) means the probe itself failed — three outcomes the file-size test
+  collapses into two. Same trap in the working tree: `[ -e <path> ]` cannot tell a tracked-and-clean
+  file from an untracked collision. Ask Git instead — `git cat-file -e <branch>:<path>` (0 = the
+  branch has it, non-zero = it does not).
 - **You're on a detached HEAD after checking out a commit** — that commit is safe as long as you
   `git switch -c <branch> HEAD` (or the reflog remembers it for ~90 days). Don't leave important
   new work on a detached HEAD across a `gc`.

--- a/git-safety-net/SKILL.md
+++ b/git-safety-net/SKILL.md
@@ -359,8 +359,12 @@ The habits that keep a branch tangle from ever stranding work:
   branch it rewrites — so it runs the existing sequence rather than a shortcut: the Mode B evidence
   path, then `git branch backup/pre-rewrite <your-branch>` (**Snapshot before any history rewrite**
   — this is what makes the rebase reversible), then `git branch rescue/foreign-<sha> <foreign-sha>`
-  (this preserves *their* work, a separate obligation and a different ref), then the rebase.
-  Retiring either ref afterwards is Mode C/E deletion-grade evidence, not a guess. Full procedure,
+  (this preserves *their* work, a separate obligation and a different ref), then
+  `git rebase --onto "<foreign-sha>^" "<foreign-sha>" <your-branch>` — **onto the foreign commit's
+  parent, never onto the base**, because `--onto "$base"` discards everything before the foreign
+  commit, your own earlier commits included, and exits 0. Then re-run the detection above: the
+  rebase's exit code does not tell you whether it took something of yours with it. Retiring either
+  ref afterwards is Mode C/E deletion-grade evidence, not a guess. Full procedure,
   and why the two obvious "did their work survive?" probes return the wrong answer, in **A foreign
   commit adopted onto your branch** in
   [references/prevention_practices.md](references/prevention_practices.md). Real incident: a
@@ -637,7 +641,10 @@ the helpers authorizes `checkout`, `reset`, `push`, `stash drop`, `branch -d`, o
   your commit — a squash or rebase merge re-writes it, so exit 1 there means "not this object", not
   "not landed", and acting on it produces exactly the double-apply this entry warns about (measured
   in one repository on one day: one merged PR's commit was an ancestor, another's was not, and both
-  had landed). The probe that survives either merge strategy is content, with its control line:
+  had landed). It has a third exit code too: **128** when `<your-sha>` is not a commit this
+  repository has — which is what you get for a hosted merge that created its own object, and it is
+  not the same answer as 1. The probe that survives either merge strategy is content, with its
+  control line:
   ```bash
   git show origin/<branch>:<path> | grep -cF '<a string only your version contains>'
   git show origin/<branch>:<path> | grep -cF 'string-that-cannot-exist'  # must be 0, or the probe is broken
@@ -645,12 +652,15 @@ the helpers authorizes `checkout`, `reset`, `push`, `stash drop`, `branch -d`, o
   Real incident: three merge attempts failed at the network layer while `origin/main` advanced
   twice — once for this author's merge, once for a parallel session's.
 - **A "did that branch get deleted?" probe says it still exists** — check the shape of the probe
-  before believing it. `git ls-remote <remote> <ref> > f` writes *error text* into that file when the
-  network fails, so a following `[ -s f ]` reads non-empty and reports "still there" for a branch
-  that is long gone. Use the exit code the command has for exactly this: `git ls-remote --exit-code
-  <remote> <ref>` returns **0** when the ref matched, **2** when it did not, and anything else (128
-  for an unreachable remote) means the probe itself failed — three outcomes the file-size test
-  collapses into two. Same trap in the working tree: `[ -e <path> ]` cannot tell a tracked-and-clean
+  before believing it, because `git ls-remote <remote> <ref> > f` followed by `[ -s f ]` is wrong in
+  **both** directions and which one you get depends on a redirection detail. Measured against an
+  unreachable remote: bare `> f` leaves the file at **0 bytes** (Git writes the failure to stderr),
+  so the test reports "already gone" for a branch whose fate is unknown — and you stop preserving
+  it. Merge the streams (`> f 2>&1`, `&> f`) and the same failure writes 155 bytes, so the test
+  reports "still there" for a branch that is long gone. Use the exit code the command has for
+  exactly this: `git ls-remote --exit-code <remote> <ref>` returns **0** when the ref matched, **2**
+  when it did not, and anything else (**128** for an unreachable remote) means the probe itself
+  failed — three outcomes the file-size test collapses into two, differently each time. Same trap in the working tree: `[ -e <path> ]` cannot tell a tracked-and-clean
   file from an untracked collision. Ask Git instead — `git cat-file -e <branch>:<path>` (0 = the
   branch has it, non-zero = it does not).
 - **You're on a detached HEAD after checking out a commit** — that commit is safe as long as you

--- a/git-safety-net/references/prevention_practices.md
+++ b/git-safety-net/references/prevention_practices.md
@@ -287,9 +287,18 @@ precondition:
 
 ```bash
 base=<the base SHA you recorded when you created the branch>
+git rev-parse --verify "$base^{commit}"   # must print a SHA, or everything below is meaningless
 git log  --oneline "$base"..HEAD          # every commit here must be yours
 git diff --name-only "$base" HEAD         # every path here must be yours
 ```
+
+Two things this check cannot do for you. If `$base` is empty or unresolvable, `"$base"..HEAD`
+degenerates to `HEAD..HEAD`: the `git log` prints nothing and exits 0, which is exactly what "clean"
+looks like — hence the verify line above, which fails loudly instead. And **Git cannot tell you
+which commits are yours**: a shared checkout gives both sessions the same author and committer
+identity, so no `--author` filter separates them. The answer comes from the SHAs you recorded as you
+committed, which is the second reason to record as you go. If you cannot say with certainty which
+commits are yours, stop and ask rather than proceed — every step below deletes a commit.
 
 **Record the base SHA at branch creation.** `git merge-base origin/main HEAD` recovers it only from
 a *cached* remote ref, and refreshing that cache is a fetch — which **Shared checkout and concurrent
@@ -324,6 +333,10 @@ existing sequence in order:
    ```bash
    git branch rescue/foreign-<short-sha> <foreign-sha>
    ```
+   If this exits 128 with `a branch named ... already exists`, do not shrug it off and continue:
+   confirm the existing ref points at the same object (`git rev-parse rescue/foreign-<short-sha>`)
+   before treating this step as done. A same-named ref at a *different* object means someone else's
+   repair is already in flight.
 4. **Rebase onto the foreign commit's parent — not onto the base.** `git rebase --onto X Y branch`
    replays `Y..branch`, so `--onto "$base" <foreign-sha>` discards **everything before the foreign
    commit, including your own earlier commits**, and reports success with exit 0. That is only
@@ -370,7 +383,11 @@ a real commit whose work had definitively shipped:
 - **"No ref contains it" does *not* prove the work is unique.** `git for-each-ref --contains <sha>`
   (or `git branch -a --contains <sha>`) reports **zero** refs for a commit that already merged,
   because a **squash or rebase merge re-writes it under a new SHA** — the original object survives
-  only as an unreachable dangler while its content sits in the integration branch.
+  only as an unreachable dangler while its content sits in the integration branch. Note you can no
+  longer observe that zero once step 3 has run: your own `rescue/foreign-<sha>` contains it, so the
+  count is never zero again (measured: 1 → 2 on creating the rescue ref). Exclude your own ref —
+  `git for-each-ref --contains <sha> --format='%(refname)' | grep -v '^refs/heads/rescue/'` — or the
+  reading is about a ref you created a minute ago.
 - **Hash-equality comparison of whole files against the integration branch does not prove it
   either.** Hashing `git show <sha>:<path>` against `git show origin/main:<path>` reports
   "different" for every file as soon as the branch moves on; any later commit touching the same
@@ -380,11 +397,18 @@ a real commit whose work had definitively shipped:
 - **A string the commit added, grepped against the integration branch, does answer** — with the
   control line that makes it an instrument rather than a guess:
   ```bash
+  git show origin/main:<path> >/dev/null   # must succeed first: 128 here means the path moved, and
+                                           # then BOTH greps below return 0 and the control passes
   git show <sha> -- <path> | grep '^+' | grep -v '^+++'   # read these; pick one distinctive line
-  needle='<a distinctive phrase from that output>'
+  needle='<that phrase WITHOUT its leading + — diff output carries one, and grep -cF is literal>'
   git show origin/main:<path> | grep -cF "$needle"                  # >0 ⇒ the work is in main
   git show origin/main:<path> | grep -cF 'string-that-cannot-exist' # must be 0, or the probe is broken
   ```
+  Both leading-`+` and a renamed path produce the same false negative — 0 hits with the control line
+  passing — so neither is caught by the control alone; that is what the first line and the `+` note
+  are for. If the file was renamed or moved in the integration branch, this probe cannot answer:
+  fall through to Mode E's rung 4 function/marker-level probe, which is
+  built for exactly the absorbed-into-a-refactor case.
   Treat the result as an explanation of *why* an ancestry check disagreed, not as deletion
   authority: it reads one string in one file, while Mode C's trial merge is the check this skill
   records as right every time. If the work turns out to exist only on your branch, it was never

--- a/git-safety-net/references/prevention_practices.md
+++ b/git-safety-net/references/prevention_practices.md
@@ -281,55 +281,91 @@ reports correctly, and reports green:
 | `git status` | clean | their work was committed, so it left the working tree |
 | `git diff --cached --name-status` | only your paths | their work left the index too, at commit time |
 
-The foreign commit is visible only in the branch's **cumulative range against the base you branched
-from** — a comparison none of the above makes:
+The foreign commit appears only in the branch's **cumulative range against the base you branched
+from** — a comparison none of the above makes. This step is read-only and carries no ownership
+precondition:
 
 ```bash
-base=$(git merge-base origin/main HEAD)   # or the base SHA you recorded when branching
+base=<the base SHA you recorded when you created the branch>
 git log  --oneline "$base"..HEAD          # every commit here must be yours
 git diff --name-only "$base" HEAD         # every path here must be yours
 ```
 
-Run it before every push and before opening any PR from a shared checkout. The signal that reaches
-you by accident is a repo validator or CI job reporting a wider blast radius than you worked on —
-"2 components changed" when you touched 1. Treat that as this failure mode until proven otherwise.
+**Record the base SHA at branch creation.** `git merge-base origin/main HEAD` recovers it only from
+a *cached* remote ref, and refreshing that cache is a fetch — which **Shared checkout and concurrent
+sessions: one writer** and Mode C both gate on exclusive ownership. A stale base widens the range,
+which is the safe direction for detection but the dangerous one for the rebase that may follow, and
+it is precisely the moment you cannot fetch to fix it. Recording one SHA at the start costs nothing
+and removes the dependency.
 
-**Repair — anchor first, analyse second.** The rebase that removes their commit is the easy half;
-the dangerous half is deciding it is safe to remove. Make that decision non-fatal before you make it:
+Run the comparison before every push and before opening any PR from a shared checkout. The signal
+that reaches you by accident is a repo validator or CI job reporting a wider blast radius than you
+worked on — "2 components changed" when you touched 1. Treat that as this failure mode until proven
+otherwise.
 
-```bash
-git branch rescue/foreign-<short-sha> <foreign-sha>    # free, instant, makes the drop reversible
-git rebase --onto "$base" <foreign-sha> <your-branch>  # replays only the commits after it
-```
+**Repair is governed by the rules that already exist here — do not shortcut them.** Finding a
+foreign commit is itself evidence that another writer was in this checkout, so the first obligation
+is the standing one: stop, and use the repository's coordination system to quiesce that writer and
+transfer exclusive ownership. If no such authority exists, stop with the evidence intact and report
+it. Nothing below is a concurrency loophole.
 
-Anchoring first is not belt-and-braces — it is what lets you be *wrong* about the next step without
-losing anything. Do it unconditionally, before any investigation.
+Once you are the sole writer, the repair is a history rewrite of your own branch — `git rebase
+--onto` checks out the branch it rewrites, so it is checkout-relative mutation — and it runs the
+existing sequence in order:
 
-**Then decide whether the rescue ref can go, and distrust the two obvious instruments.** The question
-is whether that work survives anywhere other than your branch. Both natural ways to ask it were
-measured returning the wrong answer on a real commit whose work had definitively shipped:
+1. **Audit before rebase / branch-delete** (below): select and run the applicable evidence path.
+   Local-only commits and dirty authorized worktrees must be preserved before the destructive step.
+2. **Snapshot before any history rewrite** (below): `git branch backup/pre-rewrite <your-branch>`.
+   This ref points at *your* tip and is what makes the rebase reversible. Nothing else does — after
+   `git rebase --onto` your pre-rebase tip is reachable through the reflog only (measured: zero refs
+   contain it).
+3. **Preserve their commit** — a separate obligation needing its own ref, because the backup above
+   points at your tip and the rebase drops *their* commit from your branch:
+   ```bash
+   git branch rescue/foreign-<short-sha> <foreign-sha>
+   ```
+4. **Rebase — and confirm the working tree is clean before you do.** With `rebase.autoStash`
+   enabled (measured behaviour), a rebase on a shared tree silently stashes whatever a sibling
+   session left uncommitted. On a clean run it is restored and you would never know. If the rebase
+   **stops on a conflict**, their files are gone from the working tree and `git stash list` shows
+   **nothing** — an autostash is not a stash entry, so the first check anyone runs comes back empty
+   while their work sits at `.git/rebase-merge/autostash` and in the one `Created autostash: <sha>`
+   line the rebase already printed. `git rebase --abort` restores it, but only if someone knows to
+   look. This is the unscoped stash of another session's work that this skill forbids, performed on
+   your behalf by a config flag.
+   ```bash
+   git rebase --onto "$base" <foreign-sha> <your-branch>   # replays only the commits after it
+   ```
+5. **Retiring either ref is a Mode E action** under Mode C evidence — the same standard this skill
+   applies to every other preserving ref it tells you to create, and no weaker. Do not delete
+   `rescue/foreign-<sha>` on a heuristic.
+
+**Why the obvious "did their work survive?" probes mislead.** These are worth knowing before you
+reach Mode C, because both look authoritative and both were measured returning the wrong answer on
+a real commit whose work had definitively shipped:
 
 - **"No ref contains it" does *not* prove the work is unique.** `git for-each-ref --contains <sha>`
   (or `git branch -a --contains <sha>`) reports **zero** refs for a commit that already merged,
   because a **squash or rebase merge re-writes it under a new SHA** — the original object survives
   only as an unreachable dangler while its content sits in the integration branch.
-- **Whole-file comparison against the integration branch does not prove it either.** Hashing
-  `git show <sha>:<path>` against `git show origin/main:<path>` reports "different" for every file
-  as soon as the branch moves on; any later commit touching the same files is enough. Measured: all
-  five files differed while the work was fully present.
-- **What works: grep the integration branch for a distinctive string the commit *added*.**
+- **Hash-equality comparison of whole files against the integration branch does not prove it
+  either.** Hashing `git show <sha>:<path>` against `git show origin/main:<path>` reports
+  "different" for every file as soon as the branch moves on; any later commit touching the same
+  files is enough. Measured: all five files differed while the work was fully present. (This is not
+  the superset-style same-file supersession check in Mode E rung 3, which compares content coverage
+  rather than equality.)
+- **A string the commit added, grepped against the integration branch, does answer** — with the
+  control line that makes it an instrument rather than a guess:
   ```bash
   git show <sha> -- <path> | grep '^+' | grep -v '^+++'   # read these; pick one distinctive line
   needle='<a distinctive phrase from that output>'
   git show origin/main:<path> | grep -cF "$needle"                  # >0 ⇒ the work is in main
   git show origin/main:<path> | grep -cF 'string-that-cannot-exist' # must be 0, or the probe is broken
   ```
-  The last line is not optional. It is what separates "the work is not there" from "my probe does not
-  work" — two outcomes a single grep returns identically.
-
-Delete the rescue ref only after that probe answers, in the same command shape, on a string you know
-is present. If the work turns out to exist *only* on your branch, it was never yours to drop: keep
-the rescue ref, tell the other session where it is, and let them re-land it.
+  Treat the result as an explanation of *why* an ancestry check disagreed, not as deletion
+  authority: it reads one string in one file, while Mode C's trial merge is the check this skill
+  records as right every time. If the work turns out to exist only on your branch, it was never
+  yours to drop — keep the rescue ref, tell the other session where it is, and let them re-land it.
 
 ## Audit before rebase / branch-delete
 

--- a/git-safety-net/references/prevention_practices.md
+++ b/git-safety-net/references/prevention_practices.md
@@ -324,21 +324,44 @@ existing sequence in order:
    ```bash
    git branch rescue/foreign-<short-sha> <foreign-sha>
    ```
-4. **Rebase — and confirm the working tree is clean before you do.** With `rebase.autoStash`
-   enabled (measured behaviour), a rebase on a shared tree silently stashes whatever a sibling
-   session left uncommitted. On a clean run it is restored and you would never know. If the rebase
-   **stops on a conflict**, their files are gone from the working tree and `git stash list` shows
-   **nothing** — an autostash is not a stash entry, so the first check anyone runs comes back empty
-   while their work sits at `.git/rebase-merge/autostash` and in the one `Created autostash: <sha>`
-   line the rebase already printed. `git rebase --abort` restores it, but only if someone knows to
-   look. This is the unscoped stash of another session's work that this skill forbids, performed on
-   your behalf by a config flag.
+4. **Rebase onto the foreign commit's parent — not onto the base.** `git rebase --onto X Y branch`
+   replays `Y..branch`, so `--onto "$base" <foreign-sha>` discards **everything before the foreign
+   commit, including your own earlier commits**, and reports success with exit 0. That is only
+   harmless when the foreign commit happens to be the first commit after the base. The general form
+   drops exactly one commit and keeps yours on both sides of it:
    ```bash
-   git rebase --onto "$base" <foreign-sha> <your-branch>   # replays only the commits after it
+   git rebase --onto "<foreign-sha>^" "<foreign-sha>" <your-branch>
    ```
-5. **Retiring either ref is a Mode E action** under Mode C evidence — the same standard this skill
+   Measured on a branch whose history was `A(yours) → F(foreign) → C(yours)`: the `--onto "$base"`
+   form left only `C` and silently dropped `A`; the form above kept `A` and `C` and dropped only `F`.
+   Bounds: it removes **one non-merge commit**. For several foreign commits, or one that is a merge,
+   stop and drop them explicitly through an interactive rebase, re-reading this list first.
+   The tree must be clean before you start. If it is not, `git rebase` refuses with
+   `error: cannot rebase: You have unstaged changes. / Please commit or stash them.` — and note that
+   the second half of Git's own suggestion is the unscoped stash this skill forbids. The correct
+   response is that you are not the sole writer yet: go back to the ownership step.
+   With `rebase.autoStash` enabled the refusal never happens, and that is worse (measured): the
+   rebase silently stashes whatever a sibling session left uncommitted, and if it then **stops on a
+   conflict**, their files are gone from the working tree while `git stash list` shows **nothing** —
+   an autostash is not a stash entry, so the first check anyone runs comes back empty. Their work is
+   at `.git/rebase-merge/autostash`, and in the single `Created autostash: <sha>` line already
+   printed. `git rebase --abort` restores it, but only if someone knows to look.
+5. **Re-run the detection.** The repair is not verified by the rebase's exit code:
+   ```bash
+   git log  --oneline "$base"..<your-branch>    # every commit yours — and your earlier ones still here
+   git diff --name-only "$base" <your-branch>   # every path yours
+   ```
+   Check for both failures at once: the foreign commit gone, *and* nothing of yours gone with it.
+6. **If the branch was already pushed** — which the incident above describes, since the foreign work
+   reached a PR — the rewrite makes your local branch diverge and the next `git push` is rejected
+   with `Updates were rejected because the tip of your current branch is behind`. Do not resolve that
+   here: force-updating a published ref is governed by **Destructive-operation safety (reset /
+   force-push / rewrite)** in [recovery_playbook.md](recovery_playbook.md), which requires
+   `--force-with-lease` over `--force`. Anyone else who fetched that branch also needs telling.
+7. **Retiring either ref is a Mode E action** under Mode C evidence — the same standard this skill
    applies to every other preserving ref it tells you to create, and no weaker. Do not delete
-   `rescue/foreign-<sha>` on a heuristic.
+   `rescue/foreign-<sha>` on a heuristic. Note the rescue ref may also be the only anchor for *your*
+   own commits if step 4 was run in the discarding form; step 5 is what catches that.
 
 **Why the obvious "did their work survive?" probes mislead.** These are worth knowing before you
 reach Mode C, because both look authoritative and both were measured returning the wrong answer on

--- a/git-safety-net/references/prevention_practices.md
+++ b/git-safety-net/references/prevention_practices.md
@@ -12,6 +12,7 @@ ceremony; adopt the ones whose failure mode you're exposed to.
 - Push work-in-progress branches early
 - Confirm the branch before every commit
 - Recover stranded work after a parallel session switched the shared tree
+- A foreign commit adopted onto your branch (the inverse case)
 - Audit before rebase / branch-delete
 - Audit every authorized worktree before retirement
 - Snapshot before any history rewrite
@@ -262,6 +263,73 @@ After Step 3, return to **Exact-SHA handoff and scoped completion** above: recor
 `topic_sha`, push and read back that exact object, use `git merge "$topic_sha"` for a direct merge,
 and require the hosted expected-head-SHA gate (or immediately preceding hosted head readback) for a
 PR merge. Any branch-tip drift expires the handoff.
+
+## A foreign commit adopted onto your branch (the inverse case)
+
+**Failure mode:** the mirror image of the section above. There, a parallel session moved the shared
+tree and *your uncommitted work* ended up on *their* branch. Here *their commit* ends up in *your
+branch's history*: you created a topic branch in a shared checkout, a sibling session committed while
+`HEAD` was still on it, and that commit is now a parent of yours. Open a PR and it ships their
+in-progress work under your name and your review.
+
+**Why the usual checks miss it.** Every branch-level instrument this skill already tells you to run
+reports correctly, and reports green:
+
+| Check | What it says | Why it cannot see this |
+|---|---|---|
+| `git branch --show-current` | your branch | it *is* your branch — that was never the problem |
+| `git status` | clean | their work was committed, so it left the working tree |
+| `git diff --cached --name-status` | only your paths | their work left the index too, at commit time |
+
+The foreign commit is visible only in the branch's **cumulative range against the base you branched
+from** — a comparison none of the above makes:
+
+```bash
+base=$(git merge-base origin/main HEAD)   # or the base SHA you recorded when branching
+git log  --oneline "$base"..HEAD          # every commit here must be yours
+git diff --name-only "$base" HEAD         # every path here must be yours
+```
+
+Run it before every push and before opening any PR from a shared checkout. The signal that reaches
+you by accident is a repo validator or CI job reporting a wider blast radius than you worked on —
+"2 components changed" when you touched 1. Treat that as this failure mode until proven otherwise.
+
+**Repair — anchor first, analyse second.** The rebase that removes their commit is the easy half;
+the dangerous half is deciding it is safe to remove. Make that decision non-fatal before you make it:
+
+```bash
+git branch rescue/foreign-<short-sha> <foreign-sha>    # free, instant, makes the drop reversible
+git rebase --onto "$base" <foreign-sha> <your-branch>  # replays only the commits after it
+```
+
+Anchoring first is not belt-and-braces — it is what lets you be *wrong* about the next step without
+losing anything. Do it unconditionally, before any investigation.
+
+**Then decide whether the rescue ref can go, and distrust the two obvious instruments.** The question
+is whether that work survives anywhere other than your branch. Both natural ways to ask it were
+measured returning the wrong answer on a real commit whose work had definitively shipped:
+
+- **"No ref contains it" does *not* prove the work is unique.** `git for-each-ref --contains <sha>`
+  (or `git branch -a --contains <sha>`) reports **zero** refs for a commit that already merged,
+  because a **squash or rebase merge re-writes it under a new SHA** — the original object survives
+  only as an unreachable dangler while its content sits in the integration branch.
+- **Whole-file comparison against the integration branch does not prove it either.** Hashing
+  `git show <sha>:<path>` against `git show origin/main:<path>` reports "different" for every file
+  as soon as the branch moves on; any later commit touching the same files is enough. Measured: all
+  five files differed while the work was fully present.
+- **What works: grep the integration branch for a distinctive string the commit *added*.**
+  ```bash
+  git show <sha> -- <path> | grep '^+' | grep -v '^+++'   # read these; pick one distinctive line
+  needle='<a distinctive phrase from that output>'
+  git show origin/main:<path> | grep -cF "$needle"                  # >0 ⇒ the work is in main
+  git show origin/main:<path> | grep -cF 'string-that-cannot-exist' # must be 0, or the probe is broken
+  ```
+  The last line is not optional. It is what separates "the work is not there" from "my probe does not
+  work" — two outcomes a single grep returns identically.
+
+Delete the rescue ref only after that probe answers, in the same command shape, on a string you know
+is present. If the work turns out to exist *only* on your branch, it was never yours to drop: keep
+the rescue ref, tell the other session where it is, and let them re-land it.
 
 ## Audit before rebase / branch-delete
 

--- a/git-safety-net/references/prevention_practices.md
+++ b/git-safety-net/references/prevention_practices.md
@@ -292,9 +292,11 @@ git log  --oneline "$base"..HEAD          # every commit here must be yours
 git diff --name-only "$base" HEAD         # every path here must be yours
 ```
 
-Two things this check cannot do for you. If `$base` is empty or unresolvable, `"$base"..HEAD`
-degenerates to `HEAD..HEAD`: the `git log` prints nothing and exits 0, which is exactly what "clean"
-looks like — hence the verify line above, which fails loudly instead. And **Git cannot tell you
+Two things this check cannot do for you. If `$base` is **empty** — an unset variable, or a command
+substitution that failed — `"$base"..HEAD` degenerates to `HEAD..HEAD`: the `git log` prints nothing
+and exits 0, which is exactly what "clean" looks like. A non-empty base that does not resolve is a
+different and safer case: it aborts with `fatal: Invalid revision range` at exit 128. Both are
+caught by the verify line above, but only the empty one is silent, and silence is what gets missed. And **Git cannot tell you
 which commits are yours**: a shared checkout gives both sessions the same author and committer
 identity, so no `--author` filter separates them. The answer comes from the SHAs you recorded as you
 committed, which is the second reason to record as you go. If you cannot say with certainty which
@@ -373,8 +375,10 @@ existing sequence in order:
    `--force-with-lease` over `--force`. Anyone else who fetched that branch also needs telling.
 7. **Retiring either ref is a Mode E action** under Mode C evidence — the same standard this skill
    applies to every other preserving ref it tells you to create, and no weaker. Do not delete
-   `rescue/foreign-<sha>` on a heuristic. Note the rescue ref may also be the only anchor for *your*
-   own commits if step 4 was run in the discarding form; step 5 is what catches that.
+   `rescue/foreign-<short-sha>` on a heuristic. Note that if step 4 was run in the discarding form, *your* own
+   commits are anchored only by the preserving refs — `backup/pre-rewrite` from step 2 and, for
+   anything before the foreign commit, `rescue/foreign-<short-sha>` from step 3. Neither is
+   retirable until step 5 has passed.
 
 **Why the obvious "did their work survive?" probes mislead.** These are worth knowing before you
 reach Mode C, because both look authoritative and both were measured returning the wrong answer on
@@ -386,11 +390,14 @@ a real commit whose work had definitively shipped:
   only as an unreachable dangler while its content sits in the integration branch. Note that you can no
   longer observe that zero once this procedure is under way: the foreign commit is an ancestor of
   your pre-rebase tip, so **both** preserving refs contain it — `backup/pre-rewrite` from step 2 as
-  well as `rescue/foreign-<sha>` from step 3 — and the count rises by one at each (measured in step
+  well as `rescue/foreign-<short-sha>` from step 3 — and the count rises by one at each (measured in step
   order). Exclude both, or the reading is about refs you created a minute ago:
   ```bash
   git for-each-ref --contains <sha> --format='%(refname)' | grep -vE '^refs/heads/(rescue|backup)/'
   ```
+  Read the *output*, not the exit code: when the filter removes everything, the pipeline exits 1
+  with empty stdout — which is the answer "no external ref contains it", not a failure. Under
+  `set -e` or `pipefail` that exit aborts the script instead.
 - **Hash-equality comparison of whole files against the integration branch does not prove it
   either.** Hashing `git show <sha>:<path>` against `git show origin/main:<path>` reports
   "different" for every file as soon as the branch moves on; any later commit touching the same

--- a/git-safety-net/references/prevention_practices.md
+++ b/git-safety-net/references/prevention_practices.md
@@ -383,11 +383,14 @@ a real commit whose work had definitively shipped:
 - **"No ref contains it" does *not* prove the work is unique.** `git for-each-ref --contains <sha>`
   (or `git branch -a --contains <sha>`) reports **zero** refs for a commit that already merged,
   because a **squash or rebase merge re-writes it under a new SHA** — the original object survives
-  only as an unreachable dangler while its content sits in the integration branch. Note you can no
-  longer observe that zero once step 3 has run: your own `rescue/foreign-<sha>` contains it, so the
-  count is never zero again (measured: 1 → 2 on creating the rescue ref). Exclude your own ref —
-  `git for-each-ref --contains <sha> --format='%(refname)' | grep -v '^refs/heads/rescue/'` — or the
-  reading is about a ref you created a minute ago.
+  only as an unreachable dangler while its content sits in the integration branch. Note that you can no
+  longer observe that zero once this procedure is under way: the foreign commit is an ancestor of
+  your pre-rebase tip, so **both** preserving refs contain it — `backup/pre-rewrite` from step 2 as
+  well as `rescue/foreign-<sha>` from step 3 — and the count rises by one at each (measured in step
+  order). Exclude both, or the reading is about refs you created a minute ago:
+  ```bash
+  git for-each-ref --contains <sha> --format='%(refname)' | grep -vE '^refs/heads/(rescue|backup)/'
+  ```
 - **Hash-equality comparison of whole files against the integration branch does not prove it
   either.** Hashing `git show <sha>:<path>` against `git show origin/main:<path>` reports
   "different" for every file as soon as the branch moves on; any later commit touching the same
@@ -404,6 +407,9 @@ a real commit whose work had definitively shipped:
   git show origin/main:<path> | grep -cF "$needle"                  # >0 ⇒ the work is in main
   git show origin/main:<path> | grep -cF 'string-that-cannot-exist' # must be 0, or the probe is broken
   ```
+  `origin/main` here is a cached ref. Staleness fails safe in this direction — you read 0, keep the
+  rescue ref, and over-preserve — but the `>0` half is a positive verdict off a cache, so fetch
+  first if you are the sole writer and can, and otherwise treat `>0` as provisional.
   Both leading-`+` and a renamed path produce the same false negative — 0 hits with the control line
   passing — so neither is caught by the control alone; that is what the first line and the `+` note
   are for. If the file was renamed or moved in the integration branch, this probe cannot answer:


### PR DESCRIPTION
## What

Adds the **inverse** of the shared-checkout failure v1.14.0 covers.

- v1.14.0: *your uncommitted work* stranded on *another session's* branch.
- This: *their commit* landing in *your branch's history*, shipping inside your PR.

Every branch-level check the skill already prescribes reports **green** on it — `git branch --show-current` names your branch, the tree is clean, `git diff --cached --name-status` shows only your paths — because the foreign work left both the working tree and the index the moment it was committed. It appears only in the branch's cumulative range against its recorded base.

From a real incident in this repo: a sibling session's commit landed on a freshly created branch and the only signal was a repo validator reporting two changed components when one had been touched.

## Design

Detection is new and read-only. **Repair is routed through the contracts this skill already carries**, not restated inline: finding a foreign commit is itself evidence another writer was in the checkout, so the standing quiesce/ownership rules apply first; then Mode B evidence path → `backup/pre-rewrite` at your own tip → a separate rescue ref for their commit → rebase → re-run detection → Mode C/E for retiring either ref.

## Independent review found 21 issues, all dispositioned

Two fresh-context reviewers (actionability + fidelity) against anchor `bfffd248`. Self-review had already passed everything: `quick_validate` green, regression audit 0 candidates, repo CI green, five command shapes self-calibrated. The reviewers still found:

- **A command that silently deletes the user's own commits.** The first draft's `git rebase --onto "$base" <foreign-sha> <branch>` replays `<foreign-sha>..<branch>`, discarding everything before the foreign commit — including the author's own earlier commits — at exit 0. Reproduced on `A(yours) → F(foreign) → C(yours)`: `A` vanished silently. Fixed to `--onto "<foreign-sha>^"`, which drops exactly one commit.
- **A factual claim in the wrong direction.** `git ls-remote <remote> <ref> > f` does *not* leave the file non-empty on failure — Git writes to stderr, so bare `> f` gives 0 bytes and `[ -s f ]` reports "already gone" for a branch whose fate is unknown. The original verification had used `2>&1`, a different shape from the one documented. Both directions now stated.
- **Six rule collisions** where the new material re-derived weaker inline copies of existing contracts (ownership gate, Mode B evidence path, `backup/pre-rewrite`, Mode C deletion evidence, gated fetch) — and because the new entry aimed at the reader's symptom, a literal reader would obey the weak copy.
- **Probes that fail green**: an unresolvable base turns `"$base"..HEAD` into `HEAD..HEAD` and prints nothing at exit 0; the content grep misses on an unstripped diff `+` and on a renamed path with the control line still passing; `--contains` can no longer report zero once the rescue ref exists; `ls-remote` with a bare name matches a same-named tag; `cat-file -e` returns 128 for a mistyped branch too.

Every exit code and both failure directions were measured in throwaway repositories, not recalled.

## Bookkeeping

- `marketplace.json` 1.14.0 → 1.15.0
- `CHANGELOG.md` entry under Unreleased
- `README.md` / `README.zh-CN.md` key-feature bullets
- Regression audit: **0 candidates, 760 exact preservations** — pure addition, nothing removed or reworded
- No compression this round: #437 landed 171 lines an hour before this work and the description is at 1018/1024, so compressing now would be churn with regression risk. Stated as a decision, not an omission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USvDWkeQZGbTMayut9o5Tw