### PR TITLE
fix(excalidraw-use): link scene_file_format.md from SKILL.md (v1.0.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional Claude Code and Codex skills marketplace — production-ready skills spanning GitHub and git operations (including current-base contributor PR review), document conversion and generation (Markdown, PDF, PPTX, DOCX), diagram and UI-design extraction, the full audio pipeline (ASR transcription, TTS, transcript correction, meeting minutes), financial and investment-research data, web scraping and content capture, security/PII tooling and secure repomix packaging, macOS and iOS development, CLI demo and terminal automation, prompt and skill engineering, deep research and fact-checking, QA and LLM-evaluation infrastructure, internationalization, network/Tailscale and remote-desktop diagnostics, local inter-agent messaging, Claude Code operations, and model-aware Codex workstation setup. Suite plugins bundle related skills under shared namespaces, including the StepFun StepAudio 2.5 audio family. See the Available Skills list in the README for the authoritative per-skill breakdown.",
-    "version": "3.7.0"
+    "version": "3.7.1"
   },
   "plugins": [
     {
@@ -1174,7 +1174,7 @@
       "description": "Place existing images onto an Excalidraw whiteboard, turn a slide deck into clean per-slide images first, and inspect what is inside a .excalidraw file. Use whenever someone mentions Excalidraw, a whiteboard or canvas, a .excalidraw file, 白板 or 画板 — especially \"put these screenshots on my board\", \"add my old workshop images to the canvas\", \"space them out so I don't have to adjust spacing by hand\", \"turn these slides into images I can draw on\", or \"what's in this scene file\". Also use when a talk or workshop is delivered by hand-drawing over screenshots on a shared canvas, or when someone needs a pick tray of many images to choose from. Not for generating a diagram from a text description — that is a different job.",
       "source": "./excalidraw-use",
       "strict": false,
-      "version": "1.0.0",
+      "version": "1.0.1",
       "category": "developer-tools",
       "keywords": [
         "excalidraw",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -265,6 +265,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   an order-inverted stitched quote — both fixed and re-verified pre-ship.
 
 ### Fixed
+- **excalidraw-use** v1.0.0 → v1.0.1 (marketplace v3.7.1): link
+  `references/scene_file_format.md` from SKILL.md. It shipped unreferenced, so the
+  executing agent had no route to it — an unlinked reference is unreachable at runtime
+  no matter how good its content is, and this one carries the field-by-field scene
+  breakdown behind `--template-from`. Caught by checking that every file under
+  `references/` appears in a SKILL.md link, which is worth running before any skill
+  ships. Regression audit against the merge commit confirms the three untouched
+  references and four scripts are byte-identical; only SKILL.md changed.
 - **git-safety-net** v1.13.0 → v1.14.0: replace the over-broad “one worktree per
   concurrent session” prescription with an authority-first, single-writer shared-checkout
   contract. Mode D now treats worktrees as explicitly authorized named exceptions, preserves

--- a/excalidraw-use/SKILL.md
+++ b/excalidraw-use/SKILL.md
@@ -68,6 +68,10 @@ Three decisions worth making deliberately:
   copying a live element from *their* board is the only way to be sure the field
   set matches the build they actually run. Without it a reasonable default is
   used, which has worked but is one observed field set, not a spec.
+  [references/scene_file_format.md](references/scene_file_format.md) has the
+  field-by-field breakdown, keeping what the official docs state separate from
+  what was read off a real file — open it when you need to hand-build or repair
+  a scene rather than let the script write one.
 - **`--exclude` anything already on their board.** The check is by image content,
   not filename, so a renamed copy is still caught. Skipping this is how someone
   ends up with the same picture twice and has to delete one by hand.


### PR DESCRIPTION
`references/scene_file_format.md` shipped in v1.0.0 without a link from SKILL.md.

An unlinked reference is unreachable at runtime no matter how good its content is — the executing agent has no route to it. This one carries the field-by-field scene breakdown that explains why `--template-from` exists, so losing it costs the reasoning behind the skill's least obvious flag.

**How it got through**: v1.0.0 passed `quick_validate`, `security_scan`, a doc-example run of every SKILL.md command verbatim, and CI. None of them ask whether each bundled reference is reachable. The check that catches it is one line — assert every file under `references/` appears in a SKILL.md link — and belongs before any skill ships.

**Preservation**: regression audit against merge commit `4ea9685` produced 26 candidates, all classified `preserved_or_moved`. They surfaced only because the new link widened the runtime reachability graph, not because anything moved — sha256 per file confirms the three other references and all four scripts are byte-identical, and only SKILL.md changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TU8x9ruuVfPBibFLXJ9TVc
