### PR TITLE
fix(git-safety-net): eval 9 caught the spelling, not the behaviour (v1.16.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -491,7 +491,7 @@
       "description": "Audits, preserves, recovers, and safely retires local Git state: unpushed or wrong-branch commits, dirty or detached worktrees, forgotten duplicate clones of the same repo, untracked work no bundle can back up, orphaned stashes, dangling commits, stale branches, and squash/rebase merge uncertainty. Use when the user fears work was lost; asks to recover a commit or branch; asks whether a worktree, clone, or scratch directory can be deleted; wants everything converged onto one main branch; or needs proof that cleanup will not drop work. Use it even after an audit reported clean — the usual gap is scope: every in-repo command is blind to a second clone elsewhere on disk. Triggers on \"did I lose work\", \"is everything merged\", \"is anything else lost\", \"safe to delete this clone\", \"clean up old branches/stashes\", \"only keep one main branch\", \"git reflog\", \"dangling commits\", \"分支灾难\", \"误删分支/commit\", \"worktree 能删吗\", \"还有没有丢的东西\", \"只保留一个主分支\". Covers local-Git forensics, not GitHub PR/API operations or routine sync.",
       "source": "./git-safety-net",
       "strict": false,
-      "version": "1.16.0",
+      "version": "1.16.1",
       "category": "developer-tools",
       "keywords": [
         "git",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **peer-message** v1.0.0 (marketplace v3.6.0): restore the previously uncommitted Claude UDS messenger from its source session and extend it into a local Claude Code ↔ Codex coordination layer. The bundled stdlib CLI discovers `claude:` and `codex:` targets across isolated standard Claude profiles, preserves the original authenticated UDS fallback, routes Codex through the first-party `codex queue --thread` command, supports explicitly counted cross-provider broadcasts, adds source/reply envelopes with explicit provenance strength, and verifies delivery from Claude transcripts or Codex queue/thread history without writing either product's SQLite stores. Claude uses a host-recognized peer wrapper; Codex provenance remains advisory text enforced by receiver-side governing instructions. The Skill-local official-feature reference owns the corrected availability and inbound-policy boundaries. The registered test suite, live Codex queue acceptance, and subsequent thread-history consumption were independently verified.
 
 ### Changed
+- **git-safety-net** v1.16.0 → v1.16.1: closes a discrimination gap in the
+  eval suite's first negative case. `evals.json` eval 9 asserted that ordinary
+  edit-and-commit work draws no forensic sweep, but it did so by enumerating
+  three commands — so an agent that reached for `git log -g`, which inspects
+  the same reflog, would have passed a check written to catch exactly that
+  over-triggering. The assertion now names the category (any command searching
+  for lost or unreferenced work) and keeps the three commands as anchoring
+  examples, which is what a grader with no knowledge of this Skill can still
+  match against.
+
+  Found by the second independent reviewer and deliberately reported outside
+  its own scope: it was judging assertion *judgeability*, and noted this as a
+  weakness of a different kind rather than folding it into its findings. Kept
+  as a separate change so the axis boundary stays visible.
 - **git-safety-net** v1.15.2 → v1.16.0: adds the Skill's first behavioural eval
   suite and trims one paragraph of Mode D.
 

--- a/git-safety-net/.security-scan-passed
+++ b/git-safety-net/.security-scan-passed
@@ -1,4 +1,4 @@
 Security scan passed
-Scanned at: 2026-09-02T11:23:43.103118+00:00
+Scanned at: 2026-09-02T15:13:14.012479+00:00
 Tool: gitleaks + pattern-based validation
-Content hash: 3f28879a71a8c890548ec68c4ca427914973e2bda1f11813c0d758934b994971
+Content hash: 880322521fcd600f2dcda819e0cc46ba2d5d54b1e22a29742058569448cfe7f2

--- a/git-safety-net/evals/evals.json
+++ b/git-safety-net/evals/evals.json
@@ -102,7 +102,7 @@
       "assertions": [
         "Edits README.md, or prescribes the edit, to add a `## Setup` section containing an install command",
         "Commits that change, or prescribes committing it",
-        "Does not run or propose `git reflog`, `git fsck`, or `git stash list`",
+        "Does not run or propose any command that searches for lost or unreferenced work — reflog inspection (`git reflog`, `git log -g`), a dangling-object search (`git fsck`), or a stash listing (`git stash list`)",
         "Does not create or propose any backup, rescue, or snapshot ref for this change"
       ]
     },


### PR DESCRIPTION
## The defect

Eval 9 is the suite's first negative case: an ordinary edit-and-commit in a clean solo repo must draw **no** forensic sweep. Its third assertion enforced that by enumerating three commands:

```
Does not run or propose `git reflog`, `git fsck`, or `git stash list`
```

An agent reaching for `git log -g` inspects the same reflog — and passes. The assertion tested a spelling, not the behaviour it was written to catch.

## The fix

```
Does not run or propose any command that searches for lost or unreferenced work —
reflog inspection (`git reflog`, `git log -g`), a dangling-object search (`git fsck`),
or a stash listing (`git stash list`)
```

Category first, the three commands kept as anchoring examples. That preserves what the original narrowing was *for*: in an earlier round this assertion read "repository-wide at-risk-work audit", which a grader who has not read the Skill cannot evaluate — it is this Skill's vocabulary, not an observable action. Naming the category in plain English **and** anchoring it with concrete commands satisfies both constraints at once.

Strictly a widening: every command the old text named is still named, so any transcript the old assertion would have failed still fails.

## Provenance

Found by the second independent reviewer on the judgeability axis, which **deliberately reported it outside its own scope** — it was judging whether a grader can return a defensible pass/fail, and named this as a weakness of a different kind (discrimination) rather than folding it into its findings. Shipped as its own change so that axis boundary stays visible in the history rather than being quietly absorbed into the previous PR.

## Verification

- Regression audit: 2 development candidates, 908 exact preservations; both dispositioned `preserved_or_moved` with grep evidence, `verify` passed
- `security_scan` (run before `compare`, per the ordering that bit an earlier round) · `quick_validate`: valid
- marketplace / shell-syntax / registered-tests / 63 skill tests: all green locally
- Calibrated action-verb scan re-run: still finds exactly the 12 unhedged verbs in the pre-fix baseline and 0 here

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USvDWkeQZGbTMayut9o5Tw