### PR TITLE
fix(ci): the version gate no longer fires on files that never ship

### DIFF
--- a/scripts/ci/check_version_progression.py
+++ b/scripts/ci/check_version_progression.py
@@ -10,6 +10,7 @@ those releases.
 from __future__ import annotations
 
 import argparse
+import fnmatch
 import json
 import re
 import subprocess
@@ -19,6 +20,7 @@ from pathlib import Path
 
 
 MANIFEST_PATH = ".claude-plugin/marketplace.json"
+PACKAGING_POLICY_PATH = Path("daymade-skill/skill-creator/scripts/packaging_policy.py")
 SEMVER = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
 
 
@@ -125,6 +127,55 @@ def parse_manifest(
     return metadata_version, catalog_payload, plugins
 
 
+def load_packaging_policy(repo: Path):
+    """Load the repo's single shipping-policy module, or None when absent.
+
+    The exclusion set lives in exactly one place on purpose; a consumer that
+    keeps its own copy drifts from it silently.  When the module is not there
+    -- a synthetic fixture repository, or any checkout without that Skill --
+    this returns None and no path is excluded, which is the behaviour this
+    check had before it consumed the policy.  That direction is deliberate:
+    excluding nothing can only make the gate stricter, never weaker, so a
+    missing module costs a false alarm at worst and never a silent pass.
+    """
+    import importlib.util
+
+    path = repo / PACKAGING_POLICY_PATH
+    if not path.is_file():
+        return None
+    spec = importlib.util.spec_from_file_location("packaging_policy_for_ci", path)
+    if spec is None or spec.loader is None:
+        return None
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        return None
+    for attr in ("EXCLUDE_DIRS", "EXCLUDE_FILES", "EXCLUDE_GLOBS"):
+        if not hasattr(module, attr):
+            return None
+    return module
+
+
+def never_ships(policy, path: str) -> bool:
+    """Whether this path is excluded from every package, wherever it sits.
+
+    Only the position-independent half of the policy is applied.  Its
+    directory rules for `evals`/`dist`/`tests` are indexed from a skill root,
+    so they do not carry over to repository-relative paths, and applying them
+    here would quietly stop the version gate from firing on real test changes.
+    """
+    if policy is None:
+        return False
+    parts = Path(path).parts
+    if any(part in policy.EXCLUDE_DIRS for part in parts):
+        return True
+    name = Path(path).name
+    if name in policy.EXCLUDE_FILES:
+        return True
+    return any(fnmatch.fnmatch(name, pattern) for pattern in policy.EXCLUDE_GLOBS)
+
+
 def changed_paths(repo: Path, base: str, candidate: str | None) -> list[str]:
     if candidate is None:
         raw = subprocess.run(
@@ -216,7 +267,8 @@ def check(repo: Path, base: str, candidate: str | None) -> list[str]:
             f"marketplace metadata bump above {base_metadata}"
         )
 
-    paths = changed_paths(repo, base, candidate)
+    policy = load_packaging_policy(repo)
+    paths = [p for p in changed_paths(repo, base, candidate) if not never_ships(policy, p)]
     touched_plugins: set[str] = set()
     for path in paths:
         if path == MANIFEST_PATH:


### PR DESCRIPTION
> **Rescoped.** This PR originally also deleted the 95 tracked `.security-scan-passed` markers. CI runs the **base commit's** copy of the checker on purpose — `git show "${base}:${checker_path}"`, with the comment *"every later PR/push executes the immutable base copy, never candidate bytes"* — so a PR cannot rely on a gate fix it ships itself. The gate fix lands alone here; the deletions follow in a second PR once this is on `main`.

## The defect

`changed_paths` fed a raw `git diff --name-only` into the plugin-ownership map, so a change to any file the packaging policy excludes counted as *"plugin content changed"* and demanded a version bump.

Deleting the repository's tracked `.security-scan-passed` markers — a file `packaging_policy.py` **already excludes from every package** — would have demanded bumps for **53 of the 56 plugins**. That is 53 releases pushed at every installed user for content none of them would receive.

## The fix

skill-creator's own rule already states that the shipping set is defined only by `packaging_policy.py`, and that packaging, security attestation, content hashing and regression auditing must consume that shared policy rather than keep a second exclusion list. This gate was keeping an implicit empty one.

It now loads that module and drops paths excluded by the **position-independent** half of the policy: `EXCLUDE_DIRS` (matched against any path part), `EXCLUDE_FILES` (basename), `EXCLUDE_GLOBS` (basename).

`ROOT_EXCLUDE_DIRS` is deliberately **not** applied. Its `evals`/`dist`/`tests` rules are indexed from a skill root, so carrying them to repository-relative paths would quietly stop the gate firing on real test changes — a weakening disguised as consistency.

## The fallback direction, and why an earlier draft was wrong

A missing policy module falls back to excluding nothing, which is what this check did before. Excluding nothing can only make the gate **stricter**, so a checkout without that Skill — including the synthetic fixture repos in `tests/test_git_mainline_guard.py` — costs a false alarm at worst and never a silent pass.

An earlier draft raised instead. The repository's own guard suite caught it immediately: every fixture failed. That is the more expensive failure direction, because a check that misfires on healthy input teaches operators to bypass it.

## Calibration, against the real repository rather than a fixture

| Probe | Before | After |
|---|---|---|
| Candidate deleting only excluded files, no bumps | FAIL, exactly 53 complaints | **PASS** |
| Candidate appending one line to `youtube-downloader/SKILL.md`, no bump | FAIL | **FAIL** |
| No policy module present | n/a | falls back to excluding nothing |
| `a/b/SKILL.md` excluded? | no | **no** |
| `a/tests/test_x.py` excluded? | no | **no** |
| `tests/test_git_mainline_guard.py` | 12 pass | **12 pass** |

No plugin content changes, so no version is bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
