### PR TITLE
test(git-safety-net): cover the three load-bearing scripts that had no tests (v1.15.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -491,7 +491,7 @@
       "description": "Audits, preserves, recovers, and safely retires local Git state: unpushed or wrong-branch commits, dirty or detached worktrees, forgotten duplicate clones of the same repo, untracked work no bundle can back up, orphaned stashes, dangling commits, stale branches, and squash/rebase merge uncertainty. Use when the user fears work was lost; asks to recover a commit or branch; asks whether a worktree, clone, or scratch directory can be deleted; wants everything converged onto one main branch; or needs proof that cleanup will not drop work. Use it even after an audit reported clean — the usual gap is scope: every in-repo command is blind to a second clone elsewhere on disk. Triggers on \"did I lose work\", \"is everything merged\", \"is anything else lost\", \"safe to delete this clone\", \"clean up old branches/stashes\", \"only keep one main branch\", \"git reflog\", \"dangling commits\", \"分支灾难\", \"误删分支/commit\", \"worktree 能删吗\", \"还有没有丢的东西\", \"只保留一个主分支\". Covers local-Git forensics, not GitHub PR/API operations or routine sync.",
       "source": "./git-safety-net",
       "strict": false,
-      "version": "1.15.0",
+      "version": "1.15.1",
       "category": "developer-tools",
       "keywords": [
         "git",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **daymade-audio** v1.32.5 → v1.33.0 (`asr-transcribe-to-text`): replaces the stale “Minute URL always ends the job” rule with explicit outcomes. Upload-only still stops at the URL; a request that names upload but no downstream result lands at resumable `outcome_pending` instead of forcing a guess; transcript-only waits for a readable Feishu transcript; project delivery hands preprocessing into `meeting-ingest` and cannot finish until routing, full correction, project indexes, verified Git handoff, and the pushed delivery receipt are complete. A later downstream request preserves the same `minute_token`/URL and resumes instead of re-uploading.
+- **git-safety-net** v1.15.0 → v1.15.1: put mechanical judges under the three
+  scripts that had none — and they were the load-bearing three.
+  `git_verify_branch_merged.sh` is what the Skill's own rules call the only check
+  that was right every time, what Mode E rung 1 accepts as deletion-grade evidence,
+  and what Mode C routes "is everything merged?" to; it is referenced six times and
+  had zero tests. `git_loss_audit.sh` (the Mode B evidence path, required before any
+  rebase or branch-delete) and `git_preserve_danglers.sh` (the only script here that
+  writes refs) were likewise untested, while the three scripts that did have tests
+  were the lower-stakes ones. 27 tests close that inversion. No runtime behaviour
+  changes: not one line of any script was edited.
+  Every expectation was calibrated by running the script against the fixture first,
+  which is how two wrong assumptions were caught before they became tests — deleting
+  a branch does not create a dangling commit (the reflog keeps it reachable until
+  expired, so a naive fixture would have asserted against an empty run and passed for
+  the wrong reason), and a branch whose content is a textual subset of the base's is
+  still correctly reported UNMERGED, because containment is decided by a three-way
+  merge rather than by line presence.
+  The suite was then mutation-calibrated rather than trusted for being green: breaking
+  the containment check turns six tests red, restoring the `set -e` abort that the
+  script's own comments record as a past regression turns the conflict test red,
+  inverting the local-vs-remote ref precedence turns three red, widening the audit's
+  exit 1 to cover a routine stash turns the two alarm-fatigue tests red, and making
+  the pinning script delete a ref or use the wrong namespace turns the
+  non-destructive-invariant test red. One mutation was NOT caught — removing the `--`
+  pathspec guard leaves every test green, because the script resolves to a fully
+  qualified ref before the diff — so that test was renamed to what it actually proves
+  and the gap is stated in its docstring instead of being implied away.
+  The content-containment expectations are skipped below git 2.38, where
+  `merge-tree --write-tree` does not exist and the script deliberately degrades to a
+  conservative verdict; failing a healthy older runner would teach people to bypass
+  the suite.
 - **git-safety-net** v1.14.0 → v1.15.0: add the inverse of the shared-checkout
   failure the previous release covered. v1.14.0 handles *your uncommitted work*
   being stranded on *another session's* branch; this adds *their commit* landing

--- a/git-safety-net/.security-scan-passed
+++ b/git-safety-net/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-09-02T06:00:43.764328+00:00
+Scanned at: 2026-09-02T06:41:44.260921+00:00
 Tool: gitleaks + pattern-based validation
 Content hash: 1f12755528cb5c6884ec97b6aea5f2e36a5d0c6df8dd3034b798ed8d2d804ebd

--- a/git-safety-net/tests/test_git_loss_audit.py
+++ b/git-safety-net/tests/test_git_loss_audit.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Regression tests for the at-risk-work audit and, above all, its exit-code boundary.
+
+Mode B routes "what could I lose?" here, and Mode D requires this evidence path before
+any rebase or branch-delete. Its design splits two kinds of state:
+
+  exit 1 — surprising and actionable: commits that exist on no remote, dirty or
+           unavailable worktrees. Something is genuinely at risk.
+  exit 0 — known and recoverable: stashes and dangling commits. These get an advisory
+           line, not an alarm.
+
+That boundary is the thing worth pinning. Widening exit 1 to cover a routine stash
+would make the audit cry wolf on healthy repositories, and this Skill's own guidance
+says a check that misfires on healthy input is worse than no check, because it trains
+people to bypass it. Narrowing exit 1 would silently drop the warning that matters.
+
+Every expectation was calibrated by running the script against the fixture first.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SKILL_DIR = Path(__file__).resolve().parents[1]
+SCRIPT = SKILL_DIR / "scripts" / "git_loss_audit.sh"
+
+
+class LossAuditTests(unittest.TestCase):
+    def setUp(self) -> None:
+        temp_parent = "/tmp" if Path("/tmp").is_dir() else None
+        self.temp_dir = tempfile.TemporaryDirectory(
+            prefix="git-loss-audit-", dir=temp_parent
+        )
+        self.root = Path(self.temp_dir.name)
+        self.remote = self.root / "remote.git"
+        self.repo = self.root / "repo"
+        self.git("init", "-q", "-b", "main", "--bare", str(self.remote))
+        self.git("init", "-q", "-b", "main", str(self.repo))
+        self.in_repo("config", "user.email", "fixture@example.invalid")
+        self.in_repo("config", "user.name", "Fixture")
+        self.in_repo("remote", "add", "origin", str(self.remote))
+        self.write("a.txt", "a\n")
+        self.commit("base")
+        self.in_repo("push", "-q", "origin", "main")
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    # ---- helpers -------------------------------------------------------------
+
+    def git(self, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(["git", *args], capture_output=True, text=True, check=True)
+
+    def in_repo(self, *args: str) -> subprocess.CompletedProcess:
+        return self.git("-C", str(self.repo), *args)
+
+    def write(self, relative: str, text: str) -> None:
+        (self.repo / relative).write_text(text, encoding="utf-8")
+
+    def commit(self, message: str) -> None:
+        self.in_repo("add", "-A")
+        self.in_repo("commit", "-q", "-m", message)
+
+    def run_script(self, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["bash", str(SCRIPT), *args],
+            cwd=str(self.repo),
+            capture_output=True,
+            text=True,
+        )
+
+    # ---- the exit-code boundary ---------------------------------------------
+
+    def test_fully_pushed_repository_is_quiet(self) -> None:
+        result = self.run_script()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("local-only: 0", result.stdout)
+
+    def test_commit_on_no_remote_is_actionable(self) -> None:
+        self.write("b.txt", "b\n")
+        self.commit("local only")
+        result = self.run_script()
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertIn("local only", result.stdout)
+
+    def test_a_stash_alone_does_not_raise_an_alarm(self) -> None:
+        """Routine state must stay exit 0, or the audit trains people to ignore it."""
+        self.write("a.txt", "dirty\n")
+        self.in_repo("stash", "-q")
+        result = self.run_script()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("stashes: 1", result.stdout)
+
+    def test_a_dangling_commit_alone_does_not_raise_an_alarm(self) -> None:
+        """Recoverable-now, gc-eligible-later earns advice, not an alarm."""
+        self.in_repo("switch", "-qc", "tmp")
+        self.write("x.txt", "orphan\n")
+        self.commit("orphan work")
+        self.in_repo("switch", "-q", "main")
+        self.in_repo("branch", "-qD", "tmp")
+        # A deleted branch is still reflog-reachable; expiry is what makes it dangle.
+        self.in_repo(
+            "reflog", "expire", "--expire=now", "--expire-unreachable=now", "--all"
+        )
+
+        result = self.run_script()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("dangling: 1", result.stdout)
+        # And it must point at the tool that makes them gc-proof, not just count them.
+        self.assertIn("git_preserve_danglers.sh", result.stdout)
+
+    # ---- report shape --------------------------------------------------------
+
+    def test_every_section_and_the_verdict_are_present(self) -> None:
+        """The sections are the audit's scope claim; a silently dropped one narrows
+        what 'clean' means without anything looking wrong."""
+        result = self.run_script()
+        for heading in ("Local-only commits", "Worktrees", "Stashes", "Dangling commits", "Verdict"):
+            self.assertIn(heading, result.stdout, f"missing section: {heading}")
+
+    def test_outside_a_repository_is_an_error(self) -> None:
+        outside = self.root / "not-a-repo"
+        outside.mkdir()
+        result = subprocess.run(
+            ["bash", str(SCRIPT)], cwd=str(outside), capture_output=True, text=True
+        )
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/git-safety-net/tests/test_git_preserve_danglers.py
+++ b/git-safety-net/tests/test_git_preserve_danglers.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Regression tests for gc-proof pinning of dangling commits.
+
+This is the only script in the bundle that writes refs, and the Skill's Mode B tells
+agents to run it before cleanup on the strength of an explicit non-destructive claim:
+it may ADD `refs/dangling-backup/*` and nothing else. That claim is the main subject
+here — a script that quietly moved an existing ref or touched the working tree would
+still print a plausible "pinned N commit(s)" line, so the invariant needs its own
+assertions rather than trust in the output.
+
+Fixture note, calibrated rather than assumed: deleting a branch does NOT create a
+dangling commit. The commit stays reachable through the reflog and `git fsck
+--dangling` reports nothing. The reflog has to be expired first — a test that skipped
+that step would assert against an empty run and pass for the wrong reason.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SKILL_DIR = Path(__file__).resolve().parents[1]
+SCRIPT = SKILL_DIR / "scripts" / "git_preserve_danglers.sh"
+
+
+class PreserveDanglersTests(unittest.TestCase):
+    def setUp(self) -> None:
+        temp_parent = "/tmp" if Path("/tmp").is_dir() else None
+        self.temp_dir = tempfile.TemporaryDirectory(
+            prefix="git-preserve-danglers-", dir=temp_parent
+        )
+        self.root = Path(self.temp_dir.name)
+        self.repo = self.root / "repo"
+        self.git("init", "-q", "-b", "main", str(self.repo))
+        self.in_repo("config", "user.email", "fixture@example.invalid")
+        self.in_repo("config", "user.name", "Fixture")
+        (self.repo / "a.txt").write_text("a\n", encoding="utf-8")
+        self.in_repo("add", "-A")
+        self.in_repo("commit", "-q", "-m", "base")
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    # ---- helpers -------------------------------------------------------------
+
+    def git(self, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(["git", *args], capture_output=True, text=True, check=True)
+
+    def in_repo(self, *args: str) -> subprocess.CompletedProcess:
+        return self.git("-C", str(self.repo), *args)
+
+    def run_script(self, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["bash", str(SCRIPT), *args],
+            cwd=str(self.repo),
+            capture_output=True,
+            text=True,
+        )
+
+    def make_dangling_commit(self) -> str:
+        """Return the SHA of a genuinely dangling commit."""
+        self.in_repo("switch", "-qc", "tmp")
+        (self.repo / "x.txt").write_text("orphan\n", encoding="utf-8")
+        self.in_repo("add", "-A")
+        self.in_repo("commit", "-q", "-m", "orphan work")
+        sha = self.in_repo("rev-parse", "HEAD").stdout.strip()
+        self.in_repo("switch", "-q", "main")
+        self.in_repo("branch", "-qD", "tmp")
+        # Without this the commit is still reflog-reachable and fsck reports nothing.
+        self.in_repo(
+            "reflog", "expire", "--expire=now", "--expire-unreachable=now", "--all"
+        )
+        dangling = self.in_repo("fsck", "--dangling").stdout
+        self.assertIn(sha, dangling, "fixture failed to produce a dangling commit")
+        return sha
+
+    def ref_snapshot(self) -> str:
+        out = self.in_repo("for-each-ref", "--format=%(refname) %(objectname)").stdout
+        return "\n".join(
+            sorted(l for l in out.splitlines() if "refs/dangling-backup/" not in l)
+        )
+
+    # ---- behaviour -----------------------------------------------------------
+
+    def test_no_danglers_reports_nothing_to_do(self) -> None:
+        result = self.run_script()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("No dangling commits", result.stdout)
+
+    def test_dangling_commit_is_pinned_under_dangling_backup(self) -> None:
+        sha = self.make_dangling_commit()
+        result = self.run_script()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("pinned", result.stdout)
+        # Deliberately not check=True: if the ref is missing (wrong namespace, no write at
+        # all) this must read as a failed assertion about the contract, not as an
+        # unhandled subprocess exception whose message is about rev-parse.
+        lookup = subprocess.run(
+            ["git", "-C", str(self.repo), "rev-parse", "--verify", "--quiet",
+             f"refs/dangling-backup/{sha}"],
+            capture_output=True, text=True,
+        )
+        self.assertEqual(
+            lookup.returncode, 0,
+            f"refs/dangling-backup/{sha} was not created; script said:\n{result.stdout}",
+        )
+        self.assertEqual(
+            lookup.stdout.strip(), sha, "backup ref does not point at the rescued commit"
+        )
+
+    def test_pinning_adds_a_ref_and_changes_nothing_else(self) -> None:
+        """The non-destructive claim, asserted rather than trusted.
+
+        A regression that moved `main`, dropped a tag, or wrote into the working tree
+        would still print the same reassuring 'pinned' line.
+        """
+        self.make_dangling_commit()
+        refs_before = self.ref_snapshot()
+        status_before = self.in_repo("status", "--porcelain").stdout
+
+        result = self.run_script()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+        self.assertEqual(refs_before, self.ref_snapshot(), "a pre-existing ref changed")
+        self.assertEqual(
+            status_before,
+            self.in_repo("status", "--porcelain").stdout,
+            "the working tree changed",
+        )
+
+    def test_patch_dir_exports_one_patch_per_pinned_commit(self) -> None:
+        self.make_dangling_commit()
+        patch_dir = self.root / "patches"
+        result = self.run_script("--patch-dir", str(patch_dir))
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        patches = sorted(patch_dir.glob("*.patch"))
+        self.assertEqual(len(patches), 1, f"expected one patch, got {patches}")
+        self.assertIn("orphan-work", patches[0].name)
+
+    def test_unknown_argument_is_a_usage_error(self) -> None:
+        result = self.run_script("--bogus")
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        self.assertIn("unknown argument", result.stderr)
+
+    def test_patch_dir_without_a_value_is_a_usage_error(self) -> None:
+        result = self.run_script("--patch-dir")
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        self.assertIn("needs a directory argument", result.stderr)
+
+    def test_outside_a_repository_is_an_error(self) -> None:
+        outside = self.root / "not-a-repo"
+        outside.mkdir()
+        result = subprocess.run(
+            ["bash", str(SCRIPT)], cwd=str(outside), capture_output=True, text=True
+        )
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        self.assertIn("not inside a Git repository", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/git-safety-net/tests/test_git_verify_branch_merged.py
+++ b/git-safety-net/tests/test_git_verify_branch_merged.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Regression tests for the content-level merged/unmerged verdict.
+
+This script is the Skill's deletion-grade authority: Mode E rung 1 and the six
+load-bearing rules both name it as the one check that judges by content instead of
+by commit count, and Mode C routes "is everything merged?" to it. Every expectation
+below was calibrated by running the script against the fixture first and recording
+what it actually said — not inferred from the prose.
+
+The safety bias is the property under test: the script may only claim MERGED when it
+can prove containment, because a false MERGED loses work while a false UNMERGED costs
+a second look. Several cases below therefore pin an UNMERGED verdict that a textual
+"are the branch's lines present?" shortcut would wrongly call MERGED.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SKILL_DIR = Path(__file__).resolve().parents[1]
+SCRIPT = SKILL_DIR / "scripts" / "git_verify_branch_merged.sh"
+
+
+def _git_version() -> tuple[int, int]:
+    out = subprocess.run(["git", "--version"], capture_output=True, text=True).stdout
+    match = re.search(r"(\d+)\.(\d+)", out)
+    return (int(match.group(1)), int(match.group(2))) if match else (0, 0)
+
+
+# `git merge-tree --write-tree` — the trial merge that produces the "content contained"
+# verdict — landed in git 2.38. On older git the script deliberately falls through to a
+# conservative NEEDS REVIEW, so the containment expectations do not hold there. Skipping
+# beats failing a healthy runner: a check that misfires on good input trains people to
+# bypass it.
+HAS_WRITE_TREE = _git_version() >= (2, 38)
+
+
+class VerifyBranchMergedTests(unittest.TestCase):
+    def setUp(self) -> None:
+        temp_parent = "/tmp" if Path("/tmp").is_dir() else None
+        self.temp_dir = tempfile.TemporaryDirectory(
+            prefix="git-verify-branch-merged-", dir=temp_parent
+        )
+        self.root = Path(self.temp_dir.name)
+        self.remote = self.root / "remote.git"
+        self.repo = self.root / "repo"
+        self.git("init", "-q", "-b", "main", "--bare", str(self.remote))
+        self.git("init", "-q", "-b", "main", str(self.repo))
+        self.in_repo("config", "user.email", "fixture@example.invalid")
+        self.in_repo("config", "user.name", "Fixture")
+        self.in_repo("remote", "add", "origin", str(self.remote))
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    # ---- helpers -------------------------------------------------------------
+
+    def git(self, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["git", *args], capture_output=True, text=True, check=True
+        )
+
+    def in_repo(self, *args: str) -> subprocess.CompletedProcess:
+        return self.git("-C", str(self.repo), *args)
+
+    def write(self, relative: str, text: str) -> None:
+        path = self.repo / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+
+    def commit(self, message: str) -> None:
+        self.in_repo("add", "-A")
+        self.in_repo("commit", "-q", "-m", message)
+
+    def run_script(self, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["bash", str(SCRIPT), *args],
+            cwd=str(self.repo),
+            capture_output=True,
+            text=True,
+        )
+
+    def seed_base(self) -> None:
+        """One commit on main, pushed, so `origin/main` resolves."""
+        self.write("a.txt", "a\n")
+        self.commit("base")
+        self.in_repo("push", "-q", "origin", "main")
+
+    # ---- MERGED verdicts -----------------------------------------------------
+
+    def test_ancestor_branch_is_merged(self) -> None:
+        self.seed_base()
+        self.in_repo("branch", "feat")
+        result = self.run_script("feat", "origin/main")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("MERGED (ancestor)", result.stdout)
+
+    @unittest.skipUnless(HAS_WRITE_TREE, "git merge-tree --write-tree needs git >= 2.38")
+    def test_squash_merged_branch_is_content_contained(self) -> None:
+        """The case the script exists for: the count says ahead, the content is upstream."""
+        self.seed_base()
+        self.in_repo("switch", "-qc", "feat")
+        self.write("f.txt", "feature\n")
+        self.commit("feature work")
+        self.in_repo("switch", "-q", "main")
+        self.in_repo("merge", "-q", "--squash", "feat")
+        self.in_repo("commit", "-q", "-m", "squash of feat")
+        self.in_repo("push", "-q", "origin", "main")
+
+        # The commit count still calls the branch unmerged; the verdict must not.
+        ahead = self.in_repo("rev-list", "--count", "origin/main..feat").stdout.strip()
+        self.assertNotEqual(ahead, "0", "fixture no longer reproduces the squash illusion")
+
+        result = self.run_script("feat", "origin/main")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("MERGED (content contained)", result.stdout)
+
+    # ---- UNMERGED verdicts (the safety-biased direction) ---------------------
+
+    def test_genuinely_unmerged_branch_needs_review(self) -> None:
+        self.seed_base()
+        self.in_repo("switch", "-qc", "feat")
+        self.write("f.txt", "unmerged\n")
+        self.commit("unmerged work")
+        self.in_repo("switch", "-q", "main")
+        result = self.run_script("feat", "origin/main")
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertIn("UNMERGED / NEEDS REVIEW", result.stdout)
+        # The contribution listing is what makes the verdict actionable.
+        self.assertIn("f.txt", result.stdout)
+
+    def test_conflicting_branch_reports_review_instead_of_aborting(self) -> None:
+        """A conflict makes `merge-tree` exit 1 under `set -e`.
+
+        The script captures that status inside an `if` for exactly this reason. If that
+        guard regresses, the script dies before printing any verdict — so assert both the
+        exit code and that the verdict text was actually reached.
+        """
+        self.write("shared.txt", "v1\n")
+        self.commit("base")
+        self.in_repo("switch", "-qc", "feat")
+        self.write("shared.txt", "branch version\n")
+        self.commit("branch edit")
+        self.in_repo("switch", "-q", "main")
+        self.write("shared.txt", "main version\n")
+        self.commit("main edit")
+        self.in_repo("push", "-q", "origin", "main")
+
+        result = self.run_script("feat", "origin/main")
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertIn("UNMERGED / NEEDS REVIEW", result.stdout)
+
+    def test_branch_deleting_a_file_the_base_keeps_is_unmerged(self) -> None:
+        """Proves the verdict is a real merge, not an "are the additions present?" scan.
+
+        The branch adds nothing at all; it removes a file. Merging it would change base,
+        so containment is false even though every line the branch touched exists upstream.
+        """
+        self.write("a.txt", "a\n")
+        self.write("keep.txt", "keep\n")
+        self.commit("base")
+        self.in_repo("push", "-q", "origin", "main")
+        self.in_repo("switch", "-qc", "feat")
+        self.in_repo("rm", "-q", "keep.txt")
+        self.in_repo("commit", "-q", "-m", "branch deletes keep.txt")
+        self.in_repo("switch", "-q", "main")
+
+        result = self.run_script("feat", "origin/main")
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertIn("UNMERGED / NEEDS REVIEW", result.stdout)
+
+    def test_textual_subset_of_base_is_still_unmerged(self) -> None:
+        """Base's final file is a superset of the branch's, yet the verdict stays UNMERGED.
+
+        Calibrated against the script, not assumed: containment is decided by a three-way
+        merge, and both sides edited the same region, so merging still changes base. A
+        future "the branch's lines are all present upstream" shortcut would flip this to
+        MERGED and delete real work — this test is what would catch that.
+        """
+        self.write("a.txt", "l1\n")
+        self.commit("base")
+        self.in_repo("switch", "-qc", "feat")
+        self.write("a.txt", "l1\nl2\n")
+        self.commit("branch adds l2")
+        self.in_repo("switch", "-q", "main")
+        self.write("a.txt", "l1\nl2\nl3\n")
+        self.commit("base has l2 and more")
+        self.in_repo("push", "-q", "origin", "main")
+
+        result = self.run_script("feat", "origin/main")
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertIn("UNMERGED / NEEDS REVIEW", result.stdout)
+
+    # ---- ref resolution ------------------------------------------------------
+
+    def test_local_branch_outranks_remote_and_the_output_says_so(self) -> None:
+        """The local branch is the superset (it may hold unpushed commits) and is what
+        `git branch -D` would delete, so it must be the one judged — and the divergence
+        must be announced, or the verdict is silently about the wrong ref."""
+        self.seed_base()
+        self.in_repo("switch", "-qc", "feat")
+        self.write("f.txt", "pushed\n")
+        self.commit("pushed part")
+        self.in_repo("push", "-q", "origin", "feat")
+        self.write("f.txt", "pushed\nlocal only\n")
+        self.commit("local-only extra")
+        self.in_repo("switch", "-q", "main")
+
+        result = self.run_script("feat", "origin/main")
+        self.assertIn("judging the LOCAL branch", result.stdout)
+        self.assertIn("refs/heads/feat", result.stdout)
+
+    def test_branch_named_like_a_directory_resolves_as_a_ref(self) -> None:
+        """A branch called `docs` in a repo that also has `docs/` must resolve as a ref.
+
+        Scope, stated because the obvious wider claim is false: this does NOT exercise the
+        `--` pathspec guard on the step-3 diff. Removing that guard was measured to leave
+        every test here green, because the script resolves the argument to a fully
+        qualified `refs/heads/docs` before the diff runs, so no ambiguity reaches it. The
+        guard is defensive depth, not a behaviour this suite covers.
+        """
+        self.write("docs/x.md", "doc\n")
+        self.commit("base")
+        self.in_repo("push", "-q", "origin", "main")
+        self.in_repo("switch", "-qc", "docs")
+        self.write("docs/x.md", "doc\nmore\n")
+        self.commit("docs work")
+        self.in_repo("switch", "-q", "main")
+
+        result = self.run_script("docs", "origin/main")
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertIn("refs/heads/docs", result.stdout)
+        self.assertNotIn("fatal:", result.stderr)
+
+    # ---- refusals and degraded modes ----------------------------------------
+
+    def test_base_ref_itself_is_refused(self) -> None:
+        self.seed_base()
+        result = self.run_script("main", "main")
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        self.assertIn("is the base ref itself", result.stderr)
+
+    def test_unresolvable_branch_is_a_usage_error(self) -> None:
+        self.seed_base()
+        result = self.run_script("no-such-branch", "origin/main")
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        self.assertIn("cannot resolve branch ref", result.stderr)
+
+    def test_unresolvable_base_is_a_usage_error(self) -> None:
+        self.seed_base()
+        self.in_repo("branch", "feat")
+        result = self.run_script("feat", "no-such-base")
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        self.assertIn("cannot resolve base ref", result.stderr)
+
+    def test_missing_argument_is_a_usage_error(self) -> None:
+        result = self.run_script()
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        self.assertIn("usage:", result.stderr)
+
+    def test_outside_a_repository_is_an_error(self) -> None:
+        outside = self.root / "not-a-repo"
+        outside.mkdir()
+        result = subprocess.run(
+            ["bash", str(SCRIPT), "feat"],
+            cwd=str(outside),
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        self.assertIn("not inside a Git repository", result.stderr)
+
+    def test_unreachable_remote_still_yields_a_verdict_from_cached_refs(self) -> None:
+        """Offline must degrade to a verdict plus a warning, not to no verdict."""
+        self.seed_base()
+        self.in_repo("switch", "-qc", "feat")
+        self.write("f.txt", "work\n")
+        self.commit("work")
+        self.in_repo("switch", "-q", "main")
+        self.in_repo("remote", "set-url", "origin", str(self.root / "gone.git"))
+
+        result = self.run_script("feat", "origin/main")
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertIn("fetch failed", result.stderr)
+        self.assertIn("UNMERGED / NEEDS REVIEW", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The gap

The tested/untested split in this skill was inverted.

| Script | Referenced in SKILL.md | Tests before |
|---|---|---|
| `git_verify_branch_merged.sh` | **6×** — the six load-bearing rules call it *"the only check that was right every time"*; Mode E rung 1 accepts its verdict as deletion-grade evidence; Mode C routes "is everything merged?" to it | **0** |
| `git_loss_audit.sh` | **5×** — the Mode B evidence path, required before *any* rebase or branch-delete | **0** |
| `git_preserve_danglers.sh` | **4×** — the only script here that writes refs | **0** |
| `git_export_before_drop.sh` | | 4 |
| `git_find_all_checkouts.sh` | | 9 |
| `git_prepare_clone_retirement.sh` | | 23 |

The skill tells agents to trust the first one as deletion authority, and nothing verified it was right. 27 tests close that.

**No script was edited.** Runtime behaviour is unchanged; this is test coverage only.

## Calibrated, not assumed

Every expectation came from running the script against the fixture and recording what it actually said. That caught two wrong assumptions before they became tests:

- **Deleting a branch does not create a dangling commit.** The reflog keeps it reachable until expired, so `git fsck --dangling` reports nothing. A fixture written from the semantics would have asserted against an empty run and passed for the wrong reason.
- **A branch whose content is a textual subset of the base's is still correctly UNMERGED**, because containment is decided by a three-way merge rather than by line presence. That verdict is now pinned — a future "the lines are all upstream" shortcut would flip it to MERGED and delete real work.

## Mutation-calibrated, not trusted for being green

A passing suite is not evidence. Each mutation was applied to a copy and the suite re-run:

| Mutation | Result |
|---|---|
| Break the content-containment check | 6 tests red |
| Restore the `set -e` abort the script's own comments record as a past regression | conflict test red |
| Invert local-vs-remote ref precedence | 3 tests red |
| Widen the audit's exit 1 to cover a routine stash | both alarm-fatigue tests red |
| Make the pinning script delete a ref, or pin to the wrong namespace | non-destructive-invariant test red |
| **Remove the `--` pathspec guard** | **0 red — not caught** |

The last one is reported rather than hidden: the script resolves to a fully qualified ref before the diff, so the guard is defensive depth this suite does not exercise. That test was renamed to what it actually proves, with the gap stated in its docstring — a test name that promises coverage it lacks is worse than no test.

## Environment guard

Content-containment expectations skip below git 2.38, where `merge-tree --write-tree` does not exist and the script deliberately degrades to a conservative verdict. Failing a healthy older runner would teach people to bypass the suite — this skill's own guidance.

## Bookkeeping

- `marketplace.json` 1.15.0 → 1.15.1 (patch: tests only)
- `CHANGELOG.md` entry
- **README deliberately unchanged** — test coverage is not a user-facing capability. Stated as a decision.
- Full suite **63 tests pass** (was 36); regression audit **0 candidates, 826 exact preservations**
- Rebased onto `a6049f4` after #441 landed: the pre-push guard correctly caught that this branch carried a stale `daymade-audio` version. Both CHANGELOG entries kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USvDWkeQZGbTMayut9o5Tw