### PR TITLE
docs(claude-switch-models-setup): an empty runtime-lag result was presented as an all-clear (v3.12.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -126,7 +126,7 @@
       "description": "Claude Code operations suite that bundles cross-project prior-work retrieval across code, docs, Skills, meetings, WeChat archives, and conversation history; provider-separated Claude Code and Codex history readers; identity- and lineage-gated continuation workflows; plugin/skill troubleshooting; CLAUDE.md progressive disclosure optimization; version-synced Lark CLI routing; statusline configuration; exported .txt repair; full claude.ai conversation extraction with tool-call rendering and file download; plugin marketplace development and suite consolidation; writing/testing/debugging Claude Code hooks; multi-provider profile isolation; personal-memory migration into tool-agnostic AGENTS.md reference docs; one-shot local timers that ping Claude right after subscription quota reset to start a fresh 5-hour usage window; and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
       "source": "./daymade-claude-code",
       "strict": false,
-      "version": "3.11.0",
+      "version": "3.12.0",
       "category": "suite",
       "keywords": [
         "suite",

--- a/daymade-claude-code/claude-switch-models-setup/references/troubleshooting.md
+++ b/daymade-claude-code/claude-switch-models-setup/references/troubleshooting.md
@@ -199,11 +199,16 @@ daemon deliberately runs an installed plugin version rather than the checkout, a
 nothing advances that pin on its own:
 
 ```bash
-python3 <this skill>/scripts/skill-install-audit.py --list DAEMON_RUNTIME_LAG
+python3 <this skill>/scripts/skill-install-audit.py --list DAEMON_RUNTIME_LAG SOURCE_CHECKOUT_BEHIND
 ```
 
-A non-empty result names both versions and the commands that advance the pin. The
-topology and the reason for the isolation are in
+A non-empty `DAEMON_RUNTIME_LAG` names both versions and the commands that advance
+the pin. Read the second section before trusting an empty first one: the comparison
+is made against a local checkout, so a daemon on the previous release and a checkout
+still on it agree with each other, and the lag reads clean while the published source
+has moved on. Bring the checkout current, then re-run.
+
+The topology and the reason for the isolation are in
 [local-source-sync-architecture.md](local-source-sync-architecture.md).
 
 Manual repair fallback:


### PR DESCRIPTION
The troubleshooting branch added in v3.10.0 told a reader that a **non-empty** `DAEMON_RUNTIME_LAG` names the versions to fix — which reads, by implication, as *"empty means the daemon is current"*.

#466 established that it does not. The comparison is made against a local checkout, so a daemon on the previous release and a checkout still on it agree with each other, and the lag reads clean while the published source has moved on.

Not hypothetical on the machine this was written for. Running the command right now:

```
== DAEMON_RUNTIME_LAG
== SOURCE_CHECKOUT_BEHIND
  daymade-skills: checkout on 'main' is 1 commit(s) behind its upstream …
  daymade-skills-pro: checkout on 'feat/rwm-verify-concurrency' is 5 commit(s) behind …
```

An empty lag, next to two stale references. Following the old step would have produced a false all-clear at exactly the point someone is trying to explain why their change did not appear.

Queries both sections and says which one qualifies the other. The mechanism stays in the script and the architecture reference.

Verified: the command as written in the doc runs with exit 0; suite 71 passing; `claude plugin validate --strict .` passes.
