### PR TITLE
feat(transcript-fixer): 批量 pending 音频交叉核验（verify_queue_audio + 裁决矩阵，1.37.0）

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -305,7 +305,7 @@
       "description": "Audio processing suite covering the full speech pipeline: ASR transcription (Qwen3, StepFun) with batch-mode guards against music-only repetition-loop hallucinations, speaker diarization and CAM++ voiceprint identification for multi-speaker recordings, transcript error correction, structured meeting minutes generation, and TTS voice synthesis (StepFun). Install once for the complete audio workflow.",
       "source": "./daymade-audio",
       "strict": false,
-      "version": "1.36.0",
+      "version": "1.37.0",
       "category": "suite",
       "keywords": [
         "suite",

--- a/daymade-audio/transcript-fixer/SKILL.md
+++ b/daymade-audio/transcript-fixer/SKILL.md
@@ -23,7 +23,7 @@ Use a two-phase loop:
 - Before correcting any person name, directly read both the configured global people roster and the owning project's explicit identity roster or alias ledger. Stage 1 auto-loads only global `ASR 变体` entries; it does not load project rosters or expose suppressed, disabled, and unlisted entries. If an expected source is missing or the sources conflict, leave the name unchanged and enqueue or ask once. Never use occurrence frequency as identity evidence. Read [references/dictionary_identity_and_context.md](references/dictionary_identity_and_context.md) before settling the name.
 - Resolve doubts from available evidence before escalating. Audio download is one evidence channel, not a prerequisite for Native correction. When it is unavailable, follow [evidence selection and escalation](references/native_ai_full_workflow.md#evidence-selection-and-escalation); do not require the user to change download permissions or treat every pending row as a question only they can answer.
 - Leave genuinely unresolved text unchanged and enqueue it. A visible garble is safer than a fluent wrong guess; a pending row records uncertainty, not an automatic human handoff.
-- Treat an unfamiliar token as unknown, not as an error. Exhaust the local evidence ladder first. For a load-bearing token that remains unresolved, use the clip-level cross-recognizer rung only when source audio and a permitted second engine are already available; otherwise continue with the available evidence under the escalation policy above. Agreement from a genuinely different recognizer family strongly corroborates the sound, but never chooses between homophonic spellings or overrides the person-name gate. Read native workflow step 4, rung 7 before using it.
+- Treat an unfamiliar token as unknown, not as an error. Exhaust the local evidence ladder first. For a load-bearing token that remains unresolved, use the clip-level cross-recognizer rung only when source audio and a permitted second engine are already available; otherwise continue with the available evidence under the escalation policy above. Agreement from a genuinely different recognizer family strongly corroborates the sound, but never chooses between homophonic spellings or overrides the person-name gate. Read native workflow step 4, rung 7 before using it. **A backlog of exhausted pendings is the batch form of this rung**: when a native pass leaves a queue of locally-unresolvable rows, do not hand the queue to the user wholesale — adjudicate it with `verify_queue_audio.py` (one transcript, one source audio, one second engine, both windows per row); the adjudication matrix and timestamp-mapping pitfalls live in `advanced_correction_evidence.md` § Batch pending adjudication. Only rows whose two windows disagree or stay silent survive to the human.
 - Treat a single-line `asr_note` value as correction provenance: it intentionally cites old forms and is excluded from matching. Multi-line YAML ledger values are not masked; keywords, titles, other ASR-derived metadata, and body text remain in correction scope.
 - Read [references/native_ai_full_workflow.md](references/native_ai_full_workflow.md) in full before performing a native pass. Read the task-specific references named below before their corresponding action.
 
@@ -318,6 +318,12 @@ uv run scripts/generate_word_diff.py original.md corrected.md output.html
 uv run scripts/harvest_corrections.py raw.md corrected.md \
   --context-file ~/.transcript-fixer/contexts/myproject.md --write
 
+# Batch-adjudicate a transcript's pending queue rows via clip-level
+# cross-recognition (one source audio, one second engine, both windows)
+uv run scripts/verify_queue_audio.py \
+  --transcript /abs/meeting.md --audio /abs/source.wav \
+  --speed 1.0 --engine-script /abs/stepfun-asr/scripts/asr_transcribe.py
+
 # Multi-format Stage 1/API comparison report
 uv run scripts/generate_diff_report.py \
   original.md original_stage1.md original_stage2.md \
@@ -347,7 +353,7 @@ All references are one level from this file.
 | Dictionary, people roster, domain contexts | [dictionary_identity_and_context.md](references/dictionary_identity_and_context.md) |
 | False-positive policy | [false_positive_guide.md](references/false_positive_guide.md) |
 | Queue, dashboard, audio, re-anchor | [review_queue_dashboard.md](references/review_queue_dashboard.md) |
-| Numbers, photos, multi-recording, clip cross-check, batches | [advanced_correction_evidence.md](references/advanced_correction_evidence.md) |
+| Numbers, photos, multi-recording, clip cross-check, batches, batch pending-queue audio adjudication | [advanced_correction_evidence.md](references/advanced_correction_evidence.md) |
 | Context-file grammar/template | [domain_context_guide.md](references/domain_context_guide.md) |
 | CLI flags and review-item schema | [script_parameters.md](references/script_parameters.md) |
 | Database schema and queries | [database_schema.md](references/database_schema.md), [sql_queries.md](references/sql_queries.md) |

--- a/daymade-audio/transcript-fixer/references/advanced_correction_evidence.md
+++ b/daymade-audio/transcript-fixer/references/advanced_correction_evidence.md
@@ -310,6 +310,96 @@ that token unchanged and search the permitted local authorities for its exact
 spelling. Do not replace it with a familiar phrase merely because the phrase
 fits the topic.
 
+### Batch pending adjudication — queue-level clip cross-check
+
+The single-token rung above scales to a backlog. A finished native pass often
+leaves a queue of pendings whose local ladder is already exhausted (entities,
+garbled terms, numbers). Handing that queue to the user wholesale is the
+failure this section exists to prevent (real case 2026-09-13: 38 pendings
+presented as "awaiting user verdict"; the user's ruling was "don't push work
+you can do yourself onto me" — 33 of the 38 were then settled mechanically in
+one batch, leaving 5 genuinely unresolved). The batch unit is *one transcript's
+own pending rows*, one source audio, one second recognizer. The tool is
+`scripts/verify_queue_audio.py`:
+
+```bash
+uv run scripts/verify_queue_audio.py \
+  --transcript /abs/path/meeting.md --audio /abs/path/source.wav \
+  --speed 1.3 --engine-script /abs/stepfun-asr/scripts/asr_transcribe.py
+```
+
+It parses speaker turns, maps each pending row to its turn, estimates the token
+offset by character position inside the turn, scales by `--speed`, cuts
+tight+medium windows, and writes `<outdir>/results.json` with both windows'
+recognized text per row. You then adjudicate every row — the script surfaces,
+it never decides.
+
+**Know the timestamp-to-audio mapping before cutting anything.** `ffmpeg -ss`
+counts from the start of the media file; the transcript's clock may be
+different. The recurring shapes:
+
+- **Straight-through** (local recording, same file): transcript timestamps are
+  media offsets. `--speed 1.0`.
+- **Uniformly sped-up upload** (e.g. a DJI auto-sync that uploads a 1.3x
+  m4a to save minute quota): transcript timestamps run on the *sped-up* clock,
+  so a token's position in the original-speed master is `timestamp × 1.3` —
+  pass `--speed 1.3`. Recover the factor from evidence, never assume: ratio of
+  source duration to platform duration (`ffprobe` on the master vs the
+  platform's reported duration), upload logs, or the producer's provenance
+  file. A wrong factor puts every clip on the wrong audio, and each window then
+  "fails to corroborate" for the wrong reason.
+- **Wall-clock start** (platform records the sync/upload time as the meeting
+  start): the relative offsets inside the body are still usable, but verify one
+  anchor word before trusting any absolute position.
+
+**Long turns defeat the character-ratio estimate.** A timestamp marks the
+turn's *start*; inside a multi-minute turn the ratio estimate can drift tens
+of seconds (measured: ±70 s on a >90 s turn, enough to land the clip on a
+different game segment). Treat the estimate as a starting point, not a cut
+line: when a window returns text that visibly belongs to a *different* topic
+than the anchor, the offset drifted — re-anchor by sliding ±30–60 s, or by
+listening for the turn's *end* (the estimate's error grows toward it). Cap
+re-cuts at two; a token that cannot be pinned after that stays pending with
+the drift recorded as evidence. A cut that lands silently off-target is worse
+than no cut, because "the engine didn't produce the token" reads as
+corroboration of a wrong guess.
+
+**Adjudication matrix** (per row, both windows in hand):
+
+- **Both windows agree, and agree with a candidate** (yours or the queue's
+  suggestion) → `accepted`. This is the strong case; the engine's own output
+  settles it.
+- **Both windows agree on a *different* form** → `overridden` to the engine's
+  form when it also makes sense, or `kept_original` when the agreement proves
+  the transcript was right all along (real case: `OPC` returned identically by
+  both engines — it is a real abbreviation, One Person Company; record it as
+  confirmed-correct so no future run re-opens it).
+- **Windows disagree, one window empty, or the audio is genuinely noisy**
+  (break-room chatter) → the row stays pending with both outputs recorded.
+  Disagreement between windows is itself the signal; do not pick the window
+  you like better, and do not escalate by switching to a *reasoning* pass —
+  that replaces the instrument with the guesswork this rung exists to remove.
+- **The engine returns a plausible familiar form that contradicts your domain
+  prior** — trust the engine. Real case 2026-09-13: an operator "corrected"
+  `京剧名段` into `金骏眉` because the lecturer runs a tea business; the
+  second recognizer returned `京剧名段`/`西湖风景图` in both windows, and the
+  tea reading was the fluent wrong guess. Domain plausibility is a hypothesis
+  to be tested, not evidence — a consistent second-engine reading outranks it
+  every time.
+
+**Numbers are the exception, not the rule.** For money/score arithmetic inside
+a game or estimate, both windows frequently disagree with each other and with
+the transcript (speakers misadd, engines mis-hear digits). A number row that
+stays contradictory after both windows stays pending — arithmetic truth is not
+recoverable from acoustics.
+
+**Cost and scope.** One batch costs one download plus two recognizer calls per
+row — run it on a transcript's *own* queue, not across files. It adjudicates
+queue rows only; it is not a completeness claim about the transcript (that
+stays with the full-file path above), and it never overrides the person-name
+gate: a name the engine spells differently still walks the roster ladder, and
+speaker identity is never settled from audio by an agent.
+
 ### In-room artifacts are another independent engine (whiteboard and slide photos)
 
 The two-recordings rule above has a cross-modal sibling. When the meeting

--- a/daymade-audio/transcript-fixer/scripts/verify_queue_audio.py
+++ b/daymade-audio/transcript-fixer/scripts/verify_queue_audio.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# ///
+"""verify_queue_audio.py — 批量 pending 音频交叉核验（双引擎片段识别）。
+
+对某转写文件在 review queue 里的 pending 项，逐项从源音频剪 tight/medium
+双片段，送第二识别引擎（默认 StepFun）交叉识别，输出对照表供裁决。
+
+典型场景：Native pass 后积压的 pending（实体/疑词）——本地检索阶梯已尽，
+用第二引擎的耳朵裁决，而不是把队列推给用户。
+
+用法：
+  uv run scripts/verify_queue_audio.py \
+    --transcript /abs/path/meeting.md \
+    --audio /abs/path/source.wav \
+    [--speed 1.3]            # 转写时间轴→音频轴倍速（加速上传的妙记=原始/加速比；反推法：源音频时长/妙记时长）
+    [--queue-ids 1817,1818]  # 默认该文件全部 pending
+    [--engine-script /abs/stepfun-asr/scripts/asr_transcribe.py]
+    [--outdir /tmp/asr-verify]
+
+输出：<outdir>/results.json（每项：id/line/original/suggested/token_wav_time/tight/medium 识别文本）
+判读（裁决矩阵，详 references/advanced_correction_evidence.md §批量 pending 音频核验）：
+  - 双窗一致且与候选同 → accepted
+  - 双窗一致但与候选不同 → 按引擎输出 overridden（或 kept_original 若证明原词无误）
+  - 双窗矛盾/空 → 保留 pending，不换方法重复（两窗不一致本身是信号）
+依赖：ffmpeg/ffprobe；识别引擎脚本（stdout 出文本）。
+"""
+import argparse, json, os, re, subprocess, sys
+
+TS_RE = re.compile(r'^(\S+) (\d{2}):(\d{2}):(\d{2})\.(\d{3})\s*$')
+SKILL_DIR = os.path.dirname(os.path.abspath(__file__))
+FIX = os.path.join(SKILL_DIR, "fix_transcription.py")
+
+
+def parse_turns(lines):
+    """解析转写为 turns: [(start_line, ts_seconds, speaker, text)]"""
+    turns, cur_start, cur_ts, cur_spk, cur_text = [], None, None, None, []
+    for i, line in enumerate(lines, start=1):
+        m = TS_RE.match(line)
+        if m:
+            if cur_start is not None:
+                turns.append((cur_start, cur_ts, cur_spk, " ".join(cur_text)))
+            cur_start = i
+            cur_spk = m.group(1)
+            cur_ts = int(m.group(2)) * 3600 + int(m.group(3)) * 60 + int(m.group(4)) + int(m.group(5)) / 1000
+            cur_text = []
+        elif cur_start is not None and line.strip():
+            cur_text.append(line.strip())
+    if cur_start is not None:
+        turns.append((cur_start, cur_ts, cur_spk, " ".join(cur_text)))
+    return turns
+
+
+def token_offset(turns, line_no, original):
+    """行号→turn→token 字符比例偏移（转写轴秒）。turn 时长=下一 turn 起点差。"""
+    idx = max(j for j, t in enumerate(turns) if t[0] <= line_no)
+    start_line, ts, spk, text = turns[idx]
+    if idx + 1 < len(turns):
+        dur = turns[idx + 1][1] - ts
+    else:
+        dur = 120.0
+    if dur <= 0 or dur > 600:
+        dur = min(max(dur, 10), 600)
+    pos = text.find(original)
+    if pos < 0:
+        pos = 0
+    return ts + (pos / max(len(text), 1)) * dur
+
+
+def list_pending(transcript, queue_ids):
+    r = subprocess.run(
+        ["uv", "run", FIX, "--list-review", "--review-file", transcript,
+         "--review-status", "pending", "--json"],
+        capture_output=True, text=True, cwd=SKILL_DIR)
+    if r.returncode != 0:
+        sys.exit(f"list-review failed: {r.stderr[:300]}")
+    items = json.loads(r.stdout)["items"]
+    if queue_ids:
+        items = [it for it in items if it["id"] in queue_ids]
+    return items
+
+
+def main():
+    ap = argparse.ArgumentParser(description="批量 pending 音频交叉核验（双引擎片段识别）")
+    ap.add_argument("--transcript", required=True)
+    ap.add_argument("--audio", required=True)
+    ap.add_argument("--speed", type=float, default=1.0,
+                    help="转写时间轴→音频轴倍速（加速上传的妙记=源时长/妙记时长，如 1.3）")
+    ap.add_argument("--queue-ids", default="", help="逗号分隔；默认该文件全部 pending")
+    ap.add_argument("--engine-script", required=True,
+                    help="第二识别引擎脚本（stdin 音频路径，stdout 文本），如 stepfun-asr/scripts/asr_transcribe.py")
+    ap.add_argument("--outdir", default="/tmp/asr-verify")
+    ap.add_argument("--tight", type=float, default=5.0, help="tight 窗 ±秒（默认 5）")
+    ap.add_argument("--medium", type=float, default=20.0, help="medium 窗 ±秒（默认 20）")
+    a = ap.parse_args()
+
+    os.makedirs(a.outdir, exist_ok=True)
+    lines = open(a.transcript, encoding="utf-8").read().splitlines()
+    turns = parse_turns(lines)
+    if not turns:
+        sys.exit("no speaker turns parsed — 转写需含「说话人 HH:MM:SS.mmm」行")
+    ids = {int(x) for x in a.queue_ids.split(",") if x.strip()} if a.queue_ids else None
+    items = list_pending(a.transcript, ids)
+    if not items:
+        sys.exit("no pending items for this file")
+
+    results = []
+    for it in items:
+        tok_t = token_offset(turns, it["line_number"], it["original_text"]) * a.speed
+        tid = it["id"]
+        tight = os.path.join(a.outdir, f"{tid}-tight.wav")
+        med = os.path.join(a.outdir, f"{tid}-med.wav")
+        for clip, start, dur in ((tight, tok_t - a.tight, a.tight * 2),
+                                 (med, tok_t - a.medium, a.medium * 2)):
+            subprocess.run(["ffmpeg", "-y", "-ss", f"{max(start, 0):.3f}", "-t", f"{dur:.0f}",
+                            "-i", a.audio, "-ac", "1", "-ar", "16000", "-c:a", "pcm_s16le", clip],
+                           capture_output=True, check=True)
+        r1 = subprocess.run(["python3", a.engine_script, tight], capture_output=True, text=True)
+        r2 = subprocess.run(["python3", a.engine_script, med], capture_output=True, text=True)
+        results.append({
+            "id": tid, "line": it["line_number"],
+            "original": it["original_text"], "suggested": it.get("suggested_text") or "",
+            "token_wav_time": round(tok_t, 2),
+            "tight": r1.stdout.strip()[:300], "medium": r2.stdout.strip()[:500],
+            "err": (r1.stderr + r2.stderr)[:200],
+        })
+        print(f"done {tid}: {it['original_text']}", flush=True)
+
+    out = os.path.join(a.outdir, "results.json")
+    with open(out, "w", encoding="utf-8") as f:
+        json.dump(results, f, ensure_ascii=False, indent=1)
+    print(f"\n{len(results)} items -> {out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What
- 新工具 `scripts/verify_queue_audio.py`：把一个转写文件在 review queue 里的 pending 行，逐项按 turn 定位+字符比例偏移+加速比换算，从源音频剪 tight/medium 双片段送第二识别引擎，输出 results.json 供裁决
- `references/advanced_correction_evidence.md` 新增「Batch pending adjudication」节：时间轴映射（加速上传的倍率反推法）、长 turn 漂移边界（>90s turn 实测 ±70s，两剪上限）、裁决矩阵（双窗一致→accepted；双窗矛盾→保留 pending；生僻缩写双引擎一致→kept_original+confirmed-correct；领域先验让位双引擎实证）
- `SKILL.md` rung 7 段补批量形态路由：pending 积压不整批推给用户
- 版本 bump：daymade-audio 1.36.0 → 1.37.0

## Why（实战依据 2026-09-13）
正心AI 培训入库留下 38 项 pending（实体/疑词），本地检索阶梯已尽。按旧流程这批会整体推给用户裁决；实际用 StepFun 双窗核验后 33 项机械裁决（Texts→Typeless、深南/深览→Gemini、Alice→Harness、麦乐→脉脉、小发/小花→小八、多代词→Codex、国家采购法→螺旋式流程、overcity→CC 等），仅 5 项真未决。该批次同时纠正两处领域先验误改（金骏眉→京剧名段、修复恭敬→西湖风景图——讲师卖茶不代表文案例子是茶）。

## Validation
- `quick_validate transcript-fixer --audience public` 通过
- 脚本 py_compile 通过；实战 38 项全量跑通（PKM 仓两场次转写）
- 不改任何既有 CLI 行为；纯增量（新脚本 + reference 新节 + SKILL.md 一句路由）

🤖 Generated with [Claude Code](https://claude.com/claude-code)