### PR TITLE
fix(claude-switch-models-setup): claude-plugins-sync died on every daemon run (v3.7.17)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -125,7 +125,7 @@
       "description": "Claude Code operations suite that bundles cross-project prior-work retrieval across code, docs, Skills, meetings, WeChat archives, and conversation history; provider-separated Claude Code and Codex history readers; identity- and lineage-gated continuation workflows; plugin/skill troubleshooting; CLAUDE.md progressive disclosure optimization; version-synced Lark CLI routing; statusline configuration; exported .txt repair; full claude.ai conversation extraction with tool-call rendering and file download; plugin marketplace development and suite consolidation; writing/testing/debugging Claude Code hooks; multi-provider profile isolation; personal-memory migration into tool-agnostic AGENTS.md reference docs; one-shot local timers that ping Claude right after subscription quota reset to start a fresh 5-hour usage window; and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
       "source": "./daymade-claude-code",
       "strict": false,
-      "version": "3.7.16",
+      "version": "3.7.17",
       "category": "suite",
       "keywords": [
         "suite",

--- a/daymade-claude-code/claude-switch-models-setup/scripts/claude-plugins-sync.py
+++ b/daymade-claude-code/claude-switch-models-setup/scripts/claude-plugins-sync.py
@@ -69,6 +69,8 @@ Env overrides (match claude-profiles.sh):
     CLAUDE_PROFILES_DIR   default ~/.claude-profiles
 """
 
+from __future__ import annotations
+
 import json
 import os
 import shutil

--- a/daymade-claude-code/claude-switch-models-setup/tests/test_daemon_interpreter_compat.py
+++ b/daymade-claude-code/claude-switch-models-setup/tests/test_daemon_interpreter_compat.py
@@ -1,0 +1,104 @@
+"""The daemon's scripts must import under the interpreter launchd actually hands them.
+
+`sync-local-skill-sources-daemon.sh` invokes its Python scripts as a bare `python3`.
+Under launchd's minimal PATH that resolves to the Developer Tools stub, which on
+macOS has been Python 3.9 — old enough to evaluate a PEP 604 annotation (`str | None`)
+at definition time and raise TypeError before the module finishes importing.
+
+`claude-plugins-sync.py` carried exactly that shape and crashed on every daemon run
+from 2026-07-04 until this test was added, while its sibling survived only because it
+already declared `from __future__ import annotations`. Nothing surfaced the crash: the
+daemon runs the scripts unconditionally and discards their output.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+import unittest
+
+
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = SKILL_ROOT / "scripts"
+FUTURE_IMPORT = "annotations"
+
+
+def _annotation_nodes(tree: ast.AST):
+    """Every expression that Python evaluates as an annotation at import time."""
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            args = node.args
+            for arg in (
+                *args.posonlyargs,
+                *args.args,
+                *args.kwonlyargs,
+                args.vararg,
+                args.kwarg,
+            ):
+                if arg is not None and arg.annotation is not None:
+                    yield arg.annotation
+            if node.returns is not None:
+                yield node.returns
+        elif isinstance(node, ast.AnnAssign) and node.annotation is not None:
+            yield node.annotation
+
+
+def _uses_pep604_union(tree: ast.AST) -> bool:
+    for annotation in _annotation_nodes(tree):
+        for node in ast.walk(annotation):
+            if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+                return True
+    return False
+
+
+def _declares_future_annotations(tree: ast.AST) -> bool:
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom) and node.module == "__future__":
+            if any(alias.name == FUTURE_IMPORT for alias in node.names):
+                return True
+    return False
+
+
+class DaemonInterpreterCompatTest(unittest.TestCase):
+    def test_scripts_dir_is_present(self) -> None:
+        """Guard the guard: an empty glob would make every assertion below vacuous."""
+        self.assertTrue(SCRIPTS_DIR.is_dir(), f"missing scripts dir: {SCRIPTS_DIR}")
+        self.assertTrue(
+            list(SCRIPTS_DIR.glob("*.py")), f"no Python scripts under {SCRIPTS_DIR}"
+        )
+
+    def test_pep604_annotations_require_future_import(self) -> None:
+        offenders = []
+        for script in sorted(SCRIPTS_DIR.glob("*.py")):
+            tree = ast.parse(script.read_text(encoding="utf-8"), filename=str(script))
+            if _uses_pep604_union(tree) and not _declares_future_annotations(tree):
+                offenders.append(script.name)
+        self.assertEqual(
+            [],
+            offenders,
+            "these scripts evaluate `X | Y` annotations at import time and will "
+            "raise TypeError under the Developer Tools Python the daemon gets; add "
+            f"`from __future__ import annotations`: {offenders}",
+        )
+
+    def test_detector_actually_fires(self) -> None:
+        """Calibrate against a known-bad input, so a broken detector cannot report green."""
+        bad = ast.parse("def f(x: str | None): pass\n")
+        self.assertTrue(_uses_pep604_union(bad))
+        self.assertFalse(_declares_future_annotations(bad))
+
+        good = ast.parse(
+            "from __future__ import annotations\ndef f(x: str | None): pass\n"
+        )
+        self.assertTrue(_uses_pep604_union(good))
+        self.assertTrue(_declares_future_annotations(good))
+
+        unrelated = ast.parse("def f(x: int): return x | 1\n")
+        self.assertFalse(
+            _uses_pep604_union(unrelated),
+            "a bitwise-or in the function BODY must not be mistaken for an annotation",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`sync-local-skill-sources-daemon.sh` invokes its Python scripts as a bare
`python3`. Under launchd's minimal PATH that resolves to the Developer Tools
stub — Xcode's Python 3.9 on the machine this was found on — which evaluates
annotations at definition time.

`claude-plugins-sync.py` declares `def _iter_profile_settings(skip: str | None)`,
so it raised before finishing its import, **on every daemon run since
2026-07-04**. 43 of the 44 tracebacks in `source-sync.err.log` are this one line:

```
File ".../claude-plugins-sync.py", line 327, in <module>
    def _iter_profile_settings(skip: str | None):
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

Nothing surfaced it: the daemon runs the script unconditionally and discards its
output. So multi-profile plugin sync — keeping each profile's
`known_marketplaces.json` pointed at its own config dir — silently stopped
happening for two months.

Its sibling `sync-local-skill-sources.py` survives the same interpreter only
because it already declares `from __future__ import annotations`.

## Fix

Add that same line. This matches the interpreter the daemon can actually
guarantee; pinning the daemon to a newer interpreter would only lease the
binding from another installer's lifecycle, which is the failure mode this
repo's own `CLAUDE.md` warns about for lifecycle hooks.

## Regression test

`tests/test_daemon_interpreter_compat.py` generalises past this instance: it
parses every script under `scripts/` and fails any file that evaluates a PEP 604
union in an annotation without declaring the future import. It is calibrated in
both directions — a known-bad source fires it, a known-good one does not, and a
bitwise-or in a function *body* is correctly ignored. It also asserts the glob
is non-empty, so an empty scan cannot report green.

That tests directory is registered in `scripts/ci/test-suites.txt`, so this runs
in CI.

## Verification

| Check | Result |
|---|---|
| Detector against pre-fix file | `PEP604=True future=False` → FAIL |
| Detector against post-fix file | `PEP604=True future=True` → PASS |
| `/usr/bin/python3` (3.9) running the pre-fix script | `TypeError` on import |
| `/usr/bin/python3` (3.9) running the post-fix script | exit 0, completes its sync |
| Full suite | green |
| `claude plugin validate --strict .` | pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDNhUuoCuUEednSqkuxjVh