### PR TITLE
docs(claude-switch-models-setup): the "changes do not appear" path missed a live case (v3.10.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -126,7 +126,7 @@
       "description": "Claude Code operations suite that bundles cross-project prior-work retrieval across code, docs, Skills, meetings, WeChat archives, and conversation history; provider-separated Claude Code and Codex history readers; identity- and lineage-gated continuation workflows; plugin/skill troubleshooting; CLAUDE.md progressive disclosure optimization; version-synced Lark CLI routing; statusline configuration; exported .txt repair; full claude.ai conversation extraction with tool-call rendering and file download; plugin marketplace development and suite consolidation; writing/testing/debugging Claude Code hooks; multi-provider profile isolation; personal-memory migration into tool-agnostic AGENTS.md reference docs; one-shot local timers that ping Claude right after subscription quota reset to start a fresh 5-hour usage window; and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
       "source": "./daymade-claude-code",
       "strict": false,
-      "version": "3.9.0",
+      "version": "3.10.0",
       "category": "suite",
       "keywords": [
         "suite",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,14 +72,20 @@ explicitly blocked, unshipped, or pending. Test advisory liveness across later
 fully-due windows, and leave current thresholds in the owning implementation
 rather than copying them into this file.
 
-Synchronous Claude Code/Codex lifecycle hooks must call a fixed direct
-interpreter selected by the owning installer or wrapper. Do not register a
-Python hook through a package manager, generic interpreter dispatcher, or
-`.py` shebang lookup: a shared environment/cache lock can stall every prompt or
-tool boundary. Explicit maintenance, retrieval, validation, and test commands
-may still use their declared `uv` project; the runtime boundary is the rule.
-The concrete prior-work wrapper and profile-converger registration live in
-their respective Skills rather than being copied here.
+Synchronous Claude Code/Codex lifecycle hooks and background services
+(LaunchAgents included) must call a fixed direct interpreter **owned by the
+installer that writes it**. Do not register a Python entry point through a
+package manager, generic interpreter dispatcher, or `.py` shebang lookup: a
+shared environment/cache lock can stall every prompt or tool boundary, and a
+bare `python3` resolves under launchd's minimal PATH to the Developer Tools
+stub, which is old enough to reject syntax the script was written in. The
+opposite error costs the same: resolving `sys.executable` bakes in a versioned
+path another product owns, so the job dies silently when that product upgrades.
+Own the literal path, the way `SYSTEM_GIT` is owned. Explicit maintenance,
+retrieval, validation, and test commands may still use their declared `uv`
+project; the runtime boundary is the rule. The concrete prior-work wrapper and
+profile-converger registration live in their respective Skills rather than
+being copied here.
 
 Treat `daymade-skill/skill-creator` as a locked uv project. Run its bundled Python tools from that directory with `uv run --frozen`; the project-local `.venv` is isolated from caller projects while uv's shared cache supplies the pinned packages. Do not reintroduce per-call `--with` overlays for dependencies already in its `pyproject.toml`.
 

--- a/daymade-claude-code/claude-switch-models-setup/references/troubleshooting.md
+++ b/daymade-claude-code/claude-switch-models-setup/references/troubleshooting.md
@@ -193,6 +193,19 @@ If the watcher is not installed, install it:
 ~/.config/claude-switch-models-setup/sync-local-skill-sources-daemon.sh --install
 ```
 
+If the watcher is installed, healthy and running, and the change still does not
+appear, check whether it is executing an older pinned copy than the source. The
+daemon deliberately runs an installed plugin version rather than the checkout, and
+nothing advances that pin on its own:
+
+```bash
+python3 <this skill>/scripts/skill-install-audit.py --list DAEMON_RUNTIME_LAG
+```
+
+A non-empty result names both versions and the commands that advance the pin. The
+topology and the reason for the isolation are in
+[local-source-sync-architecture.md](local-source-sync-architecture.md).
+
 Manual repair fallback:
 
 ```bash


### PR DESCRIPTION
Documentation follow-up to #457 / #461 / #463 — two gaps that let a shipped fix fail to take effect without anything saying so.

## `references/troubleshooting.md`

"Local skill source changes do not appear in Claude Code or Codex" walks a reader from symlink check → watcher check → watcher install, and stops.

It has no branch for the case that actually occurred: the watcher is installed, healthy, and running, and the change still does not appear, because the daemon executes an older **pinned** copy. That state lasted a week on this machine and no documented step would have found it.

Adds the branch, routing to `skill-install-audit.py --list DAEMON_RUNTIME_LAG` for the check and to `local-source-sync-architecture.md` for the topology — neither restated here.

## `CLAUDE.md`

The interpreter rule was scoped to *synchronous lifecycle hooks*. Both failures this week were background services, outside that scope, and they failed in **opposite directions**:

| | What it did | How it failed |
|---|---|---|
| Daemon wrapper | bare `python3` (PATH lookup) | launchd's minimal PATH resolves to the Developer Tools stub — too old for the script's own syntax. Crashed every run for two months. |
| Installer | `sys.executable` + `.resolve()` | Baked in a versioned path Xcode owns; dies silently on the next Xcode upgrade. |

The rule already had the right principle — *owned by the installer* — it just did not reach the services that needed it. Widened to name background services and both directions; concrete registrations stay in their owning Skills.

## Verification

- `skill-install-audit.py --list DAEMON_RUNTIME_LAG` executed as written in the new docs: exit 0.
- `claude plugin validate --strict .` passes.
- `check_doc_skill_lists.py`: README catalogs match marketplace.json; CLAUDE.md carries only the authority pointer.
- `claude-switch-models-setup` suite: 63 passing.
