### PR TITLE
fix(daymade-claude-code): prior-work 闸门校准 + profile drift 三键分类 (v3.26.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -126,7 +126,7 @@
       "description": "Claude Code operations suite that bundles cross-project prior-work retrieval across code, docs, Skills, meetings, WeChat archives, and conversation history; provider-separated Claude Code and Codex history readers; identity- and lineage-gated continuation workflows; plugin/skill troubleshooting; CLAUDE.md progressive disclosure optimization; version-synced Lark CLI routing; statusline configuration; exported .txt repair; full claude.ai conversation extraction with tool-call rendering and file download; plugin marketplace development and suite consolidation; writing/testing/debugging Claude Code hooks; multi-provider profile isolation; personal-memory migration into tool-agnostic AGENTS.md reference docs; one-shot local timers that ping Claude right after subscription quota reset to start a fresh 5-hour usage window; and terminal-output-to-PNG rendering for visual CLI verification under one shared namespace. Install once to get the full Claude Code power-user toolkit.",
       "source": "./daymade-claude-code",
       "strict": false,
-      "version": "3.26.0",
+      "version": "3.26.1",
       "category": "suite",
       "keywords": [
         "suite",

--- a/daymade-claude-code/claude-switch-models-setup/scripts/sync-profile-settings.py
+++ b/daymade-claude-code/claude-switch-models-setup/scripts/sync-profile-settings.py
@@ -139,6 +139,7 @@ BEHAVIOR_KEYS = {
     "fleetViewGroupMode",      # agent fleet view grouping
     "prStatusFooterEnabled",   # PR status in the footer
     "deepLinkTerminal",        # terminal for deep links
+    "showExpandedTodos",       # todo list expanded/collapsed display (bool, 2026-09-13)
 }
 
 # Keys a sync must NEVER touch: per-profile runtime state, caches, counters,
@@ -165,12 +166,17 @@ STATE_EXACT = {
     "seenNotifications", "tipsHistory", "tipLifetimeShownCounts",
     "announcementImpressions", "clientDataCacheSlots", "groveConfigCache",
     "fotwUpsellFulfilled",
+    # 按 profile 记的「自动模式环境设置」拒绝计数器（{"denials": N}），同步会把
+    # main 的计数抹到别的 profile（2026-09-13 分类）。
+    "autoModeEnvSetup",
 }
 STATE_PREFIX = ("cached", "has", "num", "unpin", "remotecontrol")
 STATE_SUBSTR = (
     "cache", "count", "seen", "dismissed", "fulfilled", "impressions",
     "watermark", "upsell", "nudge", "usage", "oauth", "apikey", "last",
     "tip", "token", "credential", "secret", "migration", "declin",
+    # 「已回答某一次性提示」的时间戳家族（XxxAnsweredAt），永不同步（2026-09-13）。
+    "answeredat",
 )
 
 # Gray keys a human already classified as "deliberately not synced", with the

--- a/daymade-claude-code/prior-work-retrieval/scripts/prior_work_hook.py
+++ b/daymade-claude-code/prior-work-retrieval/scripts/prior_work_hook.py
@@ -26,7 +26,13 @@ RECEIPT_MAX_AGE_SECONDS = 24 * 60 * 60
 # Strong signals name prior work outright ("我们之前…", "复用", "reuse"). They
 # arm the gate on their own.
 PRIOR_WORK_STRONG_SIGNAL = re.compile(
-    r"(?:我们之前|以前|之前做过|之前(?:用|跑|做|配|装|搭|建|写)|"
+    r"(?:我们之前|之前做过|之前(?:用|跑|做|配|装|搭|建|写)|"
+    # 裸「以前」不再独立武装（2026-09-13 审计实证：「和以前的那些 agent browser
+    # 有什么区别」是对比句式，被「以前」一词武装）。「以前」须带工作名词或
+    # 做事形态才算检索请求；真召回「我们以前是怎么做的」经 做的 命中。
+    r"以前[^\n，,。；;]{0,8}"
+    r"(?:代码|脚本|方案|框架|配置|文档|流程|做法|做的|做过|工具|库|接口|命令|"
+    r"模板|仓库|分支|模块|服务|规则|SOP)|"
     # Bare 已有/现有/既有 used to arm ordinary references to the current
     # checkout ("现有测试或 README 如果冲突才同步"). Existing work must name a
     # reusable asset; current tests/files/behavior are not a history request.
@@ -35,7 +41,10 @@ PRIOR_WORK_STRONG_SIGNAL = re.compile(
     r"(?:个|套|份|条|版|组|批|项|段)?\s*"
     r"(?:代码|脚本|方案|资产|成果|SOP|流程|做法|工具|模板|系统)|"
     r"历史经验|历史决策|以前的代码|已有代码|"
-    # 成功的经验 — the 的 particle broke the literal 成功经验.
+    # 成功的经验 — the 的 particle broke the literal 成功经验.（2026-09-13 收窄而
+    # 不是删除：该词同时是纠偏话术高频词「记得/保证你成功的经验」（语义=记住
+    # 本次，非检索已有），系统性误触发 4 个 session；疑问形「成功的经验又是
+    # 什么」是真召回。指令形由 IMPERATIVE_REMEMBER 剔除，见下。）
     r"成功(?:的)?经验|"
     # 不希望你重新造轮子 — the literal 不要重新/不要重造/别重复 missed every
     # natural phrasing of the same ask.
@@ -107,6 +116,12 @@ NEGATED_PRIOR_SIGNAL = re.compile(
 # "这些 Skill 也是很久之前写的" dates something to argue it is stale — the
 # opposite of asking to go find it. Excised like a negation.
 STALE_AGE_IDIOM = re.compile(r"(?:很久|太久|好久|老早|早就)\s*(?:以前|之前)")
+# 「记得/保证/记住…成功的经验」是让对方**记住本次**的纠偏话术，不是检索已有
+# 工作的请求（2026-09-13 审计：4 个 session 被它武装后，只读动作/peer 消息接连
+# 被拦）。疑问形「成功的经验又是什么」不在此模式内，仍武装。
+IMPERATIVE_REMEMBER = re.compile(
+    r"(?:记得|记住|保证|别忘了?|沉淀|记录)[^\n，,。；;]{0,12}成功(?:的)?经验"
+)
 # 「我们这个对话最开始是想要干什么来着」/「我们的主线任务是什么来着」ask what the
 # CURRENT session is about. The answer is the conversation already in front of the
 # executor: no carrier to search, no candidate to verify, and no artifact produced —
@@ -165,7 +180,12 @@ SHELL_UNKNOWN_EXECUTOR = re.compile(
     # The lookbehind keeps file-suffix collisions out: `report.sh` is a path
     # argument to read, not the interpreter `sh` — a dot (or word char)
     # immediately before the token means it is a filename component.
-    r"(?<![\w.])(?:python(?:3)?|node|bash|zsh|sh)\b",
+    # The lookahead keeps directory components out: `cd /workspace/python/x`
+    # has `python` followed by `/` — a path segment, not an interpreter
+    # (2026-09-13 审计实证：jeepay-monorepo 一条纯只读 sed/grep 被
+    # `/python/` 目录名误拦)。绝对路径解释器 `/usr/bin/python3 -c …`
+    # 后面跟的是空格，不在豁免内，照样拦。
+    r"(?<![\w.])(?:python(?:3)?|node|bash|zsh|sh)\b(?!/)",
     re.IGNORECASE,
 )
 SHELL_READ_ONLY_EXECUTOR = re.compile(
@@ -175,7 +195,7 @@ SHELL_READ_ONLY_EXECUTOR = re.compile(
 )
 RETRIEVAL_ROUTES = {
     "prior_work.py": {"validate-manifest", "retrieve", "complete", "check"},
-    "history_index.py": {"recall", "status"},
+    "history_index.py": {"recall", "status", "index"},
     "analyze_sessions.py": {"search", "locate-codex"},
     "read_chat.py": None,
 }
@@ -225,7 +245,8 @@ def classify_prompt(prompt: str, receipt_valid: bool = False) -> str:
     if USER_OPTOUT.search(text):
         return "opt_out"
     scannable = CURRENT_SESSION_RECALL.sub(
-        " ", STALE_AGE_IDIOM.sub(" ", NEGATED_PRIOR_SIGNAL.sub(" ", text))
+        " ", STALE_AGE_IDIOM.sub(" ", IMPERATIVE_REMEMBER.sub(
+            " ", NEGATED_PRIOR_SIGNAL.sub(" ", text)))
     )
     if PRIOR_WORK_STRONG_SIGNAL.search(scannable):
         return "required_prior_signal"
@@ -342,6 +363,16 @@ def _segment_is_retrieval_route(segment: str) -> bool:
         words = shlex.split(segment, posix=True)
     except ValueError:
         return False
+    # VAR=$(route …) 整段就是「检索并接住输出」：解开赋值+替换包装递归判定
+    # （2026-09-13 审计：receipt 过期后的标准解锁动作被 $( 包装误拦）。
+    # 只解「整段=赋值* + 一个替换 + 可选 stderr 合并」的形态；藏在参数里的
+    # 替换（script.py "$(rm -rf x)"）仍由下方 fail-closed 检查拦死。
+    unwrapped = re.match(
+        r"^\s*(?:[A-Za-z_][A-Za-z0-9_]*=\s*)*\$\((?P<inner>.*)\)"
+        r"\s*(?:2>&1|2>/dev/null)?\s*$",
+        segment, re.DOTALL)
+    if unwrapped:
+        return _segment_is_retrieval_route(unwrapped.group("inner"))
     substitution_tokens = ("$(", "`", "<(", ">(", "=(")
     if not words or any(
         token in word for word in words for token in substitution_tokens
@@ -457,11 +488,17 @@ def _strip_quoted_text(fragment: str) -> str:
 
 def _has_formal_file_redirection(event: dict[str, Any]) -> bool:
     for fragment in _shell_fragments(event):
-        for match in FILE_REDIRECTION.finditer(_strip_quoted_text(fragment)):
-            target = match.group("target").strip("\"'")
-            if target in {"/dev/null", "&1", "&2"}:
+        for segment in _shell_segments(fragment):
+            # 检索路由自身的输出落盘是检索动作的一部分（2026-09-13 审计实证：
+            # 「receipt 过期后重新 retrieve > /tmp/out」被当写信号拦）。
+            # 非路由段里的重定向不受影响，照旧计写信号。
+            if _segment_is_retrieval_route(segment):
                 continue
-            return True
+            for match in FILE_REDIRECTION.finditer(_strip_quoted_text(segment)):
+                target = match.group("target").strip("\"'")
+                if target in {"/dev/null", "&1", "&2"}:
+                    continue
+                return True
     return False
 
 

--- a/daymade-claude-code/prior-work-retrieval/tests/test_prior_work_hook.py
+++ b/daymade-claude-code/prior-work-retrieval/tests/test_prior_work_hook.py
@@ -318,19 +318,96 @@ class PriorWorkHookTests(unittest.TestCase):
         substantial, reason = hook.substantial_tool_use(double_quoted)
         self.assertFalse(substantial, reason)
 
-    def test_unquoted_redirection_even_after_route_stays_gated(self) -> None:
-        # Stripping quoted text must not weaken the gate: a real redirection
-        # in unquoted position — even trailing a whitelisted route command —
-        # is still a write.
-        event = {
+    def test_route_output_capture_is_exempt_nonroute_redirection_stays_gated(self) -> None:
+        # 2026-09-13 审计后有意反转旧锁定（旧测试名：unquoted redirection even
+        # after route stays gated）：receipt 过期后的标准解锁动作
+        # 「retrieve … > /tmp/out」被当写信号拦死，而重定向写的就是路由自己的
+        # stdout——检索输出落盘是检索动作的一部分，豁免。
+        # 非路由段的重定向照旧计写信号。
+        route_capture = {
             "tool_name": "Bash",
             "tool_input": {
                 "command": "uv run python scripts/prior_work.py check > receipt.json"
             },
         }
-        substantial, reason = hook.substantial_tool_use(event)
+        substantial, reason = hook.substantial_tool_use(route_capture)
+        self.assertFalse(substantial, reason)
+        nonroute_write = {
+            "tool_name": "Bash",
+            "tool_input": {
+                "command": "uv run python scripts/prior_work.py check && ls > /tmp/x"
+            },
+        }
+        substantial, reason = hook.substantial_tool_use(nonroute_write)
         self.assertTrue(substantial, reason)
         self.assertEqual(reason, "Bash:write_signal")
+
+    def test_audit_20260913_regressions(self) -> None:
+        # 2026-09-13 高频闸门审计的四个误拦实证（逐条来自真实 transcript）。
+        # #5 unknown_executor：路径组件 /python/ 不是解释器调用
+        path_seg = {
+            "tool_name": "Bash",
+            "tool_input": {
+                "command": "cd ~/workspace/python/video-rough-cut && sed -n '461,486p' tests/x.py"
+            },
+        }
+        substantial, reason = hook.substantial_tool_use(path_seg)
+        self.assertFalse(substantial, reason)
+        # 绝对路径解释器仍然拦（lookahead 只排除后紧跟 / 的目录形态）
+        abs_interp = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "/usr/bin/python3 -c 'open(\"/tmp/e\",\"w\")'"},
+        }
+        substantial, reason = hook.substantial_tool_use(abs_interp)
+        self.assertTrue(substantial, reason)
+        # #4 赋值+替换包裹的 retrieve 是检索动作
+        wrapped = {
+            "tool_name": "Bash",
+            "tool_input": {
+                "command": "RUN=$(uv run python scripts/prior_work.py retrieve --business-outcome 'x') 2>&1; ec=$?"
+            },
+        }
+        substantial, reason = hook.substantial_tool_use(wrapped)
+        self.assertFalse(substantial, reason)
+        # 藏在参数里的替换仍 fail-closed
+        hidden = {
+            "tool_name": "Bash",
+            "tool_input": {
+                "command": "uv run python scripts/prior_work.py retrieve --business-outcome \"$(rm -rf /tmp/y)\""
+            },
+        }
+        substantial, reason = hook.substantial_tool_use(hidden)
+        self.assertTrue(substantial, reason)
+
+    def test_audit_20260913_prompt_regressions(self) -> None:
+        # #9 对比句式的「以前」不武装
+        self.assertEqual(
+            hook.classify_prompt(
+                "到底和以前的那些 agent browser 有什么区别", False),
+            "none",
+        )
+        # 「以前」带做事形态仍武装
+        self.assertEqual(
+            hook.classify_prompt("不要复用 aicms-docs，但看看我们以前是怎么做的", False),
+            "required_prior_signal",
+        )
+        # 纠偏话术「记得你成功的经验」（指令形）不武装
+        self.assertEqual(
+            hook.classify_prompt(
+                "保证你在压缩上下文之后还能记得你成功的经验", False),
+            "none",
+        )
+        # 疑问形「成功的经验又是什么」仍武装
+        self.assertEqual(
+            hook.classify_prompt(
+                "最后成功的经验又是什么？如果我们以后还想去抓微信公众号", False),
+            "required_prior_signal",
+        )
+        # 召回主干不动：「我们之前」裸形态仍武装
+        self.assertEqual(
+            hook.classify_prompt("帮我回忆一下，我们之前已经见过两次了", False),
+            "required_prior_signal",
+        )
 
     def test_gate_messages_carry_the_real_session_id(self) -> None:
         # Regression (2026-08-27): the deny message only ever showed the


### PR DESCRIPTION
## 根因（2026-09-13 高频闸门审计）

prior-work-retrieval 7 天拦 144+ 次，抽样 10 条里 7 条误拦，摩擦集中在解锁动作本身（全量 33% 拦截落在含 route 脚本名的命令上）。

## 修法（逐条带审计实证）

- unknown_executor：解释器 token 后紧跟 `/` 的是路径组件（`/python/` 目录名误拦只读命令），lookahead 排除；绝对路径解释器照拦
- 路由豁免贯通重定向检查：route 段输出落盘（`retrieve > /tmp/out`）不再计写信号；非路由段照拦
- `VAR=$(route …)` 整段包装解开递归判定；参数内替换仍 fail-closed
- 「成功的经验」指令形（记得/保证你…）由 IMPERATIVE_REMEMBER 剔除；疑问形保留
- 裸「以前」须带工作名词/做事形态；「我们之前」不变
- history_index.py 白名单补 `index`

附带 sync-profile-settings.py：3 个 UNCLASSIFIED drift key 逐键分类（kimi --check 下 3→0）。

## 验证

- 测试 75 + 99 subtests 全绿（含 8 条审计回归用例）
- 本地已对精确 head 跑完全部仓 CI 等价步骤（check_marketplace / version_progression / shell_syntax / 17 注册套件全过）；CI 若因账号 Actions 预算未启动，此行为等价证据

🤖 Generated with [Claude Code](https://claude.com/claude-code)
