### PR TITLE
docs(git-safety-net): route the references by section, not in bulk (v1.15.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -491,7 +491,7 @@
       "description": "Audits, preserves, recovers, and safely retires local Git state: unpushed or wrong-branch commits, dirty or detached worktrees, forgotten duplicate clones of the same repo, untracked work no bundle can back up, orphaned stashes, dangling commits, stale branches, and squash/rebase merge uncertainty. Use when the user fears work was lost; asks to recover a commit or branch; asks whether a worktree, clone, or scratch directory can be deleted; wants everything converged onto one main branch; or needs proof that cleanup will not drop work. Use it even after an audit reported clean — the usual gap is scope: every in-repo command is blind to a second clone elsewhere on disk. Triggers on \"did I lose work\", \"is everything merged\", \"is anything else lost\", \"safe to delete this clone\", \"clean up old branches/stashes\", \"only keep one main branch\", \"git reflog\", \"dangling commits\", \"分支灾难\", \"误删分支/commit\", \"worktree 能删吗\", \"还有没有丢的东西\", \"只保留一个主分支\". Covers local-Git forensics, not GitHub PR/API operations or routine sync.",
       "source": "./git-safety-net",
       "strict": false,
-      "version": "1.15.1",
+      "version": "1.15.2",
       "category": "developer-tools",
       "keywords": [
         "git",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **daymade-audio** v1.32.5 → v1.33.0 (`asr-transcribe-to-text`): replaces the stale “Minute URL always ends the job” rule with explicit outcomes. Upload-only still stops at the URL; a request that names upload but no downstream result lands at resumable `outcome_pending` instead of forcing a guess; transcript-only waits for a readable Feishu transcript; project delivery hands preprocessing into `meeting-ingest` and cannot finish until routing, full correction, project indexes, verified Git handoff, and the pushed delivery receipt are complete. A later downstream request preserves the same `minute_token`/URL and resumes instead of re-uploading.
+- **git-safety-net** v1.15.1 → v1.15.2: give the references section-level
+  routing. Measured before the change: of 39 reference sections, only 11 had any
+  inbound pointer naming them — `recovery_playbook.md` had exactly one, so its
+  recovery ladder, the rung an agent actually needs when work has gone missing, was
+  reachable only by opening a 223-line file and scanning. SKILL.md now cites the
+  specific `§ <section>` at each decision point: Mode A routes by symptom to the
+  ladder rung that handles it, Mode B names the at-risk definition and the pinning
+  rationale, Mode C distributes the six merge-verification topics to the sentences
+  that raise them, and every Mode D bullet carries the `§` name of its full
+  treatment. 37 citations; all resolve, checked with a negative control. One
+  measured gap remains by design: `merge_verification.md` was already the
+  best-routed file and needed the least.
+  The change is routing, not rules. The regression audit flagged 18 units whose
+  wording moved; each was classified `preserved_or_moved` against a needle taken
+  from the changed file, and the 31 load-bearing phrases across the nine reworded
+  paragraphs were verified still present by literal match with a negative control.
+  One illustrative example ("an orphan from a rebase") that the rewrite had dropped
+  was restored rather than argued away. No command, condition, verdict, or stop
+  point changed, and the 63-test suite still passes.
 - **git-safety-net** v1.15.0 → v1.15.1: put mechanical judges under the three
   scripts that had none — and they were the load-bearing three.
   `git_verify_branch_merged.sh` is what the Skill's own rules call the only check

--- a/git-safety-net/.security-scan-passed
+++ b/git-safety-net/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-09-02T06:41:44.260921+00:00
+Scanned at: 2026-09-02T10:44:00.501236+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 1f12755528cb5c6884ec97b6aea5f2e36a5d0c6df8dd3034b798ed8d2d804ebd
+Content hash: dba59d035ecf941f2672d91614bb0d47eca221fa829f45092b45dedd6e7735ec

--- a/git-safety-net/SKILL.md
+++ b/git-safety-net/SKILL.md
@@ -144,9 +144,13 @@ report-only until the user expands the authorized targets.
 
 ## Mode A — Recover lost work
 
-A commit/branch/stash that "disappeared" is almost always still in the object store for ~90 days.
-Full ladder (reflog → fsck → dangling) with exact commands and the canonical Git facts:
-**[references/recovery_playbook.md](references/recovery_playbook.md)**. The 30-second version:
+A commit/branch/stash that "disappeared" is almost always still in the object store for ~90 days —
+why that is true, and what ends it, is **[references/recovery_playbook.md](references/recovery_playbook.md)** § Mental model: nothing is gone
+until gc runs. The ladder there is indexed by symptom, so go straight to your rung —
+§ Ladder step 1 — `git reflog` (where most recoveries end),
+§ Ladder step 2 — dropped stashes,
+§ Ladder step 3 — detached-HEAD work,
+§ Ladder step 4 — `git fsck` for true orphans. The 30-second version:
 
 ```bash
 git reflog --date=iso | head -40          # find the lost HEAD position (most recoveries are here)
@@ -154,12 +158,17 @@ git show <sha>                            # CONFIRM it's the right commit before
 git switch -c rescue/<name> <sha>         # recover onto a NEW branch — never reset onto live work
 ```
 
-If reflog doesn't show it (e.g. a dropped stash, an orphan from a rebase), fall through to
-`git fsck --dangling` — see the playbook.
+If reflog doesn't show it, fall through by symptom rather than reaching for `fsck` first: a
+dropped stash has its own recovery route (**[references/recovery_playbook.md](references/recovery_playbook.md)** § Ladder step 2), work
+abandoned on a detached HEAD has another (§ Ladder step 3), and only a true orphan — from a rebase, say —
+needs `git fsck --dangling` (§ Ladder step 4).
 
 ## Mode B — Audit what's at risk, then preserve it
 
-**Step 0 — establish the evidence scope (rule 1).** Run machine-wide checkout discovery only when
+**Step 0 — establish the evidence scope (rule 1).** What "at risk" covers, and the checkout kinds
+that hide it, are **[references/recovery_playbook.md](references/recovery_playbook.md)** § The authoritative "is anything at risk" check and
+§ Linked worktrees and detached worktree HEADs.
+Run machine-wide checkout discovery only when
 the Outcome contract calls for an exhaustive audit or the target checkout is unknown. For a named
 target, record that checkout and continue to Step 1 without turning an unrelated clone into work.
 When exhaustive discovery is warranted, find every checkout of this repository on the machine,
@@ -229,11 +238,15 @@ helper only when every reported dangler is actually in the authorized target set
 scripts/git_preserve_danglers.sh --patch-dir ~/git-danglers   # pin + export patches
 ```
 
+Why pinning survives `gc`, and the targeted single-ref form when the whole set is not in scope:
+**[references/recovery_playbook.md](references/recovery_playbook.md)** § Preserve: pin authorized danglers so gc can never take them.
+
 This pins every dangling commit under `refs/dangling-backup/<sha>` (garbage collection can never
 reach a referenced commit) without cluttering `git branch`, and optionally writes a `.patch` per
 non-stash commit. For a *specific* important commit, also give it the full treatment — local
 branch **and** a pushed remote branch **and** a `git format-patch` file — so a single disk or a
-single `git gc` can't take it. Details + why triple-backup: **[references/recovery_playbook.md](references/recovery_playbook.md)**.
+single `git gc` can't take it. Details + why triple-backup: **[references/recovery_playbook.md](references/recovery_playbook.md)**
+§ Triple-backup a critical commit.
 
 **Untracked files need a different tool — plain copying (rule 4).** Put `<backup>` outside the
 target repository and every checkout being retired. Everything above moves *git
@@ -255,7 +268,9 @@ and the person reading it will not be the person who made it.
 ## Mode C — Verify everything is merged (without being fooled by counts)
 
 The trap: a stale branch shows "173 commits ahead of main" yet every line is already on main
-(squash-merge artifact). Never conclude "unmerged" from counts. Per-branch content check:
+(squash-merge artifact) — the mechanism is **[references/merge_verification.md](references/merge_verification.md)** § Why commit counts lie.
+Never conclude "unmerged" from counts. Per-branch content check (procedure and output reading:
+§ Per-branch verdict procedure):
 
 ```bash
 scripts/git_verify_branch_merged.sh <branch> [<base>]   # base defaults to origin/main
@@ -270,7 +285,10 @@ read-only and report that the merge verdict is unavailable. If the fetch itself 
 ownership transfer, the script falls back to cached refs and says so **on stderr only**.
 Treat that line as a blocker, not a footnote: rerun once the network is back before acting on the
 verdict. Comparing by hand (`git diff origin/main <branch>`, `git log origin/main..<branch>`) has
-no such safety net at all — the sole writer must refresh authority first.
+no such safety net at all — the sole writer must refresh authority first, and two-dot vs three-dot
+answers different questions (**[references/merge_verification.md](references/merge_verification.md)** § Pick the diff FORM from the question
+you're asking). Signals that may inform a human but must never auto-decide are fenced off in
+§ Manual-only investigation hints.
 
 It reports **MERGED (ancestor)** or **MERGED (content contained)** — content-safe for a separately
 authorized Mode E deletion gate — versus
@@ -279,31 +297,41 @@ not heuristic: it does a trial 3-way merge of the branch *into* the base with `g
 (in memory, no checkout) and only reports content containment when that merge changes nothing — so a
 squash-merged branch reads MERGED despite a nonzero commit count, while a revert/edit/new-file the
 base lacks reads UNMERGED. It is **safety-biased**: anything it can't prove contained is reported
-for review, because a false "merged" loses work while a false "unmerged" only costs a look. Full
-technique (and why `--find-object`/blob heuristics are unsound for auto-decisions), plus the
-**adversarial multi-agent verification** pattern for a whole repo of branches (read-only agents,
-one per batch, each told to *falsify* "everything is merged," every finding independently
-re-checked): **[references/merge_verification.md](references/merge_verification.md)**.
+for review, because a false "merged" loses work while a false "unmerged" only costs a look
+(**[references/merge_verification.md](references/merge_verification.md)**
+§ Why safety-biased). Why the trial merge is sound rather than a
+heuristic, and why `--find-object`/blob comparison is not: § The sound content check. For a whole
+repo of branches, the read-only fan-out pattern — one agent per batch, each told to *falsify*
+"everything is merged," every finding independently re-checked — is
+§ Adversarial multi-agent verification, with the constraints those agents must be given in
+§ Rules for the verification agents.
 
 ## Mode D — Prevent the disaster
 
 The habits that keep a branch tangle from ever stranding work:
-**[references/prevention_practices.md](references/prevention_practices.md)**. The load-bearing few:
+**[references/prevention_practices.md](references/prevention_practices.md)**. Each bullet below carries the `§` name of its full
+treatment there — follow the one that matches your situation rather than reading the whole file.
+The load-bearing few:
 
 - **Read the current collaboration contract before prescribing topology.** An explicit user or
   project decision about shared checkouts, worktrees, branches, or contribution flow outranks this
   generic guidance. Do not turn one messy audit into a permanent "one worktree per session" rule.
+  (§ Choose topology from current authority.)
 - **One physical checkout gets one writer; parallel agents and sessions stay read-only.** A topic
   branch inside the same checkout does not isolate the shared working files, current branch, or
   index. Writer ownership comes from the repository's task/coordination contract, not a guessed
   file list. If ownership is unclear or another writer is active, do not mutate the checkout.
+  (§ Shared checkout and concurrent sessions: one writer — also governs the two "parallel session"
+  bullets below.)
 - **Commit before switching and push WIP early.** Prefer a remote-backed commit over stash
   juggling, but preserve a higher-authority narrow stash exception; never use an unscoped stash
   to make a dirty checkout look ready.
+  (§ Parallel / multi-branch work; § Push work-in-progress branches early.)
 - **Worktrees are explicitly authorized, named exceptions — not the standing default.** They
   isolate working files, `HEAD`, and index but still share refs, stashes, object storage, config,
   and hooks, and do not copy ignored dependencies. When approved, a linked worktree is safer than
   an invisible independent clone but remains a separately audited retirement target.
+  (§ Audit every authorized worktree before retirement.)
 - **Handoff and merge by exact commit, then finish with an AND gate.** Record branch, local `HEAD`,
   and fresh remote tip; require them to equal the handoff SHA. Direct merges name that SHA, not the
   branch. Hosted merges use an expected-head-SHA precondition when available, or an immediately
@@ -314,9 +342,11 @@ The habits that keep a branch tangle from ever stranding work:
   the project's existing coordination must prove it quiescent and transfer exclusive ownership;
   without that mechanism, stay read-only and report the gap. Do not stop, reconfigure, or invent a
   lease for automation under this generic Skill. Retire refs or checkouts only through separately
-  authorized Mode E evidence.
+  authorized Mode E evidence. (§ Known automated writers are not session-owned WIP.)
 - **Confirm the current branch before committing** (`git branch --show-current`) — a fix committed
   onto the wrong feature branch is invisible to its real PR and easy to lose on cleanup.
+  (§ Confirm the branch before every commit — including why removal from the wrong branch waits
+  for Mode E.)
 - **Never race another writer with checkout-relative mutation.** If another writer is active, stop
   until the repository's coordination system transfers exclusive write ownership. After transfer,
   name the exact ref and object when repairing or advancing state; do not rely on whichever branch
@@ -334,7 +364,8 @@ The habits that keep a branch tangle from ever stranding work:
   checkout position part of the operation.
 - **If a parallel session previously switched the shared tree and stranded your uncommitted work,**
   do not mutate it until that session is quiescent and exclusive ownership has transferred. Then
-  follow the incident-only relocation procedure in the prevention reference: prove your files match
+  follow the incident-only relocation procedure in § Recover stranded work after a parallel session
+  switched the shared tree: prove your files match
   across bases, commit only explicit paths, and restore the prior branch before handing ownership
   back. Branch deletion remains a separately authorized Mode E action.
 - **The inverse case: another session's *commit* lands on your branch, and every check you already
@@ -437,12 +468,13 @@ The habits that keep a branch tangle from ever stranding work:
   session's own staged entries are theirs, not yours to clear). **And before any bare commit on a
   shared tree, read that same diff as your blast radius** — every entry, `D` lines included, must
   be one you intended; an entry you don't recognize means stop, not commit.
+  (§ Commit-scope hygiene.)
 - **Before any rebase or branch-delete, run the applicable Mode B evidence path.** Use the full
   loss audit only when every worktree/ref/tag/stash/dangler it enumerates is in evidence scope;
   otherwise use the authorized checkout/ref's scoped checks and limit the safety claim accordingly.
 - **Before bumping a shared version/lockfile, check the base's current value** so two parallel
   branches don't both claim the same bump (a silent collision that blocks the later change from
-  shipping).
+  shipping). (§ Version / lockfile collisions between parallel branches.)
 
 ## Mode E — Retire worktrees, stashes, and branches safely
 
@@ -689,7 +721,11 @@ the helpers authorizes `checkout`, `reset`, `push`, `stash drop`, `branch -d`, o
   with.
 - **You're on a detached HEAD after checking out a commit** — that commit is safe as long as you
   `git switch -c <branch> HEAD` (or the reflog remembers it for ~90 days). Don't leave important
-  new work on a detached HEAD across a `gc`.
+  new work on a detached HEAD across a `gc`. Recovering work already abandoned there:
+  **[references/recovery_playbook.md](references/recovery_playbook.md)** § Ladder step 3 — detached-HEAD work. If ~90 days is too short
+  for how this repo is used, widen it once: that reference's § Widen the safety window (config),
+  and **[references/prevention_practices.md](references/prevention_practices.md)** § Set a wider reflog safety
+  window once.
 - **Only one worktree remains after cleanup** — `git worktree list` always includes the primary
   repository checkout. Do not delete it merely to make the count zero; the goal is one maintained
   checkout, not no checkout.


### PR DESCRIPTION
## The gap, measured

Of **39 reference sections, only 11 had any inbound pointer naming them.**

| Reference | Sections | Had a `§`-level pointer |
|---|---|---|
| `recovery_playbook.md` (223 lines) | 12 | **1** |
| `prevention_practices.md` (532 lines) | 15 | 3 |
| `merge_verification.md` (559 lines) | 12 | 7 |

The worst case is the one that matters most: the recovery ladder is what an agent needs *when work has gone missing*, and Mode A pointed at it twice as "see the playbook" — a 223-line file to open and scan, at the moment you are least able to afford it.

The counterexample was already in the bundle: `merge_verification.md` gets `§ Supersession triage`, `§ Worktree retirement`, `§ Converging many branches`, `§ Independent clone retirement`. That pattern just was not applied to the other two.

**Nothing here is unreachable** — the files are linked in bulk, so a reader who opens one sees everything. This is discoverability: an agent under context pressure loads what it is told to load, by name.

## What changed

SKILL.md now names the specific section at each decision point.

- **Mode A** routes by symptom to the rung that handles it: dropped stash → `§ Ladder step 2`, detached-HEAD work → `§ Ladder step 3`, true orphan → `§ Ladder step 4` — instead of "see the playbook" twice.
- **Mode B** names what "at risk" covers, the checkout kinds that hide it, and why pinning survives `gc`.
- **Mode C** distributes six merge-verification topics to the sentences that raise them, including two-dot vs three-dot diff form and the manual-only signals that must never auto-decide.
- **Mode D** — every bullet carries the `§` name of its full treatment. This is also what makes a later compression of that 158-line section safe to attempt: the detail has a named home before anything is removed.

**37 citations, all resolving**, verified with a negative control.

## Routing, not rules — and the audit checked

The regression audit flagged **18 units** whose wording moved (inserting a pointer mid-paragraph rewrites the paragraph). Each is classified `preserved_or_moved` with a needle taken from the changed file, and:

- 9 of 18 survive **verbatim**;
- for the 9 reworded, all **31 load-bearing phrases** — commands, verdict strings, absolute conditions, stop points — were verified still present by literal match, with a negative control;
- one illustrative example (*"an orphan from a rebase"*) that the rewrite had dropped was **restored** rather than argued away.

No command, condition, verdict, or stop point changed. The 63-test suite still passes.

## Bookkeeping

- `marketplace.json` 1.15.1 → 1.15.2 (patch)
- `CHANGELOG.md` entry
- **README deliberately unchanged** — internal routing is not a user-facing capability
- SKILL.md 704 → 740 lines. Routing adds lines; the compression that removes them is a separate, deliberate pass that this change is the prerequisite for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USvDWkeQZGbTMayut9o5Tw