### PR TITLE
chore: retire the tracked .security-scan-passed markers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,7 @@ recovered_deep_research/
 *-workspace/
 **/*-workspace/
 .skill-regression-reviewed
+.security-scan-passed
 .skill-regression-baseline.json
 .gstack/
 .in_use/

--- a/auto-repo-setup/.security-scan-passed
+++ b/auto-repo-setup/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-05-31T20:17:11.595969
-Tool: gitleaks + pattern-based validation
-Content hash: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855

--- a/bilibili-source/.security-scan-passed
+++ b/bilibili-source/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-08-29T10:28:23.496042+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: 0e919c9d3d89f16809ccdbb41d3625bcf560fb95a6936845a5992a2b45352a3c

--- a/cli-demo-generator/.security-scan-passed
+++ b/cli-demo-generator/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-06-13T19:44:41.146630
-Tool: gitleaks + pattern-based validation
-Content hash: 898073faf893100f21f8ab923994f8d3ab8a852d326c25613b5cddd97bbfd296

--- a/cloudflare-troubleshooting/.security-scan-passed
+++ b/cloudflare-troubleshooting/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-07-10T15:45:30.931684
-Tool: gitleaks + pattern-based validation
-Content hash: d4309df8291ba01a9499d8b7652011391f19619e41ce2c005800f8f0d49f155c

--- a/competitors-analysis/.security-scan-passed
+++ b/competitors-analysis/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-07-05T23:09:02.937839
-Tool: gitleaks + pattern-based validation
-Content hash: 5e397972f3250c0d9ce27324c348a70f46f19885786d28cd4a9b28faaf9fa427

--- a/daymade-audio/meeting-minutes-taker/.security-scan-passed
+++ b/daymade-audio/meeting-minutes-taker/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-06-13T19:44:41.312902
-Tool: gitleaks + pattern-based validation
-Content hash: b306ff7c76e3dd5c043fee0d6063f4ed43092cc818286cc42a4d3b2bdaa6a13a

--- a/daymade-audio/stepfun-asr/.security-scan-passed
+++ b/daymade-audio/stepfun-asr/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-04-30T16:44:52.294771
-Tool: gitleaks + pattern-based validation
-Content hash: a0edbbb580527ed34ca4ae9bda443c6bd93a200434e85989c2a636d4435478a5

--- a/daymade-audio/stepfun-tts/.security-scan-passed
+++ b/daymade-audio/stepfun-tts/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-04-30T16:45:06.762254
-Tool: gitleaks + pattern-based validation
-Content hash: ee9f2151ac3b8e5f198b2a4fadd1e57662b0bfb0e856b4cb27f46a36950bcb23

--- a/daymade-audio/transcript-fixer/.security-scan-passed
+++ b/daymade-audio/transcript-fixer/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-09-06T09:51:46.859870+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: ab32ddeed96e8c43eada35cfa4be687d490b2e2c703b6feea9d86b1f790bd772

--- a/daymade-claude-code/claude-code-hooks/.security-scan-passed
+++ b/daymade-claude-code/claude-code-hooks/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-08-30T14:18:28.623123+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: e9e7b24b3e2854a71df21e1755a20c4c71373fc394eef6597e0931e5e123196c

--- a/daymade-claude-code/claude-code-ping-start-5h-quota/.security-scan-passed
+++ b/daymade-claude-code/claude-code-ping-start-5h-quota/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-08-29T07:28:15.038744+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: 9b9d88a9d118f96d21efefcef79cfd39d8c7798d983736e1a75d4486fd675d93

--- a/daymade-claude-code/claude-export-txt-better/.security-scan-passed
+++ b/daymade-claude-code/claude-export-txt-better/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-04-11T23:12:01.572016
-Tool: gitleaks + pattern-based validation
-Content hash: c295177ee2b1aa1844a2758bcf6e5395f8819c445a050b80a2d34b8983515459

--- a/daymade-claude-code/claude-md-progressive-disclosurer/.security-scan-passed
+++ b/daymade-claude-code/claude-md-progressive-disclosurer/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-08-07T01:31:58.579761+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: a7b1399baa9de62de8ee718f2ba6a5c09df1e68b3c1ea78189abc820ec59e605

--- a/daymade-claude-code/claude-migrate-memory-to-doc/.security-scan-passed
+++ b/daymade-claude-code/claude-migrate-memory-to-doc/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-06-28T23:08:27.246754
-Tool: gitleaks + pattern-based validation
-Content hash: 85a5bd97f368bb1504c55d4cfaf63a549852aaa66a84e7892e7dd4b81b09db29

--- a/daymade-claude-code/claude-skills-troubleshooting/.security-scan-passed
+++ b/daymade-claude-code/claude-skills-troubleshooting/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-07-10T15:48:45.749074
-Tool: gitleaks + pattern-based validation
-Content hash: 79001973994e81a5cda8dc9d57cc670fe774988bc6c2973c34f71b852ae6725d

--- a/daymade-claude-code/claude-switch-models-setup/.security-scan-passed
+++ b/daymade-claude-code/claude-switch-models-setup/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-09-06T12:25:51.737767+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: ed98cfd525e66b511206fa679a7a7e1e0157a534bfbe137ce00d33d52e74f52b

--- a/daymade-claude-code/claude-usage-analyst/.security-scan-passed
+++ b/daymade-claude-code/claude-usage-analyst/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-06-13T10:51:09.913010
-Tool: gitleaks + pattern-based validation
-Content hash: 66de7ebd474c989a530024cc2b2f1d411ecd62bb23dfff7b8f34ab53145483f2

--- a/daymade-claude-code/continue-claude-code-work/.security-scan-passed
+++ b/daymade-claude-code/continue-claude-code-work/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-08-26T19:44:24.834468+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: 8aa35ceeb22e53bd862dd31a0136171f5d36c4c6f9d67e97496685e15db539ce

--- a/daymade-claude-code/continue-codex-work/.security-scan-passed
+++ b/daymade-claude-code/continue-codex-work/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-08-27T15:45:03.433094+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: 8c8cee1482ac0f5668acef0cd849f7631ca6beb6d3b0442309e11d62fd11bb8c

--- a/daymade-claude-code/lark-cli-router/.security-scan-passed
+++ b/daymade-claude-code/lark-cli-router/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-08-28T09:32:13.962730+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: faa33ab4e5782d0599c0bb1bce21e085e15a0a481dbf9e315017e37517e5b692

--- a/daymade-claude-code/local-conversation-history/.security-scan-passed
+++ b/daymade-claude-code/local-conversation-history/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-08-29T23:55:55.781697+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: 9d6545fdc026507734b08bec95d8f7154d923f62e560fd45c6eb7daa3c49098a

--- a/daymade-claude-code/marketplace-dev/.security-scan-passed
+++ b/daymade-claude-code/marketplace-dev/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-08-28T05:40:44.976183+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: 3feec897d9cc7f7ac5848599fd1e6c3cabae6564dea2e388398a8baa9620d43c

--- a/daymade-claude-code/prior-work-retrieval/.security-scan-passed
+++ b/daymade-claude-code/prior-work-retrieval/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-08-28T10:15:30.049668+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: 5736c5ed3004c26679080aff50fbb65203f3ab69880a1461f5f6d9a42d56960d

--- a/daymade-claude-code/read-claude-code-history/.security-scan-passed
+++ b/daymade-claude-code/read-claude-code-history/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-09-04T20:23:41.525798+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: 4b0ea475d27a6ce2cd0523cc2d5628d46689f4bfba9cc7448df21cbe32a25724

--- a/daymade-claude-code/read-codex-history/.security-scan-passed
+++ b/daymade-claude-code/read-codex-history/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-08-30T00:02:01.467953+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: 6da13cbc051aa0188d275582b94a58b154d4443568753d0fdca7d1991c387b2d

--- a/daymade-claude-code/statusline-generator/.security-scan-passed
+++ b/daymade-claude-code/statusline-generator/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-07-07T19:38:58.160473
-Tool: gitleaks + pattern-based validation
-Content hash: 1c7bf17c7f766719b835b4cc2137cb3fadd8d3554d3c04034e9f4b62b531945f

--- a/daymade-claude-code/terminal-screenshot/.security-scan-passed
+++ b/daymade-claude-code/terminal-screenshot/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-06-13T19:44:41.680411
-Tool: gitleaks + pattern-based validation
-Content hash: fe3f24dd496123e5e90de9c1c7f0b3c8bdf2850d52ef083ece7c27fdf9f62c50

--- a/daymade-codex/codex-1m-context-window-setup/.security-scan-passed
+++ b/daymade-codex/codex-1m-context-window-setup/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-08-27T07:46:27.381602+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: 6a006f7e65fd8974c2f3f7f56a47cd13496c3d357305ce899b1321d76026aa48

--- a/daymade-codex/codex-image-gallery/.security-scan-passed
+++ b/daymade-codex/codex-image-gallery/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-06-28T11:31:05.545773
-Tool: gitleaks + pattern-based validation
-Content hash: 89d30f2459796df12b29a92ac1b6c59948cdbcb9ba164b44bf38cebb9efa60b8

--- a/daymade-codex/interaction-design-board/.security-scan-passed
+++ b/daymade-codex/interaction-design-board/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-08-28T05:17:53.145337+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: f6160d68434c776e50d2ddf27f480b67d3293367f7aa15bed27b6224a9a74883

--- a/daymade-docs/doc-to-markdown/.security-scan-passed
+++ b/daymade-docs/doc-to-markdown/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-06-13T19:44:41.778833
-Tool: gitleaks + pattern-based validation
-Content hash: 186ebedf7650edacd16882f4103e608a7c2b987ad545512f9853750029c65af7

--- a/daymade-docs/docs-cleaner/.security-scan-passed
+++ b/daymade-docs/docs-cleaner/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-08-14T12:37:07.072747+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: 7b8c7876e097158ff2521a6ef6e2c59c3cda6f2a0f168eff900ace541c9e8dd4

--- a/daymade-docs/docx-creator/.security-scan-passed
+++ b/daymade-docs/docx-creator/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-08-17T08:27:10.241791+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: f0199497825ea917273d1602966367ef359e0a656b4a08a3c662f9d7eac2a0ff

--- a/daymade-docs/excel-automation/.security-scan-passed
+++ b/daymade-docs/excel-automation/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-03-02T19:48:47.112631
-Tool: gitleaks + pattern-based validation
-Content hash: e2af503b1847702eb50d3883c1a6e7bfb3f870edd786c740dee34a49611f4f6f

--- a/daymade-docs/mermaid-tools/.security-scan-passed
+++ b/daymade-docs/mermaid-tools/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-06-13T19:44:41.931593
-Tool: gitleaks + pattern-based validation
-Content hash: aeb15891ceadd351bb4c313a0a2a145d68102593f507d89dfe4dc637e98b98a9

--- a/daymade-docs/pdf-creator/.security-scan-passed
+++ b/daymade-docs/pdf-creator/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-08-29T16:29:28.869825+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: e8677276228efa4cf08b39a227ace39b56c2b4642ab556a1b2fb71f70d7f41bc

--- a/daymade-docs/pdf-to-html/.security-scan-passed
+++ b/daymade-docs/pdf-to-html/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-06-07T01:06:19.687678
-Tool: gitleaks + pattern-based validation
-Content hash: b742b75949f08f3accd8d4962e81347bd14708150ac6bb89857a92c6ba89f43f

--- a/daymade-docs/photo-to-scanned-pdf/.security-scan-passed
+++ b/daymade-docs/photo-to-scanned-pdf/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-07-31T14:49:59.882180+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: ec3c9fed1bcd8bbd0886446c3bc789511e3172b210ab8bffaa9296366bf6c23c

--- a/daymade-docs/ppt-creator/.security-scan-passed
+++ b/daymade-docs/ppt-creator/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-06-13T19:44:42.014675
-Tool: gitleaks + pattern-based validation
-Content hash: b086db6930e09973c78b4317dff8bff1623c5dc2d3759c127ca67249d471146c

--- a/daymade-docs/read-docx-review/.security-scan-passed
+++ b/daymade-docs/read-docx-review/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-08-28T20:21:59.735478+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: 2a1618e1eae6f4a5e52444a48743b116bad95267ce1190ff9f5f9dd87e0424ee

--- a/daymade-financial/benchmark-due-diligence/.security-scan-passed
+++ b/daymade-financial/benchmark-due-diligence/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-05-30T19:16:23.677752
-Tool: gitleaks + pattern-based validation
-Content hash: 930661d0365e03f3b13c11db2db0a692b2d3db369b8cc184219cfd6189486f05

--- a/daymade-financial/bigdata-skill/.security-scan-passed
+++ b/daymade-financial/bigdata-skill/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-06-13T19:44:41.069633
-Tool: gitleaks + pattern-based validation
-Content hash: 1dc770d556b9a8d204518f8435cd0ee63398ff7a544faac168b48f397238a9fc

--- a/daymade-financial/daymade-sector-research/.security-scan-passed
+++ b/daymade-financial/daymade-sector-research/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-08-13T11:12:48
-Tool: gitleaks + pattern-based validation
-Content hash: e18d4a8dc35e1e45b86649e751b8b6f9cb9b23d83a4088c66b9cd4c11cf56a87

--- a/daymade-financial/devils-advocate/.security-scan-passed
+++ b/daymade-financial/devils-advocate/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-08-14T07:38:06.473385+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: fa89e3e18f664fa697670ea8ce0099fa39a87de583c188f39b092cc8f382c377

--- a/daymade-financial/financial-data-collector/.security-scan-passed
+++ b/daymade-financial/financial-data-collector/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-06-13T19:44:42.093312
-Tool: gitleaks + pattern-based validation
-Content hash: 191228b4d56b8c3814596c77dd1ac78d6d1ac25ce4b2eb81db3d487ebef49a2b

--- a/daymade-financial/gangtise-copilot/.security-scan-passed
+++ b/daymade-financial/gangtise-copilot/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-07-19T18:05:23.499558+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: 5cee5f870458e2e49a5ef0e8868da3e4ba68a67e85ec730d6ed86d0560794dc3

--- a/daymade-financial/pharma-daily-report/.security-scan-passed
+++ b/daymade-financial/pharma-daily-report/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-06-28T15:33:54.795899
-Tool: gitleaks + pattern-based validation
-Content hash: 73d4abc6698a0f296d2c96b658d9f52392d6f39871a4c1734ef06d2ab255e4ca

--- a/daymade-macos/capture-screen/.security-scan-passed
+++ b/daymade-macos/capture-screen/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-03-02T19:48:47.107251
-Tool: gitleaks + pattern-based validation
-Content hash: 7582d78a2119851ab2abb443cf0b0ea3a262a722c28e2522f8a197a064f98bf8

--- a/daymade-macos/developing-ios-apps/.security-scan-passed
+++ b/daymade-macos/developing-ios-apps/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2025-12-15T22:23:52.306779
-Tool: gitleaks + pattern-based validation
-Content hash: 1e3661252b87a1effd6b4e458364ab4e7b8bd6356360aea058593e70ed0edd11

--- a/daymade-macos/macos-cleaner/.security-scan-passed
+++ b/daymade-macos/macos-cleaner/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-08-30T22:18:33.663675+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: 99e85f04d18a9551282b2a3a7a84045e55053d7c803d11596ef441743f24ffc3

--- a/daymade-macos/macos-watchdog/.security-scan-passed
+++ b/daymade-macos/macos-watchdog/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-08-17T08:08:24.011382+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: bdee3b1128049dc26d58a5dcfe9d832bd836a9be571c1ca8aeeb3de9e54ad1fa

--- a/daymade-skill/skill-governance/.security-scan-passed
+++ b/daymade-skill/skill-governance/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-08-28T08:25:36.264390+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: d92fdcc63633fa0db23a6903a2c3cfab319102ce89b3a23ff602268e5160ec53

--- a/daymade-skill/skill-reviewer/.security-scan-passed
+++ b/daymade-skill/skill-reviewer/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-07-10T07:19:37.761755
-Tool: gitleaks + pattern-based validation
-Content hash: 789cf6bc5897175efcfddd74e93f115d1fd556b41f289eb87475f573b20f39fb

--- a/daymade-skill/skills-search/.security-scan-passed
+++ b/daymade-skill/skills-search/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2025-11-30T03:26:12.206682
-Tool: gitleaks + pattern-based validation
-Content hash: 493826cb21eefb61a82bf0a81dbccec44888e7b68b21bfdd02a2dd301805a695

--- a/debugging-network-issues/.security-scan-passed
+++ b/debugging-network-issues/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-08-24T07:23:35.107223+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: f846b00764cb50f84e9c2a9b93fcac34d1372cea1dbe607f1377fb564c9de11c

--- a/deep-research/.security-scan-passed
+++ b/deep-research/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-01-25T15:33:59.582023
-Tool: gitleaks + pattern-based validation
-Content hash: 36de97399b27f8a70dc16d74d4abf39d62918f50c6a8f67385463f9b95cc4839

--- a/douban-skill/.security-scan-passed
+++ b/douban-skill/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-04-11T23:50:56.012411
-Tool: gitleaks + pattern-based validation
-Content hash: ddd092fe448c01dbfa4e4eababe90cd52d3a52dcc66d8e229e9fa315dd2b3724

--- a/download-gemini-images/.security-scan-passed
+++ b/download-gemini-images/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-06-28T15:00:46.577315
-Tool: gitleaks + pattern-based validation
-Content hash: e032b713d761630d2edc21fa39c84a67061811ca4bd3b1e18a976a89ae0e95cb

--- a/excalidraw-use/.security-scan-passed
+++ b/excalidraw-use/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-09-04T08:25:49.577198+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: 0c99ce40871f6fae23b50619c80ecbbedd17194a1b94c10852ceaa38a9819f42

--- a/fact-checker/.security-scan-passed
+++ b/fact-checker/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-01-05T23:29:12.688630
-Tool: gitleaks + pattern-based validation
-Content hash: f0ee8b5411aeb2d3058383ae536393e4e71e0fe0c240d0798a50aa10399870d4

--- a/feishu-doc-scraper/.security-scan-passed
+++ b/feishu-doc-scraper/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-08-25T10:18:06.436490+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: f63ad0fa202a22fc3f7a01ceed4acbabff2556ab9aff5256c49b032e3e682605

--- a/frontend-visual-qa/.security-scan-passed
+++ b/frontend-visual-qa/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-08-12T05:12:27.677162+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: dac2a16e381fa0d99ddf84876f33be6b0abb69a14d776342276855589a6759ca

--- a/gemini-history-analyzer/.security-scan-passed
+++ b/gemini-history-analyzer/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-07-10T05:27:07.362561
-Tool: gitleaks + pattern-based validation
-Content hash: 5af29efd82077aaea8c3d32c8e35a8a5c4f6ed147fcea23886ce7e8b6b93c17a

--- a/git-safety-net/.security-scan-passed
+++ b/git-safety-net/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-09-02T15:13:14.012479+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: 880322521fcd600f2dcda819e0cc46ba2d5d54b1e22a29742058569448cfe7f2

--- a/github-contributor/.security-scan-passed
+++ b/github-contributor/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-06-23T18:33:14.138886
-Tool: gitleaks + pattern-based validation
-Content hash: 932f003ea20cb7d1255b9f3791721c813cb8457adf6aeb0715d36201469083a6

--- a/github-ops/.security-scan-passed
+++ b/github-ops/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-08-29T22:09:32.585767+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: f5040b98adb3ee49d2037e09a869909af65035012f2b765fd1f58453691c8dc2

--- a/github-review-pr/.security-scan-passed
+++ b/github-review-pr/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-07-10T13:57:17.683288+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: c2e23273b2e9bb0be9ac497966a175c114d36d29963141a4d3e7934259948485

--- a/i18n-expert/.security-scan-passed
+++ b/i18n-expert/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-01-22T21:40:43.577494
-Tool: gitleaks + pattern-based validation
-Content hash: 45d5d760e2e39bb19208667a84307dca17a9ee85e1a6b07accc664adf6c45a94

--- a/ima-copilot/.security-scan-passed
+++ b/ima-copilot/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-04-11T18:24:20.697988
-Tool: gitleaks + pattern-based validation
-Content hash: b4ef2b8f095342095dd0ea8d3c98d5346beff50afddd4ae092c8f69d4299c18b

--- a/kimi-use/.security-scan-passed
+++ b/kimi-use/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-08-18T13:09:26.684835+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: e509c8d235aa177663a1eaec0f40f450f4da91185110b459a039a94f3c62959d

--- a/llm-eval-harness/.security-scan-passed
+++ b/llm-eval-harness/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-07-21T17:25:27.223628+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: 0187dad112cf754f26123dc5531b423a342e5fc35a99829c94b251832861ccf1

--- a/llm-icon-finder/.security-scan-passed
+++ b/llm-icon-finder/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-06-13T19:44:42.252113
-Tool: gitleaks + pattern-based validation
-Content hash: 91f456a8b04f0c7990ffd7dca521d6222bf1a3ee7f0476caece21ccf72041e4a

--- a/llm-wiki-setup/.security-scan-passed
+++ b/llm-wiki-setup/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-07-10T03:20:11.174488
-Tool: gitleaks + pattern-based validation
-Content hash: 03b96448560b3d09ecb208bd8ee3bc6e050fe06bf2869143650c16e122ee360f

--- a/marketplace-health-check/.security-scan-passed
+++ b/marketplace-health-check/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-06-13T18:23:23.043483
-Tool: gitleaks + pattern-based validation
-Content hash: f64bfee28590626442a44c5730257108552a084e0ac6dfbc11a7ffb5f8a5ada1

--- a/notify-wecom/.security-scan-passed
+++ b/notify-wecom/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-07-10T05:27:07.445405
-Tool: gitleaks + pattern-based validation
-Content hash: 80ff97093e018739717c524b3fabec53802d88a7e34af7bd5388daa0cb18fb8b

--- a/openclaw-model-switch/.security-scan-passed
+++ b/openclaw-model-switch/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-07-17T02:18:36.915026+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: 7451eb2f2e39cde4be50e66506052cbdf7bf22be649b4f2c6b5dd5e56d48f64b

--- a/openclaw/.security-scan-passed
+++ b/openclaw/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-06-28T11:53:01.443792
-Tool: gitleaks + pattern-based validation
-Content hash: aefa4064289f08f6167e7fa930746f65d7d68efd5fc3e68bcb9849fec2bc7d18

--- a/product-analysis/.security-scan-passed
+++ b/product-analysis/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-07-10T05:27:07.544332
-Tool: gitleaks + pattern-based validation
-Content hash: c8e6e6038c5d6fcb7ee2a5cbc377c33aa36e3719c7181e75d0d55794dbc1edc8

--- a/prompt-optimizer/.security-scan-passed
+++ b/prompt-optimizer/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2025-11-16T23:30:38.515326
-Tool: gitleaks + pattern-based validation
-Content hash: 91d8d92a27fc76565a0dc07dac515c2fd71d869ddf51b7046b3a0e512a7ff7c6

--- a/promptfoo-evaluation/.security-scan-passed
+++ b/promptfoo-evaluation/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-03-02T20:00:16.607484
-Tool: gitleaks + pattern-based validation
-Content hash: 058a48a82477727772269754ab2bae5bb1f575fc264a1e28f1a2cfad25656b95

--- a/qa-expert/.security-scan-passed
+++ b/qa-expert/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-07-19T18:05:23.666253+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: 94e7833f2bf45208f037af2857e63d88055ec826396cfb05837e52ec0d036770

--- a/repomix-safe-mixer/.security-scan-passed
+++ b/repomix-safe-mixer/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-06-13T19:48:10.902948
-Tool: gitleaks + pattern-based validation
-Content hash: 9f34d49a4c03cabe19ae3529e3d343312467a200f99413eafa97d3b668bd0580

--- a/repomix-unmixer/.security-scan-passed
+++ b/repomix-unmixer/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-06-13T19:44:42.495180
-Tool: gitleaks + pattern-based validation
-Content hash: 3804fca3509b59cad106f718b83d94db7fe317d2bc6fa21e36d07005046836ce

--- a/scrapling-skill/.security-scan-passed
+++ b/scrapling-skill/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-03-18T22:52:43.734452
-Tool: gitleaks + pattern-based validation
-Content hash: 06351e5794510c584fdf29351eb5161f4b12e213f512c3148212c82c357d124a

--- a/setup-notifications-via-wecom/.security-scan-passed
+++ b/setup-notifications-via-wecom/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-06-25T00:12:45.475514
-Tool: gitleaks + pattern-based validation
-Content hash: 72c7597cbe04c217b3612007de023c0dc089d48b0be2afe7d701574d499b6f1b

--- a/teams-channel-post-writer/.security-scan-passed
+++ b/teams-channel-post-writer/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-06-13T19:44:42.574184
-Tool: gitleaks + pattern-based validation
-Content hash: e38ded07aa16e27a4f10fe246c52011b1221979c2c10494d1c00547934a8911e

--- a/terraform-skill/.security-scan-passed
+++ b/terraform-skill/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-08-31T16:43:22.946777+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: 9182686e9c077fef2c3d154a20a7cf954645d921c0c942b733812147c4bf0e45

--- a/tibo-reset-codex/.security-scan-passed
+++ b/tibo-reset-codex/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-09-06T17:48:27.829149+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: 62b8ec29f6987bea7e3bc218564f36fc61e6962f6e4b9b94fe6e358e8dad3e14

--- a/tunnel-doctor/.security-scan-passed
+++ b/tunnel-doctor/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-08-24T07:28:00.856663+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: ad5357e8929b86f1c3b3d3d7aa89ee1b6b76242b8e3420f67d8fab5e55f7d193

--- a/twitter-reader/.security-scan-passed
+++ b/twitter-reader/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-07-10T18:50:51.462016+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: 150be2b2d00eb3eaae7c61fc2cc5da309754d7a30c79d4e09dc1bd82ade396d4

--- a/ui-designer/.security-scan-passed
+++ b/ui-designer/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-06-13T19:44:42.655453
-Tool: gitleaks + pattern-based validation
-Content hash: e6c48ac9196d10409cfcdfa93eb9df0e388cc385669d12906f0a1b1b4fea0c5a

--- a/video-comparer/.security-scan-passed
+++ b/video-comparer/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2025-10-29T01:20:09.276880
-Tool: gitleaks + pattern-based validation
-Content hash: 54ee1c2464322bf78b1ddf827546d9e90d77135549c211cf3373f6ca9539c4b0

--- a/windows-remote-desktop-connection-doctor/.security-scan-passed
+++ b/windows-remote-desktop-connection-doctor/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-07-14T07:31:07.623681+00:00
-Tool: gitleaks + pattern-based validation
-Content hash: 380e68befd9be59165cbcf7b43e5c52fa4a1b74bd1ab4994642427e3f6194610

--- a/wps-doc-scraper/.security-scan-passed
+++ b/wps-doc-scraper/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2026-06-28T15:06:29.942311
-Tool: gitleaks + pattern-based validation
-Content hash: bb72327cbea2d332955048c14a208e28965647bd1bf8d05261495e792a8ab835

--- a/youtube-downloader/.security-scan-passed
+++ b/youtube-downloader/.security-scan-passed
@@ -1,4 +1,0 @@
-Security scan passed
-Scanned at: 2025-11-19T01:20:50.532287
-Tool: gitleaks + pattern-based validation
-Content hash: 6dc9ae011eb2d8ca1ba73ceb2c6d8aa031979f7e3bb9b31bfe78fdb7283f7f66


### PR DESCRIPTION
Deletes 95 tracked `.security-scan-passed` files and adds the `.gitignore` entry that makes them local artifacts like their three siblings. Follows #488, which taught the version gate to stop firing on files that never ship — without that, this change demanded version bumps for 53 of the 56 plugins.

## How they came to be deleted

A sweep on 2026-09-05 01:48 ran:

```
find . -name ".skill-regression-reviewed" -o -name ".security-scan-passed" | xargs -r rm -f
```

`-o` made the second `-name` a peer of the first, so both matched. The first is a gitignored local receipt; the second was tracked. **91 of the 95 parent directories still carry that exact minute as their mtime**, which is how the timestamp was pinned. A restore was attempted 93 seconds later, was stopped at the guard, and the files have sat deleted since. The owner has now retried, and the decision was to let them go — this records it.

## Why retiring is coherent rather than a loss

The marker is a four-line local receipt (scan time, tool, content hash) that `security_scan.py` regenerates on demand, and `packaging_policy.py` already excludes it from every package.

| File in `EXCLUDE_FILES` | Gitignored before this PR |
|---|---|
| `.DS_Store` | yes |
| `.skill-regression-reviewed` | yes |
| `.skill-regression-baseline.json` | yes |
| `.security-scan-passed` | **no** |

It was the outlier. Its `Scanned at` timestamp also means a regenerated copy never byte-matches a committed one, so tracking it produced churn and no signal.

**The cost**, stated plainly: packaging a skill whose marker is gone now needs `security_scan.py` run first, which regenerates it locally. One command, no data loss.

## Deliberately not changed

No plugin version is bumped and no CHANGELOG entry is added — that file's entries are skill releases, and nothing ships differently here. The three documentation statements about this marker (`marketplace-health-check/SKILL.md` and its methodology reference) describe what a scan result *means*, not where the file is stored, and remain true. `CLAUDE.md` never mentioned it.

## Verification

Pre-checked locally against **main's** copy of the version gate (336 lines, contains the fix from #488): the candidate passes with no bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
