### PR TITLE
feat(claude-switch-models-setup): audit the daemon's pinned runtime (v3.9.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -126,7 +126,7 @@
       "description": "Claude Code operations suite that bundles cross-project prior-work retrieval across code, docs, Skills, meetings, WeChat archives, and conversation history; provider-separated Claude Code and Codex history readers; identity- and lineage-gated continuation workflows; plugin/skill troubleshooting; CLAUDE.md progressive disclosure optimization; version-synced Lark CLI routing; statusline configuration; exported .txt repair; full claude.ai conversation extraction with tool-call rendering and file download; plugin marketplace development and suite consolidation; writing/testing/debugging Claude Code hooks; multi-provider profile isolation; personal-memory migration into tool-agnostic AGENTS.md reference docs; one-shot local timers that ping Claude right after subscription quota reset to start a fresh 5-hour usage window; and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
       "source": "./daymade-claude-code",
       "strict": false,
-      "version": "3.8.0",
+      "version": "3.9.0",
       "category": "suite",
       "keywords": [
         "suite",

--- a/daymade-claude-code/claude-switch-models-setup/references/local-source-sync-architecture.md
+++ b/daymade-claude-code/claude-switch-models-setup/references/local-source-sync-architecture.md
@@ -122,6 +122,21 @@ Rules:
   Without it, a marketplace whose own installer activates every registered Skill will
   keep recreating links this syncer then prunes, and the two writers silently undo
   each other.
+- The background daemon executes a **pinned plugin copy**, installed into its own
+  `CLAUDE_CONFIG_DIR` under `~/.local/share/`, not the live checkout. That isolation is
+  deliberate: editing a source repo must not change what an already-running daemon does.
+  The cost is that nothing advances the pin — a fix can be merged, tested and believed
+  shipped while the daemon keeps running the old code. Advance it with the same official
+  commands that installed it, against that config dir:
+
+  ```bash
+  CLAUDE_CONFIG_DIR=<daemon config> claude plugin marketplace update <marketplace>
+  CLAUDE_CONFIG_DIR=<daemon config> claude plugin update <plugin>@<marketplace>
+  ```
+
+  then repoint the script symlinks under `~/.config/claude-switch-models-setup/` at the
+  new version directory. `skill-install-audit.py` reports the gap as `DAEMON_RUNTIME_LAG`;
+  it is the only thing that compares the two numbers.
 - Unselected source Skills remain cold inventory. Real directories and third-party
   symlinks in either root are outside automatic retirement.
 

--- a/daymade-claude-code/claude-switch-models-setup/scripts/skill-install-audit.py
+++ b/daymade-claude-code/claude-switch-models-setup/scripts/skill-install-audit.py
@@ -2,7 +2,7 @@
 """skill-install-audit.py — read-only reconciliation of every skill install surface.
 
 One command that answers "which of my skills are actually usable where?" by joining
-four layers that otherwise drift silently:
+five layers that otherwise drift silently:
 
   1. REGISTRY   each local marketplace's .claude-plugin/marketplace.json
   2. INSTALLED  ~/.claude/plugins/installed_plugins.json  (shared via symlink)
@@ -10,6 +10,8 @@ four layers that otherwise drift silently:
                 are converged onto it by claude-plugins-sync.py)
   4. CODEX      ~/.config/claude-switch-models-setup/codex-active-skills.json manifest vs
                 the real ~/.agents/skills entries
+  5. RUNTIME    the plugin version the background sync daemon actually executes, vs the
+                version registered in the source marketplace
 
 Findings (each list is empty-friendly; a clean run prints only the summary):
 
@@ -18,6 +20,8 @@ Findings (each list is empty-friendly; a clean run prints only the summary):
   INSTALLED_NO_KEY         installed, no enabledPlugins entry (NOT visible by default)
   REGISTERED_NOT_INSTALLED in a marketplace.json but never installed
   ORPHAN_INSTALLED         installed but no longer in any marketplace.json (loads nothing)
+  DAEMON_RUNTIME_LAG       the sync daemon runs a pinned copy older than the source, so every
+                           fix shipped to this repo stays invisible to it until the pin moves
   PROFILE_ONLY_RISK        enabledPlugins keys present in a profile but absent from main —
                            pre-fix these were wiped by the next mirror; now they are adopted
                            or preserved, but conflicts still deserve eyeballs
@@ -39,6 +43,7 @@ Env overrides (match the sibling sync scripts):
 import argparse
 import json
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -61,6 +66,17 @@ REGISTRY_REPOS = [
     ("cemakanshan-skills", HOME / "workspace" / "md" / "cemakanshan-skills"),
 ]
 MANAGED_REPO_PREFIXES = tuple(str(repo.resolve()) for _l, repo in REGISTRY_REPOS)
+# The background syncer deliberately executes a pinned plugin copy rather than a live
+# checkout, so editing the source cannot change what a running daemon does. Nothing
+# advances that pin automatically and nothing else compares the two numbers, so a fix
+# can be merged, tested and believed shipped while the daemon keeps running the old one.
+DAEMON_ENTRY = Path(
+    os.environ.get(
+        "SKILL_SYNC_DAEMON_ENTRY",
+        str(HOME / ".config" / "claude-switch-models-setup" / "sync-local-skill-sources.py"),
+    )
+)
+DAEMON_PLUGIN = "daymade-claude-code"
 
 
 def read_json(path: Path):
@@ -103,6 +119,49 @@ def load_codex():
     if AGENTS_SKILLS.is_dir():
         pool = {e.name for e in AGENTS_SKILLS.iterdir()}
     return manifest, pool
+
+
+def load_daemon_runtime_lag():
+    """Compare the version the daemon executes against the source registry.
+
+    Advisory only: returns [] when current, undeployed, or unparseable, so a machine
+    that does not run this daemon never looks broken.
+    """
+    if not DAEMON_ENTRY.is_symlink():
+        return []
+    try:
+        target = os.readlink(DAEMON_ENTRY)
+    except OSError:
+        return []
+    match = re.search(rf"/{re.escape(DAEMON_PLUGIN)}/([^/]+)/", target)
+    if not match:
+        return []
+    running = match.group(1)
+
+    source = None
+    for _label, repo in REGISTRY_REPOS:
+        for plugin in read_json(repo / ".claude-plugin" / "marketplace.json").get("plugins", []):
+            if plugin.get("name") == DAEMON_PLUGIN:
+                source = plugin.get("version")
+    if not source or source == running:
+        return []
+
+    def parts(value):
+        try:
+            return tuple(int(x) for x in value.split("."))
+        except ValueError:
+            return None
+
+    running_parts, source_parts = parts(running), parts(source)
+    if running_parts is None or source_parts is None or running_parts >= source_parts:
+        return []
+    return [
+        f"{DAEMON_PLUGIN}: daemon runs {running}, source registers {source}. "
+        f"Advance the pin against the daemon's own config dir "
+        f"(`claude plugin marketplace update <mkt>` then `claude plugin update "
+        f"{DAEMON_PLUGIN}@<mkt>`), then repoint the symlinks in "
+        f"{DAEMON_ENTRY.parent} at the new version directory."
+    ]
 
 
 def load_profile_only_keys():
@@ -179,6 +238,7 @@ def audit():
         "PROFILE_ONLY_RISK": profile_only,
         "MANUAL_LINK_RISK": sorted(manual_risk),
         "CODEX_UNLISTED_ENABLED": codex_unlisted,
+        "DAEMON_RUNTIME_LAG": load_daemon_runtime_lag(),
     }
 
 
@@ -222,7 +282,8 @@ def main():
     print(
         "\nLegend: DISABLED/NO_KEY -> enable via `claude plugin enable NAME@mkt`; "
         "REGISTERED_NOT_INSTALLED -> `claude plugin install NAME@mkt`; "
-        "MANUAL_LINK_RISK -> add the name to codex-active-skills.json or drop the link."
+        "MANUAL_LINK_RISK -> add the name to codex-active-skills.json or drop the link; "
+        "DAEMON_RUNTIME_LAG -> the daemon is executing code older than this repo."
     )
     return 0
 

--- a/daymade-claude-code/claude-switch-models-setup/tests/test_daemon_runtime_lag.py
+++ b/daymade-claude-code/claude-switch-models-setup/tests/test_daemon_runtime_lag.py
@@ -1,0 +1,124 @@
+"""The audit must notice when the sync daemon executes an older pin than the source.
+
+The daemon deliberately runs a pinned plugin copy rather than a live checkout, so
+editing the source cannot change what a running daemon does. Nothing advances that
+pin automatically, so a fix can be merged, tested and believed shipped while the
+daemon keeps running the old code — which is exactly what happened between
+2026-08-29 and 2026-09-05, when the pin sat at 3.6.1 while the source reached 3.8.0.
+
+This layer is advisory: a machine that does not run the daemon must stay clean.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "skill-install-audit.py"
+SPEC = importlib.util.spec_from_file_location("skill_install_audit", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+audit = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = audit
+SPEC.loader.exec_module(audit)
+
+
+class DaemonRuntimeLagTest(unittest.TestCase):
+    def _fixture(self, root: Path, running: str, source: str):
+        """A symlinked daemon entry pinned at `running`, and a registry at `source`."""
+        pinned = (
+            root
+            / "cache"
+            / "mkt"
+            / audit.DAEMON_PLUGIN
+            / running
+            / "claude-switch-models-setup"
+            / "scripts"
+        )
+        pinned.mkdir(parents=True)
+        real = pinned / "sync-local-skill-sources.py"
+        real.write_text("", encoding="utf-8")
+        entry = root / "entry.py"
+        entry.symlink_to(real)
+
+        repo = root / "repo"
+        (repo / ".claude-plugin").mkdir(parents=True)
+        (repo / ".claude-plugin" / "marketplace.json").write_text(
+            json.dumps(
+                {"plugins": [{"name": audit.DAEMON_PLUGIN, "version": source}]}
+            ),
+            encoding="utf-8",
+        )
+        return entry, [("mkt", repo)]
+
+    def test_older_pin_is_reported_with_the_two_versions(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="tinkle_runtime_lag_") as raw:
+            entry, repos = self._fixture(Path(raw), running="3.6.1", source="3.8.0")
+            with mock.patch.object(audit, "DAEMON_ENTRY", entry), mock.patch.object(
+                audit, "REGISTRY_REPOS", repos
+            ):
+                found = audit.load_daemon_runtime_lag()
+            self.assertEqual(1, len(found))
+            self.assertIn("3.6.1", found[0])
+            self.assertIn("3.8.0", found[0])
+
+    def test_matching_pin_is_silent(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="tinkle_runtime_lag_") as raw:
+            entry, repos = self._fixture(Path(raw), running="3.8.0", source="3.8.0")
+            with mock.patch.object(audit, "DAEMON_ENTRY", entry), mock.patch.object(
+                audit, "REGISTRY_REPOS", repos
+            ):
+                self.assertEqual([], audit.load_daemon_runtime_lag())
+
+    def test_newer_pin_is_silent(self) -> None:
+        """Running ahead of the registry is a release-in-flight state, not a lag."""
+        with tempfile.TemporaryDirectory(prefix="tinkle_runtime_lag_") as raw:
+            entry, repos = self._fixture(Path(raw), running="9.9.9", source="3.8.0")
+            with mock.patch.object(audit, "DAEMON_ENTRY", entry), mock.patch.object(
+                audit, "REGISTRY_REPOS", repos
+            ):
+                self.assertEqual([], audit.load_daemon_runtime_lag())
+
+    def test_machine_without_the_daemon_stays_clean(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="tinkle_runtime_lag_") as raw:
+            missing = Path(raw) / "not-deployed.py"
+            with mock.patch.object(audit, "DAEMON_ENTRY", missing):
+                self.assertEqual([], audit.load_daemon_runtime_lag())
+
+    def test_unparseable_version_does_not_raise(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="tinkle_runtime_lag_") as raw:
+            entry, repos = self._fixture(Path(raw), running="nightly", source="3.8.0")
+            with mock.patch.object(audit, "DAEMON_ENTRY", entry), mock.patch.object(
+                audit, "REGISTRY_REPOS", repos
+            ):
+                self.assertEqual([], audit.load_daemon_runtime_lag())
+
+    def test_section_is_present_in_the_audit_result(self) -> None:
+        """A section the report never emits cannot warn anyone.
+
+        Run `audit()` hermetically: every on-disk layer is stubbed empty, so this
+        asserts the wiring on a machine that has none of this installed (CI included)
+        rather than depending on the runner's home directory.
+        """
+        with tempfile.TemporaryDirectory(prefix="tinkle_runtime_lag_") as raw:
+            absent = Path(raw) / "absent"
+            # Empty every on-disk layer: no registries to read, no JSON to parse, no
+            # skill root, no deployed daemon. Whether those paths happen to exist on
+            # the machine running the tests must not change the outcome.
+            with mock.patch.object(audit, "REGISTRY_REPOS", []), \
+                mock.patch.object(audit, "read_json", lambda _path: {}), \
+                mock.patch.object(audit, "PROFILES_DIR", absent), \
+                mock.patch.object(audit, "AGENTS_SKILLS", absent), \
+                mock.patch.object(audit, "DAEMON_ENTRY", absent):
+                result = audit.audit()
+        self.assertIn("DAEMON_RUNTIME_LAG", result)
+        self.assertEqual([], result["DAEMON_RUNTIME_LAG"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

The sync daemon executes a **pinned plugin copy** installed into its own `CLAUDE_CONFIG_DIR` under `~/.local/share/`, not the live checkout. That isolation is deliberate — editing a source repo must not change what an already-running daemon does.

The cost is that nothing advances the pin, and nothing compared the two numbers.

In practice: the pin sat at **3.6.1 from 2026-08-29** while the source reached **3.8.0**. A fix could be written, tested, reviewed, merged and believed shipped while the daemon kept running the old code — and no check anywhere reported the gap. It is visible only to someone who follows the symlink by hand.

Two of this week's fixes had already landed in that state.

## Change

`skill-install-audit.py` exists to join the layers that otherwise drift silently. It covered four; this adds the fifth it was missing.

`DAEMON_RUNTIME_LAG` names both versions and the exact commands that advance the pin, so the finding is actionable without reading the architecture reference first:

```
daymade-claude-code: daemon runs 3.6.1, source registers 3.8.0. Advance the pin
against the daemon's own config dir (`claude plugin marketplace update <mkt>` then
`claude plugin update daymade-claude-code@<mkt>`), then repoint the symlinks in
~/.config/claude-switch-models-setup at the new version directory.
```

## Fails open in every direction that could cry wolf

Not deployed, not a symlink, unparseable version, or a pin **newer** than the registry (a release in flight) all return empty. Only a strictly-older pin reports. A machine that does not run this daemon never looks broken.

## Tests

Six, calibrated in both directions rather than only asserting the happy path:

- an older pin reports, and names both versions
- a matching pin is silent
- a newer pin is silent
- a machine without the daemon stays clean
- an unparseable version does not raise
- the section is actually present in `audit()` — a section the report never emits could not warn anyone

Suite 63 passing; `claude plugin validate --strict .` passes. The tests directory is registered in `scripts/ci/test-suites.txt`, so this runs in CI.

## Documentation

`references/local-source-sync-architecture.md` now describes this runtime layer and the advance procedure. It previously had **zero references anywhere in the repository**, despite being what actually runs.
