### PR TITLE
fix(github-ops): preserve contributor Write access with PR protection

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -457,7 +457,7 @@
       "description": "Operates GitHub through gh CLI and the REST/GraphQL APIs with explicit target, authorization, impact preview, and independent readback. Use for pull requests, issues, Actions, repositories, collaborators, teams, organization member privileges, base permissions, 2FA enforcement, repository settings, API automation, parallel or superseded PR convergence, and public or enterprise GitHub. Also use when a GitHub write returned success but the requested state did not change, or when deciding whether a setting is writable through CLI, REST, GraphQL, or only the GitHub UI.",
       "source": "./github-ops",
       "strict": false,
-      "version": "1.2.0",
+      "version": "1.3.0",
       "category": "developer-tools",
       "keywords": [
         "github",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **github-ops** 1.3.0: Separate contributor Write access from default-branch integration, add the PR protection and entitlement/readback workflow, and document bounded recovery through an already authorized execution host.
+
 - **feishu-doc-scraper** 1.5.0: Capture document comments and complete reply threads alongside the body, preserving source anchors, authors, timestamps, and solved scope. Partial reads remain explicit and leave older snapshots untouched.
 
 ### Added

--- a/github-ops/SKILL.md
+++ b/github-ops/SKILL.md
@@ -28,6 +28,7 @@ Read only the reference required for the task:
 | Create, edit, search, transfer, close, or bulk-manage issues | [`references/issue_operations.md`](references/issue_operations.md) |
 | Inspect, clone, create, edit, rename, archive, transfer, change visibility, or delete repositories | [`references/repository_operations.md`](references/repository_operations.md) |
 | Inspect or change collaborators, teams, base permissions, member privileges, or organization 2FA | [`references/organization_access_and_settings.md`](references/organization_access_and_settings.md) |
+| Protect a default branch while letting collaborators contribute through PRs | [`references/branch_protection.md`](references/branch_protection.md) |
 | Trigger, inspect, rerun, cancel, or purge Actions; manage secrets or variables | [`references/workflow_operations.md`](references/workflow_operations.md) |
 | Use raw REST/GraphQL endpoints, pagination, rate limits, webhooks, or Enterprise hosts | [`references/api_reference.md`](references/api_reference.md) |
 | Build scripts, retries, bulk operations, or machine-readable output | [`references/best_practices.md`](references/best_practices.md) |
@@ -51,6 +52,12 @@ This skill owns GitHub-hosted state.
 Do not turn a read-only investigation into a mutation because the fix looks obvious.
 Do not send a comment, review, issue, or invitation whose recipient or content was not
 authorized in the current task.
+
+For an authorized contributor, assess repository access against their ongoing contribution
+role, not just today's read or sync command. Repository Write access and permission to update
+the default branch are separate decisions. Follow the user's chosen contribution scope; use
+branch protection and PR review to control integration rather than silently reducing a
+contributor to Read. A diagnosis alone still does not authorize a grant.
 
 ### 2. Bind identity, host, and target
 

--- a/github-ops/references/best_practices.md
+++ b/github-ops/references/best_practices.md
@@ -99,6 +99,26 @@ Do not blindly retry comments, reviews, invitations, workflow dispatches, releas
 creation, or PR/issue creation. After a timeout or 5xx, query by exact target/content/idempotency
 key first. Retry only if readback proves the first request did not land.
 
+### Use an already authorized execution host when the local path remains unavailable
+
+When bounded retries still show transport failures and a known owner-operated host offers a
+working route, continue the same GitHub operation there rather than changing the user's network
+to complete an unrelated task. Select that host from the owner's current machine registry;
+saved SSH access alone does not authorize using a colleague's working computer.
+
+Verify the remote OS identity, GitHub host and `gh api user` login, and the effective rights
+required by the requested operation. Require Admin for administrative changes, not for a
+contributor's ordinary branch push or PR. Use only that host's existing authorized login; do not copy tokens,
+borrow a colleague's credentials, or change the requested targets. Pass a reviewed JSON payload
+on stdin to `gh api --input -` when needed; keep secrets out of command arguments.
+
+If a prior mutation's outcome is uncertain, first read its exact target through the working
+route. A transport change is not permission to duplicate a PR, invitation, rule, or comment.
+Independently read the resulting state back, then stop using the temporary execution route.
+If no authorized host works, report the transport gap; do not invent a new proxy service or
+leave a background tunnel running. Topology and host-specific commands belong to the owner's
+machine runbook, not this public Skill.
+
 ## Safe bulk operations
 
 Bulk work is a sequence of exact single-object operations, not one unreviewed pipeline.

--- a/github-ops/references/branch_protection.md
+++ b/github-ops/references/branch_protection.md
@@ -1,0 +1,120 @@
+# Contributor Access and Default-Branch Protection
+
+Use this workflow when an authorized contributor must be able to push topic branches while
+changes to the default branch require PR review. It applies only to the named repositories;
+it does not change organization-wide base permissions or future repositories by inference.
+
+## Inspect before changing rules
+
+1. Resolve the active GitHub account, repository owner, effective administrative permission,
+   visibility, `archived`, and `default_branch`. An archived repository is a lifecycle state,
+   not a collaborator-role error; do not unarchive it without that separate authorization.
+2. Read both classic branch protection and rulesets, including inherited rules. Preserve any
+   existing required checks, reviews, deployment rules and deliberate bypasses unless the
+   user explicitly changes them. Do not replace a stronger rule with the example below.
+3. Read the repository owner's current plan if the API reports an entitlement restriction.
+   Personal Pro does not establish an organization's entitlement. Check the current official
+   feature contract; neither a generic 403 nor a 404 alone proves a plan limitation.
+
+```bash
+gh api "repos/OWNER/REPO" \
+  --jq '{full_name,visibility,archived,default_branch,permissions}'
+gh api "repos/OWNER/REPO/branches/BRANCH/protection"
+gh api -X GET 'repos/OWNER/REPO/rulesets?includes_parents=true&per_page=100' --paginate
+gh api "repos/OWNER/REPO/rules/branches/BRANCH"
+```
+
+Interpret failures in context: a verified repository's explicit `Branch not protected` response
+identifies absent classic protection, not absent rulesets. An explicit upgrade response must
+be resolved at billing; changing API families, making the repository public or reporting an
+unenforced rule as protection is not a substitute. Prepare the actual seat count, billing
+cadence and total before asking for new spend. After the owner upgrades, re-read the entitlement
+and complete the already-authorized protection work without asking again.
+
+## Define the review policy
+
+Confirm any unresolved product choice, then freeze the concrete policy: branch targets, review
+count, stale-approval handling, required checks, force-push/deletion behavior, and bypass actors.
+An explicitly authorized policy does not need a second confirmation. Explain which operations
+each bypass permits; `always` is broader than `pull_request`. Never add the contributor to a
+bypass list merely to let them submit a branch.
+
+The following is a policy example, not a universal default. It requires one approving review,
+dismisses approvals after reviewable changes, resolves review threads, and prevents deletion
+and force pushes. With no bypass actors it also applies to administrators; the PR author cannot
+approve their own PR. If the owner needs to merge their own reviewed work, resolve that choice
+and add only the explicitly approved actor in `pull_request` mode. Resolve the actor ID from
+GitHub; never reuse the example author's or another environment's ID.
+
+```json
+{
+  "name": "default-branch-pr-review",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {"include": ["~DEFAULT_BRANCH"], "exclude": []}
+  },
+  "rules": [
+    {"type": "deletion"},
+    {"type": "non_fast_forward"},
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true
+      }
+    }
+  ]
+}
+```
+
+Save the approved payload to a file. Add a rule only if no existing rule already implements
+the policy; otherwise update that exact rule, preserving unrelated settings. Record the old
+JSON and rule ID for recovery. A new rule can be removed or disabled by an administrator;
+an update can be reversed by restoring its recorded previous policy.
+
+```bash
+gh api -X POST "repos/OWNER/REPO/rulesets" --input approved-ruleset.json
+# For an existing rule, use its verified ID:
+gh api -X PUT "repos/OWNER/REPO/rulesets/RULESET_ID" --input approved-ruleset.json
+```
+
+These are alternative actions, not two sequential steps. Create once. If the response is
+lost, query the current rule list before retrying; names alone are not immutable identities.
+
+## Read back both contribution and integration
+
+Run fresh reads after the change:
+
+```bash
+gh api "repos/OWNER/REPO/collaborators/USER/permission" --jq '{permission,role_name}'
+gh api "repos/OWNER/REPO/rulesets/RULESET_ID"
+gh api "repos/OWNER/REPO/rules/branches/BRANCH"
+```
+
+Verify effective contributor Write access, `enforcement=active`, exact include/exclude targets,
+the approved review parameters, and the complete bypass list. The branch's effective-rules
+endpoint must return the new rules; listing a saved rule is insufficient. Inherited rules may
+add constraints, so do not claim every future topic-branch push or merge is guaranteed merely
+because the repository role is Write.
+
+Do not create fake commits or attempt a destructive push just to test protection. Check the
+configuration against the approved contract and use an existing legitimate PR when execution
+evidence is needed. Report configuration enforcement separately from unperformed user actions.
+Stop when the selected repositories are verified, or report the precise remaining entitlement,
+identity or policy gap. Permission repair does not authorize merging a contributor's pending PR.
+
+## Contract sources
+
+- [GitHub collaborator permissions](https://docs.github.com/en/rest/collaborators/collaborators)
+- [Ruleset API inputs and effective branch rules](https://docs.github.com/en/rest/repos/rules)
+- [Protected-branch availability and review behavior](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)
+
+Recheck the current request schema and plan availability before changing hosted rules. The
+permission/ruleset reads, create operation, explicit entitlement failure, post-upgrade create,
+and effective-branch readback in this workflow were exercised on real repositories in September
+2026; the sample's actor-free policy is illustrative rather than an executed policy for a user.

--- a/github-ops/references/organization_access_and_settings.md
+++ b/github-ops/references/organization_access_and_settings.md
@@ -27,6 +27,22 @@ base-permission, and enterprise-policy evidence.
 
 Choose the narrowest grant that meets the actual job:
 
+Bind that job to the person's authorized role across the selected repositories. An immediate
+task such as pulling updates does not redefine an existing contributor as a read-only user.
+Distinguish the operations before recommending or applying a role:
+
+| Authorized work | Repository access | Integration control |
+|---|---|---|
+| Read, clone, or consume artifacts only | Read (`pull`) | No contribution capability claimed |
+| Edit code, data, Skills, or documents and submit branches for review | Write (`push`) | Protect the default branch and require PRs under the approved review policy |
+| Merge approved PRs | Verify effective role and applicable rules separately | Write is not permission to bypass review |
+| Administer access or repository settings | Explicit administrative authorization | Do not infer Admin from a request to contribute |
+
+Inspect `archived` before treating a read-only repository as a missing collaborator grant.
+An archived repository is frozen for everyone; report its replacement or lifecycle decision
+when known, and do not unarchive it as a side effect of granting access. For a requested
+Write-plus-PR arrangement, use [branch protection](branch_protection.md) and verify both halves.
+
 - One repository, no organization-wide role: outside collaborator or explicit repository
   collaborator, subject to organization policy.
 - A stable group that needs the same repositories: organization membership plus team access.
@@ -83,10 +99,11 @@ Interpret absence carefully:
 ## Grant repository access
 
 Before adding someone, record the current membership, direct access, effective role, and
-whether an invitation is already pending. Then grant the minimum role required:
+whether an invitation is already pending. Set `ROLE` to the role authorized above; do not
+copy a Read example into a contributor workflow:
 
 ```bash
-gh api -X PUT "repos/ORG/REPO/collaborators/USER" -f permission=pull
+gh api -X PUT "repos/ORG/REPO/collaborators/USER" -f permission="$ROLE"
 ```
 
 GitHub may return `201` for a new invitation or `204` when an existing collaborator/member is


### PR DESCRIPTION
Authorized contributors could be treated as read-only users because the grant example used `pull` and access was assessed from a one-off sync. Document contribution, merge, and administration separately; protect the default branch with the approved PR policy while retaining contributor Write access.

Adds ruleset and archived/entitlement preflight, effective-state readback, and recovery through an already authorized host using only the permissions required by the operation. Bumps github-ops to 1.3.0.

Validation: skill validation, marketplace validation, shell syntax, immutable-base version progression and migration regression audit passed. A bounded independent review found an overbroad Admin requirement in the fallback instructions; corrected it to operation-specific rights. No runtime scripts or hosted permissions are changed by this PR.