### PR TITLE
docs(tunnel-doctor): per-app traffic splitting + Shadowrocket config internals

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -775,7 +775,7 @@
       "description": "Diagnoses concrete tunnel and proxy-path failures across macOS and Windows/WSL: Tailscale routing, proxy env/system bypass, SSH double tunneling, VM/container propagation, stalled DNS, TUN DIRECT split-brain, Windows-host TUN cascades, and single-hop or chained proxy node/exit throughput. Use when Tailscale ping works but SSH/HTTP fails, browser returns 503 while curl works, Git SSH closes through the proxy, Docker pull/build fails behind TUN, getaddrinfo stalls while nslookup is fast, raw probes report physically impossible results, domestic DIRECT-routed sites fail while proxied sites work, a blocked port could be your tunnel or the destination's firewall, or the proxy is reachable but real downloads and full Git clones crawl. Also use when Git reports \"failed to begin relaying via HTTP\", ssh -vvv freezes at \"debug2: resolving\", ping works but dig times out, or setting up Tailscale SSH to WSL. Use debugging-network-issues only when the root cause remains unknown or belongs to an application/protocol layer.",
       "source": "./tunnel-doctor",
       "strict": false,
-      "version": "1.12.0",
+      "version": "1.12.1",
       "category": "developer-tools",
       "keywords": [
         "tailscale",

--- a/tunnel-doctor/SKILL.md
+++ b/tunnel-doctor/SKILL.md
@@ -99,6 +99,7 @@ Determine which scenario applies:
 - **Any tool using system DNS (`ssh`, `curl`, `git`) hangs ~60s before resolving, but `nslookup` returns instantly** → Stalled resolver in `getaddrinfo` chain (Step 2I)
 - **Windows+WSL host: everything offline at once (domestic AND overseas), WSL dead too, "even Tailscale won't come online" — and/or the user tried several recovery actions (switched NICs, toggled TUN) and can't tell which one fixed it** → Windows host TUN cascade + event-log forensics (Step 5C)
 - **Tailscale, DNS, route ownership, and proxy reachability all pass, but large transfers remain slow and switching the active proxy node changes throughput** → proxy node / exit / chain capacity workflow in [references/proxy_node_chain_throughput.md](references/proxy_node_chain_throughput.md)
+- **You want one app's bulk traffic (BaiduNetdisk downloads, Feishu/Lark uploads) off the metered proxy — or out of the status-bar counter entirely** → not a conflict; a splitting task. [references/proxy_conflict_reference.md](references/proxy_conflict_reference.md) § "Per-app traffic splitting on macOS" — which of the three mechanisms (DIRECT rule / `tun-excluded-routes` / `always-real-ip`) can work for the app depends on whether it connects to literal IPs or the system resolver, and the DNS-layer keys are inert on the macOS Catalyst build.
 
 **Key distinctions**:
 - SSH does NOT use `http_proxy`/`NO_PROXY` env vars. If SSH works but HTTP doesn't → Layer 2.

--- a/tunnel-doctor/references/proxy_conflict_reference.md
+++ b/tunnel-doctor/references/proxy_conflict_reference.md
@@ -88,6 +88,61 @@ curl -s -X POST "http://<ip>:8080/api/save" -d @config.txt
 
 **Important**: The API `save` only writes to the editor buffer. The user must click **Save** in the Shadowrocket UI to persist changes. After saving, the VPN connection must be restarted for route changes to take effect.
 
+**API lifecycle and exposure** (verified 2026-09-13, macOS Catalyst build): the API listens on `*:8080` — **all interfaces, so the whole LAN can read *and* rewrite the proxy config while it is up** — and exists only while the Edit Plain Text view is open. Leaving that view (back button) stops the listener. Never leave the editor open unattended; verify shutdown with `lsof -nP -iTCP:8080 -sTCP:LISTEN` (expect zero rows). `api/read` returns the editor buffer with a `# Shadowrocket: <timestamp>` header line, so it reflects unsaved edits, not necessarily the on-disk config.
+
+### Direct database writes (default.db) — when the GUI is not an option
+
+The live config on macOS is a SQLite FTS3 table, not the `.conf` text (the text is an export view):
+
+```
+~/Library/Containers/com.liguangming.Shadowrocket/Data/Documents/Databases/default.db
+  table config(section, name, value, option, ext, remarks, created)
+```
+
+Rules match in **ascending rowid order**; `FINAL` sits at the highest rowid. An `INSERT` lands *after* FINAL and never matches — to add rules you must renumber: insert your rows, `DELETE` the trailing `# China`/`GEOIP`/`# Final`/`FINAL` rows, then re-insert them so they come last. The compiled product the tunnel consumes lives at `~/Library/Group Containers/group.com.liguangming.Shadowrocket/rule.db` (NSKeyedArchiver bplists per config section) — parse it to confirm what the app actually accepted.
+
+Contract for safe writes:
+
+1. `osascript -e 'quit app "Shadowrocket"'` first — a running app holds its own copy and will overwrite the db on exit.
+2. Write with a transaction; back up `default.db` first.
+3. Relaunch the app, then reconnect the tunnel (`shadowrocket://disconnect` / `shadowrocket://connect`) — a tunnel that survived the app quit keeps the old config.
+4. **Subscription refresh (`DLWSubscribeAutoUpdateKey = true` by default) wipes direct db writes.** Direct writes are for one-shot experiments or need a replay script; durable rule injection belongs in modules (below).
+
+### Local modules (.sgmodule) — the durable injection point
+
+Local module files live at `~/Library/Containers/com.liguangming.Shadowrocket/Data/Documents/Modules/*.sgmodule` and are picked up from that directory without any plist registration (`DLWModuleManager` staying empty is normal). `[Rule]` entries in a module do apply; **`[General]` keys in a module are silently ignored** (verified 2026-09-13: `always-real-ip`/`tun-excluded-routes` in a module had no runtime effect while the same keys in the config body worked). Survive subscription refreshes; stack-safe way to ship DIRECT rules.
+
+### Per-app traffic splitting on macOS — what can and cannot escape the TUN
+
+Goal shape: "app X's traffic should not touch the metered proxy (and ideally not even the TUN/status-bar counters)". Three mechanisms stack, and they operate at different layers:
+
+| Mechanism | Layer | Effect | Limit |
+|---|---|---|---|
+| `[Rule]` DIRECT (config body or module) | policy | zero proxy cost, traffic forwarded by the tunnel directly | still traverses TUN → still counted in the status-bar speed |
+| `tun-excluded-routes` += app CIDRs | route table | packets to those CIDRs never enter the TUN; status bar silent | only catches packets whose destination IP is the real CDN IP **at connect time** |
+| `always-real-ip` / `fake-ip-filter` | DNS answer | would return real IPs so excluded-routes can catch them | **non-functional on the macOS Catalyst build** (see below) |
+
+The decisive variable is **how the app resolves** its download/upload hosts:
+
+- **Apps that connect to literal IPs** (e.g. BaiduNetdisk's downloader, which gets CDN IPs from its dispatch API and never asks the system resolver): packets carry real destination IPs, so `tun-excluded-routes` catches them at the route layer. Verified working: 90+ tunnel-forwarded connections to its CDN ranges dropped to zero after exclusion; the status bar went silent during active downloads.
+- **Apps that use the system resolver** (Feishu/Lark and most): they receive fake IPs (`198.18.0.0/15`) — under this TUN *every* domain resolves to a fake IP, including DIRECT-ruled ones, so `dig` cannot discriminate policy. The packet enters the TUN with a fake destination, excluded-routes never match, and the tunnel forwards post-resolution. For these apps the status bar always counts.
+
+`always-real-ip` / `fake-ip-filter` would close this gap, but on the macOS Catalyst build they are accepted by the config layer and inert at runtime — verified dead via four independent paths: module `[General]`, direct db writes with three syntax variants, the official Edit Plain Text API + GUI Save chain, and the absence of any Fake IP settings page (the `DLWFakeIPViewController` in the binary is iOS-only). Until a build ships them working, the only way to silence the status bar for a system-resolver app is to disconnect the VPN during its bulk transfer.
+
+**Instruments that tell the truth on this machine:**
+
+```bash
+# Which form an app's traffic takes: fake-IP (system resolver) vs real-IP (literal connect)
+lsof -nP -iTCP -a -p <pid> | grep ESTABLISHED    # destination column: 198.18.x vs real
+
+# Split-brain-proof per-policy throughput (status bar shows the SUM of these two):
+plutil -p ~/Library/Group\ Containers/group.com.liguangming.Shadowrocket/NetworkUsage
+#   directInPerBytes + proxyInPerBytes == inPerBytes (exactly) — DIRECT traffic IS counted.
+
+# What the tunnel is forwarding where (DIRECT forwarding shows as real-IP sockets owned by the tunnel):
+lsof -nP -iTCP -a -p $(pgrep -f MacPacketTunnel) | grep ESTABLISHED
+```
+
 ### Example tun-excluded-routes (correct)
 
 ```


### PR DESCRIPTION
## What

Session-proven knowledge from a BaiduNetdisk/Feishu traffic-splitting task on the macOS Catalyst build:

- **reference**: per-app splitting mechanisms table (DIRECT rule / `tun-excluded-routes` / `always-real-ip`) and which apps each mechanism can actually catch — literal-IP connectors (BaiduNetdisk downloader) vs system-resolver apps (Feishu/Lark) — plus instruments that tell the truth under TUN (NetworkUsage per-policy counters, MacPacketTunnel forwarding sockets)
- **reference**: `always-real-ip` / `fake-ip-filter` are accepted by the config layer but **inert at runtime** on the Catalyst build — four independent write paths verified dead (module `[General]`, direct db writes ×3 syntax variants, official Edit Plain Text API + GUI Save chain), and no Fake IP page exists in the Mac GUI
- **reference**: direct `default.db` write contract (quit app first, ascending-rowid rule matching means inserts must land before FINAL, subscription refresh wipes direct writes) and local `.sgmodule` scope (`[Rule]` applies, `[General]` silently ignored)
- **reference**: Config API lifecycle & exposure — listens on `*:8080` only while Edit Plain Text is open; verify listener shutdown
- **SKILL.md**: symptom-route entry for "keep one app's bulk traffic off the metered proxy / out of the status-bar counter"

🤖 Generated with [Claude Code](https://claude.com/claude-code)